### PR TITLE
[2bf21e24] Chat interface and conversation history design specs

### DIFF
--- a/docs/design/prompter/README.md
+++ b/docs/design/prompter/README.md
@@ -1,0 +1,190 @@
+# Prompter — Chat Surface Design Specifications
+
+**Last Updated:** 2026-06-03  
+**Spec Version:** 1.0  
+**Owner:** ux-dev-1  
+**Status:** Ready for frontend implementation
+
+---
+
+## Purpose
+
+This directory contains the complete design specification for the **Prompter page chat surface**. A frontend developer can implement the entire chat UI from these files alone, without a follow-up design meeting.
+
+> **Scope boundary:** This spec covers the chat interface and conversation history panel. The task-draft editing panel, Create & Launch confirmation dialog, and spatial layout between chat and draft panels are covered by a companion spec owned by ux-dev-2.
+
+---
+
+## File Index
+
+| File | Covers |
+|---|---|
+| `README.md` *(this file)* | Overview, layout, shared design tokens |
+| `chat-interface.md` | Message bubbles, input area, typing indicator, empty state |
+| `conversation-history.md` | History panel, list items, hover actions, delete flow |
+| `model-selection.md` | Model selector trigger, dropdown, option items, disabled state |
+| `interaction-states.md` | Default / hover / focus / active / disabled states for all elements |
+
+---
+
+## Page Layout — Prompter
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  App Shell: top nav bar (48px, z-index 100)                         │
+├──────────────────────┬──────────────────────────────────────────────┤
+│                      │  Chat Header Bar (48px)                      │
+│  Conversation        │  ┌──────────────────────────── [Model ▼] ┐  │
+│  History Panel       │  │                                        │  │
+│  (260px, collapsible)│  │  Message Thread Area                   │  │
+│                      │  │  (flex column, scroll, padding 24px)   │  │
+│  ─────────────────   │  │                                        │  │
+│  [New Chat]          │  │                                        │  │
+│                      │  └────────────────────────────────────────┘  │
+│  Today               │  Input Composer Area (auto-height, max 180px)│
+│  ┌──────────────────┐│  ┌───────────────────────────────[Send ↵]┐  │
+│  │ Convo title  ... ││  │ textarea (auto-grow 1–6 rows)         │  │
+│  │ Convo title  ... ││  └───────────────────────────────────────┘  │
+│  └──────────────────┘│  ⌘↵ to send  (12px, neutral-400)           │
+│                      │                                              │
+│  Previous 7 Days     │                                              │
+│  Older               │                                              │
+└──────────────────────┴──────────────────────────────────────────────┘
+```
+
+### Layout Dimensions
+
+| Region | Value |
+|---|---|
+| App shell / top nav | 48 px height, full width |
+| Conversation history panel | 260 px width (collapsed: 0 px) |
+| Panel collapse transition | 300 ms, `ease-in-out` |
+| Chat header bar | 48 px height, flex row, align-center, space-between |
+| Message thread area | flex-grow 1, overflow-y auto, padding 24 px 24 px 16 px |
+| Input composer area | auto-height, min 52 px, max 180 px, padding 12 px 16 px |
+
+---
+
+## Shared Design Tokens
+
+> These tokens are defined here and referenced by all spec files in this directory. Frontend should reconcile these names with the project's actual design token system at implementation time.
+
+### Colour Tokens
+
+| Token | Light Mode Value | Usage |
+|---|---|---|
+| `brand-500` | `#5B6CF6` | Primary actions, AI bubble border, active states |
+| `brand-600` | `#4A5BE0` | Primary action hover, active history item border |
+| `brand-100` | `#EEF0FE` | Active history item background |
+| `brand-50`  | `#F5F6FF` | Subtle brand-tinted backgrounds |
+| `surface-0` | `#FFFFFF` | Base background (dropdowns, modals) |
+| `surface-50` | `#F9FAFB` | History panel background |
+| `surface-100` | `#F3F4F6` | AI message bubble background |
+| `surface-200` | `#E5E7EB` | Chip/badge background, hover surfaces |
+| `surface-300` | `#D1D5DB` | Dividers, borders |
+| `neutral-400` | `#9CA3AF` | Placeholder text, timestamps, keyboard hints |
+| `neutral-500` | `#6B7280` | Secondary text |
+| `neutral-700` | `#374151` | Primary body text |
+| `neutral-900` | `#111827` | Headings, bold text |
+| `danger-500` | `#EF4444` | Delete actions, error states |
+| `danger-100` | `#FEE2E2` | Danger hover background |
+| `focus-ring` | `#5B6CF6` | Keyboard focus outline colour (matches `brand-500`) |
+| `user-bubble-bg` | `#5B6CF6` | User message bubble background (= `brand-500`) |
+| `user-bubble-text` | `#FFFFFF` | User message bubble text |
+| `ai-bubble-bg` | `#F3F4F6` | AI message bubble background (= `surface-100`) |
+| `ai-bubble-text` | `#374151` | AI message text (= `neutral-700`) |
+
+### Typography
+
+| Role | Font | Weight | Size | Line Height | Tracking |
+|---|---|---|---|---|---|
+| Message body | System UI stack | 400 | 14 px / 0.875 rem | 1.5 (21 px) | 0 |
+| Message sender label | System UI stack | 600 | 12 px / 0.75 rem | 1.4 | 0 |
+| History item title | System UI stack | 400 | 14 px / 0.875 rem | 1.4 | 0 |
+| History group heading | System UI stack | 600 | 11 px / 0.6875 rem | 1.3 | +0.05 em (uppercase) |
+| Timestamp / hint | System UI stack | 400 | 12 px / 0.75 rem | 1.3 | 0 |
+| Empty state headline | System UI stack | 600 | 20 px / 1.25 rem | 1.3 | −0.01 em |
+| Empty state subtext | System UI stack | 400 | 14 px / 0.875 rem | 1.5 | 0 |
+| Input textarea | System UI stack | 400 | 14 px / 0.875 rem | 1.5 | 0 |
+| Chip label | System UI stack | 400 | 13 px / 0.8125 rem | 1.4 | 0 |
+| Model selector trigger | System UI stack | 500 | 13 px / 0.8125 rem | 1 | 0 |
+| Dropdown option | System UI stack | 400 | 14 px / 0.875 rem | 1 | 0 |
+
+> **System UI stack:** `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
+
+### Spacing Scale
+
+| Token | Value |
+|---|---|
+| `space-1` | 4 px |
+| `space-2` | 8 px |
+| `space-3` | 12 px |
+| `space-4` | 16 px |
+| `space-5` | 20 px |
+| `space-6` | 24 px |
+| `space-8` | 32 px |
+| `space-10` | 40 px |
+
+### Border Radius
+
+| Token | Value | Usage |
+|---|---|---|
+| `radius-sm` | 4 px | User bubble tail corner, chip subtle corner |
+| `radius-md` | 8 px | Dropdown panels, input borders |
+| `radius-lg` | 12 px | AI bubble |
+| `radius-xl` | 18 px | User/AI bubble primary corners |
+| `radius-full` | 9999 px | Chips, badges, icon buttons |
+
+### Elevation / Shadow
+
+| Token | Value | Usage |
+|---|---|---|
+| `elevation-1` | `0 1px 3px rgba(0,0,0,0.08)` | Subtle card |
+| `elevation-2` | `0 4px 12px rgba(0,0,0,0.10)` | Input composer |
+| `elevation-3` | `0 8px 24px rgba(0,0,0,0.12)` | Dropdowns, model selector |
+
+### Z-Index Scale
+
+| Layer | Value |
+|---|---|
+| Message thread | 1 |
+| Input composer | 10 |
+| Typing indicator | 15 |
+| History panel | 50 |
+| App nav bar | 100 |
+| Model selector dropdown | 200 |
+| Modals / dialogs | 300 |
+
+### Motion / Easing
+
+| Token | Value | Usage |
+|---|---|---|
+| `ease-default` | `cubic-bezier(0.4, 0, 0.2, 1)` | General UI transitions |
+| `ease-in` | `cubic-bezier(0.4, 0, 1, 1)` | Elements exiting the screen |
+| `ease-out` | `cubic-bezier(0, 0, 0.2, 1)` | Elements entering the screen |
+| `duration-fast` | `150 ms` | Hover colour changes, icon reveals |
+| `duration-base` | `200 ms` | Height/opacity transitions (delete confirm) |
+| `duration-slow` | `300 ms` | Panel slide (history collapse), dropdown open |
+| `duration-typing` | `1200 ms` | Typing indicator full animation cycle |
+| `typing-stagger` | `160 ms` | Per-dot delay in typing indicator |
+
+---
+
+## Accessibility Requirements
+
+- All interactive elements are keyboard-operable.
+- Focus order follows visual reading order (left-to-right, top-to-bottom).
+- Focus ring: `2 px solid var(--focus-ring)` with `outline-offset: 2 px` on all focusable elements.
+- Colour contrast: minimum 4.5:1 for normal text, 3:1 for large text (≥ 18 px regular or ≥ 14 px bold) and UI components.
+- Typing indicator and suggested-prompt chips must not cause layout shift.
+- All icon-only buttons must have `aria-label` and a visible tooltip on hover.
+- Conversation history panel collapse must be announced via `aria-expanded` on the toggle button.
+- `role="log"` and `aria-live="polite"` on the message thread container for screen-reader announcement of new messages.
+
+---
+
+## Related Specs
+
+- `ux-dev-2` task — Task-draft panel, Create & Launch dialog, spatial layout: `docs/design/prompter/task-draft.md` *(pending)*
+- Frontend implementation task: `fb83fada-1bf7-4e5a-b62b-1f18b1131735`
+- Parent design task: `a2230a75-9730-4353-a45c-7a36c500d301`

--- a/docs/design/prompter/chat-interface.md
+++ b/docs/design/prompter/chat-interface.md
@@ -1,0 +1,427 @@
+# Chat Interface — Design Specification
+
+**Last Updated:** 2026-06-03  
+**Spec Version:** 1.0  
+**Owner:** ux-dev-1  
+**References:** `README.md` for shared tokens
+
+---
+
+## 1. Message Thread Area
+
+### 1.1 Container
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Message Thread (flex column, gap 16px, overflow-y auto) │
+│  padding: 24px 24px 16px 24px                           │
+│  flex-grow: 1                                           │
+│  role="log", aria-live="polite", aria-label="Chat"      │
+└─────────────────────────────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Display | `flex`, `flex-direction: column` |
+| Gap between bubbles | `16 px` (`space-4`) |
+| Padding | `24 px 24 px 16 px 24 px` |
+| Overflow | `overflow-y: auto` |
+| Scroll behaviour | `scroll-behavior: smooth` |
+| Background | `surface-0` |
+| ARIA | `role="log"`, `aria-live="polite"`, `aria-label="Conversation"` |
+
+---
+
+### 1.2 Message Timestamp Separator
+
+Timestamps are shown between messages when >10 minutes have elapsed since the previous message, or at the start of a new session.
+
+```
+──────────── Today at 14:32 ────────────
+```
+
+| Property | Value |
+|---|---|
+| Layout | Flex row, align-center, gap `8 px` |
+| Lines | `1 px` solid `surface-300`, flex-grow 1 on each side |
+| Text | 11 px, `neutral-400`, uppercase, tracking `+0.05 em` |
+| Margin | `8 px 0` above and below the separator row |
+
+---
+
+## 2. Message Bubbles
+
+### 2.1 Bubble Layout
+
+Each message is a flex row. User messages are right-aligned; AI messages are left-aligned.
+
+```
+AI message row:
+┌──────────────────────────────────────────────┐
+│ [Avatar 28px]  ┌────────────────────────────┐│
+│                │  AI response text here     ││
+│                │  can span multiple lines   ││
+│                └────────────────────────────┘│
+└──────────────────────────────────────────────┘
+
+User message row:
+┌──────────────────────────────────────────────┐
+│              ┌──────────────────────────────┐│
+│              │ User message text here       ││
+│              └──────────────────────────────┘│
+└──────────────────────────────────────────────┘
+```
+
+| Property | User Bubble | AI Bubble |
+|---|---|---|
+| Alignment | `align-self: flex-end` | `align-self: flex-start` |
+| Max width | 72% of thread container width | 72% of thread container width |
+| Background | `user-bubble-bg` (`brand-500`) | `ai-bubble-bg` (`surface-100`) |
+| Text colour | `user-bubble-text` (`#FFFFFF`) | `ai-bubble-text` (`neutral-700`) |
+| Border radius | `18px 18px 4px 18px` | `4px 18px 18px 18px` |
+| Padding | `10px 14px` | `12px 16px` |
+| Font size | 14 px | 14 px |
+| Line height | 1.5 | 1.5 |
+| Font weight | 400 | 400 |
+| Border | none | none |
+| Box shadow | none | `elevation-1` |
+
+> **Radius note:** The "tail" corner (bottom-right for user, bottom-left for AI) uses `radius-sm` (4 px) to give the visual impression of a speech tail pointing toward the sender. All other corners use `radius-xl` (18 px).
+
+### 2.2 Avatar (AI messages only)
+
+| Property | Value |
+|---|---|
+| Size | 28 × 28 px |
+| Shape | Circle (`border-radius: 9999px`) |
+| Background | `brand-500` gradient (45°, `brand-500` → `brand-600`) |
+| Icon | RoboCo logo mark, 16 px, `#FFFFFF` |
+| Alignment | `align-self: flex-end` (sits at bottom of bubble) |
+| Margin-right | `8 px` |
+
+User messages do **not** have an avatar.
+
+### 2.3 Sender Label
+
+Shown above the bubble, only on the first message in a consecutive run from the same sender.
+
+| Property | Value |
+|---|---|
+| Text | `"You"` (user) or model name e.g. `"Claude 3.5 Sonnet"` (AI) |
+| Font size | 12 px |
+| Font weight | 600 |
+| Colour | `neutral-500` |
+| Margin-bottom | `4 px` |
+| Visibility | Only on first message in a run; hidden if same sender as previous bubble |
+
+### 2.4 Code Blocks inside AI Messages
+
+When AI response contains code:
+
+| Property | Value |
+|---|---|
+| Background | `neutral-900` |
+| Text colour | `#FFFFFF` (with syntax highlighting per language token type) |
+| Font | `'JetBrains Mono', 'Fira Code', 'Courier New', monospace` |
+| Font size | 13 px |
+| Line height | 1.6 |
+| Padding | `12 px 16 px` |
+| Border radius | `radius-md` (8 px) |
+| Margin | `8 px 0` within bubble |
+| Copy button | Appears top-right corner on hover; 28 px icon button, `surface-0` bg |
+| Language tag | Top-left, 10 px, `neutral-400` |
+
+### 2.5 Message Actions (hover)
+
+On hover of any message bubble, a row of action icons appears above the bubble (user) or below the bubble (AI).
+
+| Action | Icon | Tooltip |
+|---|---|---|
+| Copy | Clipboard 16 px | "Copy message" |
+| Regenerate (AI only) | Refresh-CW 16 px | "Regenerate response" |
+| Delete | Trash 16 px, `danger-500` | "Delete message" |
+
+Action row properties:
+
+| Property | Value |
+|---|---|
+| Container | Flex row, gap `4 px`, opacity 0 → 1 on bubble hover |
+| Transition | `opacity 150 ms ease-default` |
+| Alignment | Flex-end for user, flex-start for AI |
+| Icon button size | 28 × 28 px |
+| Icon button bg | `surface-0` on hover, transparent at rest |
+| Icon button radius | `radius-full` |
+| Margin | `4 px` above (user) or below (AI) the bubble |
+
+---
+
+## 3. Input Composer Area
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Input Composer (padding 12px 16px, border-top surface-300) │
+│                                                         │
+│ ┌─────────────────────────────────────┬───────────────┐ │
+│ │ textarea (auto-grow, 14px)          │  [Send ↵ 36px]│ │
+│ │ placeholder: "Message RoboCo..."    │               │ │
+│ └─────────────────────────────────────┴───────────────┘ │
+│  ⌘↵ to send (12px neutral-400, left-aligned below row)  │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 3.1 Composer Container
+
+| Property | Value |
+|---|---|
+| Background | `surface-0` |
+| Border-top | `1 px solid surface-300` |
+| Padding | `12 px 16 px` |
+| Box-shadow | `elevation-2` (upward: `0 -4px 12px rgba(0,0,0,0.06)`) |
+| Z-index | 10 |
+
+### 3.2 Textarea
+
+| Property | Value |
+|---|---|
+| Min height | 40 px (1 row) |
+| Max height | 144 px (6 rows at 24 px/row) |
+| Auto-grow | Yes — height increases with content until max |
+| Overflow | `overflow-y: auto` when content exceeds max height |
+| Scrollbar | Native, styled thin (`scrollbar-width: thin`) |
+| Padding | `10 px 12 px` |
+| Font size | 14 px |
+| Line height | 1.5 (24 px) |
+| Colour | `neutral-900` |
+| Placeholder text | `"Message RoboCo..."` |
+| Placeholder colour | `neutral-400` |
+| Background | `surface-0` |
+| Border | `1.5 px solid surface-300` |
+| Border radius | `radius-md` (8 px) |
+| Resize | `none` (auto-grow handles height; width is constrained by layout) |
+| Focus ring | `2 px solid focus-ring`, `outline-offset: 2 px` (replaces border) |
+| Tab behaviour | `Tab` moves focus (does **not** insert a tab character) |
+| Submit shortcut | `⌘↵` (macOS) / `Ctrl+Enter` (Windows/Linux) |
+
+### 3.3 Send Button
+
+Positioned to the right of the textarea, vertically centred relative to the first row of text.
+
+| Property | Value |
+|---|---|
+| Size | 36 × 36 px |
+| Shape | `radius-full` |
+| Icon | Arrow-up or Send icon, 18 px |
+| Default state | Background `brand-500`, icon `#FFFFFF` |
+| Hover state | Background `brand-600` |
+| Active state | Background `brand-700` (darken 10%), scale `0.95` |
+| Disabled state | Background `surface-200`, icon `neutral-400`, `cursor: not-allowed` |
+| Disabled condition | Textarea is empty OR whitespace-only OR streaming in progress |
+| Transition | `background-color 150 ms ease-default`, `transform 100 ms ease-in` |
+| Margin-left | `8 px` from textarea |
+| aria-label | `"Send message"` |
+| Loading state | Spinner icon replaces send icon; button disabled while streaming |
+
+### 3.4 Keyboard Shortcut Hint
+
+Shown below the textarea row, left-aligned.
+
+| Property | Value |
+|---|---|
+| Content (macOS) | `⌘↵ to send` |
+| Content (Windows/Linux) | `Ctrl+↵ to send` |
+| Detection | Use `navigator.platform` or `userAgent` to detect OS |
+| Font size | 12 px |
+| Colour | `neutral-400` |
+| Margin-top | `6 px` |
+| Visibility | Always visible (not conditional on focus) |
+
+---
+
+## 4. Typing Indicator
+
+Shown in the message thread area after the user sends a message and before the AI begins streaming a response.
+
+### 4.1 Appearance
+
+```
+[Avatar 28px]  ●  ●  ●
+               ^  ^  ^
+               dot dot dot
+               (8px, brand-500/60%, brand-500/80%, brand-500)
+```
+
+| Property | Value |
+|---|---|
+| Container | Same layout as AI message bubble row |
+| Avatar | Same as §2.2 (28 × 28 px) |
+| Bubble bg | `ai-bubble-bg` (`surface-100`) |
+| Bubble padding | `14 px 18 px` |
+| Bubble border-radius | `4px 18px 18px 18px` (matches AI bubble) |
+| Bubble min-width | `64 px` |
+
+### 4.2 Dot Specification
+
+| Property | Value |
+|---|---|
+| Dot count | 3 |
+| Dot size | 8 × 8 px |
+| Dot shape | Circle (`border-radius: 9999px`) |
+| Dot colour | `brand-500` |
+| Gap between dots | `4 px` |
+| Container | Flex row, align-center, gap `4 px` |
+
+### 4.3 Animation
+
+Each dot animates vertically (translateY) in sequence.
+
+```css
+@keyframes typing-bounce {
+  0%   { transform: translateY(0); opacity: 0.4; }
+  33%  { transform: translateY(-6px); opacity: 1; }
+  66%  { transform: translateY(0); opacity: 0.4; }
+  100% { transform: translateY(0); opacity: 0.4; }
+}
+```
+
+| Property | Value |
+|---|---|
+| Animation name | `typing-bounce` |
+| Duration | `1200 ms` (full cycle) |
+| Easing | `cubic-bezier(0.4, 0, 0.2, 1)` (`ease-default`) |
+| Iteration | `infinite` |
+| Fill mode | `both` |
+| Dot 1 delay | `0 ms` |
+| Dot 2 delay | `160 ms` |
+| Dot 3 delay | `320 ms` |
+
+> **Accessibility:** The typing indicator container should have `role="status"`, `aria-label="AI is typing"`, and `aria-live="polite"`. It disappears when streaming begins.
+
+### 4.4 Transition In / Out
+
+| Event | Behaviour |
+|---|---|
+| User submits message | Typing indicator fades in over `200 ms` |
+| AI stream begins | Typing indicator fades out over `150 ms`, first token appears |
+| Stream completes | No visual change on the typing indicator (it's already gone) |
+
+---
+
+## 5. Empty State
+
+Shown in the message thread area when there are no messages in the current conversation (new chat or first visit).
+
+### 5.1 Layout
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                                                              │
+│                         (spacer, flex-grow 1)               │
+│                                                              │
+│              ┌──────────────────────────────┐               │
+│              │       [Logo mark 48px]        │               │
+│              │                              │               │
+│              │  What can I help you create  │               │
+│              │         today?               │               │
+│              │                              │               │
+│              │ Describe a task, ask a       │               │
+│              │ question, or pick a prompt   │               │
+│              │ below to get started.        │               │
+│              │                              │               │
+│              │  ┌─────────┐ ┌───────────┐  │               │
+│              │  │ Draft a │ │ Review my │  │               │
+│              │  │ task    │ │ backlog   │  │               │
+│              │  └─────────┘ └───────────┘  │               │
+│              │  ┌──────────────┐ ┌───────┐ │               │
+│              │  │ Explain the  │ │ Show  │ │               │
+│              │  │ architecture │ │ stats │ │               │
+│              │  └──────────────┘ └───────┘ │               │
+│              └──────────────────────────────┘               │
+│                                                              │
+│                         (spacer, flex-grow 1)               │
+│                                                              │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Container
+
+| Property | Value |
+|---|---|
+| Layout | Flex column, align-items center, justify-content center |
+| Flex-grow | 1 (fills remaining thread area) |
+| Padding | `48 px 24 px` |
+| Max width of content | `480 px`, centered |
+
+### 5.3 Logo Mark
+
+| Property | Value |
+|---|---|
+| Size | 48 × 48 px |
+| Style | RoboCo logo mark only (no wordmark) |
+| Background | `brand-50` circle, `brand-500` icon fill |
+| Shape | Circle, `radius-full` |
+| Margin-bottom | `20 px` |
+
+### 5.4 Headline Copy
+
+| Property | Value |
+|---|---|
+| Text | `"What can I help you create today?"` |
+| Font size | 20 px |
+| Font weight | 600 |
+| Colour | `neutral-900` |
+| Text align | Center |
+| Margin-bottom | `8 px` |
+
+### 5.5 Subtext Copy
+
+| Property | Value |
+|---|---|
+| Text | `"Describe a task, ask a question, or pick a prompt below to get started."` |
+| Font size | 14 px |
+| Font weight | 400 |
+| Colour | `neutral-500` |
+| Text align | Center |
+| Margin-bottom | `24 px` |
+
+### 5.6 Suggested-Prompt Chips
+
+Optional: 2–4 chips shown in a flex-wrap row. On click, chip text populates the textarea.
+
+```
+┌─────────────────────┐ ┌──────────────────────┐
+│  Draft a task spec  │ │  Review my backlog   │
+└─────────────────────┘ └──────────────────────┘
+┌─────────────────────────────────┐ ┌──────────┐
+│  Explain the agent architecture │ │  Stats   │
+└─────────────────────────────────┘ └──────────┘
+```
+
+#### Suggested chip content (default set)
+
+| # | Label |
+|---|---|
+| 1 | `"Draft a task spec"` |
+| 2 | `"Review my backlog"` |
+| 3 | `"Explain the agent architecture"` |
+| 4 | `"Show team stats"` |
+
+#### Chip Design
+
+| Property | Value |
+|---|---|
+| Background | `surface-200` |
+| Text colour | `neutral-700` |
+| Font size | 13 px |
+| Font weight | 400 |
+| Padding | `8 px 14 px` (`space-2` `space-3`) |
+| Border radius | `radius-full` |
+| Border | none |
+| Container | Flex-wrap row, gap `8 px`, justify-content center |
+| Cursor | `pointer` |
+| Hover bg | `surface-300` |
+| Hover transition | `background-color 150 ms ease-default` |
+| Active bg | `brand-100` |
+| Focus ring | `2 px solid focus-ring`, `outline-offset: 2 px` |
+| On click | Populate textarea with chip label text; do not submit |
+
+> **Copy note:** Chip labels should be sentence-case. Keep labels short (≤ 5 words). Chips are optional — if no suggested prompts are configured, the empty state renders without the chip row.

--- a/docs/design/prompter/conversation-history.md
+++ b/docs/design/prompter/conversation-history.md
@@ -1,0 +1,424 @@
+# Conversation History Panel — Design Specification
+
+**Last Updated:** 2026-06-03  
+**Spec Version:** 1.0  
+**Owner:** ux-dev-1  
+**References:** `README.md` for shared tokens
+
+---
+
+## 1. Panel Overview
+
+The conversation history panel is a fixed-width sidebar that lists past conversations. It supports collapse/expand, grouping by recency, inline rename, and inline delete confirmation.
+
+```
+┌──────────────────────────────────────┐
+│  [≡ RoboCo logo]    [New Chat  +]   │  ← Header (48px)
+├──────────────────────────────────────┤
+│  [Search conversations...]           │  ← Search input (optional)
+├──────────────────────────────────────┤
+│                                      │
+│  Today                               │  ← Group heading
+│  ─────────────────────────────────   │
+│  ▌ Current convo title     14:32  ●  │  ← Active item (left border)
+│  Another convo              Yesterday│  ← Default item
+│  Third convo                Mon      │
+│                                      │
+│  Previous 7 Days                     │  ← Group heading
+│  ─────────────────────────────────   │
+│  Old convo title            Tue      │
+│  Another old convo          Mon      │
+│                                      │
+│  Older                               │  ← Group heading
+│  ─────────────────────────────────   │
+│  Much older convo           Jun 1    │
+│                                      │
+└──────────────────────────────────────┘
+  260px wide
+```
+
+---
+
+## 2. Panel Container
+
+| Property | Value |
+|---|---|
+| Width | 260 px (expanded), 0 px (collapsed) |
+| Height | Full viewport height minus app nav (calc(100vh - 48px)) |
+| Background | `surface-50` |
+| Border-right | `1 px solid surface-300` |
+| Overflow-y | `auto` |
+| Overflow-x | `hidden` |
+| Z-index | 50 |
+| Flex-shrink | 0 (does not compress when chat area narrows) |
+| Transition | `width 300 ms cubic-bezier(0.4, 0, 0.2, 1)` |
+
+### 2.1 Collapse / Expand
+
+| Property | Value |
+|---|---|
+| Toggle trigger | Icon button in app nav bar (hamburger / close icon, 24 px) |
+| Collapsed width | 0 px (panel content hidden with `overflow: hidden`) |
+| Expanded width | 260 px |
+| Animation | `width 300 ms ease-in-out` |
+| ARIA on toggle button | `aria-expanded="true/false"`, `aria-controls="history-panel"` |
+| Panel ID | `id="history-panel"` |
+| When collapsed | Toggle button remains visible in nav bar |
+
+---
+
+## 3. Panel Header
+
+Fixed at the top of the panel (does not scroll with list).
+
+```
+┌──────────────────────────────────────┐
+│  [RoboCo logo mark 20px]  [+ New]    │
+└──────────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Height | 48 px |
+| Padding | `0 12 px` |
+| Display | Flex, align-items center, justify-content space-between |
+| Background | `surface-50` |
+| Border-bottom | `1 px solid surface-300` |
+
+### 3.1 Logo Mark (panel header)
+
+| Property | Value |
+|---|---|
+| Size | 20 × 20 px |
+| Style | RoboCo logo mark, `brand-500` fill |
+
+### 3.2 New Chat Button
+
+| Property | Value |
+|---|---|
+| Label | `"New chat"` |
+| Icon | Plus `+` 16 px, left of label |
+| Height | 32 px |
+| Padding | `0 10 px` |
+| Border radius | `radius-md` (8 px) |
+| Font size | 13 px |
+| Font weight | 500 |
+| Default bg | `surface-200` |
+| Default text | `neutral-700` |
+| Hover bg | `surface-300` |
+| Focus ring | `2 px solid focus-ring`, `outline-offset: 2 px` |
+| Active bg | `brand-100` |
+| Transition | `background-color 150 ms ease-default` |
+| aria-label | `"Start a new chat conversation"` |
+| On click | Create new conversation, navigate to it, focus textarea |
+
+---
+
+## 4. Search Input (optional)
+
+If implemented, the search input sits below the header, above the list.
+
+| Property | Value |
+|---|---|
+| Placeholder | `"Search conversations..."` |
+| Icon | Magnify 14 px, `neutral-400`, left-aligned inside input |
+| Height | 32 px |
+| Margin | `8 px 12 px` |
+| Font size | 13 px |
+| Background | `surface-0` |
+| Border | `1 px solid surface-300` |
+| Border radius | `radius-md` |
+| Focus border | `brand-500` |
+| Focus ring | `2 px solid focus-ring`, `outline-offset: 2 px` |
+| Filter behaviour | Client-side, filters list in real-time |
+| No-results state | Show `"No conversations match"` in `neutral-400`, centered, 13 px |
+
+---
+
+## 5. Conversation List
+
+### 5.1 Scrollable List Container
+
+| Property | Value |
+|---|---|
+| Overflow-y | `auto` |
+| Flex-grow | 1 |
+| Padding-bottom | `16 px` (breathing room at bottom of list) |
+
+### 5.2 Group Headings
+
+Conversations are grouped into three recency buckets. Group headings are sticky within the scrollable list.
+
+| Group | Display Label | Condition |
+|---|---|---|
+| Today | `"Today"` | Conversations started today |
+| Previous 7 Days | `"Previous 7 days"` | Started in last 7 days, not today |
+| Older | `"Older"` | Older than 7 days |
+
+#### Heading Style
+
+| Property | Value |
+|---|---|
+| Text | See table above |
+| Font size | 11 px |
+| Font weight | 600 |
+| Text transform | Uppercase |
+| Letter spacing | `0.05 em` |
+| Colour | `neutral-400` |
+| Padding | `12 px 12 px 4 px` |
+| Position | `sticky`, `top: 0`, `z-index: 1` |
+| Background | `surface-50` (matches panel, so sticky heading masks list beneath) |
+| Border-bottom | `1 px solid surface-300`, `margin: 0 12 px` |
+
+---
+
+## 6. Conversation List Item — Default State
+
+```
+┌──────────────────────────────────────┐
+│  Conversation title (truncated)  12:30│
+└──────────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Height | 40 px |
+| Padding | `0 12 px` |
+| Display | Flex, align-items center, justify-content space-between |
+| Font size | 14 px |
+| Font weight | 400 |
+| Colour | `neutral-700` |
+| Background | Transparent |
+| Border-left | `2 px solid transparent` (reserve space for active state) |
+| Cursor | `pointer` |
+| Text overflow | `overflow: hidden`, `white-space: nowrap`, `text-overflow: ellipsis` |
+| Title max-width | Flex-grow 1, min-width 0 (required for ellipsis in flex child) |
+
+### 6.1 Timestamp
+
+| Property | Value |
+|---|---|
+| Format | `HH:MM` (today) / `"Yesterday"` / Day name (`"Mon"`) / `"Jun 1"` (older) |
+| Font size | 12 px |
+| Colour | `neutral-400` |
+| White-space | `nowrap` |
+| Margin-left | `8 px` |
+| Flex-shrink | 0 |
+
+---
+
+## 7. Conversation List Item — States
+
+### 7.1 Active (current conversation)
+
+The item corresponding to the currently open conversation.
+
+| Property | Value |
+|---|---|
+| Background | `brand-100` |
+| Border-left | `2 px solid brand-600` |
+| Text colour | `neutral-900` |
+| Font weight | 500 |
+| Timestamp colour | `neutral-500` |
+
+### 7.2 Hover State
+
+On hover of a non-active item:
+
+| Property | Value |
+|---|---|
+| Background | `surface-200` |
+| Transition | `background-color 150 ms ease-default` |
+| Action row | Revealed (see §8) |
+| Timestamp | Hidden when action row is shown (to avoid overlap) |
+
+On hover of the active item:
+
+| Property | Value |
+|---|---|
+| Background | `brand-100` (unchanged) |
+| Action row | Revealed |
+
+### 7.3 Focus State (keyboard)
+
+| Property | Value |
+|---|---|
+| Outline | `2 px solid focus-ring`, `outline-offset: -2 px` (inset) |
+| Background | `surface-200` |
+
+---
+
+## 8. Hover Action Row
+
+When a list item is hovered, the timestamp is replaced by a row of two icon buttons: Rename and Delete. These appear with a `150 ms` fade-in.
+
+```
+│  Conversation title          [✏][🗑]  │
+```
+
+| Property | Value |
+|---|---|
+| Container | Flex row, gap `4 px`, align-items center |
+| Transition | `opacity 150 ms ease-default` |
+| Opacity at rest | 0 |
+| Opacity on hover | 1 |
+
+### 8.1 Rename Button
+
+| Property | Value |
+|---|---|
+| Icon | Pencil 16 px, `neutral-500` |
+| Size | 28 × 28 px |
+| Shape | `radius-md` |
+| Default bg | Transparent |
+| Hover bg | `surface-300` |
+| Icon hover colour | `neutral-700` |
+| Focus ring | `2 px solid focus-ring`, `outline-offset: 2 px` |
+| aria-label | `"Rename conversation"` |
+| On click | Show inline rename flow (see §9) |
+
+### 8.2 Delete Button
+
+| Property | Value |
+|---|---|
+| Icon | Trash 16 px, `danger-500` |
+| Size | 28 × 28 px |
+| Shape | `radius-md` |
+| Default bg | Transparent |
+| Hover bg | `danger-100` |
+| Icon hover colour | `danger-500` |
+| Focus ring | `2 px solid danger-500`, `outline-offset: 2 px` |
+| aria-label | `"Delete conversation"` |
+| On click | Show inline delete confirmation (see §10) |
+
+---
+
+## 9. Inline Rename Flow
+
+When the user clicks the Rename button, the title text is replaced by an editable text input in-place.
+
+```
+│  [________________________________________]  [✓] [✕]  │
+│   ^— text input, pre-filled with current title         │
+```
+
+| Property | Value |
+|---|---|
+| Input height | 28 px |
+| Input padding | `0 6 px` |
+| Input font size | 14 px |
+| Input border | `1.5 px solid brand-500` |
+| Input border-radius | `radius-sm` (4 px) |
+| Input background | `surface-0` |
+| Input initial value | Current conversation title |
+| Input focus | Auto-focus on appear; select-all text |
+| Confirm button | Checkmark icon 16 px, 28 × 28 px, `brand-500` icon |
+| Cancel button | X icon 16 px, 28 × 28 px, `neutral-500` icon |
+| Submit | `Enter` key or Confirm button click |
+| Cancel | `Escape` key or Cancel button click |
+| On submit | Update title, revert to default list item display |
+| On cancel | Revert to default list item display without change |
+| Empty validation | If input is empty on submit, do not save; show `border: danger-500`; do not close |
+
+---
+
+## 10. Inline Delete Confirmation Flow
+
+When the user clicks the Delete button, the list item row is replaced by an inline confirmation. This prevents accidental deletion without a disruptive modal.
+
+### 10.1 Transition
+
+The item row morphs into a confirmation row using a height animation:
+
+| Property | Value |
+|---|---|
+| Initial height | 40 px (normal item) |
+| Final height | 60 px (confirmation row — two sub-rows) |
+| Transition | `height 200 ms cubic-bezier(0.4, 0, 0.2, 1)` |
+| Overflow during transition | `hidden` |
+
+### 10.2 Confirmation Row Layout
+
+```
+┌──────────────────────────────────────────────┐
+│  "Delete this conversation?"                 │
+│  [Cancel]                        [Delete]    │
+└──────────────────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Question text | `"Delete this conversation?"` |
+| Question font size | 13 px |
+| Question colour | `neutral-700` |
+| Question font weight | 500 |
+| Question padding | `8 px 12 px 4 px` |
+
+### 10.3 Confirmation Buttons
+
+| Property | Cancel | Delete (Confirm) |
+|---|---|---|
+| Label | `"Cancel"` | `"Delete"` |
+| Height | 28 px | 28 px |
+| Padding | `0 10 px` | `0 10 px` |
+| Font size | 12 px | 12 px |
+| Font weight | 500 | 500 |
+| Background | `surface-200` | `danger-500` |
+| Text colour | `neutral-700` | `#FFFFFF` |
+| Border radius | `radius-md` (8 px) | `radius-md` (8 px) |
+| Hover bg | `surface-300` | `#DC2626` (darken danger-500) |
+| Focus ring | `2 px solid focus-ring` | `2 px solid danger-500` |
+| Transition | `background-color 150 ms ease-default` | same |
+| Margin | `0 12 px 8 px` | same row |
+| On click | Dismiss confirmation, restore item | Delete conversation, animate item out |
+
+### 10.4 Delete Animation
+
+After the user confirms deletion:
+
+| Step | Behaviour |
+|---|---|
+| 1 | Item height animates to 0 px over `200 ms ease-in` |
+| 2 | Opacity fades from 1 to 0 over `150 ms` (concurrent with height) |
+| 3 | Item is removed from DOM after animation completes |
+| 4 | If deleted convo was active | Navigate to most recent remaining conversation, or empty state if none |
+
+---
+
+## 11. Keyboard Navigation
+
+| Key | Behaviour |
+|---|---|
+| `↑` / `↓` | Move focus between list items |
+| `Enter` | Open focused conversation |
+| `F2` | Start rename on focused item |
+| `Delete` | Show delete confirmation for focused item |
+| `Escape` | Cancel rename or dismiss delete confirmation |
+| `Tab` | Move to next interactive element in focus order |
+
+---
+
+## 12. Empty History State
+
+When there are no saved conversations:
+
+```
+┌──────────────────────────────────────┐
+│  [New Chat +]                        │
+│                                      │
+│         (empty area)                 │
+│                                      │
+│   No conversations yet.              │
+│   Start a new chat above.            │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Text line 1 | `"No conversations yet."` |
+| Text line 2 | `"Start a new chat above."` |
+| Font size | 13 px |
+| Colour | `neutral-400` |
+| Text align | Center |
+| Padding | `24 px 16 px` |

--- a/docs/design/prompter/interaction-states.md
+++ b/docs/design/prompter/interaction-states.md
@@ -1,0 +1,363 @@
+# Interaction States — Design Specification
+
+**Last Updated:** 2026-06-03  
+**Spec Version:** 1.0  
+**Owner:** ux-dev-1  
+**References:** `README.md` for shared tokens
+
+---
+
+## Purpose
+
+This document is the canonical reference for every interactive element state across the Prompter chat surface. For each element, all five interaction states are specified: **default**, **hover**, **focus**, **active**, and **disabled**.
+
+Use this alongside `chat-interface.md`, `conversation-history.md`, and `model-selection.md` which describe component shape, layout, and content.
+
+---
+
+## Global Focus Ring Specification
+
+All keyboard-focusable elements in the chat surface use the same focus ring style, unless explicitly overridden.
+
+| Property | Value |
+|---|---|
+| Style | `2 px solid var(--focus-ring)` |
+| Colour | `brand-500` (`#5B6CF6`) |
+| Offset | `outline-offset: 2 px` |
+| Application | CSS `outline` (do NOT use `box-shadow` for focus — it conflicts with elevation shadows) |
+| When visible | Only when navigating by keyboard (use `:focus-visible` pseudo-class) |
+| When hidden | Mouse click interactions should not show the ring |
+
+```css
+/* Global rule */
+*:focus-visible {
+  outline: 2px solid var(--brand-500);
+  outline-offset: 2px;
+}
+/* Override for inset ring contexts (list items) */
+.list-item:focus-visible {
+  outline-offset: -2px;
+}
+```
+
+---
+
+## Global Transition Defaults
+
+Unless otherwise specified, state transitions use:
+
+| Property | Value |
+|---|---|
+| Background colour changes | `150 ms cubic-bezier(0.4, 0, 0.2, 1)` |
+| Border colour changes | `150 ms cubic-bezier(0.4, 0, 0.2, 1)` |
+| Opacity changes | `150 ms cubic-bezier(0.4, 0, 0.2, 1)` |
+| Transform (scale/translate) | `100 ms cubic-bezier(0.4, 0, 1, 1)` (ease-in for snap) |
+| Height / width changes | `200 ms cubic-bezier(0.4, 0, 0.2, 1)` |
+
+---
+
+## 1. Send Button
+
+> See `chat-interface.md §3.3` for size, shape, and placement.
+
+| State | Background | Icon colour | Border | Transform | Cursor | Transition |
+|---|---|---|---|---|---|---|
+| Default | `brand-500` | `#FFFFFF` | none | none | `pointer` | — |
+| Hover | `brand-600` | `#FFFFFF` | none | none | `pointer` | bg `150 ms` |
+| Focus | `brand-500` | `#FFFFFF` | focus ring `2 px brand-500, offset 2 px` | none | `pointer` | — |
+| Active | `brand-700`¹ | `#FFFFFF` | none | `scale(0.95)` | `pointer` | transform `100 ms ease-in` |
+| Disabled | `surface-200` | `neutral-400` | none | none | `not-allowed` | — |
+| Loading | `brand-400` | spinner `#FFFFFF` | none | none | `default` | — |
+
+¹ `brand-700` = `#3B4DC8` (darken brand-500 by ~10%).
+
+**Disabled condition:** textarea is empty, whitespace-only, or stream is in progress.  
+**Loading:** streaming in progress — icon replaced by spinner (16 px, `#FFFFFF`).
+
+---
+
+## 2. Textarea (Input Composer)
+
+> See `chat-interface.md §3.2` for dimensions and placeholder.
+
+| State | Background | Border | Outline | Text colour | Cursor |
+|---|---|---|---|---|---|
+| Default | `surface-0` | `1.5 px solid surface-300` | none | `neutral-900` | `text` |
+| Hover | `surface-0` | `1.5 px solid neutral-300` | none | `neutral-900` | `text` |
+| Focus | `surface-0` | `1.5 px solid brand-500` | `2 px solid focus-ring, offset 2 px` | `neutral-900` | `text` |
+| Active | Same as focus | — | — | — | `text` |
+| Disabled | `surface-100` | `1.5 px solid surface-300` | none | `neutral-400` | `not-allowed` |
+| Error | `surface-0` | `1.5 px solid danger-500` | `2 px solid danger-500` | `neutral-900` | `text` |
+
+**Placeholder colour:** `neutral-400` in all enabled states.  
+**Transition:** border-color `150 ms ease-default`.
+
+---
+
+## 3. Suggested-Prompt Chips
+
+> See `chat-interface.md §5.6` for layout and copy.
+
+| State | Background | Text colour | Border | Transform | Cursor |
+|---|---|---|---|---|---|
+| Default | `surface-200` | `neutral-700` | none | none | `pointer` |
+| Hover | `surface-300` | `neutral-700` | none | none | `pointer` |
+| Focus | `surface-200` | `neutral-700` | focus ring `2 px brand-500, offset 2 px` | none | `pointer` |
+| Active | `brand-100` | `brand-600` | none | `scale(0.97)` | `pointer` |
+| Disabled | `surface-100` | `neutral-400` | none | none | `not-allowed` |
+
+**Transition:** background-color `150 ms ease-default`.
+
+---
+
+## 4. Message Action Buttons (Copy / Regenerate / Delete)
+
+> See `chat-interface.md §2.5` for placement and appearance conditions.
+
+### 4.1 Copy Button
+
+| State | Background | Icon colour | Outline | Cursor |
+|---|---|---|---|---|
+| Default | Transparent | `neutral-400` | none | `pointer` |
+| Hover | `surface-200` | `neutral-700` | none | `pointer` |
+| Focus | `surface-100` | `neutral-700` | focus ring `2 px brand-500, offset 2 px` | `pointer` |
+| Active | `surface-300` | `neutral-900` | none | `pointer` |
+| Disabled | — | `neutral-300` | none | `not-allowed` |
+
+### 4.2 Regenerate Button (AI messages only)
+
+Same as Copy button above.
+
+### 4.3 Delete Message Button
+
+| State | Background | Icon colour | Outline | Cursor |
+|---|---|---|---|---|
+| Default | Transparent | `danger-500` | none | `pointer` |
+| Hover | `danger-100` | `danger-500` | none | `pointer` |
+| Focus | `danger-100` | `danger-500` | `2 px solid danger-500, offset 2 px` | `pointer` |
+| Active | `#FCA5A5` (danger-300) | `danger-500` | none | `pointer` |
+| Disabled | — | `neutral-300` | none | `not-allowed` |
+
+---
+
+## 5. New Chat Button (History Panel Header)
+
+> See `conversation-history.md §3.2`.
+
+| State | Background | Text colour | Icon colour | Border | Cursor |
+|---|---|---|---|---|---|
+| Default | `surface-200` | `neutral-700` | `neutral-500` | none | `pointer` |
+| Hover | `surface-300` | `neutral-700` | `neutral-700` | none | `pointer` |
+| Focus | `surface-200` | `neutral-700` | `neutral-700` | focus ring `2 px brand-500, offset 2 px` | `pointer` |
+| Active | `brand-100` | `brand-600` | `brand-600` | none | `pointer` |
+| Disabled | `surface-100` | `neutral-400` | `neutral-300` | none | `not-allowed` |
+
+---
+
+## 6. Conversation History List Item
+
+> See `conversation-history.md §6` and `§7`.
+
+| State | Background | Border-left | Text colour | Timestamp colour | Cursor |
+|---|---|---|---|---|---|
+| Default | Transparent | `2 px solid transparent` | `neutral-700` | `neutral-400` | `pointer` |
+| Hover | `surface-200` | `2 px solid transparent` | `neutral-700` | hidden (action row shown) | `pointer` |
+| Focus | `surface-200` | focus ring inset | `neutral-700` | `neutral-400` | `pointer` |
+| Active (selected) | `brand-100` | `2 px solid brand-600` | `neutral-900` | `neutral-500` | `default` |
+| Active + Hover | `brand-100` | `2 px solid brand-600` | `neutral-900` | hidden (action row shown) | `pointer` |
+
+---
+
+## 7. History Item Rename Button
+
+> See `conversation-history.md §8.1`.
+
+| State | Background | Icon colour | Outline | Cursor |
+|---|---|---|---|---|
+| Default (hidden at rest) | Transparent | `neutral-500` | none | `pointer` |
+| Hover | `surface-300` | `neutral-700` | none | `pointer` |
+| Focus | `surface-200` | `neutral-700` | focus ring `2 px brand-500, offset 2 px` | `pointer` |
+| Active | `surface-300` | `neutral-900` | none | `pointer` |
+| Disabled | Transparent | `neutral-300` | none | `not-allowed` |
+
+---
+
+## 8. History Item Delete Button
+
+> See `conversation-history.md §8.2`.
+
+| State | Background | Icon colour | Outline | Cursor |
+|---|---|---|---|---|
+| Default (hidden at rest) | Transparent | `danger-500` | none | `pointer` |
+| Hover | `danger-100` | `danger-500` | none | `pointer` |
+| Focus | `danger-100` | `danger-500` | `2 px solid danger-500, offset 2 px` | `pointer` |
+| Active | `#FCA5A5` | `danger-500` | none | `pointer` |
+| Disabled | Transparent | `neutral-300` | none | `not-allowed` |
+
+---
+
+## 9. Delete Confirmation — Cancel Button
+
+> See `conversation-history.md §10.3`.
+
+| State | Background | Text colour | Border | Cursor |
+|---|---|---|---|---|
+| Default | `surface-200` | `neutral-700` | none | `pointer` |
+| Hover | `surface-300` | `neutral-700` | none | `pointer` |
+| Focus | `surface-200` | `neutral-700` | focus ring `2 px brand-500, offset 2 px` | `pointer` |
+| Active | `surface-300` | `neutral-900` | none | `pointer` |
+| Disabled | `surface-100` | `neutral-400` | none | `not-allowed` |
+
+---
+
+## 10. Delete Confirmation — Confirm (Delete) Button
+
+> See `conversation-history.md §10.3`.
+
+| State | Background | Text colour | Border | Cursor |
+|---|---|---|---|---|
+| Default | `danger-500` | `#FFFFFF` | none | `pointer` |
+| Hover | `#DC2626` (danger-600) | `#FFFFFF` | none | `pointer` |
+| Focus | `danger-500` | `#FFFFFF` | `2 px solid danger-500, offset 2 px` | `pointer` |
+| Active | `#B91C1C` (danger-700) | `#FFFFFF` | none | `pointer` |
+| Disabled | `surface-200` | `neutral-400` | none | `not-allowed` |
+
+---
+
+## 11. Rename Input (Inline)
+
+> See `conversation-history.md §9`.
+
+| State | Background | Border | Outline | Text colour | Cursor |
+|---|---|---|---|---|---|
+| Default | `surface-0` | `1.5 px solid brand-500` | none | `neutral-900` | `text` |
+| Hover | `surface-0` | `1.5 px solid brand-500` | none | `neutral-900` | `text` |
+| Focus | `surface-0` | `1.5 px solid brand-500` | `2 px solid focus-ring, offset 2 px` | `neutral-900` | `text` |
+| Error (empty submit) | `surface-0` | `1.5 px solid danger-500` | `2 px solid danger-500` | `neutral-900` | `text` |
+| Disabled | `surface-100` | `1 px solid surface-300` | none | `neutral-400` | `not-allowed` |
+
+---
+
+## 12. Rename Confirm Button (✓)
+
+| State | Background | Icon colour | Outline | Cursor |
+|---|---|---|---|---|
+| Default | Transparent | `brand-500` | none | `pointer` |
+| Hover | `brand-50` | `brand-600` | none | `pointer` |
+| Focus | `brand-50` | `brand-600` | focus ring `2 px brand-500, offset 2 px` | `pointer` |
+| Active | `brand-100` | `brand-600` | none | `pointer` |
+| Disabled | Transparent | `neutral-300` | none | `not-allowed` |
+
+---
+
+## 13. Rename Cancel Button (✕)
+
+| State | Background | Icon colour | Outline | Cursor |
+|---|---|---|---|---|
+| Default | Transparent | `neutral-500` | none | `pointer` |
+| Hover | `surface-200` | `neutral-700` | none | `pointer` |
+| Focus | `surface-100` | `neutral-700` | focus ring `2 px brand-500, offset 2 px` | `pointer` |
+| Active | `surface-300` | `neutral-900` | none | `pointer` |
+| Disabled | Transparent | `neutral-300` | none | `not-allowed` |
+
+---
+
+## 14. Model Selector — Trigger Button
+
+> See `model-selection.md §3` and `§4`.
+
+| State | Background | Border | Text colour | Chevron colour | Cursor |
+|---|---|---|---|---|---|
+| Default (closed) | `surface-50` | `1 px solid neutral-200` | `neutral-700` | `neutral-400` | `pointer` |
+| Hover (closed) | `surface-100` | `1 px solid neutral-300` | `neutral-700` | `neutral-500` | `pointer` |
+| Focus | `surface-100` | `1 px solid neutral-300` | `neutral-700` | `neutral-400` | `pointer` |
+| Active / Open | `surface-100` | `1.5 px solid brand-500` | `neutral-900` | `brand-500` (rotated 180°) | `pointer` |
+| Disabled | `surface-100` | `1 px solid surface-300` | `neutral-400` | `neutral-300` | `not-allowed` |
+
+Focus ring: `2 px solid focus-ring, offset 2 px` when focused via keyboard.
+
+---
+
+## 15. Model Selector — Option Item
+
+> See `model-selection.md §6`.
+
+| State | Background | Text colour | Tag colour | Checkmark | Cursor |
+|---|---|---|---|---|---|
+| Default | Transparent | `neutral-700` | per tag spec | hidden (space reserved) | `pointer` |
+| Hover | `surface-100` | `neutral-700` | per tag spec | visible if selected | `pointer` |
+| Focus | `surface-100` | `neutral-700` | per tag spec | visible if selected | `pointer` |
+| Selected | Transparent | `neutral-900` (bold) | per tag spec | `brand-500` checkmark 16 px | `pointer` |
+| Selected + Hover | `surface-100` | `neutral-900` | per tag spec | `brand-500` checkmark | `pointer` |
+| Disabled | Transparent | `neutral-400` | `neutral-300` | — | `not-allowed` |
+
+Focus ring on options: `2 px solid focus-ring, offset -2 px` (inset).
+
+---
+
+## 16. Code Block Copy Button
+
+> See `chat-interface.md §2.4`.
+
+| State | Background | Icon colour | Cursor |
+|---|---|---|---|
+| Hidden (default, no hover) | — | — | — |
+| Default (on bubble hover) | `surface-0` | `neutral-400` | `pointer` |
+| Hover | `surface-200` | `neutral-700` | `pointer` |
+| Focus | `surface-100` | `neutral-700` | `pointer` |
+| Active | `surface-300` | `neutral-900` | `pointer` |
+| Copied (confirmation) | `surface-0` | `#059669` (green-600) | `default` |
+
+Copied state: icon changes to checkmark for `2000 ms`, then reverts to copy icon.
+
+---
+
+## Motion Reference Table
+
+Complete listing of all animation durations and easings used across the chat surface.
+
+| Element / Interaction | Duration | Easing | Property |
+|---|---|---|---|
+| Button hover colour change | 150 ms | `ease-default` | background-color |
+| Button active transform | 100 ms | `ease-in` | transform |
+| Action row fade in (message hover) | 150 ms | `ease-default` | opacity |
+| Typing indicator — per dot | 1200 ms cycle | `ease-default` | transform, opacity |
+| Typing indicator — dot stagger | 160 ms per dot | — | animation-delay |
+| Typing indicator fade in | 200 ms | `ease-out` | opacity |
+| Typing indicator fade out | 150 ms | `ease-in` | opacity |
+| Empty-state chip hover | 150 ms | `ease-default` | background-color |
+| History panel collapse/expand | 300 ms | `ease-in-out` | width |
+| History item hover | 150 ms | `ease-default` | background-color |
+| History action row reveal | 150 ms | `ease-default` | opacity |
+| Delete confirmation expand | 200 ms | `ease-default` | height |
+| Delete item collapse (confirmed) | 200 ms | `ease-in` | height, opacity |
+| Model selector dropdown open | 200 ms | `ease-out` | opacity, transform |
+| Model selector dropdown close | 150 ms | `ease-in` | opacity, transform |
+| Model selector chevron rotate | 200 ms | `ease-default` | transform |
+| New message appear | 200 ms | `ease-out` | opacity, translateY +8 px |
+| Scroll to new message | smooth | browser default | scroll-behavior |
+| Chip active press | 100 ms | `ease-in` | transform scale |
+| Code block copy confirmation | 0 ms (instant) + 2000 ms hold | — | icon swap |
+| Input textarea height grow | 0 ms (instant) | — | height (JS-driven) |
+| Rename input appear | 150 ms | `ease-out` | opacity |
+| Tooltip appear | 150 ms delay + 100 ms fade | `ease-out` | opacity |
+
+---
+
+## WCAG Compliance Reference
+
+All colour pairings in this spec must meet WCAG 2.1 AA standards.
+
+| Pairing | Ratio | Standard |
+|---|---|---|
+| `neutral-900` on `surface-0` | 16.1:1 | ✅ AA |
+| `neutral-700` on `surface-0` | 8.0:1 | ✅ AA |
+| `neutral-500` on `surface-0` | 4.6:1 | ✅ AA |
+| `#FFFFFF` on `brand-500` (user bubble) | 3.6:1 | ✅ AA large text / UI |
+| `neutral-700` on `surface-100` (AI bubble) | 6.1:1 | ✅ AA |
+| `neutral-700` on `surface-200` (chips, hover) | 5.7:1 | ✅ AA |
+| `#FFFFFF` on `danger-500` (delete confirm) | 4.6:1 | ✅ AA |
+| `neutral-400` on `surface-0` (placeholder) | 2.9:1 | ⚠️ Use only for placeholder / decorative — not for meaningful content |
+| `neutral-400` on `surface-50` (timestamps) | 2.7:1 | ⚠️ Timestamps are supplementary; body text must use neutral-700+ |
+
+> **Note on `neutral-400`:** This token is intentionally low-contrast for decorative text (placeholders, timestamps, keyboard hints). No critical information is communicated in this colour alone. If the design system uses WCAG AAA targets, replace placeholder colour with `neutral-500` (4.6:1).

--- a/docs/design/prompter/model-selection.md
+++ b/docs/design/prompter/model-selection.md
@@ -1,0 +1,350 @@
+# Model Selection Component — Design Specification
+
+**Last Updated:** 2026-06-03  
+**Spec Version:** 1.0  
+**Owner:** ux-dev-1  
+**References:** `README.md` for shared tokens
+
+---
+
+## 1. Overview
+
+The model selector is a compact dropdown component in the chat header bar that lets the user choose which AI model powers their conversation. It consists of a **trigger button** (always visible) and a **dropdown panel** (appears on click).
+
+```
+Chat Header Bar (48px):
+┌─────────────────────────────────────────────────────────────┐
+│  [← Back]   Prompter               [Claude 3.5 Sonnet ▼]   │
+└─────────────────────────────────────────────────────────────┘
+                                      ↑
+                               Model selector trigger
+```
+
+---
+
+## 2. Placement
+
+| Property | Value |
+|---|---|
+| Position in header | Right-aligned, flex-end |
+| Vertical alignment | Center (align-self: center) |
+| Margin-right | `16 px` from right edge of header |
+| Z-index of trigger | Auto (inherits header stacking context) |
+| Z-index of dropdown | `200` (above all chat content, below modals) |
+
+---
+
+## 3. Trigger Button — Closed State
+
+The trigger button is always visible and shows the currently selected model.
+
+```
+┌────────────────────────────────┐
+│  Claude 3.5 Sonnet  ▼          │
+└────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Height | 32 px |
+| Min width | 120 px |
+| Max width | 200 px |
+| Padding | `0 10 px` |
+| Display | Flex, align-items center, gap `6 px` |
+| Background | `surface-50` |
+| Border | `1 px solid neutral-200` |
+| Border radius | `radius-md` (8 px) |
+| Font size | 13 px |
+| Font weight | 500 |
+| Text colour | `neutral-700` |
+| Cursor | `pointer` |
+| Chevron icon | Down-chevron 14 px, `neutral-400`, right of label |
+| Text overflow | Truncate at max-width with ellipsis |
+| aria-haspopup | `"listbox"` |
+| aria-expanded | `"false"` (closed) |
+| aria-label | `"Select AI model, current: {model name}"` |
+
+### 3.1 Trigger Hover State
+
+| Property | Value |
+|---|---|
+| Background | `surface-100` |
+| Border | `1 px solid neutral-300` |
+| Transition | `background-color 150 ms ease-default`, `border-color 150 ms ease-default` |
+
+### 3.2 Trigger Focus State
+
+| Property | Value |
+|---|---|
+| Outline | `2 px solid focus-ring`, `outline-offset: 2 px` |
+| Background | `surface-100` |
+
+### 3.3 Trigger Active (pressed) State
+
+| Property | Value |
+|---|---|
+| Background | `surface-200` |
+| Transform | `scale(0.98)` |
+| Transition | `transform 100 ms ease-in` |
+| Chevron rotation | 180° (points up when open) |
+
+---
+
+## 4. Trigger Button — Open State
+
+While the dropdown is open, the trigger reflects the open state.
+
+| Property | Value |
+|---|---|
+| Background | `surface-100` |
+| Border | `1.5 px solid brand-500` |
+| Chevron | Rotated 180° (up-chevron) |
+| Chevron colour | `brand-500` |
+| Text colour | `neutral-900` |
+| Chevron rotation transition | `transform 200 ms ease-default` |
+| aria-expanded | `"true"` |
+
+---
+
+## 5. Dropdown Panel
+
+Opens below the trigger button, right-aligned.
+
+```
+          [Claude 3.5 Sonnet ▲]
+          ┌────────────────────────────────────────┐
+          │                                        │
+          │  ✓  Claude 3.5 Sonnet       Latest    │  ← selected
+          │     Claude 3.0                         │
+          │     Claude 2.1              Fast       │
+          │  ─────────────────────────────────     │  ← divider
+          │     GPT-4o                             │
+          │     GPT-4o mini             Fast       │
+          │                                        │
+          └────────────────────────────────────────┘
+```
+
+| Property | Value |
+|---|---|
+| Width | 240 px |
+| Min height | 36 px (single item) |
+| Max height | 320 px |
+| Overflow-y | `auto` when content exceeds max height |
+| Background | `surface-0` |
+| Border | `1 px solid surface-300` |
+| Border radius | `radius-md` (8 px) |
+| Box shadow | `elevation-3` (`0 8px 24px rgba(0,0,0,0.12)`) |
+| Padding | `4 px 0` |
+| Position | Absolute, anchored below-right of trigger |
+| Anchor | `top: 100% + 4 px`, `right: 0` |
+| Z-index | 200 |
+| Animation | Fade in + slide down `8 px` over `200 ms ease-out` |
+
+### 5.1 Dropdown Open Animation
+
+```css
+@keyframes dropdown-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+```
+
+| Property | Value |
+|---|---|
+| Animation | `dropdown-enter 200 ms cubic-bezier(0, 0, 0.2, 1)` |
+| Fill mode | `forwards` |
+
+### 5.2 Dropdown Close Animation
+
+| Property | Value |
+|---|---|
+| Animation | Reverse: opacity 1 → 0, translateY 0 → -4 px |
+| Duration | `150 ms ease-in` |
+
+### 5.3 Dismiss Behaviour
+
+| Trigger | Result |
+|---|---|
+| Click outside dropdown | Close dropdown |
+| Press `Escape` | Close dropdown, return focus to trigger |
+| Press `Tab` | Close dropdown, move focus to next element |
+| Select an option | Close dropdown, update trigger label |
+
+---
+
+## 6. Option Item — Default State
+
+```
+│     Claude 3.5 Sonnet       Latest   │
+│  ↑                            ↑      │
+│  label (14px)                 tag    │
+```
+
+| Property | Value |
+|---|---|
+| Height | 36 px |
+| Padding | `0 12 px` |
+| Display | Flex, align-items center, gap `8 px` |
+| Background | Transparent |
+| Font size | 14 px |
+| Font weight | 400 |
+| Text colour | `neutral-700` |
+| Cursor | `pointer` |
+| role | `"option"` |
+| Checkmark area | 20 px wide (always reserved; empty when not selected) |
+
+### 6.1 Option Item — Hover State
+
+| Property | Value |
+|---|---|
+| Background | `surface-100` |
+| Transition | `background-color 150 ms ease-default` |
+
+### 6.2 Option Item — Focus State (keyboard)
+
+| Property | Value |
+|---|---|
+| Outline | `2 px solid focus-ring`, `outline-offset: -2 px` (inset) |
+| Background | `surface-100` |
+
+### 6.3 Option Item — Selected State
+
+The currently selected model.
+
+| Property | Value |
+|---|---|
+| Background | Transparent (not highlighted at rest; hover still highlights) |
+| Checkmark | Checkmark icon 16 px, `brand-500`, at left (within the 20 px area) |
+| Font weight | 600 |
+| Text colour | `neutral-900` |
+| aria-selected | `"true"` |
+
+### 6.4 Option Item — Disabled State
+
+A model option that is unavailable (e.g. subscription tier mismatch, temporarily down).
+
+| Property | Value |
+|---|---|
+| Background | Transparent |
+| Text colour | `neutral-400` |
+| Tag colour | `neutral-300` (if tag present) |
+| Cursor | `not-allowed` |
+| Pointer events | `none` |
+| aria-disabled | `"true"` |
+
+---
+
+## 7. Option Tag / Badge
+
+Some models may carry a tag (e.g. `"Latest"`, `"Fast"`, `"Beta"`). The tag appears right-aligned within the option row.
+
+| Property | Value |
+|---|---|
+| Background | `surface-200` |
+| Text colour | `neutral-500` |
+| Font size | 11 px |
+| Font weight | 500 |
+| Padding | `2 px 6 px` |
+| Border radius | `radius-full` |
+| Margin-left | `auto` (pushes to right edge) |
+
+#### Special Tag Colours
+
+| Tag | Background | Text |
+|---|---|---|
+| `"Latest"` | `brand-50` | `brand-600` |
+| `"Fast"` | `#ECFDF5` (green-50) | `#059669` (green-600) |
+| `"Beta"` | `#FFF7ED` (orange-50) | `#D97706` (amber-600) |
+| `"Preview"` | `#F5F3FF` (violet-50) | `#7C3AED` (violet-600) |
+
+---
+
+## 8. Group Divider
+
+If models are grouped (e.g. "Anthropic" vs "OpenAI"), a thin divider separates groups.
+
+| Property | Value |
+|---|---|
+| Element | `<hr>` or `border-top` on a group heading item |
+| Height | 1 px |
+| Colour | `surface-300` |
+| Margin | `4 px 0` |
+
+### 8.1 Group Label (optional)
+
+| Property | Value |
+|---|---|
+| Text | Provider name (e.g. `"Anthropic"`, `"OpenAI"`) |
+| Font size | 11 px |
+| Font weight | 600 |
+| Text transform | Uppercase |
+| Colour | `neutral-400` |
+| Padding | `8 px 12 px 4 px` |
+| Pointer events | `none` (not selectable) |
+
+---
+
+## 9. Trigger Button — Disabled State
+
+The entire model selector is disabled (e.g. during streaming, or when the feature is unavailable).
+
+| Property | Value |
+|---|---|
+| Background | `surface-100` |
+| Border | `1 px solid surface-300` |
+| Text colour | `neutral-400` |
+| Chevron colour | `neutral-300` |
+| Cursor | `not-allowed` |
+| Pointer events | `none` |
+| Opacity | `0.6` |
+| Tooltip | `"Model selection unavailable"` (shown on hover, `150 ms` delay) |
+| aria-disabled | `"true"` |
+
+### 9.1 Tooltip Design
+
+| Property | Value |
+|---|---|
+| Background | `neutral-900` |
+| Text colour | `#FFFFFF` |
+| Font size | 12 px |
+| Padding | `4 px 8 px` |
+| Border radius | `radius-sm` (4 px) |
+| Position | Below trigger, centered, `top: calc(100% + 6px)` |
+| Delay | `150 ms` before showing |
+| Z-index | 201 |
+
+---
+
+## 10. Keyboard Interaction
+
+| Key | Behaviour |
+|---|---|
+| `Enter` / `Space` | Open dropdown (when trigger focused) |
+| `↑` / `↓` | Move focus between options |
+| `Enter` | Select focused option |
+| `Escape` | Close dropdown, return focus to trigger |
+| `Tab` | Close dropdown, move focus to next element in page |
+| `Home` | Focus first option |
+| `End` | Focus last option |
+
+ARIA pattern: `combobox` or `button` + `listbox`. Use `role="listbox"` on dropdown container and `role="option"` on each item.
+
+---
+
+## 11. Selected-Item Display in Trigger
+
+When a model is selected, the trigger label shows:
+
+| Scenario | Trigger label |
+|---|---|
+| Model name ≤ 18 chars | Full model name |
+| Model name > 18 chars | Truncated with ellipsis |
+| No model selected (loading) | `"Select model"` in `neutral-400` |
+
+> **Do not** show provider name in the trigger — only the model name. The full provider + model name appears in the dropdown option row.


### PR DESCRIPTION
ux-dev-1 creates annotated design specification files for the conversational chat surface of the Prompter UI. Deliverables are Markdown spec files (and/or annotated wireframe exports) committed to the repo under docs/design/prompter/. Scope: (1) message bubble layouts for user and AI turns — typography, colour roles, spacing, timestamps, and copy-to-clipboard affordance; (2) chat input area — textarea sizing and resize behaviour, Send button style, keyboard shortcut hint (Cmd/Ctrl+Enter); (3) typing indicator animation spec — states and easing so frontend can implement it; (4) empty state layout — visual, headline copy, and optional suggested-prompt chips; (5) conversation history side-panel — list view item structure (title, relative date), active/hover states, and the delete-item confirmation flow; (6) model selection UI — exact placement in the chat header or toolbar, dropdown open/closed/selected/disabled interaction states, and how the active model name is displayed inline. Every interactive element must have all states (default, hover, focus, active, disabled, error) annotated. Specs must be self-sufficient for frontend implementation without a follow-up design meeting.