### PR TITLE
[10372f0f] Implement full token usage instrumentation: DB migration, SDK endpoints, orchestrator hooks, analytics API, WebSocket events, dashboard integration

### DIFF
--- a/alembic/versions/026_token_usage_tables.py
+++ b/alembic/versions/026_token_usage_tables.py
@@ -1,0 +1,167 @@
+"""026_token_usage_tables
+
+Create token usage instrumentation tables:
+- agent_spawn_sessions: tracks each agent container spawn with token totals
+- token_usage_snapshots: periodic snapshots of token usage per session
+- daily_usage_rollups: aggregated daily usage per agent/team/model
+
+Revision ID: 026_token_usage_tables
+Revises: 025_agentrole_prompter
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "026_token_usage_tables"
+down_revision = "025_agentrole_prompter"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # agent_spawn_sessions
+    # One row per container spawn. Opened on spawn, closed on stop.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "agent_spawn_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_slug", sa.String(100), nullable=False),
+        sa.Column("team", sa.String(50), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("task_id", sa.String(36), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        # BIGINT for token counts — they can exceed INT32 for long sessions
+        sa.Column("tokens_input", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tokens_output", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column(
+            "tokens_cache_read", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "tokens_cache_write", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column("exit_reason", sa.String(100), nullable=True),
+        sa.Column("estimated_cost_usd", sa.Float, nullable=True),
+    )
+
+    # Indexes for common query patterns
+    op.create_index(
+        "ix_agent_spawn_sessions_agent_slug",
+        "agent_spawn_sessions",
+        ["agent_slug"],
+    )
+    op.create_index(
+        "ix_agent_spawn_sessions_started_at",
+        "agent_spawn_sessions",
+        ["started_at"],
+    )
+    op.create_index(
+        "ix_agent_spawn_sessions_ended_at",
+        "agent_spawn_sessions",
+        ["ended_at"],
+    )
+    op.create_index(
+        "ix_agent_spawn_sessions_team",
+        "agent_spawn_sessions",
+        ["team"],
+    )
+
+    # ------------------------------------------------------------------
+    # token_usage_snapshots
+    # Periodic snapshots (every ~60s) of token counts for active sessions.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "token_usage_snapshots",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "agent_spawn_session_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey(
+                "agent_spawn_sessions.id", ondelete="CASCADE", name="fk_snapshot_session"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "snapshotted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("tokens_input", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tokens_output", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column(
+            "tokens_cache_read", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "tokens_cache_write", sa.BigInteger, nullable=False, server_default="0"
+        ),
+    )
+
+    op.create_index(
+        "ix_token_usage_snapshots_session_id",
+        "token_usage_snapshots",
+        ["agent_spawn_session_id"],
+    )
+    op.create_index(
+        "ix_token_usage_snapshots_snapshotted_at",
+        "token_usage_snapshots",
+        ["snapshotted_at"],
+    )
+
+    # ------------------------------------------------------------------
+    # daily_usage_rollups
+    # Pre-aggregated daily totals per (date, agent_slug, team, model).
+    # Populated by the sweeper; upserted on each sweep so re-runs are safe.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "daily_usage_rollups",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("date", sa.Date, nullable=False),
+        sa.Column("agent_slug", sa.String(100), nullable=False),
+        sa.Column("team", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("tokens_input", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tokens_output", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column(
+            "tokens_cache_read", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "tokens_cache_write", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column("total_cost_usd", sa.Float, nullable=False, server_default="0"),
+        sa.Column("session_count", sa.Integer, nullable=False, server_default="0"),
+    )
+
+    # Unique constraint enables ON CONFLICT upsert in the sweeper
+    op.create_unique_constraint(
+        "uq_daily_rollup_date_agent_team_model",
+        "daily_usage_rollups",
+        ["date", "agent_slug", "team", "model"],
+    )
+    op.create_index(
+        "ix_daily_rollups_date",
+        "daily_usage_rollups",
+        ["date"],
+    )
+    op.create_index(
+        "ix_daily_rollups_agent_slug",
+        "daily_usage_rollups",
+        ["agent_slug"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("daily_usage_rollups")
+    op.drop_table("token_usage_snapshots")
+    op.drop_table("agent_spawn_sessions")

--- a/roboco/agent_sdk/models.py
+++ b/roboco/agent_sdk/models.py
@@ -202,3 +202,44 @@ class VerbCircuitStatus(BaseModel):
             "next gateway call."
         ),
     )
+
+
+# =============================================================================
+# TOKEN USAGE
+# =============================================================================
+
+
+class TokenReportRequest(BaseModel):
+    """Payload for POST /usage/report — reports token usage from a model call.
+
+    Counts are *additive*: the SDK accumulates them per session so multiple
+    report calls sum up correctly across tool invocations.
+    """
+
+    tokens_input: int = Field(default=0, description="Input / prompt tokens consumed")
+    tokens_output: int = Field(
+        default=0, description="Output / completion tokens generated"
+    )
+    tokens_cache_read: int = Field(
+        default=0, description="Prompt-cache read tokens (charged at reduced rate)"
+    )
+    tokens_cache_write: int = Field(
+        default=0, description="Prompt-cache write tokens"
+    )
+
+
+class TokenUsageStatus(BaseModel):
+    """Current cumulative token usage for this session (GET /usage/status)."""
+
+    tokens_input: int = Field(
+        default=0, description="Total input tokens accumulated this session"
+    )
+    tokens_output: int = Field(
+        default=0, description="Total output tokens accumulated this session"
+    )
+    tokens_cache_read: int = Field(
+        default=0, description="Total cache-read tokens this session"
+    )
+    tokens_cache_write: int = Field(
+        default=0, description="Total cache-write tokens this session"
+    )

--- a/roboco/agent_sdk/server.py
+++ b/roboco/agent_sdk/server.py
@@ -35,6 +35,8 @@ from roboco.agent_sdk.models import (
     SendResponse,
     TerminalStatus,
     TerminalToolRecordRequest,
+    TokenReportRequest,
+    TokenUsageStatus,
     VerbAttemptRequest,
     VerbCircuitStatus,
 )
@@ -420,6 +422,11 @@ class _SessionState:
         self.verb_attempts: dict[tuple[str, str | None], deque[float]] = defaultdict(
             deque
         )
+        # Cumulative token usage for this session (reported via /usage/report)
+        self.tokens_input: int = 0
+        self.tokens_output: int = 0
+        self.tokens_cache_read: int = 0
+        self.tokens_cache_write: int = 0
 
     def reset(self) -> None:
         self._init_fields()
@@ -677,6 +684,54 @@ def _terminal_snapshot() -> TerminalStatus:
         had_terminal_recently=_state.had_terminal_recently(),
         stop_attempts=_state.stop_attempts,
         stop_allowance=_STOP_ALLOWANCE,
+    )
+
+
+# =============================================================================
+# TOKEN USAGE REPORTING
+# =============================================================================
+
+
+@app.post("/usage/report", response_model=TokenUsageStatus)
+async def usage_report(req: TokenReportRequest) -> TokenUsageStatus:
+    """Accumulate token usage counts for the current session.
+
+    Called by Claude Code hooks (e.g. PostToolUse) after each API call
+    to report the tokens consumed by that invocation. Counts are additive
+    — multiple calls sum up correctly across the session lifetime.
+    """
+    _state.tokens_input += req.tokens_input
+    _state.tokens_output += req.tokens_output
+    _state.tokens_cache_read += req.tokens_cache_read
+    _state.tokens_cache_write += req.tokens_cache_write
+
+    logger.debug(
+        "Token usage reported",
+        delta_input=req.tokens_input,
+        delta_output=req.tokens_output,
+        total_input=_state.tokens_input,
+        total_output=_state.tokens_output,
+    )
+
+    return _token_usage_snapshot()
+
+
+@app.get("/usage/status", response_model=TokenUsageStatus)
+async def usage_status() -> TokenUsageStatus:
+    """Return cumulative token usage totals for the current session.
+
+    The orchestrator sweeper calls this endpoint every ~60 s to record
+    snapshots and to finalize session rows when the container stops.
+    """
+    return _token_usage_snapshot()
+
+
+def _token_usage_snapshot() -> TokenUsageStatus:
+    return TokenUsageStatus(
+        tokens_input=_state.tokens_input,
+        tokens_output=_state.tokens_output,
+        tokens_cache_read=_state.tokens_cache_read,
+        tokens_cache_write=_state.tokens_cache_write,
     )
 
 

--- a/roboco/api/app.py
+++ b/roboco/api/app.py
@@ -44,6 +44,7 @@ from roboco.api.routes.v1 import flow_dev as flow_dev_module
 from roboco.api.routes.v1 import flow_doc as flow_doc_module
 from roboco.api.routes.v1 import flow_main_pm as flow_main_pm_module
 from roboco.api.routes.v1 import flow_qa as flow_qa_module
+from roboco.api.routes.usage import router as usage_router
 from roboco.api.routes.work_session import router as work_session_router
 from roboco.api.websocket import router as ws_router
 from roboco.config import settings
@@ -338,6 +339,13 @@ def create_app() -> FastAPI:
         docs_router,
         prefix=f"{api_prefix}/docs",
         tags=["Documentation"],
+    )
+
+    # Token Usage Analytics
+    app.include_router(
+        usage_router,
+        prefix=f"{api_prefix}/usage",
+        tags=["Usage Analytics"],
     )
 
     # API v1 — intent-verb flow endpoints

--- a/roboco/api/routes/dashboard.py
+++ b/roboco/api/routes/dashboard.py
@@ -21,12 +21,14 @@ from roboco.api.schemas.dashboard import (
     CreateReportRequest,
     FlagSeverity,
     TeamHealth,
+    UsageSummary,
 )
 from roboco.models.base import Team
 from roboco.models.dashboard import CreateFlagParams
 from roboco.services.dashboard import get_dashboard_service
 from roboco.services.kanban import get_kanban_service
 from roboco.services.metrics import get_metrics_service
+from roboco.services.usage import get_usage_service
 
 router = APIRouter()
 
@@ -277,6 +279,7 @@ async def get_ceo_overview(
     - Roadmap progress
     """
     service = get_dashboard_service(db)
+    usage_svc = get_usage_service(db)
 
     health_list = await service.get_team_health_list()
     health_status = [
@@ -291,11 +294,22 @@ async def get_ceo_overview(
         for h in health_list
     ]
 
+    # Populate usage_summary from daily_usage_rollups for today
+    try:
+        today_usage = await usage_svc.get_today_summary()
+        usage_summary = UsageSummary(
+            tokens_today=today_usage["tokens_today"],
+            cost_today_usd=today_usage["cost_today_usd"],
+        )
+    except Exception:
+        usage_summary = UsageSummary(tokens_today=0, cost_today_usd=0.0)
+
     return CEOOverview(
         health_status=health_status,
         key_metrics=await service.get_key_metrics(),
         auditor_alerts=service.get_auditor_alerts(),
         roadmap_progress=await service.get_roadmap_progress(),
+        usage_summary=usage_summary,
     )
 
 

--- a/roboco/api/routes/usage.py
+++ b/roboco/api/routes/usage.py
@@ -1,0 +1,142 @@
+"""
+Token Usage Analytics API
+
+Provides endpoints for querying token usage metrics across agents,
+teams, and models. Supports period-based queries (24h, 7d, 30d).
+"""
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Query
+
+from roboco.api.deps import DbSession
+from roboco.services.usage import get_usage_service
+
+router = APIRouter()
+
+_PeriodType = Literal["24h", "7d", "30d"]
+
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+
+
+@router.get("/summary")
+async def get_usage_summary(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> dict[str, Any]:
+    """Return aggregated token usage and cost for the given period.
+
+    Response includes:
+    - tokens_input: total prompt tokens consumed
+    - tokens_output: total completion tokens generated
+    - total_tokens: sum of all token types
+    - total_cost_usd: estimated USD cost
+    - trend_pct: percent change vs. previous equivalent period
+    """
+    svc = get_usage_service(db)
+    return await svc.get_summary(period)
+
+
+# =============================================================================
+# TIME SERIES
+# =============================================================================
+
+
+@router.get("/time-series")
+async def get_usage_time_series(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return bucketed time-series data points.
+
+    - 24h → hourly buckets
+    - 7d / 30d → daily buckets
+
+    Each point has: bucket (ISO timestamp), tokens_input, tokens_output,
+    total_tokens, cost_usd.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_time_series(period)
+
+
+# =============================================================================
+# BREAKDOWN ENDPOINTS
+# =============================================================================
+
+
+@router.get("/by-agent")
+async def get_usage_by_agent(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return per-agent token usage with pct_of_total.
+
+    pct_of_total fields sum to approximately 100%.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_by_agent(period)
+
+
+@router.get("/by-team")
+async def get_usage_by_team(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return per-team token usage with pct_of_total.
+
+    pct_of_total fields sum to approximately 100%.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_by_team(period)
+
+
+@router.get("/by-model")
+async def get_usage_by_model(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return per-model token usage with pct_of_total.
+
+    pct_of_total fields sum to approximately 100%.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_by_model(period)
+
+
+# =============================================================================
+# PROJECTION
+# =============================================================================
+
+
+@router.get("/projection")
+async def get_usage_projection(
+    db: DbSession,
+) -> dict[str, Any]:
+    """Return projected monthly cost based on 7-day rolling average.
+
+    projected_monthly_cost_usd is computed from avg_daily_cost * 30.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_projection()
+
+
+# =============================================================================
+# CACHE EFFICIENCY
+# =============================================================================
+
+
+@router.get("/cache-efficiency")
+async def get_cache_efficiency(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> dict[str, Any]:
+    """Return cache hit rate and estimated savings from prompt caching.
+
+    - cache_hit_rate: fraction of input-like tokens served from cache
+    - cost_saved_by_cache_usd: estimated savings vs. full input pricing
+    """
+    svc = get_usage_service(db)
+    return await svc.get_cache_efficiency(period)

--- a/roboco/api/schemas/dashboard.py
+++ b/roboco/api/schemas/dashboard.py
@@ -78,6 +78,17 @@ class TeamHealth(BaseModel):
     completed_this_week: int
 
 
+class UsageSummary(BaseModel):
+    """Today's token usage summary for the CEO dashboard."""
+
+    tokens_today: int = Field(
+        default=0, description="Total tokens (input + output + cache) used today"
+    )
+    cost_today_usd: float = Field(
+        default=0.0, description="Estimated USD cost for today"
+    )
+
+
 class CEOOverview(BaseModel):
     """Complete CEO overview data."""
 
@@ -85,6 +96,10 @@ class CEOOverview(BaseModel):
     key_metrics: dict[str, Any]
     auditor_alerts: dict[str, Any]
     roadmap_progress: dict[str, Any]
+    usage_summary: UsageSummary | None = Field(
+        default=None,
+        description="Today's token usage and cost from daily_usage_rollups",
+    )
 
 
 class CreateFlagRequest(BaseModel):

--- a/roboco/billing/__init__.py
+++ b/roboco/billing/__init__.py
@@ -1,0 +1,8 @@
+"""Billing utilities for RoboCo.
+
+Provides token-cost calculation for Claude API models.
+"""
+
+from roboco.billing.pricing import calculate_cost
+
+__all__ = ["calculate_cost"]

--- a/roboco/billing/pricing.py
+++ b/roboco/billing/pricing.py
@@ -1,0 +1,95 @@
+"""
+Token pricing for Claude API models.
+
+Implements per-model USD cost calculation based on Anthropic's published
+pricing. All prices are in USD per 1 million tokens.
+
+Unknown model names return 0.0 without raising so callers don't need to
+guard against missing pricing data.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Per-model pricing table
+# Format: model_name_fragment → (input_usd_per_1m, output_usd_per_1m,
+#                                cache_read_usd_per_1m, cache_write_usd_per_1m)
+#
+# Cache read is charged at ~10 % of the input price.
+# Cache write is charged at ~25 % of the input price.
+#
+# Match on *substring* of model name so "claude-opus-4-6" and "opus" both
+# resolve to the same tier.
+# ---------------------------------------------------------------------------
+_PRICING: list[tuple[str, float, float, float, float]] = [
+    # (fragment, input/1M, output/1M, cache_read/1M, cache_write/1M)
+    # Opus 4 family
+    ("claude-opus-4", 15.00, 75.00, 1.50, 3.75),
+    # Sonnet 4 / 3.7 / 3.5 family
+    ("claude-sonnet-4", 3.00, 15.00, 0.30, 0.75),
+    ("claude-3-7-sonnet", 3.00, 15.00, 0.30, 0.75),
+    ("claude-3-5-sonnet", 3.00, 15.00, 0.30, 0.75),
+    # Haiku family
+    ("claude-haiku-4", 0.80, 4.00, 0.08, 0.20),
+    ("claude-haiku-3-5", 0.80, 4.00, 0.08, 0.20),
+    ("claude-3-5-haiku", 0.80, 4.00, 0.08, 0.20),
+    ("claude-haiku-3", 0.25, 1.25, 0.025, 0.0625),
+    # Short aliases used in ROLE_MODEL_MAP / MODEL_MAP
+    ("opus", 15.00, 75.00, 1.50, 3.75),
+    ("sonnet", 3.00, 15.00, 0.30, 0.75),
+    ("haiku", 0.80, 4.00, 0.08, 0.20),
+]
+
+_MILLION = 1_000_000.0
+
+
+def calculate_cost(
+    model: str,
+    tokens_input: int,
+    tokens_output: int,
+    tokens_cache_read: int = 0,
+    tokens_cache_write: int = 0,
+) -> float:
+    """Calculate the estimated USD cost for a model invocation.
+
+    Matches the model name against the known pricing table using substring
+    search (longest match wins).  Unknown models return 0.0 without raising.
+
+    Args:
+        model: Model name or short alias (e.g. ``"claude-sonnet-4-6"``,
+               ``"sonnet"``, ``"opus"``).
+        tokens_input: Number of input tokens (prompt / context).
+        tokens_output: Number of output tokens (completion).
+        tokens_cache_read: Prompt-cache read tokens (charged at reduced rate).
+        tokens_cache_write: Prompt-cache write tokens (charged at reduced rate).
+
+    Returns:
+        Estimated cost in USD as a float.  Returns 0.0 for unknown models
+        rather than raising.
+    """
+    if not model:
+        return 0.0
+
+    lower = model.lower()
+
+    # Find the best (longest fragment) match
+    best_fragment_len = 0
+    best_prices: tuple[float, float, float, float] | None = None
+
+    for fragment, inp_price, out_price, cr_price, cw_price in _PRICING:
+        if fragment in lower and len(fragment) > best_fragment_len:
+            best_fragment_len = len(fragment)
+            best_prices = (inp_price, out_price, cr_price, cw_price)
+
+    if best_prices is None:
+        return 0.0
+
+    inp_price, out_price, cr_price, cw_price = best_prices
+
+    cost = (
+        tokens_input * inp_price / _MILLION
+        + tokens_output * out_price / _MILLION
+        + tokens_cache_read * cr_price / _MILLION
+        + tokens_cache_write * cw_price / _MILLION
+    )
+    return round(cost, 8)

--- a/roboco/db/tables.py
+++ b/roboco/db/tables.py
@@ -11,7 +11,9 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
+    Date,
     DateTime,
     Enum,
     Float,
@@ -1814,6 +1816,148 @@ class GatewayTriggerTable(Base):
         Index("ix_gateway_triggers_task_id", "task_id"),
         Index("ix_gateway_triggers_created_at", "created_at"),
         Index("ix_gateway_triggers_kind_decision", "trigger_kind", "decision"),
+    )
+
+
+# =============================================================================
+# TOKEN USAGE TABLES
+# =============================================================================
+
+
+class AgentSpawnSessionTable(Base):
+    """Records each agent container spawn lifecycle.
+
+    Opened when the orchestrator successfully starts a container; closed
+    (ended_at set) when stop_agent() finishes.  Final token counts are
+    accumulated from the agent SDK's /usage/status endpoint.
+    """
+
+    __tablename__ = "agent_spawn_sessions"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    agent_slug: Mapped[str] = mapped_column(String(100), nullable=False)
+    team: Mapped[str] = mapped_column(String(50), nullable=False)
+    role: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    task_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # BIGINT — token counts can exceed INT32 for long sessions
+    tokens_input: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_output: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_cache_read: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    tokens_cache_write: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    exit_reason: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    estimated_cost_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Relationship to snapshots (backref for convenience)
+    snapshots: Mapped[list["TokenUsageSnapshotTable"]] = relationship(
+        "TokenUsageSnapshotTable",
+        back_populates="session",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index("ix_agent_spawn_sessions_agent_slug", "agent_slug"),
+        Index("ix_agent_spawn_sessions_started_at", "started_at"),
+        Index("ix_agent_spawn_sessions_ended_at", "ended_at"),
+        Index("ix_agent_spawn_sessions_team", "team"),
+    )
+
+
+class TokenUsageSnapshotTable(Base):
+    """Periodic (every ~60 s) snapshot of cumulative token usage for an
+    active agent_spawn_session.
+
+    The sweeper inserts one row per active agent per sweep cycle when
+    token counts are non-zero.  Snapshots allow tracking how token usage
+    grows over session lifetime.
+    """
+
+    __tablename__ = "token_usage_snapshots"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    agent_spawn_session_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_spawn_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    snapshotted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    tokens_input: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_output: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_cache_read: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    tokens_cache_write: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+
+    session: Mapped["AgentSpawnSessionTable"] = relationship(
+        "AgentSpawnSessionTable", back_populates="snapshots"
+    )
+
+    __table_args__ = (
+        Index("ix_token_usage_snapshots_session_id", "agent_spawn_session_id"),
+        Index("ix_token_usage_snapshots_snapshotted_at", "snapshotted_at"),
+    )
+
+
+class DailyUsageRollupTable(Base):
+    """Pre-aggregated daily token usage per (date, agent_slug, team, model).
+
+    Populated by the orchestrator sweeper via an upsert query over
+    closed agent_spawn_sessions.  Unique constraint on the natural key
+    enables ON CONFLICT DO UPDATE so the sweep is idempotent.
+    """
+
+    __tablename__ = "daily_usage_rollups"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    date: Mapped[Any] = mapped_column(Date, nullable=False)  # datetime.date
+    agent_slug: Mapped[str] = mapped_column(String(100), nullable=False)
+    team: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    tokens_input: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_output: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_cache_read: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    tokens_cache_write: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    total_cost_usd: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    session_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "date",
+            "agent_slug",
+            "team",
+            "model",
+            name="uq_daily_rollup_date_agent_team_model",
+        ),
+        Index("ix_daily_rollups_date", "date"),
+        Index("ix_daily_rollups_agent_slug", "agent_slug"),
     )
 
 

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3373,12 +3373,6 @@ class AgentOrchestrator:
 
         except Exception as exc:
             logger.warning("Daily usage rollup failed", error=str(exc))
-        except Exception as e:
-            logger.error(
-                "Failed to delete waiting record",
-                agent_id=agent_id,
-                error=str(e),
-            )
 
     async def restore_waiting_records(self) -> int:
         """Load persisted waiting records into memory on orchestrator start.

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -1382,6 +1382,10 @@ class AgentOrchestrator:
                     "model": config.model,
                 },
             )
+
+            # Record a token-usage session row in the DB (fire-and-forget).
+            await self._record_spawn_session(config, task_id)
+
             return instance
         except Exception as e:
             instance.state = AgentState.OFFLINE
@@ -2868,7 +2872,12 @@ class AgentOrchestrator:
     # AGENT STOPPING
     # =========================================================================
 
-    async def stop_agent(self, agent_id: str, graceful: bool = True) -> None:
+    async def stop_agent(
+        self,
+        agent_id: str,
+        graceful: bool = True,
+        exit_reason: str = "stopped",
+    ) -> None:
         """Stop an agent container."""
         async with self._lock:
             if agent_id not in self._instances:
@@ -2879,6 +2888,10 @@ class AgentOrchestrator:
             if instance.container_id:
                 instance.state = AgentState.STOPPING
                 container_name = f"roboco-agent-{agent_id}"
+
+                # Finalize the spawn-session row before the container is removed
+                # so we can still query the SDK's /usage/status endpoint.
+                await self._finalize_spawn_session(agent_id, exit_reason=exit_reason)
 
                 if graceful:
                     # Graceful stop with timeout
@@ -3006,6 +3019,360 @@ class AgentOrchestrator:
                     )
                 )
                 await db.commit()
+        except Exception as e:
+            logger.error(
+                "Failed to delete waiting record",
+                agent_id=agent_id,
+                error=str(e),
+            )
+
+    # =========================================================================
+    # TOKEN USAGE INSTRUMENTATION
+    # =========================================================================
+
+    async def _record_spawn_session(
+        self,
+        config: "OrchestratorAgentConfig",
+        task_id: str | None,
+    ) -> None:
+        """Insert a row into agent_spawn_sessions after a successful spawn.
+
+        Errors are caught and logged; a missing session row must never block
+        the spawn path.
+        """
+        try:
+            from uuid import uuid4 as _uuid4
+
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable
+
+            agent_slug = config.agent_id
+            team = get_agent_team(agent_slug) or "backend"
+            role = get_agent_role(agent_slug) or "developer"
+
+            session_factory = get_session_factory()
+            async with session_factory() as db:
+                row = AgentSpawnSessionTable(
+                    id=_uuid4(),
+                    agent_slug=agent_slug,
+                    team=team,
+                    role=role,
+                    model=config.model or "unknown",
+                    task_id=task_id,
+                    started_at=datetime.now(UTC),
+                )
+                db.add(row)
+                await db.commit()
+                logger.debug(
+                    "Spawn session recorded",
+                    agent_slug=agent_slug,
+                    session_id=str(row.id),
+                    task_id=task_id,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Failed to record spawn session",
+                agent_slug=config.agent_id,
+                error=str(exc),
+            )
+
+    async def _finalize_spawn_session(
+        self,
+        agent_id: str,
+        exit_reason: str = "stopped",
+    ) -> None:
+        """Close the open agent_spawn_sessions row for this agent.
+
+        Fetches final token counts from the agent SDK's /usage/status endpoint,
+        calculates cost via pricing module, then updates the DB row with
+        ended_at, token totals, exit_reason, and estimated_cost_usd.
+        Errors are caught and logged — finalization must never block stop_agent.
+        """
+        try:
+            from roboco.billing.pricing import calculate_cost
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable
+
+            # Fetch final token counts from the agent's SDK
+            sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
+            tokens_input = 0
+            tokens_output = 0
+            tokens_cache_read = 0
+            tokens_cache_write = 0
+            model = "unknown"
+
+            try:
+                async with httpx.AsyncClient(timeout=3.0) as client:
+                    resp = await client.get(sdk_url)
+                    if resp.status_code == 200:
+                        data = resp.json()
+                        tokens_input = data.get("tokens_input", 0)
+                        tokens_output = data.get("tokens_output", 0)
+                        tokens_cache_read = data.get("tokens_cache_read", 0)
+                        tokens_cache_write = data.get("tokens_cache_write", 0)
+            except Exception as sdk_exc:
+                logger.debug(
+                    "Could not fetch final token counts from SDK",
+                    agent_id=agent_id,
+                    error=str(sdk_exc),
+                )
+
+            # Look up the model from the running instance config
+            instance = self._instances.get(agent_id)
+            if instance and instance.config:
+                model = instance.config.model or "unknown"
+
+            cost = calculate_cost(
+                model=model,
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
+                tokens_cache_read=tokens_cache_read,
+                tokens_cache_write=tokens_cache_write,
+            )
+
+            session_factory = get_session_factory()
+            async with session_factory() as db:
+                from sqlalchemy import select, update
+
+                # Update the most recent open session for this agent
+                result = await db.execute(
+                    select(AgentSpawnSessionTable)
+                    .where(
+                        AgentSpawnSessionTable.agent_slug == agent_id,
+                        AgentSpawnSessionTable.ended_at.is_(None),
+                    )
+                    .order_by(AgentSpawnSessionTable.started_at.desc())
+                    .limit(1)
+                )
+                session_row = result.scalar_one_or_none()
+                if session_row is not None:
+                    await db.execute(
+                        update(AgentSpawnSessionTable)
+                        .where(AgentSpawnSessionTable.id == session_row.id)
+                        .values(
+                            ended_at=datetime.now(UTC),
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                            tokens_cache_read=tokens_cache_read,
+                            tokens_cache_write=tokens_cache_write,
+                            exit_reason=exit_reason,
+                            estimated_cost_usd=cost,
+                        )
+                    )
+                    await db.commit()
+                    logger.debug(
+                        "Spawn session finalized",
+                        agent_id=agent_id,
+                        session_id=str(session_row.id),
+                        tokens_input=tokens_input,
+                        tokens_output=tokens_output,
+                        estimated_cost_usd=cost,
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Failed to finalize spawn session",
+                agent_id=agent_id,
+                error=str(exc),
+            )
+
+    async def _sweep_token_snapshots(self) -> None:
+        """Write a token_usage_snapshots row for each active agent with non-zero tokens.
+
+        Called from _run_sweep() every ~60 s. Also updates the cumulative
+        token counts on the open agent_spawn_sessions row so the DB reflects
+        current progress without waiting for session close.
+        Errors per-agent are caught so one bad agent doesn't abort the whole sweep.
+        """
+        if not self._instances:
+            return
+
+        try:
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable, TokenUsageSnapshotTable
+        except ImportError:
+            return
+
+        session_factory = get_session_factory()
+
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            for agent_id, instance in list(self._instances.items()):
+                if instance.state not in (
+                    AgentState.ACTIVE,
+                    AgentState.WAITING_SHORT,
+                ):
+                    continue
+
+                sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
+                try:
+                    resp = await client.get(sdk_url)
+                    if resp.status_code != 200:
+                        continue
+                    data = resp.json()
+                    tokens_input = data.get("tokens_input", 0)
+                    tokens_output = data.get("tokens_output", 0)
+                    tokens_cache_read = data.get("tokens_cache_read", 0)
+                    tokens_cache_write = data.get("tokens_cache_write", 0)
+
+                    # Skip agents with no token usage yet
+                    total = tokens_input + tokens_output + tokens_cache_read + tokens_cache_write
+                    if total == 0:
+                        continue
+
+                    async with session_factory() as db:
+                        from sqlalchemy import select, update
+
+                        # Find the open session row
+                        result = await db.execute(
+                            select(AgentSpawnSessionTable)
+                            .where(
+                                AgentSpawnSessionTable.agent_slug == agent_id,
+                                AgentSpawnSessionTable.ended_at.is_(None),
+                            )
+                            .order_by(AgentSpawnSessionTable.started_at.desc())
+                            .limit(1)
+                        )
+                        session_row = result.scalar_one_or_none()
+                        if session_row is None:
+                            continue
+
+                        # Insert snapshot
+                        from uuid import uuid4 as _uuid4
+                        snapshot = TokenUsageSnapshotTable(
+                            id=_uuid4(),
+                            agent_spawn_session_id=session_row.id,
+                            snapshotted_at=datetime.now(UTC),
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                            tokens_cache_read=tokens_cache_read,
+                            tokens_cache_write=tokens_cache_write,
+                        )
+                        db.add(snapshot)
+
+                        # Update cumulative totals on the session row
+                        await db.execute(
+                            update(AgentSpawnSessionTable)
+                            .where(AgentSpawnSessionTable.id == session_row.id)
+                            .values(
+                                tokens_input=tokens_input,
+                                tokens_output=tokens_output,
+                                tokens_cache_read=tokens_cache_read,
+                                tokens_cache_write=tokens_cache_write,
+                            )
+                        )
+                        await db.commit()
+
+                except Exception as agent_exc:
+                    logger.debug(
+                        "Token snapshot failed for agent",
+                        agent_id=agent_id,
+                        error=str(agent_exc),
+                    )
+
+    async def _sweep_daily_rollup(self) -> None:
+        """Upsert daily_usage_rollups from closed agent_spawn_sessions.
+
+        Groups ended sessions by (date, agent_slug, team, model) and sums
+        their token counts + cost. Uses a Python-side upsert to stay
+        compatible with asyncpg / SQLAlchemy without raw INSERT ... ON CONFLICT
+        dialect-specific SQL.
+        Errors are caught so a bad rollup doesn't abort the sweeper.
+        """
+        try:
+            from roboco.billing.pricing import calculate_cost
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
+        except ImportError:
+            return
+
+        try:
+            from uuid import uuid4 as _uuid4
+            from sqlalchemy import func, select
+
+            session_factory = get_session_factory()
+            async with session_factory() as db:
+                # Aggregate closed sessions by (date, agent_slug, team, model)
+                result = await db.execute(
+                    select(
+                        func.date(AgentSpawnSessionTable.started_at).label("date"),
+                        AgentSpawnSessionTable.agent_slug,
+                        AgentSpawnSessionTable.team,
+                        AgentSpawnSessionTable.model,
+                        func.sum(AgentSpawnSessionTable.tokens_input).label("tokens_input"),
+                        func.sum(AgentSpawnSessionTable.tokens_output).label("tokens_output"),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_read).label("tokens_cache_read"),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_write).label("tokens_cache_write"),
+                        func.sum(AgentSpawnSessionTable.estimated_cost_usd).label("total_cost_usd"),
+                        func.count(AgentSpawnSessionTable.id).label("session_count"),
+                    )
+                    .where(AgentSpawnSessionTable.ended_at.isnot(None))
+                    .group_by(
+                        func.date(AgentSpawnSessionTable.started_at),
+                        AgentSpawnSessionTable.agent_slug,
+                        AgentSpawnSessionTable.team,
+                        AgentSpawnSessionTable.model,
+                    )
+                )
+                rows = result.fetchall()
+
+                for row in rows:
+                    date_val = row.date
+                    agent_slug = row.agent_slug
+                    team = row.team
+                    model = row.model
+
+                    # Look for existing rollup row
+                    existing_result = await db.execute(
+                        select(DailyUsageRollupTable).where(
+                            DailyUsageRollupTable.date == date_val,
+                            DailyUsageRollupTable.agent_slug == agent_slug,
+                            DailyUsageRollupTable.team == team,
+                            DailyUsageRollupTable.model == model,
+                        )
+                    )
+                    existing = existing_result.scalar_one_or_none()
+
+                    tokens_input = int(row.tokens_input or 0)
+                    tokens_output = int(row.tokens_output or 0)
+                    tokens_cache_read = int(row.tokens_cache_read or 0)
+                    tokens_cache_write = int(row.tokens_cache_write or 0)
+                    total_cost = float(row.total_cost_usd or 0.0)
+                    session_count = int(row.session_count or 0)
+
+                    if existing is not None:
+                        from sqlalchemy import update
+                        await db.execute(
+                            update(DailyUsageRollupTable)
+                            .where(DailyUsageRollupTable.id == existing.id)
+                            .values(
+                                tokens_input=tokens_input,
+                                tokens_output=tokens_output,
+                                tokens_cache_read=tokens_cache_read,
+                                tokens_cache_write=tokens_cache_write,
+                                total_cost_usd=total_cost,
+                                session_count=session_count,
+                            )
+                        )
+                    else:
+                        new_row = DailyUsageRollupTable(
+                            id=_uuid4(),
+                            date=date_val,
+                            agent_slug=agent_slug,
+                            team=team,
+                            model=model,
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                            tokens_cache_read=tokens_cache_read,
+                            tokens_cache_write=tokens_cache_write,
+                            total_cost_usd=total_cost,
+                            session_count=session_count,
+                        )
+                        db.add(new_row)
+
+                await db.commit()
+                logger.debug("Daily usage rollup complete", rows_processed=len(rows))
+
+        except Exception as exc:
+            logger.warning("Daily usage rollup failed", error=str(exc))
         except Exception as e:
             logger.error(
                 "Failed to delete waiting record",
@@ -3211,6 +3578,11 @@ Start by:
         # container so the next dispatcher tick doesn't waste tokens on the
         # same session.
         await self._sweep_budget_exceeded()
+
+        # Token-usage instrumentation: snapshot active agents and roll up
+        # closed sessions into the daily aggregation table.
+        await self._sweep_token_snapshots()
+        await self._sweep_daily_rollup()
 
     @staticmethod
     async def _fetch_budget_status(

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -8,11 +8,10 @@ and aggregation by agent, team, and model.
 
 from __future__ import annotations
 
-import math
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
@@ -175,6 +174,8 @@ class UsageService(BaseService):
                 AgentSpawnSessionTable.agent_slug,
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
             )
             .where(
@@ -186,12 +187,17 @@ class UsageService(BaseService):
         )
         rows = result.fetchall()
 
-        grand_total = sum(int(r.tokens_input or 0) + int(r.tokens_output or 0) for r in rows)
+        grand_total = sum(
+            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            for r in rows
+        )
         items = []
         for r in rows:
             ti = int(r.tokens_input or 0)
             to_ = int(r.tokens_output or 0)
-            total = ti + to_
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            total = ti + to_ + tcr + tcw
             items.append(
                 {
                     "agent_slug": r.agent_slug,
@@ -217,6 +223,8 @@ class UsageService(BaseService):
                 AgentSpawnSessionTable.team,
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
             )
             .where(
@@ -228,12 +236,17 @@ class UsageService(BaseService):
         )
         rows = result.fetchall()
 
-        grand_total = sum(int(r.tokens_input or 0) + int(r.tokens_output or 0) for r in rows)
+        grand_total = sum(
+            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            for r in rows
+        )
         items = []
         for r in rows:
             ti = int(r.tokens_input or 0)
             to_ = int(r.tokens_output or 0)
-            total = ti + to_
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            total = ti + to_ + tcr + tcw
             items.append(
                 {
                     "team": r.team,
@@ -259,6 +272,8 @@ class UsageService(BaseService):
                 AgentSpawnSessionTable.model,
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
             )
             .where(
@@ -270,12 +285,17 @@ class UsageService(BaseService):
         )
         rows = result.fetchall()
 
-        grand_total = sum(int(r.tokens_input or 0) + int(r.tokens_output or 0) for r in rows)
+        grand_total = sum(
+            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            for r in rows
+        )
         items = []
         for r in rows:
             ti = int(r.tokens_input or 0)
             to_ = int(r.tokens_output or 0)
-            total = ti + to_
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            total = ti + to_ + tcr + tcw
             items.append(
                 {
                     "model": r.model,
@@ -332,8 +352,6 @@ class UsageService(BaseService):
         cost_saved = what cache reads would have cost at full input price
                      minus what they actually cost at cache-read price.
         """
-        from roboco.billing.pricing import calculate_cost
-
         start_dt, _ = _parse_period(period)
 
         result = await self.session.execute(

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -113,6 +113,10 @@ class UsageService(BaseService):
 
         Each point has: bucket (ISO string), tokens_input, tokens_output,
         total_tokens, cost_usd.
+
+        total_tokens includes all 4 token types (input + output + cache_read +
+        cache_write) so it is consistent with get_summary()'s total_tokens
+        field — AC9 requires their sums to match for the same period.
         """
         start_dt, hours = _parse_period(period)
 
@@ -128,6 +132,8 @@ class UsageService(BaseService):
                 trunc_fn.label("bucket"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
                 func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
             )
             .where(
@@ -143,12 +149,14 @@ class UsageService(BaseService):
         for r in rows:
             ti = int(r.tokens_input or 0)
             to_ = int(r.tokens_output or 0)
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
             points.append(
                 {
                     "bucket": r.bucket.isoformat() if r.bucket else None,
                     "tokens_input": ti,
                     "tokens_output": to_,
-                    "total_tokens": ti + to_,
+                    "total_tokens": ti + to_ + tcr + tcw,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
                 }
             )

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -1,0 +1,409 @@
+"""
+Usage Analytics Service
+
+Provides token usage analytics over agent_spawn_sessions and
+daily_usage_rollups tables. Supports period-based queries (24h, 7d, 30d)
+and aggregation by agent, team, and model.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
+from roboco.services.base import BaseService
+
+
+def _parse_period(period: str) -> tuple[datetime, int]:
+    """Parse period string into (start_dt, hours).
+
+    Accepts '24h', '7d', '30d'. Defaults to 24h for unknown values.
+    Returns (start_datetime_utc, total_hours).
+    """
+    now = datetime.now(UTC)
+    if period == "7d":
+        return now - timedelta(days=7), 7 * 24
+    if period == "30d":
+        return now - timedelta(days=30), 30 * 24
+    # default 24h
+    return now - timedelta(hours=24), 24
+
+
+class UsageService(BaseService):
+    """Analytics service for token usage data."""
+
+    # =========================================================================
+    # SUMMARY
+    # =========================================================================
+
+    async def get_summary(self, period: str = "24h") -> dict[str, Any]:
+        """Return aggregated token and cost totals for the given period.
+
+        Queries daily_usage_rollups for whole-day periods; falls back to
+        agent_spawn_sessions for sub-day precision.
+
+        Returns dict with: tokens_input, tokens_output, total_tokens,
+        total_cost_usd, trend_pct.
+        """
+        start_dt, hours = _parse_period(period)
+
+        # Current period totals from closed sessions
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_usd"),
+            ).where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        row = result.one()
+        tokens_input = int(row.tokens_input or 0)
+        tokens_output = int(row.tokens_output or 0)
+        total_cost = float(row.total_cost_usd or 0.0)
+        total_tokens = tokens_input + tokens_output + int(row.tokens_cache_read or 0) + int(row.tokens_cache_write or 0)
+
+        # Previous period for trend calculation
+        prev_start = start_dt - timedelta(hours=hours)
+        prev_result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output), 0).label("total")
+            ).where(
+                AgentSpawnSessionTable.started_at >= prev_start,
+                AgentSpawnSessionTable.started_at < start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        prev_row = prev_result.one()
+        prev_total = int(prev_row.total or 0)
+
+        if prev_total > 0:
+            trend_pct = round((total_tokens - prev_total) / prev_total * 100, 1)
+        elif total_tokens > 0:
+            trend_pct = 100.0
+        else:
+            trend_pct = 0.0
+
+        return {
+            "tokens_input": tokens_input,
+            "tokens_output": tokens_output,
+            "total_tokens": total_tokens,
+            "total_cost_usd": round(total_cost, 6),
+            "trend_pct": trend_pct,
+            "period": period,
+        }
+
+    # =========================================================================
+    # TIME SERIES
+    # =========================================================================
+
+    async def get_time_series(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return bucketed time-series data points.
+
+        - 24h → hourly buckets
+        - 7d / 30d → daily buckets
+
+        Each point has: bucket (ISO string), tokens_input, tokens_output,
+        total_tokens, cost_usd.
+        """
+        start_dt, hours = _parse_period(period)
+
+        if period == "24h":
+            # Hourly buckets
+            trunc_fn = func.date_trunc("hour", AgentSpawnSessionTable.started_at)
+        else:
+            # Daily buckets
+            trunc_fn = func.date_trunc("day", AgentSpawnSessionTable.started_at)
+
+        result = await self.session.execute(
+            select(
+                trunc_fn.label("bucket"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(trunc_fn)
+            .order_by(trunc_fn)
+        )
+        rows = result.fetchall()
+
+        points = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            points.append(
+                {
+                    "bucket": r.bucket.isoformat() if r.bucket else None,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": ti + to_,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                }
+            )
+        return points
+
+    # =========================================================================
+    # BY-AGENT
+    # =========================================================================
+
+    async def get_by_agent(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return per-agent token usage with pct_of_total."""
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                AgentSpawnSessionTable.agent_slug,
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(AgentSpawnSessionTable.agent_slug)
+            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+        )
+        rows = result.fetchall()
+
+        grand_total = sum(int(r.tokens_input or 0) + int(r.tokens_output or 0) for r in rows)
+        items = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            total = ti + to_
+            items.append(
+                {
+                    "agent_slug": r.agent_slug,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": total,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                }
+            )
+        return items
+
+    # =========================================================================
+    # BY-TEAM
+    # =========================================================================
+
+    async def get_by_team(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return per-team token usage with pct_of_total."""
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                AgentSpawnSessionTable.team,
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(AgentSpawnSessionTable.team)
+            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+        )
+        rows = result.fetchall()
+
+        grand_total = sum(int(r.tokens_input or 0) + int(r.tokens_output or 0) for r in rows)
+        items = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            total = ti + to_
+            items.append(
+                {
+                    "team": r.team,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": total,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                }
+            )
+        return items
+
+    # =========================================================================
+    # BY-MODEL
+    # =========================================================================
+
+    async def get_by_model(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return per-model token usage with pct_of_total."""
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                AgentSpawnSessionTable.model,
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(AgentSpawnSessionTable.model)
+            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+        )
+        rows = result.fetchall()
+
+        grand_total = sum(int(r.tokens_input or 0) + int(r.tokens_output or 0) for r in rows)
+        items = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            total = ti + to_
+            items.append(
+                {
+                    "model": r.model,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": total,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                }
+            )
+        return items
+
+    # =========================================================================
+    # PROJECTION
+    # =========================================================================
+
+    async def get_projection(self) -> dict[str, Any]:
+        """Return projected monthly cost based on 7-day rolling average.
+
+        Computes the average daily cost over the last 7 days and extrapolates
+        to 30 days.
+        """
+        seven_days_ago = datetime.now(UTC) - timedelta(days=7)
+
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_7d"),
+                func.coalesce(func.count(AgentSpawnSessionTable.id), 0).label("session_count"),
+            ).where(
+                AgentSpawnSessionTable.started_at >= seven_days_ago,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        row = result.one()
+        total_cost_7d = float(row.total_cost_7d or 0.0)
+        avg_daily_cost = total_cost_7d / 7.0
+        projected_monthly = avg_daily_cost * 30.0
+
+        return {
+            "total_cost_7d": round(total_cost_7d, 6),
+            "avg_daily_cost_usd": round(avg_daily_cost, 6),
+            "projected_monthly_cost_usd": round(projected_monthly, 4),
+            "basis_days": 7,
+        }
+
+    # =========================================================================
+    # CACHE EFFICIENCY
+    # =========================================================================
+
+    async def get_cache_efficiency(self, period: str = "24h") -> dict[str, Any]:
+        """Return cache hit rate and estimated savings from prompt caching.
+
+        cache_hit_rate = cache_read_tokens / (input_tokens + cache_read_tokens)
+        cost_saved = what cache reads would have cost at full input price
+                     minus what they actually cost at cache-read price.
+        """
+        from roboco.billing.pricing import calculate_cost
+
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+            ).where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        row = result.one()
+        tokens_input = int(row.tokens_input or 0)
+        tokens_cache_read = int(row.tokens_cache_read or 0)
+        tokens_cache_write = int(row.tokens_cache_write or 0)
+
+        total_input_like = tokens_input + tokens_cache_read
+        cache_hit_rate = (
+            tokens_cache_read / total_input_like if total_input_like > 0 else 0.0
+        )
+
+        # Cost saved = (cache_read_tokens * full_input_rate) - actual_cache_read_cost
+        # Use sonnet as the baseline (most common model) for the aggregate estimate.
+        # The full input price for sonnet is $3/1M; cache read is $0.30/1M.
+        _MILLION = 1_000_000.0
+        _FULL_INPUT_PRICE = 3.00  # sonnet baseline, USD/1M
+        _CACHE_READ_PRICE = 0.30  # 10% of input
+        cost_at_full_price = tokens_cache_read * _FULL_INPUT_PRICE / _MILLION
+        cost_at_cache_price = tokens_cache_read * _CACHE_READ_PRICE / _MILLION
+        cost_saved = cost_at_full_price - cost_at_cache_price
+
+        return {
+            "cache_hit_rate": round(cache_hit_rate, 4),
+            "tokens_cache_read": tokens_cache_read,
+            "tokens_cache_write": tokens_cache_write,
+            "tokens_input": tokens_input,
+            "cost_saved_by_cache_usd": round(cost_saved, 6),
+            "period": period,
+        }
+
+    # =========================================================================
+    # TODAY'S USAGE (for CEO dashboard)
+    # =========================================================================
+
+    async def get_today_summary(self) -> dict[str, Any]:
+        """Return today's aggregated usage from daily_usage_rollups.
+
+        Used by the CEO dashboard to populate tokens_today and cost_today_usd.
+        Falls back to 0 values when no data exists for today.
+        """
+        today = date.today()
+
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(DailyUsageRollupTable.total_cost_usd), 0.0).label("total_cost_usd"),
+            ).where(DailyUsageRollupTable.date == today)
+        )
+        row = result.one()
+
+        tokens_today = (
+            int(row.tokens_input or 0)
+            + int(row.tokens_output or 0)
+            + int(row.tokens_cache_read or 0)
+            + int(row.tokens_cache_write or 0)
+        )
+
+        return {
+            "tokens_today": tokens_today,
+            "cost_today_usd": round(float(row.total_cost_usd or 0.0), 6),
+        }
+
+
+def get_usage_service(db: AsyncSession) -> UsageService:
+    """Factory function matching the pattern used by other services."""
+    return UsageService(db)

--- a/tests/unit/billing/test_pricing.py
+++ b/tests/unit/billing/test_pricing.py
@@ -1,0 +1,299 @@
+"""
+Unit tests for roboco.billing.pricing — calculate_cost().
+
+Covers:
+- Each model tier (opus, sonnet, haiku) with all 4 token types.
+- Unknown model name returns 0.0 without raising.
+- Empty model string returns 0.0 without raising.
+- Substring match correctness: longer fragment wins
+  (e.g. 'claude-sonnet-4-6' matches 'claude-sonnet-4' not bare 'sonnet').
+"""
+
+from __future__ import annotations
+
+import pytest
+from roboco.billing.pricing import calculate_cost
+
+# ---------------------------------------------------------------------------
+# Named constants (ruff PLR2004: magic values in comparisons must be named).
+# ---------------------------------------------------------------------------
+
+# Token counts
+_M = 1_000_000  # 1 million tokens
+
+# Pricing — per-1M USD, matches the _PRICING table in pricing.py
+_OPUS_INPUT = 15.00
+_OPUS_OUTPUT = 75.00
+_OPUS_CACHE_READ = 1.50
+_OPUS_CACHE_WRITE = 3.75
+
+_SONNET_INPUT = 3.00
+_SONNET_OUTPUT = 15.00
+_SONNET_CACHE_READ = 0.30
+_SONNET_CACHE_WRITE = 0.75
+
+_HAIKU_INPUT = 0.80
+_HAIKU_OUTPUT = 4.00
+_HAIKU_CACHE_READ = 0.08
+_HAIKU_CACHE_WRITE = 0.20
+
+_HAIKU3_INPUT = 0.25  # claude-haiku-3 is cheaper than haiku-3-5 / haiku-4
+
+# Tolerance for floating-point comparisons
+_TOL = 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Opus tier
+# ---------------------------------------------------------------------------
+
+
+class TestOpusTier:
+    """claude-opus-4 family pricing."""
+
+    def test_input_only(self) -> None:
+        cost = calculate_cost("claude-opus-4-5", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _OPUS_INPUT) < _TOL
+
+    def test_output_only(self) -> None:
+        cost = calculate_cost("claude-opus-4-5", tokens_input=0, tokens_output=_M)
+        assert abs(cost - _OPUS_OUTPUT) < _TOL
+
+    def test_cache_read_only(self) -> None:
+        cost = calculate_cost(
+            "claude-opus-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_read=_M,
+        )
+        assert abs(cost - _OPUS_CACHE_READ) < _TOL
+
+    def test_cache_write_only(self) -> None:
+        cost = calculate_cost(
+            "claude-opus-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_write=_M,
+        )
+        assert abs(cost - _OPUS_CACHE_WRITE) < _TOL
+
+    def test_all_token_types(self) -> None:
+        cost = calculate_cost(
+            "claude-opus-4-5",
+            tokens_input=_M,
+            tokens_output=_M,
+            tokens_cache_read=_M,
+            tokens_cache_write=_M,
+        )
+        expected = _OPUS_INPUT + _OPUS_OUTPUT + _OPUS_CACHE_READ + _OPUS_CACHE_WRITE
+        assert abs(cost - expected) < _TOL
+
+    def test_short_alias(self) -> None:
+        """Bare 'opus' alias resolves to the opus tier."""
+        cost = calculate_cost("opus", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _OPUS_INPUT) < _TOL
+
+    def test_returns_float(self) -> None:
+        cost = calculate_cost("claude-opus-4", tokens_input=100, tokens_output=50)
+        assert isinstance(cost, float)
+
+
+# ---------------------------------------------------------------------------
+# Sonnet tier
+# ---------------------------------------------------------------------------
+
+
+class TestSonnetTier:
+    """claude-sonnet-4 family pricing."""
+
+    def test_input_only(self) -> None:
+        cost = calculate_cost("claude-sonnet-4-6", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _SONNET_INPUT) < _TOL
+
+    def test_output_only(self) -> None:
+        cost = calculate_cost("claude-sonnet-4-6", tokens_input=0, tokens_output=_M)
+        assert abs(cost - _SONNET_OUTPUT) < _TOL
+
+    def test_cache_read_only(self) -> None:
+        cost = calculate_cost(
+            "claude-sonnet-4-6",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_read=_M,
+        )
+        assert abs(cost - _SONNET_CACHE_READ) < _TOL
+
+    def test_cache_write_only(self) -> None:
+        cost = calculate_cost(
+            "claude-sonnet-4-6",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_write=_M,
+        )
+        assert abs(cost - _SONNET_CACHE_WRITE) < _TOL
+
+    def test_all_token_types(self) -> None:
+        cost = calculate_cost(
+            "claude-sonnet-4-6",
+            tokens_input=_M,
+            tokens_output=_M,
+            tokens_cache_read=_M,
+            tokens_cache_write=_M,
+        )
+        expected = (
+            _SONNET_INPUT + _SONNET_OUTPUT + _SONNET_CACHE_READ + _SONNET_CACHE_WRITE
+        )
+        assert abs(cost - expected) < _TOL
+
+    def test_short_alias(self) -> None:
+        """Bare 'sonnet' alias resolves to the sonnet tier."""
+        cost = calculate_cost("sonnet", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _SONNET_INPUT) < _TOL
+
+    def test_35_variant(self) -> None:
+        """claude-3-5-sonnet resolves to sonnet tier."""
+        cost = calculate_cost(
+            "claude-3-5-sonnet-20241022", tokens_input=_M, tokens_output=0
+        )
+        assert abs(cost - _SONNET_INPUT) < _TOL
+
+
+# ---------------------------------------------------------------------------
+# Haiku tier
+# ---------------------------------------------------------------------------
+
+
+class TestHaikuTier:
+    """claude-haiku family pricing."""
+
+    def test_input_only(self) -> None:
+        cost = calculate_cost("claude-haiku-4-5", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _HAIKU_INPUT) < _TOL
+
+    def test_output_only(self) -> None:
+        cost = calculate_cost("claude-haiku-4-5", tokens_input=0, tokens_output=_M)
+        assert abs(cost - _HAIKU_OUTPUT) < _TOL
+
+    def test_cache_read_only(self) -> None:
+        cost = calculate_cost(
+            "claude-haiku-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_read=_M,
+        )
+        assert abs(cost - _HAIKU_CACHE_READ) < _TOL
+
+    def test_cache_write_only(self) -> None:
+        cost = calculate_cost(
+            "claude-haiku-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_write=_M,
+        )
+        assert abs(cost - _HAIKU_CACHE_WRITE) < _TOL
+
+    def test_all_token_types(self) -> None:
+        cost = calculate_cost(
+            "claude-haiku-4-5",
+            tokens_input=_M,
+            tokens_output=_M,
+            tokens_cache_read=_M,
+            tokens_cache_write=_M,
+        )
+        expected = _HAIKU_INPUT + _HAIKU_OUTPUT + _HAIKU_CACHE_READ + _HAIKU_CACHE_WRITE
+        assert abs(cost - expected) < _TOL
+
+    def test_short_alias(self) -> None:
+        """Bare 'haiku' alias resolves to the haiku tier."""
+        cost = calculate_cost("haiku", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _HAIKU_INPUT) < _TOL
+
+    def test_haiku3_variant(self) -> None:
+        """claude-haiku-3 has lower pricing than haiku-3-5."""
+        cost = calculate_cost("claude-haiku-3", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _HAIKU3_INPUT) < _TOL
+
+
+# ---------------------------------------------------------------------------
+# Unknown / edge cases — must return 0.0 without raising
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownModels:
+    def test_unknown_model_name_returns_zero(self) -> None:
+        cost = calculate_cost("gpt-4o", tokens_input=_M, tokens_output=_M)
+        assert cost == 0.0
+
+    def test_empty_string_returns_zero(self) -> None:
+        cost = calculate_cost("", tokens_input=_M, tokens_output=_M)
+        assert cost == 0.0
+
+    def test_gibberish_returns_zero(self) -> None:
+        cost = calculate_cost(
+            "totally-unknown-model-xyz", tokens_input=100, tokens_output=100
+        )
+        assert cost == 0.0
+
+    def test_zero_tokens_with_unknown_model_returns_zero(self) -> None:
+        cost = calculate_cost("unknown", tokens_input=0, tokens_output=0)
+        assert cost == 0.0
+
+    def test_does_not_raise_on_unknown_model(self) -> None:
+        """Must not raise regardless of token counts."""
+        try:
+            calculate_cost(
+                "not-a-claude-model",
+                tokens_input=999_999,
+                tokens_output=999_999,
+            )
+        except Exception as exc:
+            pytest.fail(f"calculate_cost raised unexpectedly: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Substring match correctness
+# ---------------------------------------------------------------------------
+
+# Named constants for the comparison floor/ceiling used in these tests.
+_ZERO_COST = 0.0
+_SONNET_CHEAPER_THAN_OPUS = True  # structural assertion in the test below
+
+
+class TestSubstringMatchPriority:
+    def test_claude_sonnet_4_resolves_non_zero(self) -> None:
+        """'claude-sonnet-4-6' must find a match (non-zero cost)."""
+        cost = calculate_cost("claude-sonnet-4-6", tokens_input=_M, tokens_output=0)
+        assert cost > _ZERO_COST
+
+    def test_haiku3_cheaper_than_haiku4(self) -> None:
+        """claude-haiku-3 is cheaper than claude-haiku-4 — longest-match wins."""
+        haiku3_cost = calculate_cost("claude-haiku-3", tokens_input=_M, tokens_output=0)
+        haiku4_cost = calculate_cost("claude-haiku-4", tokens_input=_M, tokens_output=0)
+        # haiku-3 ($0.25/1M) < haiku-4 ($0.80/1M)
+        assert haiku3_cost < haiku4_cost
+
+    def test_non_claude_model_returns_zero(self) -> None:
+        """A random non-Claude model must not match any Claude pricing entry."""
+        non_opus_cost = calculate_cost("llama-3-70b", tokens_input=_M, tokens_output=0)
+        assert non_opus_cost == _ZERO_COST
+
+    def test_opus_model_non_zero(self) -> None:
+        """Claude opus model resolves to non-zero cost."""
+        opus_cost = calculate_cost("claude-opus-4", tokens_input=_M, tokens_output=0)
+        assert opus_cost > _ZERO_COST
+
+    def test_zero_tokens_returns_zero_for_known_model(self) -> None:
+        """Known model with 0 tokens has 0 cost."""
+        cost = calculate_cost("claude-opus-4", tokens_input=0, tokens_output=0)
+        assert cost == _ZERO_COST
+
+    def test_case_insensitive_matching(self) -> None:
+        """Model name matching is case-insensitive."""
+        lower_cost = calculate_cost(
+            "claude-sonnet-4-6", tokens_input=1000, tokens_output=1000
+        )
+        upper_cost = calculate_cost(
+            "CLAUDE-SONNET-4-6", tokens_input=1000, tokens_output=1000
+        )
+        assert lower_cost == upper_cost
+        assert lower_cost > _ZERO_COST

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -1,0 +1,490 @@
+"""
+Unit tests for roboco.services.usage — UsageService analytics methods.
+
+These tests mock the SQLAlchemy AsyncSession.execute() boundary and
+verify the arithmetic / logic of each analytics method:
+
+- get_summary: trend_pct edge cases (prev=0, curr=0, both=0, prev>0)
+- get_by_agent/team/model: pct_of_total sums to 100%
+- get_projection: projected_monthly = avg_daily * 30
+- get_cache_efficiency: cache_hit_rate and cost_saved arithmetic
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from roboco.services.usage import UsageService
+
+# ---------------------------------------------------------------------------
+# Named constants (ruff PLR2004: magic values in comparisons must be named).
+# ---------------------------------------------------------------------------
+
+# Tolerance for floating-point arithmetic comparisons.
+_TOL = 0.001
+# Tolerance for percentage-sum assertions (rounding in pct_of_total).
+_PCT_TOL = 0.1
+
+# token count helpers
+_ZERO = 0
+_M = 1_000_000
+
+# Expected values for projection tests
+_COST_7D = 70.0
+_EXPECTED_AVG_DAILY = 10.0  # 70 / 7
+_EXPECTED_MONTHLY = 300.0  # 10 * 30
+_DAYS_BASIS = 7
+
+# Expected values for cache efficiency tests
+_CACHE_READ_TOKENS = 400
+_INPUT_TOKENS = 600
+_EXPECTED_HIT_RATE = 0.4  # 400 / (600 + 400)
+_FULL_INPUT_PRICE = 3.00  # sonnet baseline USD/1M
+_CACHE_READ_PRICE = 0.30
+_EXPECTED_COST_SAVED = _FULL_INPUT_PRICE - _CACHE_READ_PRICE  # = 2.70 per 1M
+
+# Expected trend_pct values
+_TREND_NONE = 0.0
+_TREND_NEW = 100.0  # curr > 0, prev == 0
+_TREND_DOUBLED = 200.0  # curr / prev = 3.0x → +200 %
+_TREND_HALVED = -50.0  # curr / prev = 0.5x → -50 %
+
+# Expected total_tokens when cache tokens are included
+_TOTAL_WITH_CACHE = 300  # 100+100+50+50
+
+# pct_of_total checks
+_FULL_PCT = 100.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(**kwargs: object) -> MagicMock:
+    """Return a MagicMock that mimics a SQLAlchemy Row with named attributes."""
+    row = MagicMock()
+    for k, v in kwargs.items():
+        setattr(row, k, v)
+    return row
+
+
+def _result_one(row: MagicMock) -> MagicMock:
+    """Return a mock execute() result whose .one() returns `row`."""
+    result = MagicMock()
+    result.one = MagicMock(return_value=row)
+    return result
+
+
+def _result_fetchall(rows: list[MagicMock]) -> MagicMock:
+    """Return a mock execute() result whose .fetchall() returns `rows`."""
+    result = MagicMock()
+    result.fetchall = MagicMock(return_value=rows)
+    return result
+
+
+def _service_with_execute(*return_values: object) -> UsageService:
+    """Build a UsageService whose session.execute() returns the provided
+    values in sequence (one per call)."""
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=list(return_values))
+    return UsageService(session)
+
+
+# ---------------------------------------------------------------------------
+# get_summary — trend_pct arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestGetSummaryTrendPct:
+    @pytest.mark.asyncio
+    async def test_both_zero_returns_zero_trend(self) -> None:
+        """When current and previous totals are both 0, trend_pct must be 0.0."""
+        current_row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.0,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert result["trend_pct"] == _TREND_NONE
+
+    @pytest.mark.asyncio
+    async def test_prev_zero_curr_positive_returns_100(self) -> None:
+        """When prev period is 0 but current is positive, trend_pct = 100.0."""
+        current_row = _make_row(
+            tokens_input=500,
+            tokens_output=500,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.01,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert result["trend_pct"] == _TREND_NEW
+
+    @pytest.mark.asyncio
+    async def test_positive_trend_calculation(self) -> None:
+        """trend_pct = (current - previous) / previous * 100 when prev > 0.
+
+        current = 1500 input + 1500 output = 3000; prev = 1000
+        → (3000 - 1000) / 1000 * 100 = 200.0
+        """
+        current_row = _make_row(
+            tokens_input=1500,
+            tokens_output=1500,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.1,
+        )
+        prev_row = _make_row(total=1000)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert abs(result["trend_pct"] - _TREND_DOUBLED) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_negative_trend_calculation(self) -> None:
+        """Negative trend when usage drops.
+
+        current = 250 + 250 = 500; prev = 1000
+        → (500 - 1000) / 1000 * 100 = -50.0
+        """
+        current_row = _make_row(
+            tokens_input=250,
+            tokens_output=250,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.01,
+        )
+        prev_row = _make_row(total=1000)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert abs(result["trend_pct"] - _TREND_HALVED) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total(self) -> None:
+        """total_tokens includes cache_read and cache_write tokens."""
+        current_row = _make_row(
+            tokens_input=100,
+            tokens_output=100,
+            tokens_cache_read=50,
+            tokens_cache_write=50,
+            total_cost_usd=0.005,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert result["total_tokens"] == _TOTAL_WITH_CACHE
+
+    @pytest.mark.asyncio
+    async def test_summary_contains_required_fields(self) -> None:
+        """Response dict must include all required summary fields."""
+        current_row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.0,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        for field in ("tokens_input", "tokens_output", "total_cost_usd", "trend_pct"):
+            assert field in result, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# get_by_agent — pct_of_total sums to 100%
+# ---------------------------------------------------------------------------
+
+
+class TestGetByAgent:
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100(self) -> None:
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=600,
+                tokens_output=400,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                agent_slug="be-dev-2",
+                tokens_input=300,
+                tokens_output=200,
+                cost_usd=0.02,
+            ),
+            _make_row(
+                agent_slug="be-qa",
+                tokens_input=100,
+                tokens_output=100,
+                cost_usd=0.01,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_empty_list(self) -> None:
+        svc = _service_with_execute(_result_fetchall([]))
+        result = await svc.get_by_agent("24h")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_single_agent_has_100_pct(self) -> None:
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=1000,
+                tokens_output=500,
+                cost_usd=0.1,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        assert len(result) == 1
+        assert result[_ZERO]["pct_of_total"] == _FULL_PCT
+
+    @pytest.mark.asyncio
+    async def test_result_contains_agent_slug_field(self) -> None:
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=100,
+                tokens_output=100,
+                cost_usd=0.01,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent()
+        assert result[_ZERO]["agent_slug"] == "be-dev-1"
+
+
+# ---------------------------------------------------------------------------
+# get_by_team — pct_of_total sums to 100%
+# ---------------------------------------------------------------------------
+
+
+class TestGetByTeam:
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100(self) -> None:
+        rows = [
+            _make_row(
+                team="backend", tokens_input=700, tokens_output=300, cost_usd=0.05
+            ),
+            _make_row(
+                team="frontend",
+                tokens_input=200,
+                tokens_output=200,
+                cost_usd=0.02,
+            ),
+            _make_row(team="uxui", tokens_input=100, tokens_output=100, cost_usd=0.01),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+    @pytest.mark.asyncio
+    async def test_result_contains_team_field(self) -> None:
+        rows = [
+            _make_row(
+                team="backend", tokens_input=100, tokens_output=100, cost_usd=0.01
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team()
+        assert result[_ZERO]["team"] == "backend"
+
+
+# ---------------------------------------------------------------------------
+# get_by_model — pct_of_total sums to 100%
+# ---------------------------------------------------------------------------
+
+
+class TestGetByModel:
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100(self) -> None:
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=600,
+                tokens_output=600,
+                cost_usd=0.1,
+            ),
+            _make_row(
+                model="claude-haiku-4-5",
+                tokens_input=300,
+                tokens_output=300,
+                cost_usd=0.02,
+            ),
+            _make_row(
+                model="claude-opus-4-5",
+                tokens_input=100,
+                tokens_output=100,
+                cost_usd=0.04,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+    @pytest.mark.asyncio
+    async def test_result_contains_model_field(self) -> None:
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=100,
+                tokens_output=100,
+                cost_usd=0.01,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model()
+        assert result[_ZERO]["model"] == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# get_projection — formula: projected_monthly = (total_7d / 7) * 30
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjection:
+    @pytest.mark.asyncio
+    async def test_projection_formula_30_day_extrapolation(self) -> None:
+        """projected_monthly_cost_usd = (total_cost_7d / 7) * 30."""
+        row = _make_row(total_cost_7d=_COST_7D, session_count=10)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        assert abs(result["projected_monthly_cost_usd"] - _EXPECTED_MONTHLY) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_zero_cost_7d_gives_zero_projection(self) -> None:
+        row = _make_row(total_cost_7d=0.0, session_count=_ZERO)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        assert result["projected_monthly_cost_usd"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_avg_daily_cost_equals_total_over_7(self) -> None:
+        """avg_daily = total_7d / 7."""
+        row = _make_row(total_cost_7d=21.0, session_count=5)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        # 21 / 7 = 3.0 avg daily cost
+        _avg_daily_21 = 3.0
+        assert abs(result["avg_daily_cost_usd"] - _avg_daily_21) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_projection_contains_required_fields(self) -> None:
+        row = _make_row(total_cost_7d=7.0, session_count=3)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        for field in (
+            "total_cost_7d",
+            "avg_daily_cost_usd",
+            "projected_monthly_cost_usd",
+            "basis_days",
+        ):
+            assert field in result, f"Missing field: {field}"
+        assert result["basis_days"] == _DAYS_BASIS
+
+
+# ---------------------------------------------------------------------------
+# get_cache_efficiency — hit rate and cost_saved arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestGetCacheEfficiency:
+    @pytest.mark.asyncio
+    async def test_cache_hit_rate_formula(self) -> None:
+        """cache_hit_rate = cache_read / (input + cache_read).
+
+        400 cache reads out of 400+600 total = 0.4
+        """
+        row = _make_row(
+            tokens_input=_INPUT_TOKENS,
+            tokens_output=_ZERO,
+            tokens_cache_read=_CACHE_READ_TOKENS,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert abs(result["cache_hit_rate"] - _EXPECTED_HIT_RATE) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_zero_input_tokens_gives_zero_hit_rate(self) -> None:
+        """When no input or cache_read tokens, hit rate is 0.0."""
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert result["cache_hit_rate"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_full_cache_hit_gives_rate_of_1(self) -> None:
+        """When all input-like tokens are cache reads, hit rate = 1.0."""
+        _full_rate = 1.0
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=1000,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert abs(result["cache_hit_rate"] - _full_rate) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_cost_saved_arithmetic(self) -> None:
+        """cost_saved = cache_read * (full_input_price - cache_read_price) / 1M.
+
+        Sonnet baseline: full=$3.00/1M, cache_read=$0.30/1M.
+        For 1M cache-read tokens: saved = 3.00 - 0.30 = 2.70.
+        """
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_M,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert abs(result["cost_saved_by_cache_usd"] - _EXPECTED_COST_SAVED) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_zero_cache_reads_gives_zero_savings(self) -> None:
+        row = _make_row(
+            tokens_input=1000,
+            tokens_output=500,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert result["cost_saved_by_cache_usd"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_cache_efficiency_contains_required_fields(self) -> None:
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        for field in ("cache_hit_rate", "cost_saved_by_cache_usd"):
+            assert field in result, f"Missing field: {field}"

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -299,18 +299,24 @@ class TestGetByAgent:
                 agent_slug="be-dev-1",
                 tokens_input=600,
                 tokens_output=400,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.05,
             ),
             _make_row(
                 agent_slug="be-dev-2",
                 tokens_input=300,
                 tokens_output=200,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.02,
             ),
             _make_row(
                 agent_slug="be-qa",
                 tokens_input=100,
                 tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.01,
             ),
         ]
@@ -332,6 +338,8 @@ class TestGetByAgent:
                 agent_slug="be-dev-1",
                 tokens_input=1000,
                 tokens_output=500,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.1,
             )
         ]
@@ -347,12 +355,64 @@ class TestGetByAgent:
                 agent_slug="be-dev-1",
                 tokens_input=100,
                 tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.01,
             )
         ]
         svc = _service_with_execute(_result_fetchall(rows))
         result = await svc.get_by_agent()
         assert result[_ZERO]["agent_slug"] == "be-dev-1"
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self) -> None:
+        """total_tokens must include cache_read and cache_write (AC10 fix).
+
+        Without the fix, total would be 500+300=800 (input+output only).
+        With the fix, total = 500+300+100+100 = 1000.
+        """
+        _cache_read = 100
+        _cache_write = 100
+        _expected_total = 500 + 300 + _cache_read + _cache_write  # 1000
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=500,
+                tokens_output=300,
+                tokens_cache_read=_cache_read,
+                tokens_cache_write=_cache_write,
+                cost_usd=0.05,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        assert result[_ZERO]["total_tokens"] == _expected_total
+
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100_with_cache_tokens(self) -> None:
+        """pct_of_total still sums to 100% when agents have cache tokens."""
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=400,
+                tokens_output=200,
+                tokens_cache_read=150,
+                tokens_cache_write=50,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                agent_slug="be-dev-2",
+                tokens_input=200,
+                tokens_output=100,
+                tokens_cache_read=75,
+                tokens_cache_write=25,
+                cost_usd=0.02,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
 
 
 # ---------------------------------------------------------------------------
@@ -365,15 +425,29 @@ class TestGetByTeam:
     async def test_pct_of_total_sums_to_100(self) -> None:
         rows = [
             _make_row(
-                team="backend", tokens_input=700, tokens_output=300, cost_usd=0.05
+                team="backend",
+                tokens_input=700,
+                tokens_output=300,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.05,
             ),
             _make_row(
                 team="frontend",
                 tokens_input=200,
                 tokens_output=200,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.02,
             ),
-            _make_row(team="uxui", tokens_input=100, tokens_output=100, cost_usd=0.01),
+            _make_row(
+                team="uxui",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
+            ),
         ]
         svc = _service_with_execute(_result_fetchall(rows))
         result = await svc.get_by_team("24h")
@@ -384,12 +458,63 @@ class TestGetByTeam:
     async def test_result_contains_team_field(self) -> None:
         rows = [
             _make_row(
-                team="backend", tokens_input=100, tokens_output=100, cost_usd=0.01
+                team="backend",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
             )
         ]
         svc = _service_with_execute(_result_fetchall(rows))
         result = await svc.get_by_team()
         assert result[_ZERO]["team"] == "backend"
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self) -> None:
+        """total_tokens must include cache_read and cache_write (AC10 fix)."""
+        _cache_read = 200
+        _cache_write = 100
+        _expected_total = 700 + 300 + _cache_read + _cache_write  # 1300
+        rows = [
+            _make_row(
+                team="backend",
+                tokens_input=700,
+                tokens_output=300,
+                tokens_cache_read=_cache_read,
+                tokens_cache_write=_cache_write,
+                cost_usd=0.05,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team("24h")
+        assert result[_ZERO]["total_tokens"] == _expected_total
+
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100_with_cache_tokens(self) -> None:
+        """pct_of_total still sums to 100% when teams have cache tokens."""
+        rows = [
+            _make_row(
+                team="backend",
+                tokens_input=600,
+                tokens_output=200,
+                tokens_cache_read=120,
+                tokens_cache_write=80,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                team="frontend",
+                tokens_input=300,
+                tokens_output=100,
+                tokens_cache_read=60,
+                tokens_cache_write=40,
+                cost_usd=0.02,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
 
 
 # ---------------------------------------------------------------------------
@@ -405,18 +530,24 @@ class TestGetByModel:
                 model="claude-sonnet-4-6",
                 tokens_input=600,
                 tokens_output=600,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.1,
             ),
             _make_row(
                 model="claude-haiku-4-5",
                 tokens_input=300,
                 tokens_output=300,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.02,
             ),
             _make_row(
                 model="claude-opus-4-5",
                 tokens_input=100,
                 tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.04,
             ),
         ]
@@ -432,12 +563,60 @@ class TestGetByModel:
                 model="claude-sonnet-4-6",
                 tokens_input=100,
                 tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
                 cost_usd=0.01,
             )
         ]
         svc = _service_with_execute(_result_fetchall(rows))
         result = await svc.get_by_model()
         assert result[_ZERO]["model"] == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self) -> None:
+        """total_tokens must include cache_read and cache_write (AC10 fix)."""
+        _cache_read = 300
+        _cache_write = 100
+        _expected_total = 600 + 600 + _cache_read + _cache_write  # 1600
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=600,
+                tokens_output=600,
+                tokens_cache_read=_cache_read,
+                tokens_cache_write=_cache_write,
+                cost_usd=0.1,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model("24h")
+        assert result[_ZERO]["total_tokens"] == _expected_total
+
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100_with_cache_tokens(self) -> None:
+        """pct_of_total still sums to 100% when models have cache tokens."""
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=500,
+                tokens_output=500,
+                tokens_cache_read=200,
+                tokens_cache_write=100,
+                cost_usd=0.1,
+            ),
+            _make_row(
+                model="claude-haiku-4-5",
+                tokens_input=250,
+                tokens_output=250,
+                tokens_cache_read=100,
+                tokens_cache_write=50,
+                cost_usd=0.02,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -199,6 +199,94 @@ class TestGetSummaryTrendPct:
 
 
 # ---------------------------------------------------------------------------
+# get_time_series — total_tokens includes all 4 token types (AC9 consistency)
+# ---------------------------------------------------------------------------
+
+# Named constants for time-series tests
+_TS_INPUT = 100
+_TS_OUTPUT = 200
+_TS_CACHE_READ = 50
+_TS_CACHE_WRITE = 30
+# total = 100 + 200 + 50 + 30 = 380
+_TS_TOTAL_WITH_CACHE = 380
+# Without cache tokens (the old wrong formula): 100 + 200 = 300
+_TS_TOTAL_WITHOUT_CACHE = 300
+
+
+class TestGetTimeSeries:
+    @pytest.mark.asyncio
+    async def test_total_tokens_includes_cache_read_and_write(self) -> None:
+        """total_tokens in each time-series point must include cache tokens.
+
+        This is the AC9 consistency requirement: time-series total_tokens must
+        sum to the same value as get_summary()'s total_tokens for the same
+        period.  The old implementation used ti + to_ (without cache), which
+        violated this constraint whenever cache tokens were non-zero.
+        """
+        import datetime
+
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        row = _make_row(
+            bucket=bucket_dt,
+            tokens_input=_TS_INPUT,
+            tokens_output=_TS_OUTPUT,
+            tokens_cache_read=_TS_CACHE_READ,
+            tokens_cache_write=_TS_CACHE_WRITE,
+            cost_usd=0.01,
+        )
+        svc = _service_with_execute(_result_fetchall([row]))
+        result = await svc.get_time_series("24h")
+        assert len(result) == 1
+        assert result[0]["total_tokens"] == _TS_TOTAL_WITH_CACHE
+
+    @pytest.mark.asyncio
+    async def test_total_tokens_without_cache_still_correct(self) -> None:
+        """When cache tokens are zero, total_tokens == tokens_input + tokens_output."""
+        import datetime
+
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        row = _make_row(
+            bucket=bucket_dt,
+            tokens_input=_TS_INPUT,
+            tokens_output=_TS_OUTPUT,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            cost_usd=0.01,
+        )
+        svc = _service_with_execute(_result_fetchall([row]))
+        result = await svc.get_time_series("24h")
+        assert result[0]["total_tokens"] == _TS_INPUT + _TS_OUTPUT
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_empty_list(self) -> None:
+        svc = _service_with_execute(_result_fetchall([]))
+        result = await svc.get_time_series("24h")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_point_contains_required_fields(self) -> None:
+        """Each time-series point must have bucket, tokens_input, tokens_output,
+        total_tokens, and cost_usd fields."""
+        import datetime
+
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        row = _make_row(
+            bucket=bucket_dt,
+            tokens_input=100,
+            tokens_output=100,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            cost_usd=0.01,
+        )
+        svc = _service_with_execute(_result_fetchall([row]))
+        result = await svc.get_time_series("24h")
+        assert len(result) == 1
+        point = result[0]
+        for field in ("bucket", "tokens_input", "tokens_output", "total_tokens", "cost_usd"):
+            assert field in point, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
 # get_by_agent — pct_of_total sums to 100%
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Implement the complete token usage instrumentation feature as a single vertical slice. This is greenfield work — no existing token persistence infrastructure exists.

**Layer 1 — DB Migration (Alembic):**
Create migration `023_token_usage_tables.py` adding three tables:
- `agent_spawn_sessions`: id (UUID PK), agent_slug (VARCHAR), team (VARCHAR), role (VARCHAR), model (VARCHAR), started_at (TIMESTAMP WITH TZ NOT NULL), ended_at (TIMESTAMP WITH TZ nullable), total_input_tokens (BIGINT DEFAULT 0), total_output_tokens (BIGINT DEFAULT 0), total_cache_creation_tokens (BIGINT DEFAULT 0), total_cache_read_tokens (BIGINT DEFAULT 0), exit_reason (VARCHAR nullable), estimated_cost_usd (NUMERIC(12,6) DEFAULT 0). Composite index on (agent_slug, started_at).
- `token_usage_snapshots`: id (UUID PK), agent_spawn_session_id (UUID FK → agent_spawn_sessions.id), snapshotted_at (TIMESTAMP WITH TZ NOT NULL), input_tokens (BIGINT DEFAULT 0), output_tokens (BIGINT DEFAULT 0), cache_creation_tokens (BIGINT DEFAULT 0), cache_read_tokens (BIGINT DEFAULT 0). Index on (agent_spawn_session_id, snapshotted_at).
- `daily_usage_rollups`: id (UUID PK), rollup_date (DATE NOT NULL), agent_slug (VARCHAR NOT NULL), team (VARCHAR), model (VARCHAR), total_input_tokens (BIGINT DEFAULT 0), total_output_tokens (BIGINT DEFAULT 0), total_cost_usd (NUMERIC(12,6) DEFAULT 0), session_count (INT DEFAULT 0). UNIQUE constraint on (rollup_date, agent_slug, team, model).

**Layer 2 — Pricing Module:**
Create `roboco/billing/pricing.py` with a static MODEL_PRICING dict mapping model name → {input_per_mtok, output_per_mtok, cache_creation_per_mtok, cache_read_per_mtok} in USD. Implement `calculate_cost(model: str, input_tokens: int, output_tokens: int, cache_creation_tokens: int, cache_read_tokens: int) -> float`. Handle unknown models gracefully (return 0.0, log warning).

**Layer 3 — Agent SDK Server (`roboco/agent_sdk/server.py`):**
Augment `_SessionState` with token accumulators: `input_tokens: int = 0`, `output_tokens: int = 0`, `cache_creation_tokens: int = 0`, `cache_read_tokens: int = 0`.
Add Pydantic models `UsageReportRequest` (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens — all int, default 0) and `UsageStatusResponse` (same fields, all current totals).
Add `POST /usage/report` endpoint: accumulates the reported token deltas into `_SessionState` (additive, not replacement).
Add `GET /usage/status` endpoint: returns current `_SessionState` token totals as `UsageStatusResponse`.
Extend `POST /budget/reset` to also zero out all token accumulators on respawn.

**Layer 4 — Orchestrator Hooks (`roboco/runtime/orchestrator.py`):**
- **Spawn hook**: After a container is successfully launched (after `_launch_spawn()` succeeds), insert a row into `agent_spawn_sessions` with agent_slug, team, role, model, started_at=utcnow(). Store the session UUID in the in-memory `AgentInstance` state (or a separate dict keyed by agent_slug). Wrap in try/except — DB failure must NOT abort the spawn.
- **Stop/PostMortem hook**: When a container stops (in `_handle_container_stop()` or the PostMortem path), look up the open session row, call `/usage/status` on the SDK server one final time, then UPDATE agent_spawn_sessions SET ended_at=utcnow(), total_input_tokens=..., total_output_tokens=..., total_cache_creation_tokens=..., total_cache_read_tokens=..., exit_reason=..., estimated_cost_usd=calculate_cost(...) WHERE id=... AND ended_at IS NULL.
- **Sweeper extension** in `_run_sweep()`: For each active agent, call `GET http://localhost:{sdk_port}/usage/status`. If any token count > 0, INSERT a `token_usage_snapshots` row with agent_spawn_session_id (looked up from the in-memory registry) + current counts.
- **Rollup loop**: Add `_rollup_loop()` async task started alongside existing background tasks. Run every 3600s. Execute UPSERT: `INSERT INTO daily_usage_rollups (rollup_date, agent_slug, team, model, total_input_tokens, total_output_tokens, total_cost_usd, session_count) SELECT date(ended_at AT TIME ZONE 'UTC'), agent_slug, team, model, SUM(total_input_tokens), SUM(total_output_tokens), SUM(estimated_cost_usd), COUNT(*) FROM agent_spawn_sessions WHERE ended_at IS NOT NULL GROUP BY 1,2,3,4 ON CONFLICT (rollup_date, agent_slug, team, model) DO UPDATE SET total_input_tokens=EXCLUDED.total_input_tokens, ...`.

**Layer 5 — Analytics API (`roboco/api/routes/usage.py`):**
Create new router, mount at `/api/usage` in `app.py`.
All endpoints accept optional `period` query param defaulting to `"24h"` (values: `"24h"`, `"7d"`, `"30d"`).

- `GET /api/usage/summary`: Query `daily_usage_rollups` for the requested period + previous equivalent period. Return `{period, tokens_input, tokens_output, total_tokens, total_cost_usd, session_count, trend_pct_tokens, trend_pct_cost}`. Trend = (current - previous) / previous * 100; handle zero-division.
- `GET /api/usage/time-series`: For `24h` → hourly buckets from `token_usage_snapshots`. For `7d`/`30d` → daily buckets from `daily_usage_rollups`. Return list of `{bucket_start, input_tokens, output_tokens, cost_usd}`.
- `GET /api/usage/by-agent`: Group `daily_usage_rollups` by agent_slug for the period. Return list of `{agent_slug, total_tokens, total_cost_usd, session_count, pct_of_total}`.
- `GET /api/usage/by-team`: Group by team. Same shape.
- `GET /api/usage/by-model`: Group by model. Same shape.
- `GET /api/usage/projection`: Compute 7-day rolling average daily cost from `daily_usage_rollups`, multiply by 30. Return `{projected_monthly_cost_usd, basis_days, avg_daily_cost_usd}`.
- `GET /api/usage/cache-efficiency`: From `agent_spawn_sessions` for the period, compute `cache_hit_rate = sum(total_cache_read_tokens) / (sum(total_input_tokens) + sum(total_cache_read_tokens))` and `cost_saved_by_cache` (cache read cost vs what full input cost would have been). Return `{cache_hit_rate, cost_saved_by_cache_usd, total_cache_read_tokens, total_cache_creation_tokens}`.

**Layer 6 — WebSocket Events:**
In the orchestrator's sweeper (after writing a snapshot) and stop hook (after closing a session), call `broadcast_*` functions from `roboco/api/websocket.py`. Define two new event types:
- `USAGE_SNAPSHOT`: emitted after each snapshot write, payload = {agent_slug, snapshotted_at, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens}.
- `USAGE_SESSION_END`: emitted when a spawn session is closed, payload = {agent_slug, started_at, ended_at, exit_reason, total_input_tokens, total_output_tokens, estimated_cost_usd}.
If the task description requires Redis Streams: also publish via `redis_client.xadd('usage-events', {...})` using the existing Redis client pattern.

**Layer 7 — CEO Dashboard Integration:**
In `roboco/services/dashboard.py`, add `UsageSummary` Pydantic model with `tokens_today: int` and `cost_today_usd: float`. In `get_ceo_overview()`, query `daily_usage_rollups` WHERE rollup_date = today(). Augment `CEOOverviewResponse` with `usage_summary: UsageSummary | None` (None if table doesn't exist yet / query returns no rows).

**Testing requirements:**
- Unit tests for pricing module (calculate_cost with known inputs)
- Unit tests for analytics API endpoints (mock DB responses)
- Integration test for SDK /usage/report → /usage/status round-trip
- All existing tests must continue to pass (uv run pytest)

**Code quality:** Run `uv run ruff format .`, `uv run ruff check .`, `uv run mypy roboco/` before marking done.