### PR TITLE
[ccee5c63] Implement Prompter chat API, DB persistence, and task-creation integration

### DIFF
--- a/alembic/versions/021_add_prompter_tables.py
+++ b/alembic/versions/021_add_prompter_tables.py
@@ -1,0 +1,105 @@
+"""Add prompter_conversations and prompter_messages tables.
+
+Revision ID: 021_add_prompter_tables
+Revises: 020_backfill_enum_values
+Create Date: 2026-06-04
+
+Adds two tables to support the Prompter chat feature:
+
+  - ``prompter_conversations`` — a persistent chat thread (id, title,
+    message_count, created_at, updated_at).
+  - ``prompter_messages`` — individual user/assistant turns within a
+    conversation (id, conversation_id FK, role, content, model_used,
+    created_at).  Cascade-deletes when the parent conversation is removed.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "021_add_prompter_tables"
+down_revision = "020_backfill_enum_values"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # prompter_conversations
+    # ------------------------------------------------------------------
+    op.create_table(
+        "prompter_conversations",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(255), nullable=False, server_default=""),
+        sa.Column("message_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_prompter_conversations")),
+    )
+    op.create_index(
+        "ix_prompter_conv_created_at",
+        "prompter_conversations",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_prompter_conv_updated_at",
+        "prompter_conversations",
+        ["updated_at"],
+    )
+
+    # ------------------------------------------------------------------
+    # prompter_messages
+    # ------------------------------------------------------------------
+    op.create_table(
+        "prompter_messages",
+        sa.Column("id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("conversation_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("role", sa.String(20), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("model_used", sa.String(100), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["prompter_conversations.id"],
+            name=op.f("fk_prompter_messages_conversation_id_prompter_conversations"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_prompter_messages")),
+    )
+    op.create_index(
+        "ix_prompter_messages_conversation_id",
+        "prompter_messages",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_prompter_messages_created_at",
+        "prompter_messages",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_prompter_msg_conv_created",
+        "prompter_messages",
+        ["conversation_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("prompter_messages")
+    op.drop_table("prompter_conversations")

--- a/roboco/api/app.py
+++ b/roboco/api/app.py
@@ -29,6 +29,7 @@ from roboco.api.routes.optimal import router as optimal_router
 from roboco.api.routes.orchestrator import router as orchestrator_router
 from roboco.api.routes.product import router as product_router
 from roboco.api.routes.project import router as project_router
+from roboco.api.routes.prompter import router as prompter_router
 from roboco.api.routes.provider import router as provider_router
 from roboco.api.routes.sessions import router as sessions_router
 from roboco.api.routes.stream import router as stream_router
@@ -300,6 +301,13 @@ def create_app() -> FastAPI:
         docs_router,
         prefix=f"{api_prefix}/docs",
         tags=["Documentation"],
+    )
+
+    # Prompter chat
+    app.include_router(
+        prompter_router,
+        prefix=f"{api_prefix}/prompter",
+        tags=["Prompter"],
     )
 
     # API v1 — intent-verb flow endpoints

--- a/roboco/api/routes/prompter.py
+++ b/roboco/api/routes/prompter.py
@@ -1,0 +1,203 @@
+"""
+Prompter API Routes
+
+Endpoints:
+  POST   /api/prompter/chat
+      Send a user message (and optionally a conversation_id) to the LLM.
+      Auto-creates a new conversation when conversation_id is omitted.
+
+  GET    /api/prompter/conversations
+      List all prompter conversations.
+
+  GET    /api/prompter/conversations/{conversation_id}
+      Get a single conversation including its full message history.
+
+  DELETE /api/prompter/conversations/{conversation_id}
+      Delete a conversation and all its messages (cascade).
+
+  POST   /api/prompter/conversations/{conversation_id}/create-task
+      Generate a structured task draft from the conversation history,
+      validate it, and create a real Task record.
+"""
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from roboco.api.deps import CurrentAgentId, CurrentAgentSlug, DbSession
+from roboco.api.schemas.prompter import (
+    PrompterChatRequest,
+    PrompterChatResponse,
+    PrompterConversationDetailResponse,
+    PrompterConversationResponse,
+    PrompterCreateTaskRequest,
+    PrompterCreateTaskResponse,
+    PrompterMessageResponse,
+)
+from roboco.services.base import NotFoundError, ServiceError
+from roboco.services.prompter import get_prompter_service
+
+router = APIRouter()
+
+
+# =============================================================================
+# Chat
+# =============================================================================
+
+
+@router.post(
+    "/chat", response_model=PrompterChatResponse, status_code=status.HTTP_200_OK
+)
+async def chat(
+    body: PrompterChatRequest,
+    db: DbSession,
+    agent_slug: CurrentAgentSlug,
+) -> PrompterChatResponse:
+    """Send a user message to the LLM and get a response.
+
+    If ``conversation_id`` is not provided a new conversation is created
+    automatically and its id is returned in the response.
+    """
+    svc = get_prompter_service(db)
+    try:
+        conv, assistant_text, model_used = await svc.chat(
+            user_message=body.message,
+            agent_slug=agent_slug,
+            conversation_id=body.conversation_id,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except ServiceError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"LLM call failed: {exc}",
+        ) from exc
+
+    await db.commit()
+    return PrompterChatResponse(
+        conversation_id=UUID(str(conv.id)),
+        assistant_text=assistant_text,
+        model_used=model_used,
+    )
+
+
+# =============================================================================
+# Conversations CRUD
+# =============================================================================
+
+
+@router.get(
+    "/conversations",
+    response_model=list[PrompterConversationResponse],
+)
+async def list_conversations(
+    db: DbSession,
+    agent_slug: CurrentAgentSlug,  # noqa: ARG001 — presence ensures auth header
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> list[PrompterConversationResponse]:
+    """Return a paginated list of all conversations."""
+    svc = get_prompter_service(db)
+    conversations = await svc.list_conversations(limit=limit, offset=offset)
+    return [PrompterConversationResponse.model_validate(c) for c in conversations]
+
+
+@router.get(
+    "/conversations/{conversation_id}",
+    response_model=PrompterConversationDetailResponse,
+)
+async def get_conversation(
+    conversation_id: UUID,
+    db: DbSession,
+    agent_slug: CurrentAgentSlug,  # noqa: ARG001 — ensures auth header present
+) -> PrompterConversationDetailResponse:
+    """Get a conversation with its full message history."""
+    svc = get_prompter_service(db)
+    try:
+        conv = await svc.get_conversation(conversation_id)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+
+    messages = [
+        PrompterMessageResponse.model_validate(m)
+        for m in sorted(conv.messages, key=lambda m: m.created_at)
+    ]
+    return PrompterConversationDetailResponse(
+        id=UUID(str(conv.id)),
+        title=conv.title,
+        message_count=conv.message_count,
+        created_at=conv.created_at,
+        updated_at=conv.updated_at,
+        messages=messages,
+    )
+
+
+@router.delete(
+    "/conversations/{conversation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_conversation(
+    conversation_id: UUID,
+    db: DbSession,
+    agent_slug: CurrentAgentSlug,  # noqa: ARG001 — ensures auth header present
+) -> None:
+    """Delete a conversation and all its messages."""
+    svc = get_prompter_service(db)
+    try:
+        await svc.delete_conversation(conversation_id)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    await db.commit()
+
+
+# =============================================================================
+# Task creation from conversation
+# =============================================================================
+
+
+@router.post(
+    "/conversations/{conversation_id}/create-task",
+    response_model=PrompterCreateTaskResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_task_from_conversation(
+    conversation_id: UUID,
+    body: PrompterCreateTaskRequest,
+    db: DbSession,
+    agent_slug: CurrentAgentSlug,
+    agent_id: CurrentAgentId,
+) -> PrompterCreateTaskResponse:
+    """Generate a task draft from the conversation and create a real Task record.
+
+    The LLM reads the conversation history and produces a structured task
+    draft (title, description, acceptance_criteria, team, task_type, nature,
+    estimated_complexity).  The draft is validated and a ``Task`` row is
+    created and returned by id.
+    """
+    svc = get_prompter_service(db)
+    try:
+        task_id = await svc.create_task_from_conversation(
+            conversation_id=conversation_id,
+            agent_slug=agent_slug,
+            created_by=agent_id,
+            project_id=body.project_id,
+            product_id=body.product_id,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
+    except ServiceError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
+    await db.commit()
+    return PrompterCreateTaskResponse(task_id=task_id)

--- a/roboco/api/schemas/prompter.py
+++ b/roboco/api/schemas/prompter.py
@@ -1,0 +1,106 @@
+"""
+Prompter API Schemas
+
+Request / response Pydantic models for the Prompter chat endpoints.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+# =============================================================================
+# Request schemas
+# =============================================================================
+
+
+class PrompterChatRequest(BaseModel):
+    """Request body for POST /api/prompter/chat."""
+
+    message: str = Field(..., min_length=1, description="User message to send")
+    conversation_id: UUID | None = Field(
+        default=None,
+        description=(
+            "Existing conversation to continue. "
+            "Omit (or pass null) to start a new conversation."
+        ),
+    )
+
+
+class PrompterCreateTaskRequest(BaseModel):
+    """Request body for POST /api/prompter/conversations/{id}/create-task.
+
+    Exactly one of ``project_id`` or ``product_id`` must be supplied —
+    the same constraint as ``TaskCreate``.
+    """
+
+    project_id: UUID | None = Field(
+        default=None,
+        description="Target git repository project UUID (single-cell task)",
+    )
+    product_id: UUID | None = Field(
+        default=None,
+        description="Product UUID for fan-out (multi-cell) task",
+    )
+
+    @model_validator(mode="after")
+    def _require_one(self) -> "PrompterCreateTaskRequest":
+        if self.project_id is None and self.product_id is None:
+            raise ValueError("Either project_id or product_id must be provided")
+        return self
+
+
+# =============================================================================
+# Response schemas
+# =============================================================================
+
+
+class PrompterMessageResponse(BaseModel):
+    """A single message within a conversation."""
+
+    id: UUID
+    role: str = Field(..., description="'user' or 'assistant'")
+    content: str
+    model_used: str | None = Field(
+        default=None,
+        description="Model name used to generate this message (assistant only)",
+    )
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PrompterConversationResponse(BaseModel):
+    """Summary of a prompter conversation (no messages)."""
+
+    id: UUID
+    title: str
+    message_count: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class PrompterConversationDetailResponse(PrompterConversationResponse):
+    """Full conversation including message history."""
+
+    messages: list[PrompterMessageResponse] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}
+
+
+class PrompterChatResponse(BaseModel):
+    """Response from POST /api/prompter/chat."""
+
+    conversation_id: UUID
+    assistant_text: str = Field(..., description="The LLM's response text")
+    model_used: str = Field(
+        ..., description="Model name resolved by ModelRoutingService"
+    )
+
+
+class PrompterCreateTaskResponse(BaseModel):
+    """Response from POST /api/prompter/conversations/{id}/create-task."""
+
+    task_id: UUID = Field(..., description="UUID of the newly created task")

--- a/roboco/db/tables.py
+++ b/roboco/db/tables.py
@@ -1799,3 +1799,101 @@ class GatewayTriggerTable(Base):
         Index("ix_gateway_triggers_created_at", "created_at"),
         Index("ix_gateway_triggers_kind_decision", "trigger_kind", "decision"),
     )
+
+
+# =============================================================================
+# PROMPTER TABLES
+# =============================================================================
+
+
+class PrompterConversationTable(Base):
+    """
+    A prompter conversation (a sequence of user/assistant messages).
+
+    Each conversation is a persistent chat thread.  Messages cascade-delete
+    when the conversation is removed.
+    """
+
+    __tablename__ = "prompter_conversations"
+
+    # Identity
+    id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+
+    # Display
+    title: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    # Stats
+    message_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    # Relationships
+    messages: Mapped[list["PrompterMessageTable"]] = relationship(
+        "PrompterMessageTable",
+        back_populates="conversation",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index("ix_prompter_conv_created_at", "created_at"),
+        Index("ix_prompter_conv_updated_at", "updated_at"),
+    )
+
+
+class PrompterMessageTable(Base):
+    """
+    A single message within a prompter conversation.
+
+    ``role`` is either ``'user'`` or ``'assistant'``.
+    ``model_used`` is populated only for assistant messages and records the
+    model name resolved by ModelRoutingService at call time.
+    """
+
+    __tablename__ = "prompter_messages"
+
+    # Identity
+    id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    conversation_id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("prompter_conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Content
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Only set for assistant messages
+    model_used: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+        index=True,
+    )
+
+    # Relationships
+    conversation: Mapped["PrompterConversationTable"] = relationship(
+        "PrompterConversationTable", back_populates="messages"
+    )
+
+    __table_args__ = (
+        Index("ix_prompter_msg_conv_created", "conversation_id", "created_at"),
+    )

--- a/roboco/services/prompter.py
+++ b/roboco/services/prompter.py
@@ -1,0 +1,424 @@
+"""
+Prompter Service
+
+Provides a chat interface where an agent (or human via the API) can
+converse with an LLM, with full message persistence, and can turn a
+conversation into a real Task.
+
+The LLM model is always resolved via ``ModelRoutingService`` — no
+hardcoded model names appear here or in the route handlers.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any, ClassVar
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from roboco.db.tables import (
+    PrompterConversationTable,
+    PrompterMessageTable,
+)
+from roboco.models.base import ModelProvider
+from roboco.services.base import BaseService, NotFoundError, ServiceError
+from roboco.services.llm import ModelRoutingService
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+_MAX_TITLE_LEN = 80
+
+
+class PrompterService(BaseService):
+    """Service for prompter chat conversations and task creation."""
+
+    service_name: ClassVar[str] = "prompter"
+
+    # =========================================================================
+    # Conversation CRUD
+    # =========================================================================
+
+    async def create_conversation(self, title: str = "") -> PrompterConversationTable:
+        """Create a new (empty) conversation."""
+        conv = PrompterConversationTable(title=title)
+        self.session.add(conv)
+        await self.session.flush()
+        self.log.info("Conversation created", conversation_id=str(conv.id))
+        return conv
+
+    async def get_conversation(
+        self, conversation_id: UUID
+    ) -> PrompterConversationTable:
+        """Return a conversation with its messages eagerly loaded.
+
+        Raises ``NotFoundError`` if the id does not exist.
+        """
+        result = await self.session.execute(
+            select(PrompterConversationTable)
+            .where(PrompterConversationTable.id == conversation_id)
+            .options(selectinload(PrompterConversationTable.messages))
+        )
+        conv = result.scalar_one_or_none()
+        if conv is None:
+            raise NotFoundError(
+                resource_type="PrompterConversation",
+                resource_id=str(conversation_id),
+            )
+        return conv
+
+    async def list_conversations(
+        self,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[PrompterConversationTable]:
+        """Return conversations ordered by most-recently-updated first."""
+        result = await self.session.execute(
+            select(PrompterConversationTable)
+            .order_by(PrompterConversationTable.updated_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(result.scalars().all())
+
+    async def delete_conversation(self, conversation_id: UUID) -> None:
+        """Delete a conversation (cascade removes messages).
+
+        Raises ``NotFoundError`` if the id does not exist.
+        """
+        result = await self.session.execute(
+            select(PrompterConversationTable).where(
+                PrompterConversationTable.id == conversation_id
+            )
+        )
+        conv = result.scalar_one_or_none()
+        if conv is None:
+            raise NotFoundError(
+                resource_type="PrompterConversation",
+                resource_id=str(conversation_id),
+            )
+        await self.session.delete(conv)
+        await self.session.flush()
+        self.log.info("Conversation deleted", conversation_id=str(conversation_id))
+
+    # =========================================================================
+    # Chat
+    # =========================================================================
+
+    async def chat(
+        self,
+        user_message: str,
+        agent_slug: str,
+        conversation_id: UUID | None = None,
+    ) -> tuple[PrompterConversationTable, str, str]:
+        """Send a user message and get an LLM response.
+
+        If ``conversation_id`` is ``None`` a new conversation is created
+        automatically.  The user message and assistant response are both
+        persisted as ``PrompterMessage`` rows.
+
+        Returns:
+            ``(conversation, assistant_text, model_used)`` where
+            ``model_used`` is the model name resolved via
+            ``ModelRoutingService``.
+        """
+        # --- fetch or create conversation ---
+        if conversation_id is not None:
+            conv = await self.get_conversation(conversation_id)
+        else:
+            title = (
+                (user_message[:_MAX_TITLE_LEN] + "…")
+                if len(user_message) > _MAX_TITLE_LEN
+                else user_message
+            )
+            conv = await self.create_conversation(title=title)
+
+        # --- load messages for context window ---
+        result = await self.session.execute(
+            select(PrompterMessageTable)
+            .where(PrompterMessageTable.conversation_id == conv.id)
+            .order_by(PrompterMessageTable.created_at)
+        )
+        history: list[PrompterMessageTable] = list(result.scalars().all())
+
+        # --- persist user message ---
+        user_msg = PrompterMessageTable(
+            conversation_id=conv.id,  # type: ignore[arg-type]
+            role="user",
+            content=user_message,
+        )
+        self.session.add(user_msg)
+        await self.session.flush()
+
+        # --- build context for LLM ---
+        lm_messages: list[dict[str, str]] = [
+            {"role": m.role, "content": m.content} for m in history
+        ]
+        lm_messages.append({"role": "user", "content": user_message})
+
+        # --- resolve model + call LLM ---
+        assistant_text, model_used = await self._call_llm(lm_messages, agent_slug)
+
+        # --- persist assistant message ---
+        assistant_msg = PrompterMessageTable(
+            conversation_id=conv.id,  # type: ignore[arg-type]
+            role="assistant",
+            content=assistant_text,
+            model_used=model_used,
+        )
+        self.session.add(assistant_msg)
+
+        # --- update conversation stats ---
+        conv.message_count = len(history) + 2  # user + assistant
+        await self.session.flush()
+
+        self.log.info(
+            "Chat turn completed",
+            conversation_id=str(conv.id),
+            model_used=model_used,
+        )
+        return conv, assistant_text, model_used
+
+    # =========================================================================
+    # Task Creation from Conversation
+    # =========================================================================
+
+    async def create_task_from_conversation(
+        self,
+        conversation_id: UUID,
+        agent_slug: str,
+        created_by: UUID,
+        project_id: UUID | None = None,
+        product_id: UUID | None = None,
+    ) -> UUID:
+        """Generate a task draft from a conversation and create a real Task.
+
+        Reads the conversation history, asks the LLM to produce a structured
+        task draft (JSON), validates it, and creates a ``TaskTable`` row via
+        ``TaskService``.
+
+        Returns the new task's UUID.
+
+        Raises:
+            ``NotFoundError`` — conversation does not exist.
+            ``ServiceError``  — LLM returned unparseable JSON or the draft
+                                fails ``TaskCreate`` validation.
+        """
+        from roboco.models.base import Complexity, TaskNature, TaskType
+        from roboco.models.task import TaskCreate, TaskCreateRequest
+        from roboco.services.task import get_task_service
+
+        if project_id is None and product_id is None:
+            raise ServiceError(
+                "Either project_id or product_id must be provided to create a task"
+            )
+
+        conv = await self.get_conversation(conversation_id)
+        result = await self.session.execute(
+            select(PrompterMessageTable)
+            .where(PrompterMessageTable.conversation_id == conv.id)
+            .order_by(PrompterMessageTable.created_at)
+        )
+        history: list[PrompterMessageTable] = list(result.scalars().all())
+
+        conversation_text = "\n".join(f"{m.role.upper()}: {m.content}" for m in history)
+
+        from roboco.foundation.identity import Team
+
+        valid_teams = [t.value for t in Team]
+        valid_types = [t.value for t in TaskType]
+        valid_natures = [n.value for n in TaskNature]
+        valid_complexities = [c.value for c in Complexity]
+
+        task_prompt = (
+            "Based on the following conversation, generate a task draft as JSON.\n\n"
+            f"Conversation:\n{conversation_text}\n\n"
+            "Return ONLY a JSON object (no markdown, no code fences) with these"
+            " fields:\n"
+            "  title: string (1-200 chars)\n"
+            "  description: string (at least 20 chars)\n"
+            "  acceptance_criteria: array of strings (at least 1 item)\n"
+            f"  team: one of {valid_teams}\n"
+            f"  task_type: one of {valid_types}\n"
+            f"  nature: one of {valid_natures}\n"
+            f"  estimated_complexity: one of {valid_complexities}\n\n"
+            "Example:\n"
+            '{"title":"Implement login","description":"Add JWT auth to the API",'
+            '"acceptance_criteria":["POST /login returns token"],'
+            '"team":"backend","task_type":"code","nature":"technical",'
+            '"estimated_complexity":"medium"}'
+        )
+
+        lm_messages: list[dict[str, str]] = [{"role": "user", "content": task_prompt}]
+        draft_json, _ = await self._call_llm(lm_messages, agent_slug)
+
+        # --- parse draft ---
+        draft = self._parse_task_draft(draft_json)
+
+        # --- validate via TaskCreate Pydantic model ---
+        try:
+            task_create = TaskCreate(
+                title=draft.get("title", ""),
+                description=draft.get("description", ""),
+                acceptance_criteria=draft.get("acceptance_criteria", []),
+                team=draft.get("team", ""),
+                task_type=draft.get("task_type", ""),
+                nature=draft.get("nature", ""),
+                estimated_complexity=draft.get("estimated_complexity", ""),
+                project_id=project_id,
+                product_id=product_id,
+            )
+        except Exception as exc:
+            raise ServiceError(
+                f"LLM-generated task draft failed validation: {exc}",
+                details={"draft": draft},
+            ) from exc
+
+        # --- create the task ---
+        task_svc = get_task_service(self.session)
+        req = TaskCreateRequest(
+            title=task_create.title,
+            description=task_create.description,
+            acceptance_criteria=task_create.acceptance_criteria,
+            team=task_create.team,
+            created_by=created_by,
+            task_type=task_create.task_type,
+            nature=task_create.nature,
+            estimated_complexity=task_create.estimated_complexity,
+            project_id=task_create.project_id,
+            product_id=task_create.product_id,
+        )
+        task = await task_svc.create(req)
+        await self.session.flush()
+
+        self.log.info(
+            "Task created from conversation",
+            conversation_id=str(conversation_id),
+            task_id=str(task.id),
+        )
+        return UUID(str(task.id))
+
+    # =========================================================================
+    # Internal helpers
+    # =========================================================================
+
+    async def _call_llm(
+        self,
+        messages: list[dict[str, str]],
+        agent_slug: str,
+    ) -> tuple[str, str]:
+        """Resolve route via ModelRoutingService and call the LLM.
+
+        Returns ``(response_text, model_name)``.
+        """
+        routing_svc = ModelRoutingService(self.session)
+        route = await routing_svc.resolve_for_agent(agent_slug)
+
+        if route.provider_type == ModelProvider.ANTHROPIC:
+            return await self._call_anthropic(messages, route)
+        # All other providers (OLLAMA_CLOUD, OPENAI, LOCAL) use the
+        # OpenAI-compatible chat completions endpoint.
+        return await self._call_openai_compat(messages, route)
+
+    async def _call_anthropic(
+        self,
+        messages: list[dict[str, str]],
+        route: Any,
+    ) -> tuple[str, str]:
+        """Call Anthropic API and return (text, model_name)."""
+        from anthropic import AsyncAnthropic
+
+        from roboco.config import settings
+
+        api_key = route.auth_token or settings.anthropic_api_key
+        client = AsyncAnthropic(api_key=api_key)
+        response = await client.messages.create(
+            model=route.model_name,
+            max_tokens=4096,
+            messages=messages,  # type: ignore[arg-type]
+        )
+        text = ""
+        for block in response.content:
+            if hasattr(block, "text"):
+                text = block.text  # type: ignore[union-attr]
+                break
+        return text, route.model_name
+
+    async def _call_openai_compat(
+        self,
+        messages: list[dict[str, str]],
+        route: Any,
+    ) -> tuple[str, str]:
+        """Call an OpenAI-compatible endpoint (Ollama, etc.).
+
+        Uses ``route.base_url`` when set, otherwise falls back to
+        ``settings.local_llm_base_url``.
+        """
+        import httpx
+
+        from roboco.config import settings
+
+        base_url = route.base_url or settings.local_llm_base_url
+        headers: dict[str, str] = {}
+        if route.auth_token:
+            headers["Authorization"] = f"Bearer {route.auth_token}"
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(
+                f"{base_url}/chat/completions",
+                headers=headers,
+                json={
+                    "model": route.model_name,
+                    "messages": messages,
+                    "max_tokens": 4096,
+                },
+            )
+            resp.raise_for_status()
+            data: dict[str, Any] = resp.json()
+
+        text: str = data["choices"][0]["message"]["content"]
+        return text, route.model_name
+
+    @staticmethod
+    def _parse_task_draft(raw: str) -> dict[str, Any]:
+        """Extract a JSON object from the LLM's raw response.
+
+        Handles both bare JSON and JSON wrapped in markdown code fences.
+        Raises ``ServiceError`` when no valid JSON object can be extracted.
+        """
+        # Try stripping markdown code fences first
+        clean = raw.strip()
+        fence_match = re.search(r"```(?:json)?\s*([\s\S]+?)```", clean)
+        if fence_match:
+            clean = fence_match.group(1).strip()
+
+        try:
+            data = json.loads(clean)
+            if isinstance(data, dict):
+                return data
+            raise ServiceError(
+                "LLM task draft was JSON but not an object", details={"raw": raw}
+            )
+        except json.JSONDecodeError as json_err:
+            # Try extracting first JSON object from surrounding text
+            obj_match = re.search(r"\{[\s\S]+\}", clean)
+            if obj_match:
+                try:
+                    data = json.loads(obj_match.group(0))
+                    if isinstance(data, dict):
+                        return data
+                except json.JSONDecodeError:
+                    pass
+            raise ServiceError(
+                "Could not parse task draft from LLM response as JSON",
+                details={"raw": raw[:500]},
+            ) from json_err
+
+
+def get_prompter_service(session: AsyncSession) -> PrompterService:
+    """Factory function for PrompterService."""
+    return PrompterService(session)


### PR DESCRIPTION
Implement the full Prompter feature from scratch across four interdependent layers:

**1. DB layer** — Add `PrompterConversation` and `PrompterMessage` SQLAlchemy ORM tables to `db/tables.py` and generate an Alembic migration. PrompterConversation: id (UUID PK), title (VARCHAR), agent_id (FK→agents, nullable), created_at, updated_at. PrompterMessage: id (UUID PK), conversation_id (FK→prompter_conversations, CASCADE delete), role (VARCHAR: 'user'/'assistant'/'system'), content (TEXT), model_used (VARCHAR, nullable), created_at.

**2. Service layer** — Create `services/prompter.py` with a `PrompterService` class. It must: resolve the LLM provider+model via `ModelRoutingService` (inspect `services/llm.py` — use the existing precedence chain: agent > role > global; NEVER hardcode model names like 'gpt-4' or 'glm-5:cloud'). Load the full conversation message history for multi-turn context. Generate structured task drafts by including a system prompt that instructs the LLM to output a JSON block with fields: title (str), description (str, ≥20 chars), acceptance_criteria (list[str]), team (str), task_type (str), nature (str), estimated_complexity (str).

**3. API layer** — Create `api/routes/prompter.py` with a FastAPI router registered under `/api/prompter` in `api/app.py` (tags=['Prompter']). Expose: POST /prompter/chat (accepts conversation_id and user message, persists user+assistant messages, returns assistant response + model used), GET /prompter/conversations (list all), GET /prompter/conversations/{id} (get one with messages), DELETE /prompter/conversations/{id} (delete with cascade), DELETE /prompter/conversations/{id}/messages/{msg_id}.

**4. Task-creation integration** — Add POST /prompter/conversations/{id}/create-task that: (a) generates or uses an existing task draft from the conversation, (b) validates the draft fields against the TaskCreate schema, (c) calls the task-creation logic (see existing `api/routes/tasks.py` POST handler or the underlying service) to persist a real Task record, (d) returns the created task id and status. Parse the LLM JSON response with json.loads() inside try/except — return HTTP 422 with a helpful error if the JSON is malformed or fields are missing.

**Patterns to follow:** routers in `api/routes/`, Pydantic request/response schemas in `api/schemas/`, services subclassing `BaseService` from `services/base.py`, agent context via `get_agent_context()` in `api/deps.py`. Register the new router in `api/app.py` alongside existing routers. Run `uv run ruff format .`, `uv run ruff check .`, `uv run mypy src/`, `uv run pytest` before submitting.