### PR TITLE
[4cc3eec0] UX/UI — Prompter conversational flow and component design

### DIFF
--- a/panel/src/components/prompter/ChatInterface.tsx
+++ b/panel/src/components/prompter/ChatInterface.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface ChatMessage {
+  id: string
+  role: "user" | "assistant"
+  content: string
+}
+
+export interface ChatInterfaceProps {
+  messages: ChatMessage[]
+  className?: string
+}
+
+export function ChatInterface({ messages, className }: ChatInterfaceProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 overflow-y-auto p-4",
+        className
+      )}
+    >
+      {messages.map((message) => (
+        <div
+          key={message.id}
+          className={cn(
+            "flex",
+            message.role === "user" ? "justify-end" : "justify-start"
+          )}
+        >
+          <div
+            className={cn(
+              "max-w-[75%] rounded-2xl px-4 py-2.5 text-sm",
+              message.role === "user"
+                ? "bg-primary text-primary-foreground rounded-br-sm"
+                : "bg-muted text-muted-foreground rounded-bl-sm"
+            )}
+          >
+            {message.content}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/panel/src/components/prompter/ConfirmationDialog.tsx
+++ b/panel/src/components/prompter/ConfirmationDialog.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import * as React from "react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+
+export interface ConfirmationDialogProps {
+  title: string
+  description: string
+  onConfirm: () => void
+  onCancel: () => void
+  trigger: React.ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+}
+
+export function ConfirmationDialog({
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  trigger,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+}: ConfirmationDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/panel/src/components/prompter/DraftCard.tsx
+++ b/panel/src/components/prompter/DraftCard.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDown, ChevronUp } from "lucide-react"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { Checkbox } from "@/components/ui/checkbox"
+import { cn } from "@/lib/utils"
+
+export interface DraftCardProps {
+  title: string
+  summary: string
+  detail: string
+  acceptanceCriteria: string[]
+  className?: string
+}
+
+export function DraftCard({
+  title,
+  summary,
+  detail,
+  acceptanceCriteria,
+  className,
+}: DraftCardProps) {
+  const [isOpen, setIsOpen] = React.useState(false)
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground shadow-xs",
+        className
+      )}
+    >
+      <div className="flex items-center justify-between p-4">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        <CollapsibleTrigger asChild>
+          <button
+            className="rounded-md p-1 hover:bg-accent hover:text-accent-foreground transition-colors"
+            aria-label={isOpen ? "Collapse" : "Expand"}
+          >
+            {isOpen ? (
+              <ChevronUp className="size-4" />
+            ) : (
+              <ChevronDown className="size-4" />
+            )}
+          </button>
+        </CollapsibleTrigger>
+      </div>
+
+      {!isOpen && (
+        <div className="px-4 pb-4 text-sm text-muted-foreground">{summary}</div>
+      )}
+
+      <CollapsibleContent>
+        <div className="border-t px-4 py-3 space-y-3">
+          <p className="text-sm text-foreground">{detail}</p>
+
+          {acceptanceCriteria.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Acceptance Criteria
+              </p>
+              <ul className="space-y-1.5">
+                {acceptanceCriteria.map((criterion, index) => (
+                  <li key={index} className="flex items-start gap-2">
+                    <Checkbox
+                      id={`criterion-${index}`}
+                      className="mt-0.5 shrink-0"
+                    />
+                    <label
+                      htmlFor={`criterion-${index}`}
+                      className="text-sm leading-snug cursor-pointer"
+                    >
+                      {criterion}
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/panel/src/components/prompter/EmptyState.tsx
+++ b/panel/src/components/prompter/EmptyState.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export interface EmptyStateProps {
+  onSelectExample: (prompt: string) => void
+  examples?: string[]
+  className?: string
+}
+
+const DEFAULT_EXAMPLES = [
+  "Write a product requirements document for a mobile app",
+  "Explain the trade-offs between REST and GraphQL APIs",
+  "Generate unit tests for a user authentication service",
+]
+
+export function EmptyState({
+  onSelectExample,
+  examples = DEFAULT_EXAMPLES,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-6 py-12 px-4 text-center",
+        className
+      )}
+    >
+      <div className="flex flex-col items-center gap-2">
+        <div className="rounded-full bg-muted p-3">
+          <Sparkles className="size-5 text-muted-foreground" />
+        </div>
+        <h3 className="text-sm font-semibold">Start a conversation</h3>
+        <p className="text-sm text-muted-foreground max-w-xs">
+          Choose an example prompt below or type your own message.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-2">
+        {examples.map((example, index) => (
+          <Button
+            key={index}
+            variant="outline"
+            size="sm"
+            onClick={() => onSelectExample(example)}
+            className="text-xs h-auto py-2 px-3 whitespace-normal text-left"
+          >
+            {example}
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/panel/src/components/prompter/HistoryView.tsx
+++ b/panel/src/components/prompter/HistoryView.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import { RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export interface HistoryItem {
+  id: string
+  title: string
+}
+
+export interface HistoryViewProps {
+  items?: HistoryItem[]
+  onReuse: (id: string) => void
+  className?: string
+}
+
+const DEFAULT_ITEMS: HistoryItem[] = [
+  { id: "1", title: "Summarize the latest sprint retrospective" },
+  { id: "2", title: "Write a user story for the login feature" },
+]
+
+export function HistoryView({
+  items = DEFAULT_ITEMS,
+  onReuse,
+  className,
+}: HistoryViewProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-1 overflow-y-auto max-h-80",
+        className
+      )}
+    >
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-6">
+          No saved prompts yet.
+        </p>
+      ) : (
+        items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center justify-between gap-3 rounded-md px-3 py-2.5 hover:bg-accent transition-colors group"
+          >
+            <span className="text-sm truncate flex-1">{item.title}</span>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onReuse(item.id)}
+              aria-label={`Reuse: ${item.title}`}
+              className="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+            >
+              <RotateCcw className="size-3.5" />
+            </Button>
+          </div>
+        ))
+      )}
+    </div>
+  )
+}

--- a/panel/src/components/prompter/ModelSelector.tsx
+++ b/panel/src/components/prompter/ModelSelector.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import * as React from "react"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { cn } from "@/lib/utils"
+
+export interface ModelSelectorProps {
+  models: string[]
+  selected: string
+  onSelect: (model: string) => void
+  className?: string
+}
+
+export function ModelSelector({
+  models,
+  selected,
+  onSelect,
+  className,
+}: ModelSelectorProps) {
+  return (
+    <Select value={selected} onValueChange={onSelect}>
+      <SelectTrigger className={cn("w-[200px]", className)}>
+        <SelectValue placeholder="Select a model" />
+      </SelectTrigger>
+      <SelectContent>
+        {models.map((model) => (
+          <SelectItem key={model} value={model}>
+            {model}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/panel/src/components/prompter/index.ts
+++ b/panel/src/components/prompter/index.ts
@@ -1,0 +1,17 @@
+export { ChatInterface } from "./ChatInterface"
+export type { ChatInterfaceProps, ChatMessage } from "./ChatInterface"
+
+export { DraftCard } from "./DraftCard"
+export type { DraftCardProps } from "./DraftCard"
+
+export { ConfirmationDialog } from "./ConfirmationDialog"
+export type { ConfirmationDialogProps } from "./ConfirmationDialog"
+
+export { HistoryView } from "./HistoryView"
+export type { HistoryViewProps, HistoryItem } from "./HistoryView"
+
+export { EmptyState } from "./EmptyState"
+export type { EmptyStateProps } from "./EmptyState"
+
+export { ModelSelector } from "./ModelSelector"
+export type { ModelSelectorProps } from "./ModelSelector"


### PR DESCRIPTION
Design the UX for Prompter's conversational task-authoring flow. This is the human front door to RoboCo — the primary interface where the CEO converses with an LLM to craft tasks. The designs must cover: the chat-to-draft progressive disclosure pattern (an inline draft card that appears and updates live as the conversation produces task structure), the Create & Launch confirmation dialog, conversation history browsing and template reuse flow, the empty state experience with example prompts for first-time users, and model selector UX. The panel uses shadcn/ui + Tailwind + lucide-react. The existing mentor-chat layout (knowledge-base/mentor-chat.tsx) is a reference for the chat component pattern. Designs inform the frontend cell's implementation.