### PR TITLE
[af249aa2] DB models, Alembic migration, and PromptService core

### DIFF
--- a/alembic/versions/015_prompter_tables.py
+++ b/alembic/versions/015_prompter_tables.py
@@ -1,0 +1,73 @@
+"""Add prompter_conversations and prompter_messages tables.
+
+Revision ID: 015_prompter_tables
+Revises: 014_drop_pm_approvals
+Create Date: 2026-06-03
+
+Adds two tables for the human-facing Prompter feature:
+- ``prompter_conversations``: one row per conversation thread.
+- ``prompter_messages``: individual user/assistant turns; cascade-deleted
+  when the parent conversation is removed.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "015_prompter_tables"
+down_revision = "014_drop_pm_approvals"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "prompter_conversations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_id", sa.String(100), nullable=False),
+        sa.Column("title", sa.String(500), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index(
+        "ix_prompter_conv_agent_created",
+        "prompter_conversations",
+        ["agent_id", "created_at"],
+    )
+
+    op.create_table(
+        "prompter_messages",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "conversation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("prompter_conversations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("role", sa.String(20), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+    op.create_index(
+        "ix_prompter_msg_conv_created",
+        "prompter_messages",
+        ["conversation_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_prompter_msg_conv_created", table_name="prompter_messages")
+    op.drop_table("prompter_messages")
+    op.drop_index("ix_prompter_conv_agent_created", table_name="prompter_conversations")
+    op.drop_table("prompter_conversations")

--- a/roboco/db/tables.py
+++ b/roboco/db/tables.py
@@ -1724,3 +1724,82 @@ class GatewayTriggerTable(Base):
         Index("ix_gateway_triggers_created_at", "created_at"),
         Index("ix_gateway_triggers_kind_decision", "trigger_kind", "decision"),
     )
+
+
+# =============================================================================
+# PROMPTER CONVERSATION TABLE
+# =============================================================================
+
+
+class PromptConversationTable(Base):
+    """
+    Persistent conversation thread for the human-facing Prompter feature.
+
+    Each row represents one conversation between a user and the assistant.
+    Messages are stored in PromptMessageTable with cascade-delete so that
+    deleting a conversation removes all its messages automatically.
+    """
+
+    __tablename__ = "prompter_conversations"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    agent_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+
+    # Relationship: cascade-delete so messages are removed with the conversation
+    messages: Mapped[list["PromptMessageTable"]] = relationship(
+        "PromptMessageTable",
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        lazy="select",
+        order_by="PromptMessageTable.created_at",
+    )
+
+    __table_args__ = (
+        Index("ix_prompter_conv_agent_created", "agent_id", "created_at"),
+    )
+
+
+# =============================================================================
+# PROMPTER MESSAGE TABLE
+# =============================================================================
+
+
+class PromptMessageTable(Base):
+    """
+    Individual message within a Prompter conversation.
+
+    ``role`` is either ``"user"`` or ``"assistant"``.  Content stores the
+    full text of the message.  Messages are ordered by ``created_at``.
+    """
+
+    __tablename__ = "prompter_messages"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    conversation_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("prompter_conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+
+    # Relationship
+    conversation: Mapped["PromptConversationTable"] = relationship(
+        "PromptConversationTable", back_populates="messages"
+    )
+
+    __table_args__ = (
+        Index("ix_prompter_msg_conv_created", "conversation_id", "created_at"),
+    )

--- a/roboco/services/prompter.py
+++ b/roboco/services/prompter.py
@@ -1,0 +1,217 @@
+"""
+Prompter Service
+
+Human-facing conversational AI service backed by Anthropic Claude.
+Persists conversation threads and message history in the database so
+that context is maintained across requests.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+from sqlalchemy import select
+
+from roboco.config import settings
+from roboco.db.tables import PromptConversationTable, PromptMessageTable
+from roboco.services.base import BaseService, NotFoundError
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+# ---------------------------------------------------------------------------
+# System prompt used for every Prompter conversation
+# ---------------------------------------------------------------------------
+
+PROMPTER_SYSTEM_PROMPT = (
+    "You are a helpful assistant embedded in the RoboCo platform. "
+    "You help users understand the status of projects, answer questions "
+    "about the AI agents and their work, and assist with general queries. "
+    "Be concise, accurate, and professional."
+)
+
+# ---------------------------------------------------------------------------
+# Available models (returned by list_models)
+# ---------------------------------------------------------------------------
+
+_AVAILABLE_MODELS: list[str] = [
+    "claude-opus-4-5",
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku-20241022",
+    "claude-3-opus-20240229",
+]
+
+
+class PromptService(BaseService):
+    """
+    Service for the human-facing Prompter feature.
+
+    Manages conversation threads and message history, and streams
+    responses from the Anthropic API using the full conversation context.
+    """
+
+    service_name: ClassVar[str] = "prompter"
+
+    # ------------------------------------------------------------------
+    # Model catalogue
+    # ------------------------------------------------------------------
+
+    async def list_models(self) -> list[str]:
+        """Return the list of available Anthropic model identifiers."""
+        return list(_AVAILABLE_MODELS)
+
+    # ------------------------------------------------------------------
+    # Conversation CRUD
+    # ------------------------------------------------------------------
+
+    async def create_conversation(
+        self,
+        agent_id: str,
+        title: str | None = None,
+    ) -> PromptConversationTable:
+        """Create a new conversation thread for *agent_id*."""
+        conversation = PromptConversationTable(agent_id=agent_id, title=title)
+        self.session.add(conversation)
+        await self.session.flush()
+        await self.session.refresh(conversation)
+        self.log.info(
+            "Created prompter conversation",
+            conversation_id=str(conversation.id),
+            agent_id=agent_id,
+        )
+        return conversation
+
+    async def get_conversation(self, conversation_id: UUID) -> PromptConversationTable:
+        """
+        Return the conversation with *conversation_id*.
+
+        Raises :class:`~roboco.services.base.NotFoundError` when no row exists.
+        """
+        result = await self.session.execute(
+            select(PromptConversationTable).where(
+                PromptConversationTable.id == conversation_id
+            )
+        )
+        conversation = result.scalar_one_or_none()
+        if conversation is None:
+            raise NotFoundError("PromptConversation", resource_id=str(conversation_id))
+        return conversation
+
+    async def list_conversations(self, agent_id: str) -> list[PromptConversationTable]:
+        """Return all conversations for *agent_id*, newest first."""
+        result = await self.session.execute(
+            select(PromptConversationTable)
+            .where(PromptConversationTable.agent_id == agent_id)
+            .order_by(PromptConversationTable.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def delete_conversation(self, conversation_id: UUID) -> None:
+        """
+        Delete the conversation and all its messages (cascade on FK).
+
+        Raises :class:`~roboco.services.base.NotFoundError` when no row exists.
+        """
+        conversation = await self.get_conversation(conversation_id)
+        await self.session.delete(conversation)
+        await self.session.flush()
+        self.log.info(
+            "Deleted prompter conversation",
+            conversation_id=str(conversation_id),
+        )
+
+    # ------------------------------------------------------------------
+    # Streaming message
+    # ------------------------------------------------------------------
+
+    async def stream_message(
+        self,
+        conversation_id: UUID,
+        user_content: str,
+        model: str = "claude-3-5-sonnet-20241022",
+    ) -> AsyncIterator[str]:
+        """
+        Stream an assistant reply for *user_content* in *conversation_id*.
+
+        This method is an async generator.  Iterate it with ``async for``::
+
+            async for delta in service.stream_message(conv_id, "Hello"):
+                print(delta, end="", flush=True)
+
+        Steps performed on first iteration:
+
+        1. Validate the conversation exists (raises ``NotFoundError`` if not).
+        2. Persist the user ``PromptMessageTable`` row.
+        3. Reload full message history and call the Anthropic streaming API
+           with :data:`PROMPTER_SYSTEM_PROMPT` as the system prompt.
+        4. Yield each text delta as it arrives.
+        5. After the stream ends, persist the complete assistant response.
+        """
+        from anthropic import AsyncAnthropic
+
+        # 1. Validate conversation
+        await self.get_conversation(conversation_id)
+
+        # 2. Persist user message
+        user_msg = PromptMessageTable(
+            conversation_id=conversation_id,
+            role="user",
+            content=user_content,
+        )
+        self.session.add(user_msg)
+        await self.session.flush()
+
+        # 3. Load full message history (ordered by created_at asc)
+        history_result = await self.session.execute(
+            select(PromptMessageTable)
+            .where(PromptMessageTable.conversation_id == conversation_id)
+            .order_by(PromptMessageTable.created_at)
+        )
+        history = list(history_result.scalars().all())
+        messages = [{"role": msg.role, "content": msg.content} for msg in history]
+
+        # 4. Stream from Anthropic, yielding text deltas
+        client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+        full_response: list[str] = []
+
+        async with client.messages.stream(
+            model=model,
+            max_tokens=4096,
+            system=PROMPTER_SYSTEM_PROMPT,
+            messages=messages,
+        ) as stream:
+            async for text_delta in stream.text_stream:
+                full_response.append(text_delta)
+                yield text_delta
+
+        # 5. Persist complete assistant response
+        assistant_content = "".join(full_response)
+        assistant_msg = PromptMessageTable(
+            conversation_id=conversation_id,
+            role="assistant",
+            content=assistant_content,
+        )
+        self.session.add(assistant_msg)
+        await self.session.flush()
+
+        self.log.info(
+            "Streamed prompter message",
+            conversation_id=str(conversation_id),
+            model=model,
+            response_chars=len(assistant_content),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory function
+# ---------------------------------------------------------------------------
+
+
+def get_prompt_service(db: AsyncSession) -> PromptService:
+    """Factory function — returns a :class:`PromptService` bound to *db*."""
+    return PromptService(db)


### PR DESCRIPTION
Implement the data and business-logic foundation for the Prompter chat feature. This subtask covers three files:

1. `/app/roboco/db/tables.py` — add two new ORM table classes using SQLAlchemy 2.0 `Mapped[T]` + `mapped_column()` style (do NOT use legacy `Column()`):
   - `PromptConversationTable` (`__tablename__ = "prompter_conversations"`): UUID PK, `agent_id` UUID FK → agents.id (SET NULL on delete), `title` String(255), `created_at` datetime, `updated_at` datetime, `metadata_` JSONB nullable (store extra config). Add a `messages` relationship (lazy="select") back-referenced from PromptMessageTable.
   - `PromptMessageTable` (`__tablename__ = "prompter_messages"`): UUID PK, `conversation_id` UUID FK → prompter_conversations.id (CASCADE on delete), `role` String(20) (values: "user" or "assistant"), `content` Text, `created_at` datetime, `token_count` Integer nullable, `draft` JSONB nullable (structured task extraction JSON from assistant messages). Add index on conversation_id.

2. Alembic migration — inspect `/app/alembic/versions/` to find the current head revision, then create a new migration file (e.g. `NNN_add_prompter_tables.py`) with `down_revision` set to the current head. Use `op.create_table()` for both tables. If `/app/alembic/` does not exist, initialize it with `alembic init alembic` under `/app/` and set `sqlalchemy.url` in alembic.ini, then write the migration.

3. `/app/roboco/services/prompter.py` — implement `PromptService(BaseService)` with `service_name = "prompter"` and these async methods:
   - `list_models() -> list[str]` — return hardcoded list of supported Anthropic model IDs: ["claude-opus-4-5-20251101", "claude-sonnet-4-5-20251101", "claude-haiku-4-5-20251101"] (or check `roboco/models/llm_catalog.py` for existing model constants).
   - `create_conversation(agent_id: UUID, title: str) -> PromptConversationTable` — insert and return new row.
   - `get_conversation(conv_id: UUID) -> PromptConversationTable` — fetch with messages eagerly loaded; raise `NotFoundError` if missing.
   - `list_conversations(agent_id: UUID) -> list[PromptConversationTable]` — ordered by created_at desc.
   - `delete_conversation(conv_id: UUID) -> None` — delete row (cascade removes messages); raise `NotFoundError` if missing.
   - `stream_message(conv_id: UUID, user_content: str) -> AsyncIterator[str]` — async generator that: (a) persists the user message row, (b) loads full conversation history, (c) calls Anthropic SDK `client.messages.stream()` with the system prompt (see below) and full message history, (d) yields each text delta as a plain string, (e) on stream completion persists the full assistant response as a new message row (with token_count from usage). Handle `anthropic.APIError` by raising `ServiceError`.

   System prompt to use (embed as a module-level constant `PROMPTER_SYSTEM_PROMPT`):
   ```
   You are a task-planning assistant. Help the user define a clear software task. When you have gathered enough information, output a structured JSON block (and ONLY the JSON block) between triple backticks tagged as json, containing exactly these fields: title (string), description (string, multi-paragraph markdown), acceptance_criteria (list of strings), team (one of: backend, frontend, ux_ui), task_type (one of: code, documentation, research, planning, design, administrative), nature (one of: technical, non_technical), estimated_complexity (one of: low, medium, high). Until then, ask clarifying questions.
   ```

   Use `settings.anthropic_api_key` (from `roboco/config.py` Settings) to instantiate `anthropic.AsyncAnthropic`. Import `AsyncAnthropic` from the `anthropic` package already in pyproject.toml.

Also expose a `get_prompt_service(db: AsyncSession) -> PromptService` factory function at module bottom.

All code must pass `uv run ruff format .` and `uv run ruff check .` without errors.