### PR TITLE
[24d77b0b] Prompter API routes: streaming chat, models catalog, HTTP CRUD, and Create+Launch action

### DIFF
--- a/roboco/api/app.py
+++ b/roboco/api/app.py
@@ -29,6 +29,7 @@ from roboco.api.routes.optimal import router as optimal_router
 from roboco.api.routes.orchestrator import router as orchestrator_router
 from roboco.api.routes.product import router as product_router
 from roboco.api.routes.project import router as project_router
+from roboco.api.routes.prompter import router as prompter_router
 from roboco.api.routes.provider import router as provider_router
 from roboco.api.routes.sessions import router as sessions_router
 from roboco.api.routes.stream import router as stream_router
@@ -238,6 +239,12 @@ def create_app() -> FastAPI:
         kanban_router,
         prefix=f"{api_prefix}/kanban",
         tags=["Kanban"],
+    )
+
+    app.include_router(
+        prompter_router,
+        prefix=f"{api_prefix}/prompter",
+        tags=["Prompter"],
     )
 
     app.include_router(

--- a/roboco/api/routes/prompter.py
+++ b/roboco/api/routes/prompter.py
@@ -1,0 +1,583 @@
+"""
+Prompter API Routes
+
+LLM-powered task-creation assistant: streaming chat, model catalog,
+session CRUD, and the Create+Launch action.
+
+Endpoints
+---------
+GET  /api/prompter/models
+    Human-readable model catalog.  No raw provider model IDs exposed.
+
+POST /api/prompter/sessions
+    Create a new prompt session (DRAFT).
+
+GET  /api/prompter/sessions
+    List sessions, optionally filtered by created_by / status.
+
+GET  /api/prompter/sessions/{session_id}
+    Fetch a single session including its full conversation history.
+
+PATCH /api/prompter/sessions/{session_id}/status
+    Transition the session to a new status.
+
+POST /api/prompter/chat
+    Send a message and receive an SSE stream of LLM response tokens.
+    The system prompt instructs the LLM to produce structured output
+    matching the TaskCreate schema.
+
+POST /api/prompter/sessions/{session_id}/launch
+    Validate the latest assistant turn against TaskCreate constraints,
+    create the task, and set the session to LAUNCHED.
+"""
+
+import json
+import re
+from collections.abc import AsyncGenerator
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+
+from roboco.api.deps import CurrentAgentContext, DbSession
+from roboco.api.schemas.prompter import (
+    ChatRequest,
+    LaunchRequest,
+    LaunchResponse,
+    ModelInfo,
+    PromptSessionCreate,
+    PromptSessionResponse,
+    PromptSessionStatusUpdate,
+    session_to_response,
+)
+from roboco.models.base import (
+    Complexity,
+    PromptSessionStatus,
+    TaskNature,
+    TaskType,
+    Team,
+)
+from roboco.models.llm_catalog import MODEL_CATALOG
+from roboco.models.runtime import MODEL_MAP
+from roboco.models.task import TaskCreateRequest
+from roboco.services.base import NotFoundError, ValidationError
+from roboco.services.prompter import get_prompt_service
+from roboco.services.task import get_task_service
+
+router = APIRouter()
+
+# =============================================================================
+# SYSTEM PROMPT
+# =============================================================================
+
+_TASK_CREATE_SYSTEM_PROMPT = """\
+You are a task creation assistant for RoboCo, an AI software development company.
+Your role is to help users define well-structured development tasks.
+
+When describing a task, engage conversationally to clarify requirements, then
+produce a structured JSON block at the end of your response.
+
+The JSON block MUST be wrapped in a ```json ... ``` code fence and contain
+exactly these fields (all required):
+
+{
+  "title": "<concise task title, 1-200 characters>",
+  "description": "<detailed description, minimum 20 characters>",
+  "acceptance_criteria": ["<criterion 1>", "<criterion 2>", ...],
+  "team": "<one of: backend | frontend | ux_ui>",
+  "task_type": "<code|documentation|research|planning|design|administrative>",
+  "nature": "<one of: technical | non_technical>",
+  "estimated_complexity": "<one of: low | medium | high>"
+}
+
+Guidelines:
+- acceptance_criteria must be a non-empty list of clear, measurable criteria.
+- Choose team based on the technology involved:
+    backend - Python/API/database work
+    frontend - JavaScript/TypeScript/UI work
+    ux_ui - design, wireframes, user research
+- Choose task_type accurately:
+    code - writing or modifying source code
+    documentation - writing or updating docs
+    research - investigation or spike work
+    planning - architecture or coordination
+    design - visual or system design
+    administrative - process, configuration, or non-technical work
+- estimated_complexity reflects effort:
+    low - hours, well-understood work
+    medium - 1-3 days, some unknowns
+    high - 3+ days, significant complexity or risk
+
+Always end your response with the JSON block, even for follow-up turns.
+Update the JSON as the conversation refines the requirements.
+"""
+
+# =============================================================================
+# MODELS CATALOG
+# =============================================================================
+
+# Human-friendly descriptions keyed by routing slug.  These never expose raw
+# provider model IDs such as "claude-opus-4-6" or "claude-sonnet-4-6".
+_MODEL_DESCRIPTIONS: dict[str, str] = {
+    "opus": (
+        "Most capable model. Best for complex, nuanced tasks requiring deep reasoning."
+    ),
+    "sonnet": (
+        "Balanced model. Excellent for most tasks with a good "
+        "speed/capability tradeoff."
+    ),
+    "haiku": (
+        "Fastest and most efficient model. Ideal for quick, straightforward tasks."
+    ),
+    "glm-5.1:cloud": (
+        "GLM 5.1 via Ollama Cloud. Top SWE-Bench score; strong iterative reasoning."
+    ),
+    "kimi-k2.6:cloud": (
+        "Kimi K2.6 via Ollama Cloud. Leading HLE score; built for agentic tool use."
+    ),
+    "minimax-m3:cloud": (
+        "MiniMax M3 via Ollama Cloud. Purpose-built for coding; fastest Ollama option."
+    ),
+}
+
+_RAW_ID_SUFFIX = re.compile(r"\s*[··]\s*\S+$")
+
+
+def _friendly_label(display_name: str) -> str:
+    """Strip the raw model-ID suffix from a catalog display name.
+
+    Removes the `` · <model-id>`` suffix that ``llm_catalog.py`` appends so
+    the response never exposes a raw provider identifier.
+    """
+    return _RAW_ID_SUFFIX.sub("", display_name).strip()
+
+
+# Build the prompter-specific model list once at import time.
+PROMPTER_MODELS: list[ModelInfo] = [
+    ModelInfo(
+        id=entry.model_name,
+        label=_friendly_label(entry.display_name),
+        description=_MODEL_DESCRIPTIONS.get(
+            entry.model_name,
+            f"{_friendly_label(entry.display_name)} model.",
+        ),
+    )
+    for entry in MODEL_CATALOG
+]
+
+# =============================================================================
+# LLM CALL HELPERS
+# =============================================================================
+
+
+def _resolve_anthropic_model(model_key: str | None) -> str:
+    """Map a prompter model routing key to the full Anthropic model ID.
+
+    Falls back to the ``"sonnet"`` slot when the key is absent or unknown.
+    """
+    key = model_key or "sonnet"
+    return MODEL_MAP.get(key, MODEL_MAP.get("sonnet", "claude-sonnet-4-6"))
+
+
+def _is_ollama_model(model_key: str | None) -> bool:
+    """Return True when the model key routes to an Ollama Cloud provider."""
+    return bool(model_key and model_key.endswith(":cloud"))
+
+
+# =============================================================================
+# MODEL CATALOG ENDPOINT
+# =============================================================================
+
+
+@router.get("/models", response_model=list[ModelInfo])
+async def list_models(
+    _agent: CurrentAgentContext,
+) -> list[ModelInfo]:
+    """Return the available LLM models for prompt sessions.
+
+    Human-readable labels and descriptions only — no raw provider model
+    IDs are included in the response.
+    """
+    return PROMPTER_MODELS
+
+
+# =============================================================================
+# SESSION CRUD ENDPOINTS
+# =============================================================================
+
+
+@router.post(
+    "/sessions",
+    response_model=PromptSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_session(
+    data: PromptSessionCreate,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> PromptSessionResponse:
+    """Create a new prompt session in DRAFT status."""
+    svc = get_prompt_service(db)
+    created_by = data.created_by or agent.agent_id
+    row = await svc.create_session(
+        created_by=created_by,
+        system_prompt=data.system_prompt,
+        model=data.model,
+    )
+    return session_to_response(row)
+
+
+@router.get("/sessions", response_model=list[PromptSessionResponse])
+async def list_sessions(
+    db: DbSession,
+    _agent: CurrentAgentContext,
+    created_by: Annotated[UUID | None, Query()] = None,
+    status_filter: Annotated[str | None, Query(alias="status")] = None,
+) -> list[PromptSessionResponse]:
+    """List prompt sessions with optional filters."""
+    svc = get_prompt_service(db)
+    rows = await svc.list_sessions(
+        created_by=created_by,
+        status=status_filter,
+    )
+    return [session_to_response(row) for row in rows]
+
+
+@router.get("/sessions/{session_id}", response_model=PromptSessionResponse)
+async def get_session(
+    session_id: UUID,
+    db: DbSession,
+    _agent: CurrentAgentContext,
+) -> PromptSessionResponse:
+    """Fetch a single session with its full conversation history."""
+    svc = get_prompt_service(db)
+    try:
+        row = await svc.get_session(session_id)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=exc.message,
+        ) from exc
+    turns = await svc.list_turns(session_id)
+    return session_to_response(row, turns=turns)
+
+
+@router.patch(
+    "/sessions/{session_id}/status",
+    response_model=PromptSessionResponse,
+)
+async def update_session_status(
+    session_id: UUID,
+    data: PromptSessionStatusUpdate,
+    db: DbSession,
+    _agent: CurrentAgentContext,
+) -> PromptSessionResponse:
+    """Transition a session to a new status."""
+    svc = get_prompt_service(db)
+    try:
+        row = await svc.update_session_status(session_id, data.status)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=exc.message,
+        ) from exc
+    turns = await svc.list_turns(session_id)
+    return session_to_response(row, turns=turns)
+
+
+# =============================================================================
+# CHAT STREAMING ENDPOINT
+# =============================================================================
+
+
+@router.post("/chat")
+async def chat(
+    request: Request,
+    body: ChatRequest,
+    db: DbSession,
+    _agent: CurrentAgentContext,
+) -> Any:
+    """Stream LLM response tokens for the given session and user message.
+
+    Saves the user turn to the session, calls the configured LLM with the
+    full conversation history, and streams each response token as a
+    Server-Sent Event.
+
+    SSE event types
+    ---------------
+    ``token``
+        One chunk of response text from the LLM.
+    ``done``
+        Emitted after the last token; the ``data`` field contains the full
+        concatenated assistant response.
+    ``error``
+        Emitted if the LLM call fails.
+    """
+    from sse_starlette import EventSourceResponse
+
+    svc = get_prompt_service(db)
+
+    # Validate session exists.
+    try:
+        session_row = await svc.get_session(body.session_id)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=exc.message,
+        ) from exc
+
+    # Compute next turn_index.
+    existing_turns = await svc.list_turns(body.session_id)
+    user_turn_index = len(existing_turns)
+
+    # Save user turn.
+    await svc.create_turn(
+        body.session_id,
+        role="user",
+        content=body.message,
+        turn_index=user_turn_index,
+    )
+
+    # Re-fetch all turns (including the new user turn) for LLM context.
+    all_turns = await svc.list_turns(body.session_id)
+
+    # Build the messages array for the LLM.
+    messages: list[dict[str, str]] = [
+        {"role": t.role, "content": t.content}
+        for t in all_turns
+        if t.role in ("user", "assistant")
+    ]
+
+    system_prompt = session_row.system_prompt or _TASK_CREATE_SYSTEM_PROMPT
+    model_key = session_row.model
+
+    async def generate_tokens() -> AsyncGenerator[dict[str, Any]]:
+        """Stream LLM tokens as SSE events, then persist the full response."""
+        full_response: list[str] = []
+
+        try:
+            if _is_ollama_model(model_key):
+                from openai import AsyncOpenAI
+
+                from roboco.config import settings
+
+                ollama_client = AsyncOpenAI(
+                    base_url=settings.local_llm_base_url,
+                    api_key="ollama",
+                )
+                system_msg: dict[str, str] = {
+                    "role": "system",
+                    "content": system_prompt,
+                }
+                all_messages = [system_msg, *messages]
+                stream = await ollama_client.chat.completions.create(
+                    model=model_key or "",
+                    messages=all_messages,
+                    stream=True,
+                )
+                async for chunk in stream:
+                    if await request.is_disconnected():
+                        break
+                    delta = chunk.choices[0].delta.content
+                    if delta:
+                        full_response.append(delta)
+                        yield {"event": "token", "data": delta}
+            else:
+                from anthropic import AsyncAnthropic
+
+                from roboco.config import settings
+
+                anthropic_client = AsyncAnthropic(api_key=settings.anthropic_api_key)
+                model_id = _resolve_anthropic_model(model_key)
+
+                async with anthropic_client.messages.stream(
+                    model=model_id,
+                    max_tokens=4096,
+                    system=system_prompt,
+                    messages=messages,
+                ) as stream:
+                    async for text in stream.text_stream:
+                        if await request.is_disconnected():
+                            break
+                        full_response.append(text)
+                        yield {"event": "token", "data": text}
+
+        except Exception as exc:
+            yield {"event": "error", "data": str(exc)}
+            return
+
+        full_text = "".join(full_response)
+        if full_text:
+            await svc.create_turn(
+                body.session_id,
+                role="assistant",
+                content=full_text,
+                turn_index=user_turn_index + 1,
+            )
+
+        yield {"event": "done", "data": full_text}
+
+    return EventSourceResponse(generate_tokens(), ping=15)
+
+
+# =============================================================================
+# LAUNCH ENDPOINT
+# =============================================================================
+
+_REQUIRED_LAUNCH_FIELDS: frozenset[str] = frozenset(
+    {
+        "title",
+        "description",
+        "acceptance_criteria",
+        "team",
+        "task_type",
+        "nature",
+        "estimated_complexity",
+    }
+)
+
+
+def _extract_json_from_content(content: str) -> dict[str, Any]:
+    """Parse the structured JSON block from an assistant turn's content.
+
+    Searches for the first ``json ... `` code fence.  Falls back to
+    bare-JSON parsing if no fence is found.
+
+    Raises:
+        ValueError: If no valid JSON object can be extracted.
+    """
+    fence_match = re.search(
+        r"```json\s*(\{.*?\})\s*```",
+        content,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if fence_match:
+        return dict(json.loads(fence_match.group(1)))
+
+    bare_match = re.search(r"\{[^{}]*\}", content, re.DOTALL)
+    if bare_match:
+        return dict(json.loads(bare_match.group()))
+
+    raise ValueError("No JSON object found in assistant turn content.")
+
+
+@router.post(
+    "/sessions/{session_id}/launch",
+    response_model=LaunchResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def launch_session(
+    session_id: UUID,
+    data: LaunchRequest,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> LaunchResponse:
+    """Validate the latest assistant turn and create a task from its content.
+
+    The latest assistant turn must contain a JSON block with all required
+    TaskCreate fields.  On success the session transitions to LAUNCHED and
+    the new task ID is returned.
+
+    Raises:
+        400: No assistant turns exist, JSON cannot be parsed, required
+            fields are missing or invalid, or both/neither
+            project_id/product_id are supplied.
+        404: Session not found.
+        422: Provided field values fail TaskCreate validation.
+    """
+    if (data.project_id is None) == (data.product_id is None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=("Exactly one of project_id or product_id must be provided."),
+        )
+
+    prompt_svc = get_prompt_service(db)
+
+    try:
+        await prompt_svc.get_session(session_id)
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=exc.message,
+        ) from exc
+
+    turns = await prompt_svc.list_turns(session_id)
+    assistant_turns = [t for t in turns if t.role == "assistant"]
+    if not assistant_turns:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "No assistant turns found in this session. "
+                "Send at least one message via POST /api/prompter/chat first."
+            ),
+        )
+    latest_turn = assistant_turns[-1]
+
+    try:
+        payload = _extract_json_from_content(latest_turn.content)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Could not extract valid JSON from the latest assistant turn: {exc}"
+            ),
+        ) from exc
+
+    missing_fields = _REQUIRED_LAUNCH_FIELDS - set(payload.keys())
+    if missing_fields:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "JSON payload is missing required TaskCreate fields: "
+                f"{sorted(missing_fields)}"
+            ),
+        )
+
+    try:
+        team = Team(payload["team"])
+        task_type = TaskType(payload["task_type"])
+        nature = TaskNature(payload["nature"])
+        complexity = Complexity(payload["estimated_complexity"])
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Invalid enum value in task payload: {exc}",
+        ) from exc
+
+    acceptance_criteria = payload["acceptance_criteria"]
+    if not isinstance(acceptance_criteria, list) or not acceptance_criteria:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="acceptance_criteria must be a non-empty list of strings.",
+        )
+
+    task_svc = get_task_service(db)
+    create_req = TaskCreateRequest(
+        title=str(payload["title"]),
+        description=str(payload["description"]),
+        acceptance_criteria=[str(c) for c in acceptance_criteria],
+        team=team,
+        created_by=agent.agent_id,
+        task_type=task_type,
+        nature=nature,
+        estimated_complexity=complexity,
+        project_id=data.project_id,
+        product_id=data.product_id,
+    )
+    try:
+        task_row = await task_svc.create(create_req)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.message,
+        ) from exc
+
+    updated_session = await prompt_svc.update_session_status(
+        session_id, PromptSessionStatus.LAUNCHED
+    )
+
+    return LaunchResponse(
+        task_id=UUID(str(task_row.id)),
+        session_id=UUID(str(updated_session.id)),
+        session_status=updated_session.status,
+    )

--- a/roboco/api/schemas/prompter.py
+++ b/roboco/api/schemas/prompter.py
@@ -1,0 +1,182 @@
+"""
+Prompter API Schemas
+
+Request/response models for the Prompter endpoints and conversion helpers
+that map ORM rows to Pydantic responses.
+"""
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from roboco.db.tables import PromptSessionTable, PromptTurnTable
+from roboco.models.base import PromptSessionStatus
+
+# =============================================================================
+# TURN SCHEMAS
+# =============================================================================
+
+
+class PromptTurnResponse(BaseModel):
+    """A single turn (user or assistant message) within a prompt session."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    session_id: UUID
+    role: str
+    content: str
+    turn_index: int
+    created_at: datetime
+
+
+# =============================================================================
+# SESSION SCHEMAS
+# =============================================================================
+
+
+class PromptSessionCreate(BaseModel):
+    """Request body for creating a new prompt session."""
+
+    system_prompt: str | None = Field(
+        default=None,
+        description=("Optional system-level prompt to initialise the conversation."),
+    )
+    model: str | None = Field(
+        default=None,
+        description=(
+            "Model identifier from GET /api/prompter/models. "
+            "Defaults to the server-side default when omitted."
+        ),
+    )
+    created_by: UUID | None = Field(
+        default=None,
+        description="UUID of the agent/user creating the session.",
+    )
+
+
+class PromptSessionResponse(BaseModel):
+    """Full representation of a prompt session, including its turns."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    created_by: UUID | None
+    status: str
+    system_prompt: str | None
+    model: str | None
+    created_at: datetime
+    turns: list[PromptTurnResponse] = Field(default_factory=list)
+
+
+class PromptSessionStatusUpdate(BaseModel):
+    """Request body for updating a session's status."""
+
+    status: PromptSessionStatus
+
+
+# =============================================================================
+# CHAT SCHEMAS
+# =============================================================================
+
+
+class ChatRequest(BaseModel):
+    """Request body for the SSE-streaming chat endpoint."""
+
+    session_id: UUID = Field(..., description="ID of the prompt session to continue.")
+    message: str = Field(..., min_length=1, description="The user's message.")
+
+
+# =============================================================================
+# MODELS CATALOG SCHEMAS
+# =============================================================================
+
+
+class ModelInfo(BaseModel):
+    """A selectable LLM model with a human-readable label.
+
+    The ``id`` is the routing key stored in ``PromptSession.model`` and
+    accepted by ``PromptSessionCreate.model``.  Raw provider model IDs (such
+    as ``claude-opus-4-6``) are never exposed here.
+    """
+
+    id: str = Field(..., description="Routing key used when creating a session.")
+    label: str = Field(..., description="Human-readable display name.")
+    description: str = Field(
+        ..., description="Brief description of this model's strengths."
+    )
+
+
+# =============================================================================
+# LAUNCH SCHEMAS
+# =============================================================================
+
+
+class LaunchRequest(BaseModel):
+    """Request body for the launch action.
+
+    The LLM-generated content in the latest assistant turn provides
+    ``title``, ``description``, ``acceptance_criteria``, ``team``,
+    ``task_type``, ``nature``, and ``estimated_complexity``.  The caller
+    must supply the repository context (``project_id`` **or**
+    ``product_id``) because the LLM cannot know which repo to target.
+
+    Exactly one of ``project_id`` / ``product_id`` must be set.
+    """
+
+    project_id: UUID | None = Field(
+        default=None,
+        description="Project the new task will be linked to.",
+    )
+    product_id: UUID | None = Field(
+        default=None,
+        description="Product (multi-cell) the new task will be linked to.",
+    )
+
+
+class LaunchResponse(BaseModel):
+    """Response returned after a successful launch."""
+
+    task_id: UUID
+    session_id: UUID
+    session_status: str
+
+
+# =============================================================================
+# CONVERTERS
+# =============================================================================
+
+
+def turn_to_response(row: PromptTurnTable) -> PromptTurnResponse:
+    """Convert a :class:`PromptTurnTable` ORM row to a response schema."""
+    return PromptTurnResponse(
+        id=UUID(str(row.id)),
+        session_id=UUID(str(row.session_id)),
+        role=row.role,
+        content=row.content,
+        turn_index=row.turn_index,
+        created_at=row.created_at,
+    )
+
+
+def session_to_response(
+    row: PromptSessionTable,
+    turns: list[PromptTurnTable] | None = None,
+) -> PromptSessionResponse:
+    """Convert a :class:`PromptSessionTable` ORM row to a response schema.
+
+    Args:
+        row: The ORM session row.
+        turns: Optional pre-fetched list of turns to embed in the response.
+            When ``None``, the ``turns`` field on the response will be empty.
+    """
+    return PromptSessionResponse(
+        id=UUID(str(row.id)),
+        created_by=UUID(str(row.created_by)) if row.created_by else None,
+        status=row.status,
+        system_prompt=row.system_prompt,
+        model=row.model,
+        created_at=row.created_at,
+        turns=[turn_to_response(t) for t in (turns or [])],
+    )

--- a/tests/integration/test_prompter_routes.py
+++ b/tests/integration/test_prompter_routes.py
@@ -1,0 +1,563 @@
+"""Integration tests for Prompter API routes.
+
+Covers: model catalog, session CRUD, SSE chat streaming,
+and the launch action (task creation + session status transition).
+
+All tests that touch the database require a live Postgres instance and are
+skipped automatically when Postgres is unreachable (see top-level conftest.py).
+"""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from roboco.api.deps import get_agent_context, get_db
+from roboco.api.routes.prompter import router as prompter_router
+from roboco.db.tables import AgentTable, ProjectTable
+from roboco.models import AgentRole, AgentStatus, Team
+from roboco.models.permissions import AgentContext
+from roboco.services.prompter import PromptService
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse_events(content: bytes) -> list[dict[str, str]]:
+    """Parse raw SSE bytes into a list of ``{event, data}`` dicts."""
+    events: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for raw_line in content.decode().splitlines():
+        line = raw_line.rstrip()
+        if line.startswith("event:"):
+            current["event"] = line[len("event:") :].strip()
+        elif line.startswith("data:"):
+            current["data"] = line[len("data:") :].strip()
+        elif line == "" and current:
+            events.append(current)
+            current = {}
+    if current:
+        events.append(current)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def prompt_client(
+    db_session: AsyncSession,
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield a dict with an httpx client and seeded DB objects."""
+    agent = AgentTable(
+        id=uuid4(),
+        name="PM",
+        slug=f"be-pm-{uuid4().hex[:8]}",
+        role=AgentRole.MAIN_PM,
+        team=None,
+        status=AgentStatus.ACTIVE,
+        model_config={},
+        system_prompt="pm",
+        capabilities=[],
+        permissions={},
+        metrics={},
+    )
+    db_session.add(agent)
+    await db_session.flush()
+
+    project = ProjectTable(
+        id=uuid4(),
+        name="P",
+        slug=f"p-{uuid4().hex[:6]}",
+        git_url="https://example.com/r.git",
+        assigned_cell=Team.BACKEND,
+        created_by=agent.id,
+    )
+    db_session.add(project)
+    await db_session.flush()
+
+    app = FastAPI()
+    app.include_router(prompter_router, prefix="/api/prompter")
+
+    async def _override_db() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    async def _override_agent() -> AgentContext:
+        return AgentContext(
+            agent_id=UUID(str(agent.id)),
+            role=AgentRole.MAIN_PM,
+            team=None,
+        )
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_agent_context] = _override_agent
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield {
+            "client": client,
+            "agent": agent,
+            "project": project,
+            "db": db_session,
+        }
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Minimal client for tests that don't touch the database (e.g. /models).
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def prompter_app_client() -> AsyncIterator[AsyncClient]:
+    """Yield an httpx client wired to the prompter router only.
+
+    This fixture does NOT require a live Postgres instance — it overrides
+    ``get_agent_context`` with a stub returning a synthetic AgentContext and
+    does not override ``get_db`` (the models endpoint never touches the DB).
+    """
+    stub_agent_id = uuid4()
+
+    app = FastAPI()
+    app.include_router(prompter_router, prefix="/api/prompter")
+
+    async def _override_agent() -> AgentContext:
+        return AgentContext(
+            agent_id=stub_agent_id,
+            role=AgentRole.MAIN_PM,
+            team=None,
+        )
+
+    app.dependency_overrides[get_agent_context] = _override_agent
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Model catalog (no DB required)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_models_returns_200_and_list(
+    prompter_app_client: AsyncClient,
+) -> None:
+    """GET /api/prompter/models returns a non-empty list with label+description."""
+    response = await prompter_app_client.get("/api/prompter/models")
+
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+    first = data[0]
+    assert "id" in first
+    assert "label" in first
+    assert "description" in first
+
+
+@pytest.mark.asyncio
+async def test_get_models_no_raw_provider_ids(
+    prompter_app_client: AsyncClient,
+) -> None:
+    """Labels must not contain raw Claude model IDs (e.g. 'claude-opus-4-6')."""
+    response = await prompter_app_client.get("/api/prompter/models")
+
+    data = response.json()
+    for model in data:
+        # Raw Claude model IDs follow the pattern "claude-*-N[-YYYMMDD]"
+        assert "claude-" not in model["label"], (
+            f"Raw model ID found in label: {model['label']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Session CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_201(prompt_client: dict) -> None:
+    """POST /api/prompter/sessions creates a DRAFT session."""
+    client = prompt_client["client"]
+    response = await client.post(
+        "/api/prompter/sessions",
+        json={"model": "sonnet"},
+    )
+    assert response.status_code == HTTPStatus.CREATED
+    data = response.json()
+    assert data["status"] == "draft"
+    assert data["model"] == "sonnet"
+    assert data["turns"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_returns_200(prompt_client: dict) -> None:
+    """GET /api/prompter/sessions returns sessions created in this test."""
+    client = prompt_client["client"]
+    await client.post("/api/prompter/sessions", json={})
+    await client.post("/api/prompter/sessions", json={})
+
+    response = await client.get("/api/prompter/sessions")
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert isinstance(data, list)
+    _MIN_SESSIONS = 2
+    assert len(data) >= _MIN_SESSIONS
+
+
+@pytest.mark.asyncio
+async def test_get_session_by_id(prompt_client: dict) -> None:
+    """GET /api/prompter/sessions/{id} returns the session with turns list."""
+    client = prompt_client["client"]
+    create_resp = await client.post(
+        "/api/prompter/sessions",
+        json={"system_prompt": "Be helpful."},
+    )
+    session_id = create_resp.json()["id"]
+
+    response = await client.get(f"/api/prompter/sessions/{session_id}")
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["id"] == session_id
+    assert data["system_prompt"] == "Be helpful."
+    assert data["turns"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_session_not_found(prompt_client: dict) -> None:
+    """GET /api/prompter/sessions/{unknown_id} returns 404."""
+    client = prompt_client["client"]
+    response = await client.get(f"/api/prompter/sessions/{uuid4()}")
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_patch_session_status(prompt_client: dict) -> None:
+    """PATCH /api/prompter/sessions/{id}/status transitions the status."""
+    client = prompt_client["client"]
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    patch_resp = await client.patch(
+        f"/api/prompter/sessions/{session_id}/status",
+        json={"status": "abandoned"},
+    )
+    assert patch_resp.status_code == HTTPStatus.OK
+    assert patch_resp.json()["status"] == "abandoned"
+
+
+@pytest.mark.asyncio
+async def test_patch_session_status_not_found(prompt_client: dict) -> None:
+    """PATCH on an unknown session returns 404."""
+    client = prompt_client["client"]
+    response = await client.patch(
+        f"/api/prompter/sessions/{uuid4()}/status",
+        json={"status": "abandoned"},
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Chat streaming
+# ---------------------------------------------------------------------------
+
+
+class _MockTextStream:
+    """Async iterator that yields a preset list of text tokens."""
+
+    def __init__(self, tokens: list[str]) -> None:
+        self._tokens = iter(tokens)
+
+    def __aiter__(self) -> _MockTextStream:
+        return self
+
+    async def __anext__(self) -> str:
+        try:
+            return next(self._tokens)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class _MockAnthropicStream:
+    """Async context manager that exposes a fake text_stream."""
+
+    def __init__(self, tokens: list[str]) -> None:
+        self.text_stream = _MockTextStream(tokens)
+
+    async def __aenter__(self) -> _MockAnthropicStream:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_chat_streaming_happy_path(prompt_client: dict) -> None:
+    """POST /api/prompter/chat streams tokens then a done event."""
+    client = prompt_client["client"]
+
+    # Create a session to chat on.
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    tokens = ["Hello", " world", "!"]
+    mock_stream = _MockAnthropicStream(tokens)
+
+    mock_anthropic_instance = MagicMock()
+    mock_anthropic_instance.messages.stream.return_value = mock_stream
+
+    with patch("anthropic.AsyncAnthropic", return_value=mock_anthropic_instance):
+        response = await client.post(
+            "/api/prompter/chat",
+            json={"session_id": session_id, "message": "Hello!"},
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    assert "text/event-stream" in response.headers.get("content-type", "")
+
+    events = _parse_sse_events(response.content)
+    token_events = [e for e in events if e.get("event") == "token"]
+    done_events = [e for e in events if e.get("event") == "done"]
+
+    assert len(token_events) == len(tokens)
+    for i, ev in enumerate(token_events):
+        assert ev["data"] == tokens[i]
+
+    assert len(done_events) == 1
+    assert done_events[0]["data"] == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_chat_persists_turns(
+    prompt_client: dict,
+    db_session: AsyncSession,
+) -> None:
+    """After chat, a user turn and an assistant turn are saved to the session."""
+    client = prompt_client["client"]
+
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    tokens = ["Test", " response"]
+    mock_stream = _MockAnthropicStream(tokens)
+    mock_instance = MagicMock()
+    mock_instance.messages.stream.return_value = mock_stream
+
+    with patch("anthropic.AsyncAnthropic", return_value=mock_instance):
+        await client.post(
+            "/api/prompter/chat",
+            json={"session_id": session_id, "message": "Test question"},
+        )
+
+    # Refresh via service.
+    svc = PromptService(db_session)
+    turns = await svc.list_turns(UUID(session_id))
+    _EXPECTED_TURNS = 2
+    assert len(turns) == _EXPECTED_TURNS
+    assert turns[0].role == "user"
+    assert turns[0].content == "Test question"
+    assert turns[1].role == "assistant"
+    assert turns[1].content == "Test response"
+
+
+@pytest.mark.asyncio
+async def test_chat_session_not_found(prompt_client: dict) -> None:
+    """POST /api/prompter/chat with unknown session_id returns 404."""
+    client = prompt_client["client"]
+    response = await client.post(
+        "/api/prompter/chat",
+        json={"session_id": str(uuid4()), "message": "hi"},
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# Launch action
+# ---------------------------------------------------------------------------
+
+_VALID_TASK_JSON = json.dumps(
+    {
+        "title": "Add user authentication endpoint",
+        "description": "Implement a POST /auth/login endpoint that validates creds.",
+        "acceptance_criteria": [
+            "Returns 200 with JWT on valid credentials",
+            "Returns 401 on invalid credentials",
+        ],
+        "team": "backend",
+        "task_type": "code",
+        "nature": "technical",
+        "estimated_complexity": "medium",
+    }
+)
+
+
+@pytest.mark.asyncio
+async def test_launch_creates_task_and_sets_launched(
+    prompt_client: dict,
+    db_session: AsyncSession,
+) -> None:
+    """POST /launch creates a task and transitions session to LAUNCHED."""
+    client = prompt_client["client"]
+    project = prompt_client["project"]
+
+    # Create a session and add an assistant turn with valid task JSON.
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    svc = PromptService(db_session)
+    session_uuid = UUID(session_id)
+    await svc.create_turn(
+        session_uuid, role="user", content="Create a login endpoint.", turn_index=0
+    )
+    await svc.create_turn(
+        session_uuid,
+        role="assistant",
+        content=f"Sure! Here is the task:\n\n```json\n{_VALID_TASK_JSON}\n```",
+        turn_index=1,
+    )
+
+    response = await client.post(
+        f"/api/prompter/sessions/{session_id}/launch",
+        json={"project_id": str(project.id)},
+    )
+
+    assert response.status_code == HTTPStatus.CREATED, response.text
+    data = response.json()
+    assert "task_id" in data
+    assert data["session_id"] == session_id
+    assert data["session_status"] == "launched"
+
+
+@pytest.mark.asyncio
+async def test_launch_requires_project_or_product(prompt_client: dict) -> None:
+    """Omitting both project_id and product_id returns 400."""
+    client = prompt_client["client"]
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    response = await client.post(
+        f"/api/prompter/sessions/{session_id}/launch",
+        json={},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_launch_both_project_and_product_returns_400(
+    prompt_client: dict,
+) -> None:
+    """Supplying both project_id and product_id returns 400."""
+    client = prompt_client["client"]
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    response = await client.post(
+        f"/api/prompter/sessions/{session_id}/launch",
+        json={"project_id": str(uuid4()), "product_id": str(uuid4())},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_launch_no_assistant_turns_returns_400(prompt_client: dict) -> None:
+    """Launching a session with no assistant turns returns 400."""
+    client = prompt_client["client"]
+    project = prompt_client["project"]
+
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+
+    response = await client.post(
+        f"/api/prompter/sessions/{session_id}/launch",
+        json={"project_id": str(project.id)},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_launch_invalid_json_in_turn_returns_400(
+    prompt_client: dict,
+    db_session: AsyncSession,
+) -> None:
+    """An assistant turn with no extractable JSON returns 400."""
+    client = prompt_client["client"]
+    project = prompt_client["project"]
+
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+    session_uuid = UUID(session_id)
+
+    svc = PromptService(db_session)
+    await svc.create_turn(
+        session_uuid,
+        role="assistant",
+        content="I don't have a JSON block here.",
+        turn_index=0,
+    )
+
+    response = await client.post(
+        f"/api/prompter/sessions/{session_id}/launch",
+        json={"project_id": str(project.id)},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_launch_missing_required_fields_returns_400(
+    prompt_client: dict,
+    db_session: AsyncSession,
+) -> None:
+    """A JSON block missing required fields returns 400."""
+    client = prompt_client["client"]
+    project = prompt_client["project"]
+
+    create_resp = await client.post("/api/prompter/sessions", json={})
+    session_id = create_resp.json()["id"]
+    session_uuid = UUID(session_id)
+
+    incomplete_json = json.dumps({"title": "Only title"})
+    svc = PromptService(db_session)
+    await svc.create_turn(
+        session_uuid,
+        role="assistant",
+        content=f"```json\n{incomplete_json}\n```",
+        turn_index=0,
+    )
+
+    response = await client.post(
+        f"/api/prompter/sessions/{session_id}/launch",
+        json={"project_id": str(project.id)},
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_launch_session_not_found(prompt_client: dict) -> None:
+    """Launching an unknown session returns 404."""
+    client = prompt_client["client"]
+    project = prompt_client["project"]
+
+    response = await client.post(
+        f"/api/prompter/sessions/{uuid4()}/launch",
+        json={"project_id": str(project.id)},
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
Implement the full HTTP API surface for the Prompter feature on top of the already-merged persistence foundation (PromptSession, PromptTurn tables and PromptService CRUD from PR #62).

The following endpoints must be added under the `/api/prompter` prefix and wired into the FastAPI app router:

1. **POST /api/prompter/chat** — SSE streaming endpoint. Accepts a JSON body `{session_id, message}`. Reuses ModelRoutingService to resolve provider/model. The system prompt must guide the LLM to produce structured output matching the TaskCreate schema (title, description, acceptance_criteria, team, task_type, nature, estimated_complexity). Persists each exchange as a PromptTurn via PromptService. Streams the LLM response tokens back as `text/event-stream`.

2. **GET /api/prompter/models** — Returns a list of available models with human-readable labels and descriptions (no raw model IDs exposed to callers). Reuses ModelRoutingService for resolution.

3. **Session HTTP CRUD** — HTTP endpoints wrapping the existing PromptService methods: POST /api/prompter/sessions, GET /api/prompter/sessions (list), GET /api/prompter/sessions/{session_id} (retrieve for fork/reuse), PATCH /api/prompter/sessions/{session_id}/status.

4. **POST /api/prompter/sessions/{session_id}/launch** — Create & Launch action. Validates the latest structured draft turn against the TaskCreate schema constraints, then calls the existing POST /api/tasks endpoint (internal service call or HTTP). Sets session status to LAUNCHED on success.

All new routes must have request/response Pydantic schemas, dependency injection for PromptService, and integration tests covering the happy path and key error cases.