### PR TITLE
[cd2bf666] Core token usage UI components, hooks, and page integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ panel/.env.local
 panel/.env.*.local
 # Internal-only: strategy/scratch/reference dumps — never publish
 docs/internal/
+.pnpm-store/

--- a/panel/package.json
+++ b/panel/package.json
@@ -42,6 +42,7 @@
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/panel/pnpm-lock.yaml
+++ b/panel/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.8)(react@19.2.3)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -121,7 +124,7 @@ importers:
         version: 4.3.5
       zustand:
         specifier: ^5.0.10
-        version: 5.0.10(@types/react@19.2.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 5.0.10(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -362,89 +365,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -511,24 +530,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -1071,8 +1094,22 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -1118,24 +1155,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1193,6 +1234,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1233,6 +1301,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
@@ -1295,6 +1366,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1335,41 +1407,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1581,6 +1661,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1615,6 +1739,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -1697,6 +1824,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1828,6 +1958,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2007,6 +2140,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2021,6 +2160,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2238,24 +2381,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -2639,6 +2786,18 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -2673,6 +2832,22 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2692,6 +2867,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2871,6 +3049,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -3002,6 +3183,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3971,7 +4155,21 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -4073,6 +4271,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4112,6 +4334,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4476,6 +4700,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -4505,6 +4767,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -4656,6 +4920,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.47.0: {}
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -4667,7 +4933,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -4690,7 +4956,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4705,14 +4971,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4727,7 +4993,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4866,6 +5132,8 @@ snapshots:
   estree-util-is-identifier-name@3.0.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   extend@3.0.2: {}
 
@@ -5051,6 +5319,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5065,6 +5337,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -5886,6 +6160,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.8)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -5914,6 +6197,32 @@ snapshots:
       '@types/react': 19.2.8
 
   react@19.2.3: {}
+
+  recharts@3.8.1(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.47.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 16.13.1
+      react-redux: 9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5968,6 +6277,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -6206,6 +6517,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6391,6 +6704,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -6448,9 +6778,10 @@ snapshots:
 
   zod@4.3.5: {}
 
-  zustand@5.0.10(@types/react@19.2.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  zustand@5.0.10(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:
       '@types/react': 19.2.8
+      immer: 11.1.8
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
 

--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -6,7 +6,8 @@ import {
   useWaitingAgents,
   useAgentDefinitions,
 } from "@/hooks/use-agents";
-import { AgentStatusResponse } from "@/types";
+import { useAgentUsage } from "@/hooks/use-usage";
+import { AgentStatusResponse, AgentUsageRow } from "@/types";
 import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 import { OfflineState } from "@/components/ui/offline-state";
@@ -27,6 +28,7 @@ export default function AgentsPage() {
   const { data: agents = [], isLoading: agentsLoading } = useAgentDefinitions();
   const { data: status, isLoading, error, refetch } = useOrchestratorStatus();
   const { data: waitingAgents } = useWaitingAgents();
+  const { data: usageRows } = useAgentUsage();
 
   // Check if it's a connection error (backend not running)
   const isOffline = error && (
@@ -45,6 +47,15 @@ export default function AgentsPage() {
     }
     return result;
   }, [status]);
+
+  // Convert usage rows to a record keyed by agent_id
+  const agentUsageMap = useMemo(() => {
+    const result: Record<string, AgentUsageRow> = {};
+    for (const row of usageRows ?? []) {
+      result[row.agent_id] = row;
+    }
+    return result;
+  }, [usageRows]);
 
   return (
     <div className="space-y-6">
@@ -83,6 +94,7 @@ export default function AgentsPage() {
         title="Board"
         agents={getBoardAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />
@@ -91,6 +103,7 @@ export default function AgentsPage() {
         title="Main PM"
         agents={getMainPm(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />
@@ -99,6 +112,7 @@ export default function AgentsPage() {
         title="Backend Cell"
         agents={getBackendAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={5}
       />
@@ -107,6 +121,7 @@ export default function AgentsPage() {
         title="Frontend Cell"
         agents={getFrontendAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={5}
       />
@@ -115,6 +130,7 @@ export default function AgentsPage() {
         title="UX/UI Cell"
         agents={getUxAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />

--- a/panel/src/app/(dashboard)/metrics/page.tsx
+++ b/panel/src/app/(dashboard)/metrics/page.tsx
@@ -2,14 +2,30 @@
 
 import { useOrchestratorStatus } from "@/hooks/use-agents";
 import { useTasks } from "@/hooks/use-tasks";
+import {
+  useUsageSnapshot,
+  useUsageTimeSeries,
+  useAgentUsage,
+  useUsageSessions,
+  useModelUsage,
+} from "@/hooks/use-usage";
 import { TaskStatus, Team } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { OfflineState } from "@/components/ui/offline-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  UsageTimeSeriesChart,
+  ModelUsageDonut,
+  AgentUsageChart,
+  TeamUsageChart,
+  SessionsTable,
+} from "@/components/metrics";
 import {
   Activity,
   TrendingUp,
+  TrendingDown,
   Clock,
   AlertTriangle,
   Users,
@@ -18,6 +34,8 @@ import {
   RefreshCw,
   Zap,
   Timer,
+  Coins,
+  Sparkles,
 } from "lucide-react";
 
 interface MetricCardProps {
@@ -295,8 +313,236 @@ export default function MetricsPage() {
               ))}
             </div>
           </div>
+
+          {/* ─── Token Usage & Costs ─────────────────────────────────── */}
+          <TokenUsageCostsSection />
         </>
       )}
     </div>
+  );
+}
+
+// =============================================================================
+// TOKEN USAGE & COSTS SECTION
+// =============================================================================
+
+function TokenUsageCostsSection() {
+  const { data: snapshot, isLoading: loadingSnap } = useUsageSnapshot();
+  const { data: timeSeries, isLoading: loadingTS } = useUsageTimeSeries(24);
+  const { data: agentUsage, isLoading: loadingAgents } = useAgentUsage();
+  const { data: sessions, isLoading: loadingSessions } = useUsageSessions(100);
+  const { data: modelUsage, isLoading: loadingModels } = useModelUsage();
+
+  const weekTrend = snapshot
+    ? snapshot.cost_this_week - snapshot.cost_last_week
+    : 0;
+  const weekIsUp = weekTrend >= 0;
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold">Token Usage &amp; Costs</h2>
+
+      {/* Row 1 — Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        <SummaryCard
+          title="Tokens Today"
+          value={snapshot ? fmtTokens(snapshot.tokens_today) : undefined}
+          icon={<Zap className="h-4 w-4 text-yellow-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Cost Today"
+          value={snapshot ? "$" + snapshot.cost_today.toFixed(2) : undefined}
+          icon={<Coins className="h-4 w-4 text-green-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Cost This Week"
+          value={snapshot ? "$" + snapshot.cost_this_week.toFixed(2) : undefined}
+          icon={
+            weekIsUp ? (
+              <TrendingUp className="h-4 w-4 text-red-500" />
+            ) : (
+              <TrendingDown className="h-4 w-4 text-green-500" />
+            )
+          }
+          trend={
+            snapshot
+              ? {
+                  dir: weekIsUp ? "up" : "down",
+                  label:
+                    (weekIsUp ? "▲ " : "▼ ") +
+                    Math.abs(weekTrend).toFixed(2) +
+                    " vs last wk",
+                }
+              : undefined
+          }
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Active Sessions"
+          value={snapshot ? String(snapshot.active_sessions) : undefined}
+          icon={<Activity className="h-4 w-4 text-blue-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Cache Savings"
+          value={snapshot ? "$" + snapshot.cache_savings.toFixed(2) : undefined}
+          icon={<Sparkles className="h-4 w-4 text-purple-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Top Consumer"
+          value={snapshot?.top_consumer ?? undefined}
+          icon={<Users className="h-4 w-4 text-orange-500" />}
+          isLoading={loadingSnap}
+        />
+      </div>
+
+      {/* Row 2 — Time series + model donut */}
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <UsageTimeSeriesChart data={timeSeries} isLoading={loadingTS} />
+        </div>
+        <ModelUsageDonut data={modelUsage} isLoading={loadingModels} />
+      </div>
+
+      {/* Row 3 — Agent bar + team bar */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <AgentUsageChart data={agentUsage} isLoading={loadingAgents} />
+        <TeamUsageChart data={agentUsage} isLoading={loadingAgents} />
+      </div>
+
+      {/* Row 4 — Projection + cache efficiency */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ProjectionCard snapshot={snapshot} isLoading={loadingSnap} />
+        <CacheEfficiencyCard sessions={sessions} isLoading={loadingAgents || loadingSessions} />
+      </div>
+
+      {/* Row 5 — Sessions table */}
+      <SessionsTable data={sessions} isLoading={loadingSessions} />
+    </div>
+  );
+}
+
+// ─── Helper sub-components ────────────────────────────────────────────────────
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+interface SummaryCardProps {
+  title: string;
+  value: string | undefined;
+  icon: React.ReactNode;
+  trend?: { dir: "up" | "down"; label: string };
+  isLoading: boolean;
+}
+
+function SummaryCard({ title, value, icon, trend, isLoading }: SummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-7 w-24" />
+        ) : (
+          <>
+            <div className="text-2xl font-bold">{value ?? "—"}</div>
+            {trend && (
+              <p
+                className={
+                  "text-xs mt-1 " +
+                  (trend.dir === "up" ? "text-red-500" : "text-green-500")
+                }
+              >
+                {trend.label}
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+import type { TokenUsageSnapshot as TUS, UsageSession as US } from "@/types";
+
+interface ProjectionCardProps {
+  snapshot: TUS | undefined;
+  isLoading: boolean;
+}
+
+function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
+  const weeklyRun = snapshot
+    ? snapshot.cost_this_week / 7 * 30
+    : null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-blue-500" />
+          Monthly Projection
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-10 w-full" />
+        ) : (
+          <div>
+            <div className="text-3xl font-bold">
+              {weeklyRun != null ? "$" + weeklyRun.toFixed(2) : "—"}
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Based on this week&apos;s daily average
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface CacheEfficiencyCardProps {
+  sessions: US[] | undefined;
+  isLoading: boolean;
+}
+
+function CacheEfficiencyCard({ sessions, isLoading }: CacheEfficiencyCardProps) {
+  const totalCache = (sessions ?? []).reduce((s, r) => s + r.tokens_cache, 0);
+  const totalAll = (sessions ?? []).reduce(
+    (s, r) => s + r.tokens_input + r.tokens_output + r.tokens_cache,
+    0
+  );
+  const pct = totalAll > 0 ? (totalCache / totalAll) * 100 : 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-purple-500" />
+          Cache Efficiency
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-10 w-full" />
+        ) : (
+          <div>
+            <div className="text-3xl font-bold">{pct.toFixed(1)}%</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {fmtTokens(totalCache)} cached of {fmtTokens(totalAll)} total tokens
+            </p>
+            <Progress value={pct} className="mt-2" />
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/panel/src/components/agents/agent-card.tsx
+++ b/panel/src/components/agents/agent-card.tsx
@@ -17,13 +17,15 @@ import { MoreHorizontal, Activity, Square } from "lucide-react";
 import { toast } from "sonner";
 import { AgentStateBadge } from "./agent-state-badge";
 import { SpawnAgentDialog } from "./spawn-agent-dialog";
+import type { AgentUsageRow } from "@/types";
 
 interface AgentCardProps {
   agent: AgentDefinition;
   agentStatus: AgentStatusResponse | null;
+  usageRow?: AgentUsageRow | null;
 }
 
-export function AgentCard({ agent, agentStatus }: AgentCardProps) {
+export function AgentCard({ agent, agentStatus, usageRow }: AgentCardProps) {
   const stopAgent = useStopAgent();
   const state = agentStatus?.state || "stopped";
   const isActive = ["running", "ready", "starting", "waiting_long"].includes(state);
@@ -99,6 +101,30 @@ export function AgentCard({ agent, agentStatus }: AgentCardProps) {
           <p className="text-xs text-red-500 mt-2">
             Errors: {agentStatus.error_count}
           </p>
+        )}
+        {usageRow && (
+          <div className="mt-3 pt-2 border-t">
+            <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+              <span>
+                {usageRow.tokens_today >= 1_000
+                  ? (usageRow.tokens_today / 1_000).toFixed(1) + "K"
+                  : String(usageRow.tokens_today)}{" "}
+                tokens
+              </span>
+              <span className="font-medium text-foreground">
+                ${usageRow.cost_today.toFixed(2)}
+              </span>
+            </div>
+            <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-[var(--chart-1)]"
+                style={{
+                  width:
+                    Math.min(100, (usageRow.tokens_today / 30_000) * 100) + "%",
+                }}
+              />
+            </div>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/panel/src/components/agents/agent-grid.tsx
+++ b/panel/src/components/agents/agent-grid.tsx
@@ -1,4 +1,4 @@
-import { AgentStatusResponse } from "@/types";
+import { AgentStatusResponse, AgentUsageRow } from "@/types";
 import { AgentDefinition } from "@/lib/agent-definitions";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -8,6 +8,7 @@ interface AgentGridProps {
   title: string;
   agents: AgentDefinition[];
   agentStatuses: Record<string, AgentStatusResponse>;
+  agentUsage?: Record<string, AgentUsageRow>;
   isLoading: boolean;
   columns?: number;
 }
@@ -16,8 +17,9 @@ export function AgentGrid({
   title,
   agents,
   agentStatuses,
+  agentUsage,
   isLoading,
-  columns = 4
+  columns = 4,
 }: AgentGridProps) {
   const gridCols = {
     3: "md:grid-cols-3",
@@ -44,6 +46,7 @@ export function AgentGrid({
               key={agent.id}
               agent={agent}
               agentStatus={agentStatuses[agent.id] || null}
+              usageRow={agentUsage?.[agent.id] ?? null}
             />
           ))
         )}

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -11,6 +11,7 @@ import { QuickActionsBar } from "./quick-actions-bar";
 import { CeoApprovalQueue } from "./ceo-approval-queue";
 import type { Activity } from "./activity-item";
 import { Button } from "@/components/ui/button";
+import { UsageOverviewPanel } from "./usage-overview-panel";
 import { RefreshCw, Settings } from "lucide-react";
 import Link from "next/link";
 
@@ -61,13 +62,14 @@ export function CommandCenter() {
         <CeoApprovalQueue />
       </section>
 
-      {/* Metrics and Alerts Row */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Metrics, Alerts, and Usage Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <KeyMetricsPanel
           metrics={overview?.key_metrics}
           isLoading={loadingOverview}
         />
         <AuditorAlertsPanel alerts={flags} isLoading={loadingFlags} />
+        <UsageOverviewPanel />
       </div>
 
       {/* Blockers and Activity Row */}

--- a/panel/src/components/dashboard/index.ts
+++ b/panel/src/components/dashboard/index.ts
@@ -9,3 +9,4 @@ export { ActivityItem } from "./activity-item";
 export { QuickActionsBar } from "./quick-actions-bar";
 export { HealthIndicator } from "./health-indicator";
 export { CeoApprovalQueue } from "./ceo-approval-queue";
+export { UsageOverviewPanel } from "./usage-overview-panel";

--- a/panel/src/components/dashboard/usage-overview-panel.tsx
+++ b/panel/src/components/dashboard/usage-overview-panel.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUsageSnapshot } from "@/hooks/use-usage";
+import { Coins, TrendingUp, TrendingDown, Zap, Users, Sparkles } from "lucide-react";
+
+function fmt(n: number, decimals = 0): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return n.toFixed(decimals);
+}
+
+function fmtCost(n: number): string {
+  return "$" + n.toFixed(2);
+}
+
+interface MetricRowProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: React.ReactNode;
+}
+
+function MetricRow({ icon, label, value, sub }: MetricRowProps) {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="font-semibold text-sm">{value}</span>
+        {sub}
+      </div>
+    </div>
+  );
+}
+
+export function UsageOverviewPanel() {
+  const { data: snapshot, isLoading } = useUsageSnapshot();
+
+  const weekTrend = snapshot
+    ? snapshot.cost_this_week - snapshot.cost_last_week
+    : 0;
+  const weekTrendPct = snapshot?.cost_last_week
+    ? Math.abs(weekTrend / snapshot.cost_last_week) * 100
+    : 0;
+  const weekIsUp = weekTrend >= 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Coins className="h-5 w-5" />
+          Token Usage &amp; Cost
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-6" />
+            ))}
+          </div>
+        ) : (
+          <div className="divide-y">
+            <MetricRow
+              icon={<Zap className="h-4 w-4" />}
+              label="Tokens today"
+              value={snapshot ? fmt(snapshot.tokens_today) : "—"}
+            />
+            <MetricRow
+              icon={<Coins className="h-4 w-4" />}
+              label="Cost today"
+              value={snapshot ? fmtCost(snapshot.cost_today) : "—"}
+            />
+            <MetricRow
+              icon={
+                weekIsUp ? (
+                  <TrendingUp className="h-4 w-4 text-red-500" />
+                ) : (
+                  <TrendingDown className="h-4 w-4 text-green-500" />
+                )
+              }
+              label="Cost this week"
+              value={snapshot ? fmtCost(snapshot.cost_this_week) : "—"}
+              sub={
+                snapshot ? (
+                  <span
+                    className={
+                      "text-xs " + (weekIsUp ? "text-red-500" : "text-green-500")
+                    }
+                  >
+                    {weekIsUp ? "▲" : "▼"} {weekTrendPct.toFixed(0)}%
+                  </span>
+                ) : undefined
+              }
+            />
+            <MetricRow
+              icon={<Users className="h-4 w-4" />}
+              label="Active sessions"
+              value={snapshot ? String(snapshot.active_sessions) : "—"}
+            />
+            <MetricRow
+              icon={<Sparkles className="h-4 w-4 text-yellow-500" />}
+              label="Cache savings"
+              value={snapshot ? fmtCost(snapshot.cache_savings) : "—"}
+            />
+            <MetricRow
+              icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
+              label="Top consumer"
+              value={snapshot?.top_consumer ?? "—"}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { AgentUsageRow } from "@/types";
+
+interface AgentUsageChartProps {
+  data: AgentUsageRow[] | undefined;
+  isLoading: boolean;
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(0) + "k";
+  return String(n);
+}
+
+export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
+  const chartData = [...(data ?? [])]
+    .sort((a, b) => b.tokens_today - a.tokens_today)
+    .slice(0, 10)
+    .map((row) => ({
+      name: row.agent_name,
+      Tokens: row.tokens_today,
+    }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Agent Tokens Today</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <BarChart
+              data={chartData}
+              margin={{ top: 4, right: 8, left: 0, bottom: 24 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 10 }}
+                angle={-30}
+                textAnchor="end"
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tickFormatter={fmtK}
+                tick={{ fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={36}
+              />
+              <Tooltip
+                formatter={(value) => [
+                  fmtK(typeof value === "number" ? value : 0),
+                  "Tokens",
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/index.ts
+++ b/panel/src/components/metrics/index.ts
@@ -1,0 +1,5 @@
+export { UsageTimeSeriesChart } from "./usage-time-series-chart";
+export { ModelUsageDonut } from "./model-usage-donut";
+export { AgentUsageChart } from "./agent-usage-chart";
+export { TeamUsageChart } from "./team-usage-chart";
+export { SessionsTable } from "./sessions-table";

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ModelUsageSlice } from "@/types";
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+interface ModelUsageDonutProps {
+  data: ModelUsageSlice[] | undefined;
+  isLoading: boolean;
+}
+
+export function ModelUsageDonut({ data, isLoading }: ModelUsageDonutProps) {
+  const chartData = (data ?? []).map((s) => ({
+    name: s.model,
+    value: s.tokens,
+    cost: s.cost,
+    pct: s.percentage,
+  }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">By Model</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={52}
+                outerRadius={80}
+                dataKey="value"
+                paddingAngle={3}
+              >
+                {chartData.map((_, idx) => (
+                  <Cell
+                    key={idx}
+                    fill={CHART_COLORS[idx % CHART_COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value, name) => [
+                  (typeof value === "number" ? value : 0).toLocaleString() +
+                    " tokens",
+                  name,
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Legend wrapperStyle={{ fontSize: 11 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/sessions-table.tsx
+++ b/panel/src/components/metrics/sessions-table.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronUp, ChevronDown } from "lucide-react";
+import type { UsageSession } from "@/types";
+
+const PAGE_SIZE = 10;
+
+type SortKey = keyof Pick<
+  UsageSession,
+  | "agent_name"
+  | "started_at"
+  | "total_tokens"
+  | "tokens_input"
+  | "tokens_output"
+  | "tokens_cache"
+  | "cost"
+  | "model"
+>;
+
+type SortDir = "asc" | "desc";
+
+interface Column {
+  key: SortKey;
+  label: string;
+}
+
+const COLUMNS: Column[] = [
+  { key: "agent_name", label: "Agent" },
+  { key: "model", label: "Model" },
+  { key: "started_at", label: "Started" },
+  { key: "total_tokens", label: "Total" },
+  { key: "tokens_input", label: "Input" },
+  { key: "tokens_output", label: "Output" },
+  { key: "tokens_cache", label: "Cache" },
+  { key: "cost", label: "Cost" },
+];
+
+function formatTime(ts: string): string {
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "k";
+  return String(n);
+}
+
+interface SessionsTableProps {
+  data: UsageSession[] | undefined;
+  isLoading: boolean;
+}
+
+export function SessionsTable({ data, isLoading }: SessionsTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("started_at");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [page, setPage] = useState(0);
+
+  const sorted = useMemo(() => {
+    const rows = [...(data ?? [])];
+    rows.sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      const cmp =
+        typeof av === "number" && typeof bv === "number"
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return rows;
+  }, [data, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const visible = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+    setPage(0);
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col) return <ChevronUp className="h-3 w-3 opacity-30 ml-1 inline" />;
+    return sortDir === "asc" ? (
+      <ChevronUp className="h-3 w-3 ml-1 inline" />
+    ) : (
+      <ChevronDown className="h-3 w-3 ml-1 inline" />
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Recent Sessions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+              <Skeleton key={i} className="h-8" />
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {COLUMNS.map((col) => (
+                      <TableHead
+                        key={col.key}
+                        className="cursor-pointer select-none text-xs whitespace-nowrap"
+                        onClick={() => toggleSort(col.key)}
+                      >
+                        {col.label}
+                        <SortIcon col={col.key} />
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visible.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={COLUMNS.length} className="text-center text-muted-foreground text-sm py-8">
+                        No sessions recorded yet
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    visible.map((s) => (
+                      <TableRow key={s.id}>
+                        <TableCell className="text-xs font-medium">{s.agent_name}</TableCell>
+                        <TableCell className="text-xs">{s.model}</TableCell>
+                        <TableCell className="text-xs">{formatTime(s.started_at)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.total_tokens)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.tokens_input)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.tokens_output)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.tokens_cache)}</TableCell>
+                        <TableCell className="text-xs">${s.cost.toFixed(4)}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between mt-3 pt-3 border-t text-sm">
+              <span className="text-muted-foreground text-xs">
+                {sorted.length === 0
+                  ? "No sessions"
+                  : `${page * PAGE_SIZE + 1}–${Math.min((page + 1) * PAGE_SIZE, sorted.length)} of ${sorted.length}`}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                >
+                  Prev
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { AgentUsageRow } from "@/types";
+
+interface TeamUsageChartProps {
+  data: AgentUsageRow[] | undefined;
+  isLoading: boolean;
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(0) + "k";
+  return String(n);
+}
+
+export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
+  // Aggregate tokens by team
+  const teamTotals = new Map<string, number>();
+  for (const row of data ?? []) {
+    const prev = teamTotals.get(row.team) ?? 0;
+    teamTotals.set(row.team, prev + row.tokens_today);
+  }
+
+  const chartData = [...teamTotals.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .map(([team, tokens]) => ({
+      name: team.replace(/_/g, " "),
+      Tokens: tokens,
+    }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Team Tokens Today</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <BarChart
+              data={chartData}
+              margin={{ top: 4, right: 8, left: 0, bottom: 8 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tickFormatter={fmtK}
+                tick={{ fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={36}
+              />
+              <Tooltip
+                formatter={(value) => [
+                  fmtK(typeof value === "number" ? value : 0),
+                  "Tokens",
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Bar dataKey="Tokens" fill="var(--chart-2)" radius={[3, 3, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { UsageTimePoint } from "@/types";
+
+interface UsageTimeSeriesChartProps {
+  data: UsageTimePoint[] | undefined;
+  isLoading: boolean;
+}
+
+function formatHour(ts: string): string {
+  const d = new Date(ts);
+  return d.getHours().toString().padStart(2, "0") + ":00";
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(0) + "k";
+  return String(n);
+}
+
+export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartProps) {
+  const chartData = (data ?? []).map((p) => ({
+    hour: formatHour(p.timestamp),
+    Input: p.tokens_input,
+    Output: p.tokens_output,
+    Cache: p.tokens_cache,
+  }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Token Usage Over Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <AreaChart
+              data={chartData}
+              margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id="fillInput" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0.1} />
+                </linearGradient>
+                <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
+                </linearGradient>
+                <linearGradient id="fillCache" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--chart-3)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-3)" stopOpacity={0.1} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+              <XAxis
+                dataKey="hour"
+                tick={{ fontSize: 10 }}
+                interval={3}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tickFormatter={fmtK}
+                tick={{ fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={36}
+              />
+              <Tooltip
+                formatter={(value, name) => [
+                  fmtK(typeof value === "number" ? value : 0),
+                  name,
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Area
+                type="monotone"
+                dataKey="Input"
+                stackId="1"
+                stroke="var(--chart-1)"
+                fill="url(#fillInput)"
+              />
+              <Area
+                type="monotone"
+                dataKey="Output"
+                stackId="1"
+                stroke="var(--chart-2)"
+                fill="url(#fillOutput)"
+              />
+              <Area
+                type="monotone"
+                dataKey="Cache"
+                stackId="1"
+                stroke="var(--chart-3)"
+                fill="url(#fillCache)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/hooks/index.ts
+++ b/panel/src/hooks/index.ts
@@ -33,3 +33,4 @@ export * from "./use-websocket";
 export * from "./use-journals";
 export * from "./use-projects";
 export * from "./use-work-sessions";
+export * from "./use-usage";

--- a/panel/src/hooks/use-usage.ts
+++ b/panel/src/hooks/use-usage.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { usageApi } from "@/lib/api/usage";
+import type {
+  TokenUsageSnapshot,
+  AgentUsageRow,
+  UsageSession,
+  UsageTimePoint,
+  ModelUsageSlice,
+} from "@/types";
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const usageKeys = {
+  all: ["usage"] as const,
+  snapshot: () => [...usageKeys.all, "snapshot"] as const,
+  timeSeries: (hours: number) => [...usageKeys.all, "time-series", hours] as const,
+  agentUsage: () => [...usageKeys.all, "agents"] as const,
+  sessions: (limit: number) => [...usageKeys.all, "sessions", limit] as const,
+  modelUsage: () => [...usageKeys.all, "models"] as const,
+};
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+/** Snapshot of current-day usage totals (tokens, cost, sessions, cache) */
+export function useUsageSnapshot() {
+  return useQuery<TokenUsageSnapshot>({
+    queryKey: usageKeys.snapshot(),
+    queryFn: () => usageApi.getUsageSnapshot(),
+    refetchInterval: 60_000,
+  });
+}
+
+/** Hourly time-series data for the stacked area chart */
+export function useUsageTimeSeries(hours: number = 24) {
+  return useQuery<UsageTimePoint[]>({
+    queryKey: usageKeys.timeSeries(hours),
+    queryFn: () => usageApi.getUsageTimeSeries(hours),
+    refetchInterval: 120_000,
+  });
+}
+
+/** Per-agent usage rows for bar chart and agent card mini-bars */
+export function useAgentUsage() {
+  return useQuery<AgentUsageRow[]>({
+    queryKey: usageKeys.agentUsage(),
+    queryFn: () => usageApi.getAgentUsage(),
+    refetchInterval: 60_000,
+  });
+}
+
+/** Recent inference sessions for the sessions table */
+export function useUsageSessions(limit: number = 100) {
+  return useQuery<UsageSession[]>({
+    queryKey: usageKeys.sessions(limit),
+    queryFn: () => usageApi.getUsageSessions(limit),
+    refetchInterval: 30_000,
+  });
+}
+
+/** Per-model slices for the donut chart */
+export function useModelUsage() {
+  return useQuery<ModelUsageSlice[]>({
+    queryKey: usageKeys.modelUsage(),
+    queryFn: () => usageApi.getModelUsage(),
+    refetchInterval: 120_000,
+  });
+}

--- a/panel/src/lib/api/index.ts
+++ b/panel/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 export { api, API_URL } from "./client";
+export { usageApi } from "./usage";
 export { tasksApi } from "./tasks";
 export { orchestratorApi } from "./orchestrator";
 export { channelsApi } from "./channels";

--- a/panel/src/lib/api/usage.ts
+++ b/panel/src/lib/api/usage.ts
@@ -1,0 +1,145 @@
+import api from "./client";
+import { isMockMode } from "@/lib/mock-data";
+import type {
+  TokenUsageSnapshot,
+  AgentUsageRow,
+  UsageSession,
+  UsageTimePoint,
+  ModelUsageSlice,
+} from "@/types";
+
+// =============================================================================
+// MOCK DATA
+// =============================================================================
+
+function mockSnapshot(): TokenUsageSnapshot {
+  return {
+    tokens_today: 124_800,
+    cost_today: 3.74,
+    cost_this_week: 22.50,
+    cost_last_week: 18.20,
+    active_sessions: 3,
+    cache_savings: 1.25,
+    top_consumer: "be-dev-1",
+  };
+}
+
+function mockTimeSeries(): UsageTimePoint[] {
+  const now = new Date();
+  return Array.from({ length: 24 }, (_, i) => {
+    const ts = new Date(now);
+    ts.setHours(now.getHours() - (23 - i), 0, 0, 0);
+    const base = 3_000 + Math.round(Math.random() * 4_000);
+    return {
+      timestamp: ts.toISOString(),
+      tokens_input: Math.round(base * 0.45),
+      tokens_output: Math.round(base * 0.35),
+      tokens_cache: Math.round(base * 0.20),
+    };
+  });
+}
+
+function mockAgentUsage(): AgentUsageRow[] {
+  const agents = [
+    { agent_id: "be-dev-1", agent_name: "BE-Dev-1", team: "backend" },
+    { agent_id: "be-dev-2", agent_name: "BE-Dev-2", team: "backend" },
+    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1", team: "frontend" },
+    { agent_id: "fe-dev-2", agent_name: "FE-Dev-2", team: "frontend" },
+    { agent_id: "ux-dev-1", agent_name: "UX-Dev-1", team: "ux_ui" },
+    { agent_id: "be-qa", agent_name: "BE-QA", team: "backend" },
+    { agent_id: "fe-qa", agent_name: "FE-QA", team: "frontend" },
+    { agent_id: "main-pm", agent_name: "Main-PM", team: "main_pm" },
+  ];
+  return agents.map((a) => ({
+    ...a,
+    tokens_today: Math.round(5_000 + Math.random() * 25_000),
+    cost_today: parseFloat((0.15 + Math.random() * 0.75).toFixed(2)),
+    tokens_total: Math.round(50_000 + Math.random() * 200_000),
+  }));
+}
+
+function mockSessions(): UsageSession[] {
+  const models = ["claude-opus-4", "claude-sonnet-4", "claude-haiku-4"];
+  const agents = [
+    { agent_id: "be-dev-1", agent_name: "BE-Dev-1" },
+    { agent_id: "be-dev-2", agent_name: "BE-Dev-2" },
+    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1" },
+    { agent_id: "fe-qa", agent_name: "FE-QA" },
+    { agent_id: "main-pm", agent_name: "Main-PM" },
+  ];
+  return Array.from({ length: 35 }, (_, i) => {
+    const agent = agents[i % agents.length];
+    const model = models[i % models.length];
+    const input = Math.round(2_000 + Math.random() * 8_000);
+    const output = Math.round(500 + Math.random() * 3_000);
+    const cache = Math.round(100 + Math.random() * 1_000);
+    const started = new Date(Date.now() - (i + 1) * 12 * 60_000);
+    const ended = i < 3 ? null : new Date(started.getTime() + Math.round(5 + Math.random() * 55) * 60_000);
+    return {
+      id: `session-mock-${i + 1}`,
+      agent_id: agent.agent_id,
+      agent_name: agent.agent_name,
+      started_at: started.toISOString(),
+      ended_at: ended ? ended.toISOString() : null,
+      tokens_input: input,
+      tokens_output: output,
+      tokens_cache: cache,
+      total_tokens: input + output + cache,
+      cost: parseFloat(((input + output) * 0.00003 + cache * 0.000003).toFixed(4)),
+      model,
+    };
+  });
+}
+
+function mockModelUsage(): ModelUsageSlice[] {
+  return [
+    { model: "claude-opus-4", tokens: 68_400, cost: 2.05, percentage: 54.8 },
+    { model: "claude-sonnet-4", tokens: 43_200, cost: 1.30, percentage: 34.6 },
+    { model: "claude-haiku-4", tokens: 13_200, cost: 0.40, percentage: 10.6 },
+  ];
+}
+
+// =============================================================================
+// API OBJECT
+// =============================================================================
+
+export const usageApi = {
+  /** Current-day snapshot for the overview panel */
+  getUsageSnapshot: async (): Promise<TokenUsageSnapshot> => {
+    if (isMockMode()) return mockSnapshot();
+    const { data } = await api.get<TokenUsageSnapshot>("/usage/snapshot");
+    return data;
+  },
+
+  /** Hourly time-series data for the stacked area chart */
+  getUsageTimeSeries: async (hours: number = 24): Promise<UsageTimePoint[]> => {
+    if (isMockMode()) return mockTimeSeries();
+    const { data } = await api.get<UsageTimePoint[]>("/usage/time-series", {
+      params: { hours },
+    });
+    return data;
+  },
+
+  /** Per-agent usage rows for the bar chart and agent cards */
+  getAgentUsage: async (): Promise<AgentUsageRow[]> => {
+    if (isMockMode()) return mockAgentUsage();
+    const { data } = await api.get<AgentUsageRow[]>("/usage/agents");
+    return data;
+  },
+
+  /** Recent inference sessions for the sessions table */
+  getUsageSessions: async (limit: number = 100): Promise<UsageSession[]> => {
+    if (isMockMode()) return mockSessions();
+    const { data } = await api.get<UsageSession[]>("/usage/sessions", {
+      params: { limit },
+    });
+    return data;
+  },
+
+  /** Per-model usage slices for the donut chart */
+  getModelUsage: async (): Promise<ModelUsageSlice[]> => {
+    if (isMockMode()) return mockModelUsage();
+    const { data } = await api.get<ModelUsageSlice[]>("/usage/models");
+    return data;
+  },
+};

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -1253,3 +1253,59 @@ export interface CEOApprovalRequest {
 export interface CEORejectRequest {
   notes: string; // Required for rejection
 }
+
+// =============================================================================
+// TOKEN USAGE TYPES
+// =============================================================================
+
+/** Snapshot of current token usage totals for the overview panel */
+export interface TokenUsageSnapshot {
+  tokens_today: number;
+  cost_today: number;
+  cost_this_week: number;
+  cost_last_week: number;
+  active_sessions: number;
+  cache_savings: number;
+  top_consumer: string;
+}
+
+/** Per-agent usage row for the agent bar chart and agent card mini-bar */
+export interface AgentUsageRow {
+  agent_id: string;
+  agent_name: string;
+  tokens_today: number;
+  cost_today: number;
+  tokens_total: number;
+  team: string;
+}
+
+/** Individual inference session for the sessions table */
+export interface UsageSession {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  started_at: string;
+  ended_at: string | null;
+  tokens_input: number;
+  tokens_output: number;
+  tokens_cache: number;
+  total_tokens: number;
+  cost: number;
+  model: string;
+}
+
+/** One data point in a token-usage time series (hourly or daily) */
+export interface UsageTimePoint {
+  timestamp: string;
+  tokens_input: number;
+  tokens_output: number;
+  tokens_cache: number;
+}
+
+/** A model's share of overall token usage for the donut chart */
+export interface ModelUsageSlice {
+  model: string;
+  tokens: number;
+  cost: number;
+  percentage: number;
+}


### PR DESCRIPTION
Implement all static token-usage UI components and data-fetching infrastructure for the roboco-panel frontend, covering 6 of the 7 acceptance criteria.

**What to build (in suggested order):**

1. **TypeScript interfaces** — add to `src/types/index.ts`:
   - `TokenUsageSnapshot`: `{ tokensToday: number; costToday: number; costThisWeek: number; costTrend: 'up'|'down'|'flat'; activeSessions: number; cacheSavings: number; topConsumer: string; }`
   - `AgentUsageRow`: `{ agentId: string; agentName: string; team: string; tokensToday: number; costToday: number; inputTokens: number; outputTokens: number; cacheTokens: number; }`
   - `UsageSession`: `{ sessionId: string; agentId: string; agentName: string; startedAt: string; endedAt: string | null; inputTokens: number; outputTokens: number; cacheTokens: number; totalCost: number; model: string; }`
   - `UsageTimePoint`: `{ timestamp: string; inputTokens: number; outputTokens: number; cacheTokens: number; }`
   - `ModelUsageSlice`: `{ model: string; tokens: number; }`

2. **Axios API module** — create `src/lib/api/usage.ts`:
   - Import the `api` singleton from `src/lib/api/client.ts` and `isMockMode()` from constants
   - Implement `getUsageSnapshot(): Promise<TokenUsageSnapshot>` calling `GET /api/usage/snapshot`
   - Implement `getUsageTimeSeries(range?: string): Promise<UsageTimePoint[]>` calling `GET /api/usage/timeseries`
   - Implement `getAgentUsage(): Promise<AgentUsageRow[]>` calling `GET /api/usage/agents`
   - Implement `getUsageSessions(page: number, pageSize: number): Promise<{ items: UsageSession[]; total: number }>` calling `GET /api/usage/sessions`
   - Each function must check `isMockMode()` first and return rich typed mock data when true (follow the exact pattern in `src/lib/api/dashboard.ts` or `tasks.ts`)

3. **React Query hooks** — create `src/hooks/use-usage.ts`:
   - Export `usageKeys` factory: `{ all: ['usage'], snapshot: () => [...all, 'snapshot'], timeSeries: (range?) => [...all, 'timeseries', range], agents: () => [...all, 'agents'], sessions: (page, pageSize) => [...all, 'sessions', page, pageSize] }`
   - `useUsageSnapshot()`: `useQuery({ queryKey: usageKeys.snapshot(), queryFn: getUsageSnapshot, staleTime: 30_000 })`
   - `useUsageTimeSeries(range?)`: `useQuery` with `staleTime: 60_000`
   - `useAgentUsage()`: `useQuery` with `staleTime: 30_000`
   - `useUsageSessions(page, pageSize)`: `useQuery` with `keepPreviousData: true`

4. **UsageOverviewPanel component** — create `src/components/dashboard/usage-overview-panel.tsx`:
   - Props: `{ snapshot: TokenUsageSnapshot | undefined; isLoading: boolean }`
   - Use `<Card><CardHeader><CardContent>` (shadcn/ui new-york style)
   - Show Skeleton while loading (follow `key-metrics-panel.tsx` pattern exactly)
   - Display 6 metric rows: Tokens Today, Cost Today, Cost This Week (with trend arrow icon from lucide-react: TrendingUp/TrendingDown), Active Sessions, Cache Savings, Top Consumer
   - Export from `src/components/dashboard/index.ts`

5. **CommandCenter update** — edit `src/components/dashboard/command-center.tsx`:
   - Import and call `useUsageSnapshot()`
   - Change the `<KeyMetricsPanel>` + `<AuditorAlertsPanel>` 2-column grid to a **3-column grid** (`grid grid-cols-1 md:grid-cols-3 gap-4` or match existing Tailwind classes)
   - Add `<UsageOverviewPanel snapshot={usageSnapshot} isLoading={usageLoading} />` as the third column

6. **Metrics page Token Usage & Costs section** — create `src/components/metrics/` folder with:
   a. `UsageTimeSeriesChart` component: Recharts `<AreaChart>` (check if recharts is in package.json; install if not). Three `<Area>` stacks with `stackId="usage"`, fills using CSS vars `var(--chart-1)`, `var(--chart-2)`, `var(--chart-3)` for input/output/cache respectively. Also add a `<PieChart>` (model donut) alongside it.
   b. `AgentUsageChart` + `TeamUsageChart`: Recharts `<BarChart>` for agent breakdown and team breakdown side-by-side.
   c. `UsageProjectionCard` + `CacheEfficiencyCard`: simple metric cards for the 4th row.
   d. `SessionsTable` component: tabular display of `UsageSession[]`, column headers are clickable and toggle sort direction (`useState<{col, dir}>`), paginate at 10 rows per page using `useState<number>` page index with Prev/Next buttons.
   - Update `src/app/(dashboard)/metrics/page.tsx` to import and render a `<TokenUsageCostsSection>` wrapper containing all 5 rows

7. **Agents page mini-bar** — find the agent card component (likely in `src/components/agents/`), import `useAgentUsage()`, look up the agent's row, and render a small progress bar (`<div>` with Tailwind width based on % of max) showing today's token count and cost beneath the existing card content.

**Standards to follow:**
- All new files must be `"use client"` where they use hooks
- TypeScript strict: no `any`, explicit return types on exported functions
- shadcn/ui new-york style: `<Card>`, `<CardHeader>`, `<CardTitle>`, `<CardContent>`, `<Badge>`, `<Skeleton>` from `@/components/ui/`
- Lucide-react for icons (already installed)
- Export all new components from their folder's `index.ts` barrel