### PR TITLE
[65cb1dfd] Persistence layer: PromptSession + PromptTurn tables, migration, and PromptService CRUD

### DIFF
--- a/alembic/versions/023_prompt_session_tables.py
+++ b/alembic/versions/023_prompt_session_tables.py
@@ -1,0 +1,172 @@
+"""Add prompt_sessions and prompt_turns tables.
+
+Revision ID: 023_prompt_session_tables
+Revises: 022_default_branch_master
+Create Date: 2026-06-04
+
+Adds:
+- ``promptsessionstatus`` Postgres enum: draft | launched | abandoned
+- ``prompt_sessions``: container for a series of LLM prompt turns, with a
+  status lifecycle (draft → launched | abandoned).
+- ``prompt_turns``: individual turn (message exchange) within a session,
+  FK→prompt_sessions with CASCADE delete.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import context, op
+from sqlalchemy import inspect
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "023_prompt_session_tables"
+down_revision = "022_default_branch_master"
+branch_labels = None
+depends_on = None
+
+_PROMPT_SESSION_STATUS_ENUM = "promptsessionstatus"
+
+
+def _table_exists(name: str) -> bool:
+    """True if ``name`` already exists in the current DB schema.
+
+    Guards against re-running on DBs bootstrapped via Base.metadata.create_all.
+    Returns False in offline (--sql) mode so SQL stubs are always emitted.
+    """
+    if context.is_offline_mode():
+        return False
+    bind = op.get_bind()
+    return inspect(bind).has_table(name)
+
+
+def _enum_exists(name: str) -> bool:
+    """True if a Postgres enum type with ``name`` already exists."""
+    if context.is_offline_mode():
+        return False
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            "SELECT 1 FROM pg_type WHERE typname = :name AND typtype = 'e'"
+        ),
+        {"name": name},
+    )
+    return result.scalar() is not None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Create the promptsessionstatus enum type (idempotent guard).
+    # ------------------------------------------------------------------
+    if not _enum_exists(_PROMPT_SESSION_STATUS_ENUM):
+        op.execute(
+            "CREATE TYPE promptsessionstatus AS ENUM "
+            "('draft', 'launched', 'abandoned')"
+        )
+
+    # ------------------------------------------------------------------
+    # 2. prompt_sessions table.
+    # ------------------------------------------------------------------
+    if not _table_exists("prompt_sessions"):
+        op.create_table(
+            "prompt_sessions",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+            ),
+            sa.Column(
+                "created_by",
+                postgresql.UUID(as_uuid=True),
+                nullable=True,
+            ),
+            sa.Column(
+                "status",
+                sa.Enum(
+                    "draft",
+                    "launched",
+                    "abandoned",
+                    name=_PROMPT_SESSION_STATUS_ENUM,
+                    create_type=False,
+                ),
+                nullable=False,
+                server_default="draft",
+            ),
+            sa.Column("system_prompt", sa.Text, nullable=True),
+            sa.Column("model", sa.String(100), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+        op.create_index(
+            "ix_prompt_sessions_created_by", "prompt_sessions", ["created_by"]
+        )
+        op.create_index(
+            "ix_prompt_sessions_status", "prompt_sessions", ["status"]
+        )
+        op.create_index(
+            "ix_prompt_sessions_created_at", "prompt_sessions", ["created_at"]
+        )
+
+    # ------------------------------------------------------------------
+    # 3. prompt_turns table.
+    # ------------------------------------------------------------------
+    if not _table_exists("prompt_turns"):
+        op.create_table(
+            "prompt_turns",
+            sa.Column(
+                "id",
+                postgresql.UUID(as_uuid=True),
+                primary_key=True,
+            ),
+            sa.Column(
+                "session_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("prompt_sessions.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("role", sa.String(20), nullable=False),
+            sa.Column("content", sa.Text, nullable=False),
+            sa.Column(
+                "turn_index",
+                sa.Integer,
+                nullable=False,
+                server_default="0",
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+        op.create_index(
+            "ix_prompt_turns_session_id", "prompt_turns", ["session_id"]
+        )
+        op.create_index(
+            "ix_prompt_turns_session_index",
+            "prompt_turns",
+            ["session_id", "turn_index"],
+        )
+
+
+def downgrade() -> None:
+    # Drop in reverse dependency order.
+    op.drop_index("ix_prompt_turns_session_index", table_name="prompt_turns")
+    op.drop_index("ix_prompt_turns_session_id", table_name="prompt_turns")
+    op.drop_table("prompt_turns")
+
+    op.drop_index("ix_prompt_sessions_created_at", table_name="prompt_sessions")
+    op.drop_index("ix_prompt_sessions_status", table_name="prompt_sessions")
+    op.drop_index("ix_prompt_sessions_created_by", table_name="prompt_sessions")
+    op.drop_table("prompt_sessions")
+
+    op.execute("DROP TYPE IF EXISTS promptsessionstatus")

--- a/roboco/db/tables.py
+++ b/roboco/db/tables.py
@@ -41,6 +41,7 @@ from roboco.models.base import (
     ModelProvider,
     NotificationPriority,
     NotificationType,
+    PromptSessionStatus,
     SessionStatus,
     TaskNature,
     TaskStatus,
@@ -1806,4 +1807,85 @@ class GatewayTriggerTable(Base):
         Index("ix_gateway_triggers_task_id", "task_id"),
         Index("ix_gateway_triggers_created_at", "created_at"),
         Index("ix_gateway_triggers_kind_decision", "trigger_kind", "decision"),
+    )
+
+
+# =============================================================================
+# PROMPT SESSION TABLES
+# =============================================================================
+
+
+class PromptSessionTable(Base):
+    """Persisted LLM prompt session — container for a series of prompt turns."""
+
+    __tablename__ = "prompt_sessions"
+
+    id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    created_by: Mapped[PyUUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
+    status: Mapped[str] = mapped_column(
+        _str_enum(PromptSessionStatus),
+        nullable=False,
+        default=PromptSessionStatus.DRAFT,
+    )
+    system_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=True,
+    )
+
+    turns: Mapped[list["PromptTurnTable"]] = relationship(
+        "PromptTurnTable",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="PromptTurnTable.turn_index",
+    )
+
+    __table_args__ = (
+        Index("ix_prompt_sessions_created_by", "created_by"),
+        Index("ix_prompt_sessions_status", "status"),
+        Index("ix_prompt_sessions_created_at", "created_at"),
+    )
+
+
+class PromptTurnTable(Base):
+    """A single turn (message exchange) within a PromptSession."""
+
+    __tablename__ = "prompt_turns"
+
+    id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    session_id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("prompt_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    role: Mapped[str] = mapped_column(String(20), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    turn_index: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    session: Mapped["PromptSessionTable"] = relationship(
+        "PromptSessionTable",
+        back_populates="turns",
+    )
+
+    __table_args__ = (
+        Index("ix_prompt_turns_session_id", "session_id"),
+        Index("ix_prompt_turns_session_index", "session_id", "turn_index"),
     )

--- a/roboco/models/base.py
+++ b/roboco/models/base.py
@@ -185,6 +185,14 @@ class HandoffStatus(StrEnum):
     COMPLETED = "completed"
 
 
+class PromptSessionStatus(StrEnum):
+    """Lifecycle states for a PromptSession."""
+
+    DRAFT = "draft"
+    LAUNCHED = "launched"
+    ABANDONED = "abandoned"
+
+
 class ModelProvider(StrEnum):
     """LLM provider options.
 

--- a/roboco/services/prompter.py
+++ b/roboco/services/prompter.py
@@ -1,0 +1,265 @@
+"""
+PromptService — CRUD for PromptSession and PromptTurn.
+
+Manages the lifecycle of LLM prompt sessions and their turn histories.
+Each session holds metadata (status, optional system prompt, optional model)
+and an ordered list of turns (role + content pairs).
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+from uuid import UUID
+
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from roboco.db.base import get_db
+from roboco.db.tables import PromptSessionTable, PromptTurnTable
+from roboco.models.base import PromptSessionStatus
+from roboco.services.base import BaseService, NotFoundError
+
+
+class PromptService(BaseService):
+    """Service for managing PromptSession and PromptTurn records."""
+
+    service_name: ClassVar[str] = "prompt"
+
+    # =========================================================================
+    # SESSION CRUD
+    # =========================================================================
+
+    async def create_session(
+        self,
+        *,
+        created_by: UUID | None = None,
+        system_prompt: str | None = None,
+        model: str | None = None,
+    ) -> PromptSessionTable:
+        """Create a new prompt session in DRAFT status.
+
+        Args:
+            created_by: Optional UUID of the agent/user creating the session.
+            system_prompt: Optional system-level prompt to initialise the session.
+            model: Optional model identifier (e.g. ``"claude-opus-4"``) to use.
+
+        Returns:
+            The newly created :class:`PromptSessionTable` row.
+        """
+        session_row = PromptSessionTable(
+            created_by=created_by,
+            status=PromptSessionStatus.DRAFT,
+            system_prompt=system_prompt,
+            model=model,
+        )
+        self.session.add(session_row)
+        await self.session.commit()
+        await self.session.refresh(session_row)
+
+        self.log.info(
+            "Created prompt session",
+            session_id=str(session_row.id),
+            created_by=str(created_by) if created_by else None,
+        )
+        return session_row
+
+    async def get_session(self, session_id: UUID) -> PromptSessionTable:
+        """Fetch a prompt session by primary key.
+
+        Args:
+            session_id: UUID of the session to retrieve.
+
+        Returns:
+            The :class:`PromptSessionTable` row.
+
+        Raises:
+            :class:`~roboco.services.base.NotFoundError`: If no session with
+                ``session_id`` exists.
+        """
+        result = await self.session.execute(
+            select(PromptSessionTable).where(PromptSessionTable.id == session_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise NotFoundError("PromptSession", str(session_id))
+        return row
+
+    async def list_sessions(
+        self,
+        *,
+        created_by: UUID | None = None,
+        status: PromptSessionStatus | str | None = None,
+    ) -> list[PromptSessionTable]:
+        """List prompt sessions, optionally filtered.
+
+        Args:
+            created_by: Only return sessions whose ``created_by`` matches.
+            status: Only return sessions in this status (accepts enum or
+                lowercase string value).
+
+        Returns:
+            Ordered list of matching :class:`PromptSessionTable` rows
+            (newest first by ``created_at``).
+        """
+        query = select(PromptSessionTable)
+
+        if created_by is not None:
+            query = query.where(PromptSessionTable.created_by == created_by)
+
+        if status is not None:
+            # Accept both PromptSessionStatus enum and raw string values.
+            status_val = (
+                status.value if isinstance(status, PromptSessionStatus) else status
+            )
+            query = query.where(PromptSessionTable.status == status_val)
+
+        query = query.order_by(PromptSessionTable.created_at.desc())
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def update_session_status(
+        self,
+        session_id: UUID,
+        status: PromptSessionStatus | str,
+    ) -> PromptSessionTable:
+        """Transition a session to a new status.
+
+        Args:
+            session_id: UUID of the session to update.
+            status: Target status (``PromptSessionStatus`` enum or lowercase
+                string value such as ``"launched"``).
+
+        Returns:
+            The updated :class:`PromptSessionTable` row.
+
+        Raises:
+            :class:`~roboco.services.base.NotFoundError`: If no session with
+                ``session_id`` exists.
+        """
+        row = await self.get_session(session_id)
+        new_status = (
+            status if isinstance(status, PromptSessionStatus)
+            else PromptSessionStatus(status)
+        )
+        row.status = new_status.value
+        await self.session.commit()
+        await self.session.refresh(row)
+
+        self.log.info(
+            "Updated prompt session status",
+            session_id=str(session_id),
+            new_status=new_status.value,
+        )
+        return row
+
+    async def delete_session(self, session_id: UUID) -> bool:
+        """Delete a prompt session and all its turns (via cascade).
+
+        Args:
+            session_id: UUID of the session to delete.
+
+        Returns:
+            ``True`` if the session existed and was deleted, ``False`` if it
+            was not found.
+        """
+        result = await self.session.execute(
+            select(PromptSessionTable).where(PromptSessionTable.id == session_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return False
+
+        await self.session.delete(row)
+        await self.session.commit()
+
+        self.log.info("Deleted prompt session", session_id=str(session_id))
+        return True
+
+    # =========================================================================
+    # TURN CRUD
+    # =========================================================================
+
+    async def create_turn(
+        self,
+        session_id: UUID,
+        role: str,
+        content: str,
+        *,
+        turn_index: int = 0,
+    ) -> PromptTurnTable:
+        """Append a new turn to a prompt session.
+
+        Args:
+            session_id: UUID of the parent session.
+            role: Speaker role, e.g. ``"user"``, ``"assistant"``, ``"system"``.
+            content: Text content of the turn.
+            turn_index: Ordering index within the session (default 0; callers
+                are responsible for passing monotonically increasing values).
+
+        Returns:
+            The newly created :class:`PromptTurnTable` row.
+
+        Raises:
+            :class:`~roboco.services.base.NotFoundError`: If no session with
+                ``session_id`` exists (FK guard).
+        """
+        # Validate parent exists before inserting to give a useful error.
+        await self.get_session(session_id)
+
+        turn_row = PromptTurnTable(
+            session_id=session_id,
+            role=role,
+            content=content,
+            turn_index=turn_index,
+        )
+        self.session.add(turn_row)
+        await self.session.commit()
+        await self.session.refresh(turn_row)
+
+        self.log.info(
+            "Created prompt turn",
+            turn_id=str(turn_row.id),
+            session_id=str(session_id),
+            role=role,
+        )
+        return turn_row
+
+    async def list_turns(self, session_id: UUID) -> list[PromptTurnTable]:
+        """Return all turns for a session, ordered by ``turn_index`` ascending.
+
+        Args:
+            session_id: UUID of the parent session.
+
+        Returns:
+            Ordered list of :class:`PromptTurnTable` rows.
+        """
+        result = await self.session.execute(
+            select(PromptTurnTable)
+            .where(PromptTurnTable.session_id == session_id)
+            .order_by(PromptTurnTable.turn_index)
+        )
+        return list(result.scalars().all())
+
+
+# =============================================================================
+# FASTAPI DEPENDENCY
+# =============================================================================
+
+
+def get_prompt_service(
+    session: AsyncSession = Depends(get_db),
+) -> PromptService:
+    """FastAPI dependency that returns a :class:`PromptService` wired to the
+    current request's async DB session.
+
+    Usage::
+
+        @router.get("/sessions/{session_id}")
+        async def get_session(
+            session_id: UUID,
+            svc: PromptService = Depends(get_prompt_service),
+        ) -> ...:
+            return await svc.get_session(session_id)
+    """
+    return PromptService(session)

--- a/tests/integration/test_prompt_service.py
+++ b/tests/integration/test_prompt_service.py
@@ -1,0 +1,313 @@
+"""Integration tests for PromptService (PromptSession + PromptTurn CRUD).
+
+All tests require a live Postgres instance.  They are skipped automatically
+when Postgres is unreachable (see top-level conftest.py).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from roboco.models.base import PromptSessionStatus
+from roboco.services.base import NotFoundError
+from roboco.services.prompter import PromptService
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def prompt_setup(
+    db_session: AsyncSession,
+) -> AsyncIterator[dict]:
+    """Yield a seeded dict with a ``PromptService`` backed by ``db_session``."""
+    svc = PromptService(db_session)
+    yield {"svc": svc}
+
+
+# ---------------------------------------------------------------------------
+# Session happy-path tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_session_happy_path(prompt_setup: dict) -> None:
+    """create_session returns a row with DRAFT status and the expected fields."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session(system_prompt="You are helpful.", model="gpt-4o")
+
+    assert session.id is not None
+    assert session.status == PromptSessionStatus.DRAFT
+    assert session.system_prompt == "You are helpful."
+    assert session.model == "gpt-4o"
+    assert session.created_by is None
+
+
+@pytest.mark.asyncio
+async def test_create_session_with_created_by(prompt_setup: dict) -> None:
+    """create_session stores created_by when provided."""
+    svc: PromptService = prompt_setup["svc"]
+    owner = uuid4()
+
+    session = await svc.create_session(created_by=owner)
+
+    assert str(session.created_by) == str(owner)
+
+
+@pytest.mark.asyncio
+async def test_get_session_happy_path(prompt_setup: dict) -> None:
+    """get_session returns the same row that was created."""
+    svc: PromptService = prompt_setup["svc"]
+
+    created = await svc.create_session()
+    fetched = await svc.get_session(created.id)
+
+    assert str(fetched.id) == str(created.id)
+    assert fetched.status == PromptSessionStatus.DRAFT
+
+
+@pytest.mark.asyncio
+async def test_get_session_raises_not_found_for_unknown_id(
+    prompt_setup: dict,
+) -> None:
+    """get_session raises NotFoundError for an unknown UUID."""
+    svc: PromptService = prompt_setup["svc"]
+
+    with pytest.raises(NotFoundError) as exc_info:
+        await svc.get_session(uuid4())
+
+    assert exc_info.value.resource_type == "PromptSession"
+
+
+# ---------------------------------------------------------------------------
+# list_sessions filter tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_returns_all_when_unfiltered(
+    prompt_setup: dict,
+) -> None:
+    """list_sessions with no filters returns all sessions created in this test."""
+    svc: PromptService = prompt_setup["svc"]
+
+    a = await svc.create_session()
+    b = await svc.create_session()
+
+    sessions = await svc.list_sessions()
+    session_ids = {str(s.id) for s in sessions}
+
+    assert str(a.id) in session_ids
+    assert str(b.id) in session_ids
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_filter_by_status_draft(prompt_setup: dict) -> None:
+    """list_sessions(status=DRAFT) returns only draft sessions."""
+    svc: PromptService = prompt_setup["svc"]
+
+    draft = await svc.create_session()
+    launched = await svc.create_session()
+    await svc.update_session_status(launched.id, PromptSessionStatus.LAUNCHED)
+
+    drafts = await svc.list_sessions(status=PromptSessionStatus.DRAFT)
+    draft_ids = {str(s.id) for s in drafts}
+
+    assert str(draft.id) in draft_ids
+    assert str(launched.id) not in draft_ids
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_filter_by_status_launched(prompt_setup: dict) -> None:
+    """list_sessions(status=LAUNCHED) returns only launched sessions."""
+    svc: PromptService = prompt_setup["svc"]
+
+    draft = await svc.create_session()
+    launched = await svc.create_session()
+    await svc.update_session_status(launched.id, PromptSessionStatus.LAUNCHED)
+
+    launched_list = await svc.list_sessions(status=PromptSessionStatus.LAUNCHED)
+    launched_ids = {str(s.id) for s in launched_list}
+
+    assert str(launched.id) in launched_ids
+    assert str(draft.id) not in launched_ids
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_filter_by_created_by(prompt_setup: dict) -> None:
+    """list_sessions(created_by=...) returns only sessions belonging to that owner."""
+    svc: PromptService = prompt_setup["svc"]
+    owner = uuid4()
+    other = uuid4()
+
+    mine = await svc.create_session(created_by=owner)
+    await svc.create_session(created_by=other)
+
+    mine_list = await svc.list_sessions(created_by=owner)
+    mine_ids = {str(s.id) for s in mine_list}
+
+    assert str(mine.id) in mine_ids
+    # The other owner's session should not appear.
+    for s in mine_list:
+        assert str(s.created_by) == str(owner)
+
+
+# ---------------------------------------------------------------------------
+# update_session_status transition tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_session_status_draft_to_launched(prompt_setup: dict) -> None:
+    """Status can transition from DRAFT to LAUNCHED."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    assert session.status == PromptSessionStatus.DRAFT
+
+    updated = await svc.update_session_status(session.id, PromptSessionStatus.LAUNCHED)
+    assert updated.status == PromptSessionStatus.LAUNCHED
+
+
+@pytest.mark.asyncio
+async def test_update_session_status_draft_to_abandoned(prompt_setup: dict) -> None:
+    """Status can transition from DRAFT to ABANDONED."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    updated = await svc.update_session_status(
+        session.id, PromptSessionStatus.ABANDONED
+    )
+    assert updated.status == PromptSessionStatus.ABANDONED
+
+
+@pytest.mark.asyncio
+async def test_update_session_status_accepts_string_value(
+    prompt_setup: dict,
+) -> None:
+    """update_session_status accepts a plain lowercase string as the status arg."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    updated = await svc.update_session_status(session.id, "launched")
+    assert updated.status == PromptSessionStatus.LAUNCHED
+
+
+# ---------------------------------------------------------------------------
+# delete_session tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_session_removes_record(prompt_setup: dict) -> None:
+    """delete_session returns True and the session is gone afterwards."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    result = await svc.delete_session(session.id)
+
+    assert result is True
+
+    with pytest.raises(NotFoundError):
+        await svc.get_session(session.id)
+
+
+@pytest.mark.asyncio
+async def test_delete_session_returns_false_for_unknown_id(
+    prompt_setup: dict,
+) -> None:
+    """delete_session returns False (not an error) for an unknown UUID."""
+    svc: PromptService = prompt_setup["svc"]
+
+    result = await svc.delete_session(uuid4())
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Turn happy-path tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_turn_happy_path(prompt_setup: dict) -> None:
+    """create_turn returns a turn linked to the correct session."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    turn = await svc.create_turn(session.id, role="user", content="Hello, world!")
+
+    assert turn.id is not None
+    assert str(turn.session_id) == str(session.id)
+    assert turn.role == "user"
+    assert turn.content == "Hello, world!"
+    assert turn.turn_index == 0
+
+
+@pytest.mark.asyncio
+async def test_create_turn_raises_not_found_for_unknown_session(
+    prompt_setup: dict,
+) -> None:
+    """create_turn raises NotFoundError when the parent session does not exist."""
+    svc: PromptService = prompt_setup["svc"]
+
+    with pytest.raises(NotFoundError) as exc_info:
+        await svc.create_turn(uuid4(), role="user", content="orphaned turn")
+
+    assert exc_info.value.resource_type == "PromptSession"
+
+
+@pytest.mark.asyncio
+async def test_list_turns_happy_path(prompt_setup: dict) -> None:
+    """list_turns returns all turns ordered by turn_index ascending."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    t0 = await svc.create_turn(session.id, role="user", content="q1", turn_index=0)
+    t1 = await svc.create_turn(session.id, role="assistant", content="a1", turn_index=1)
+    t2 = await svc.create_turn(session.id, role="user", content="q2", turn_index=2)
+
+    turns = await svc.list_turns(session.id)
+
+    assert len(turns) == 3
+    assert str(turns[0].id) == str(t0.id)
+    assert str(turns[1].id) == str(t1.id)
+    assert str(turns[2].id) == str(t2.id)
+
+
+@pytest.mark.asyncio
+async def test_list_turns_returns_empty_for_new_session(
+    prompt_setup: dict,
+) -> None:
+    """list_turns returns an empty list for a session with no turns."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    turns = await svc.list_turns(session.id)
+
+    assert turns == []
+
+
+@pytest.mark.asyncio
+async def test_delete_session_cascades_to_turns(prompt_setup: dict) -> None:
+    """Deleting a session removes all its turns via cascade."""
+    svc: PromptService = prompt_setup["svc"]
+
+    session = await svc.create_session()
+    await svc.create_turn(session.id, role="user", content="before delete")
+
+    await svc.delete_session(session.id)
+
+    # Session gone — turns should be gone too (cascade).
+    turns = await svc.list_turns(session.id)
+    assert turns == []


### PR DESCRIPTION
Implement the persistence foundation for the Prompter feature. This subtask covers:

1. **DB Tables** — add `PromptSessionTable` and `PromptTurnTable` to `roboco/db/tables.py` (or a dedicated `roboco/db/prompter_tables.py` imported from there) using SQLAlchemy 2.x `Mapped[T]` / `mapped_column(...)` declarative style consistent with existing tables:
   - `PromptSessionTable`: `id` (UUID PK, server_default uuid_generate_v4()), `title` (String, nullable), `status` (String enum: draft/launched/abandoned, default='draft'), `project_id` (UUID FK to projects, nullable), `created_by` (String FK to agents, nullable), `created_at` (DateTime, server_default now()), `updated_at` (DateTime, onupdate now())
   - `PromptTurnTable`: `id` (UUID PK), `session_id` (UUID FK → PromptSessionTable.id ON DELETE CASCADE), `role` (String enum: user/assistant), `content` (Text, NOT NULL), `turn_index` (Integer, NOT NULL), `created_at` (DateTime, server_default now())
   - Add `turns` relationship on `PromptSessionTable` (lazy='select', ordered by turn_index)

2. **Alembic migration** — create a new migration file numbered after 022 (check existing max). Migration must be fully reversible (both `upgrade()` and `downgrade()` implemented).

3. **PromptService** — create `roboco/services/prompter.py` with `class PromptService(BaseService)`:
   - `async def create_session(self, title: str | None, project_id: UUID | None, created_by: str | None) -> PromptSessionTable`
   - `async def get_session(self, session_id: UUID) -> PromptSessionTable` (raises `NotFoundError` if missing)
   - `async def list_sessions(self, created_by: str | None = None, status: str | None = None, limit: int = 50, offset: int = 0) -> list[PromptSessionTable]`
   - `async def update_session_status(self, session_id: UUID, status: str) -> PromptSessionTable`
   - `async def create_turn(self, session_id: UUID, role: str, content: str, turn_index: int) -> PromptTurnTable`
   - `async def list_turns(self, session_id: UUID) -> list[PromptTurnTable]`
   - `async def delete_session(self, session_id: UUID) -> None`
   - FastAPI dependency: `def get_prompt_service(session: AsyncSession = Depends(get_db)) -> PromptService`

4. **Tests** — unit/integration tests in `tests/` covering: create session, get session (found + not-found), list sessions with filters, update status, create turn, list turns, delete session.

Patterns to follow:
- Look at `roboco/services/task.py` and `roboco/services/llm.py` for `BaseService` usage patterns
- Look at existing table definitions in `roboco/db/tables.py` for column/relationship style
- Look at `alembic/versions/` for migration numbering and format