### PR TITLE
[499f9eb1] Token Usage & Cost Analytics — Full-Stack Instrumentation, Persistence, and Visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ panel/.env.local
 panel/.env.*.local
 # Internal-only: strategy/scratch/reference dumps — never publish
 docs/internal/
+.pnpm-store/

--- a/alembic/versions/026_token_usage_tables.py
+++ b/alembic/versions/026_token_usage_tables.py
@@ -17,7 +17,10 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
 revision = "026_token_usage_tables"
-down_revision = "025_agentrole_prompter"
+# Rebased onto 026_completed_dependency_ids so the chain stays linear: the
+# master merge brought in a second migration off 025_agentrole_prompter, which
+# forked the head. Chain is now 025 -> 026_completed_dependency_ids -> this.
+down_revision = "026_completed_dependency_ids"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/026_token_usage_tables.py
+++ b/alembic/versions/026_token_usage_tables.py
@@ -1,0 +1,167 @@
+"""026_token_usage_tables
+
+Create token usage instrumentation tables:
+- agent_spawn_sessions: tracks each agent container spawn with token totals
+- token_usage_snapshots: periodic snapshots of token usage per session
+- daily_usage_rollups: aggregated daily usage per agent/team/model
+
+Revision ID: 026_token_usage_tables
+Revises: 025_agentrole_prompter
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "026_token_usage_tables"
+down_revision = "025_agentrole_prompter"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # agent_spawn_sessions
+    # One row per container spawn. Opened on spawn, closed on stop.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "agent_spawn_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_slug", sa.String(100), nullable=False),
+        sa.Column("team", sa.String(50), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("task_id", sa.String(36), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("ended_at", sa.DateTime(timezone=True), nullable=True),
+        # BIGINT for token counts — they can exceed INT32 for long sessions
+        sa.Column("tokens_input", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tokens_output", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column(
+            "tokens_cache_read", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "tokens_cache_write", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column("exit_reason", sa.String(100), nullable=True),
+        sa.Column("estimated_cost_usd", sa.Float, nullable=True),
+    )
+
+    # Indexes for common query patterns
+    op.create_index(
+        "ix_agent_spawn_sessions_agent_slug",
+        "agent_spawn_sessions",
+        ["agent_slug"],
+    )
+    op.create_index(
+        "ix_agent_spawn_sessions_started_at",
+        "agent_spawn_sessions",
+        ["started_at"],
+    )
+    op.create_index(
+        "ix_agent_spawn_sessions_ended_at",
+        "agent_spawn_sessions",
+        ["ended_at"],
+    )
+    op.create_index(
+        "ix_agent_spawn_sessions_team",
+        "agent_spawn_sessions",
+        ["team"],
+    )
+
+    # ------------------------------------------------------------------
+    # token_usage_snapshots
+    # Periodic snapshots (every ~60s) of token counts for active sessions.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "token_usage_snapshots",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "agent_spawn_session_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey(
+                "agent_spawn_sessions.id", ondelete="CASCADE", name="fk_snapshot_session"
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "snapshotted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("tokens_input", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tokens_output", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column(
+            "tokens_cache_read", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "tokens_cache_write", sa.BigInteger, nullable=False, server_default="0"
+        ),
+    )
+
+    op.create_index(
+        "ix_token_usage_snapshots_session_id",
+        "token_usage_snapshots",
+        ["agent_spawn_session_id"],
+    )
+    op.create_index(
+        "ix_token_usage_snapshots_snapshotted_at",
+        "token_usage_snapshots",
+        ["snapshotted_at"],
+    )
+
+    # ------------------------------------------------------------------
+    # daily_usage_rollups
+    # Pre-aggregated daily totals per (date, agent_slug, team, model).
+    # Populated by the sweeper; upserted on each sweep so re-runs are safe.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "daily_usage_rollups",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("date", sa.Date, nullable=False),
+        sa.Column("agent_slug", sa.String(100), nullable=False),
+        sa.Column("team", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("tokens_input", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("tokens_output", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column(
+            "tokens_cache_read", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "tokens_cache_write", sa.BigInteger, nullable=False, server_default="0"
+        ),
+        sa.Column("total_cost_usd", sa.Float, nullable=False, server_default="0"),
+        sa.Column("session_count", sa.Integer, nullable=False, server_default="0"),
+    )
+
+    # Unique constraint enables ON CONFLICT upsert in the sweeper
+    op.create_unique_constraint(
+        "uq_daily_rollup_date_agent_team_model",
+        "daily_usage_rollups",
+        ["date", "agent_slug", "team", "model"],
+    )
+    op.create_index(
+        "ix_daily_rollups_date",
+        "daily_usage_rollups",
+        ["date"],
+    )
+    op.create_index(
+        "ix_daily_rollups_agent_slug",
+        "daily_usage_rollups",
+        ["agent_slug"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("daily_usage_rollups")
+    op.drop_table("token_usage_snapshots")
+    op.drop_table("agent_spawn_sessions")

--- a/panel/package.json
+++ b/panel/package.json
@@ -42,6 +42,7 @@
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",

--- a/panel/pnpm-lock.yaml
+++ b/panel/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.8)(react@19.2.3)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -121,7 +124,7 @@ importers:
         version: 4.3.5
       zustand:
         specifier: ^5.0.10
-        version: 5.0.10(@types/react@19.2.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+        version: 5.0.10(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -362,89 +365,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -511,24 +530,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -1071,8 +1094,22 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -1118,24 +1155,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1193,6 +1234,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1233,6 +1301,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
@@ -1295,6 +1366,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1335,41 +1407,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1581,6 +1661,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1615,6 +1739,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
@@ -1697,6 +1824,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1828,6 +1958,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2007,6 +2140,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2021,6 +2160,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2238,24 +2381,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -2639,6 +2786,18 @@ packages:
       '@types/react': '>=18'
       react: '>=18'
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -2673,6 +2832,22 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -2692,6 +2867,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2871,6 +3049,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -3002,6 +3183,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3971,7 +4155,21 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
 
@@ -4073,6 +4271,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -4112,6 +4334,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4476,6 +4700,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -4505,6 +4767,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.2.0:
     dependencies:
@@ -4656,6 +4920,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.47.0: {}
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -4667,7 +4933,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -4690,7 +4956,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4705,14 +4971,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4727,7 +4993,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4866,6 +5132,8 @@ snapshots:
   estree-util-is-identifier-name@3.0.0: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   extend@3.0.2: {}
 
@@ -5051,6 +5319,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -5065,6 +5337,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -5886,6 +6160,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      redux: 5.0.1
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.8)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -5914,6 +6197,32 @@ snapshots:
       '@types/react': 19.2.8
 
   react@19.2.3: {}
+
+  recharts@3.8.1(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.47.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 16.13.1
+      react-redux: 9.3.0(@types/react@19.2.8)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5968,6 +6277,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -6206,6 +6517,8 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -6391,6 +6704,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -6448,9 +6778,10 @@ snapshots:
 
   zod@4.3.5: {}
 
-  zustand@5.0.10(@types/react@19.2.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
+  zustand@5.0.10(@types/react@19.2.8)(immer@11.1.8)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:
       '@types/react': 19.2.8
+      immer: 11.1.8
       react: 19.2.3
       use-sync-external-store: 1.6.0(react@19.2.3)
 

--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -48,11 +48,11 @@ export default function AgentsPage() {
     return result;
   }, [status]);
 
-  // Convert usage rows to a record keyed by agent_id
+  // Convert usage rows to a record keyed by agent_slug
   const agentUsageMap = useMemo(() => {
     const result: Record<string, AgentUsageRow> = {};
     for (const row of usageRows ?? []) {
-      result[row.agent_id] = row;
+      result[row.agent_slug] = row;
     }
     return result;
   }, [usageRows]);

--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -6,7 +6,8 @@ import {
   useWaitingAgents,
   useAgentDefinitions,
 } from "@/hooks/use-agents";
-import { AgentStatusResponse } from "@/types";
+import { useAgentUsage } from "@/hooks/use-usage";
+import { AgentStatusResponse, AgentUsageRow } from "@/types";
 import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 import { OfflineState } from "@/components/ui/offline-state";
@@ -27,6 +28,7 @@ export default function AgentsPage() {
   const { data: agents = [], isLoading: agentsLoading } = useAgentDefinitions();
   const { data: status, isLoading, error, refetch } = useOrchestratorStatus();
   const { data: waitingAgents } = useWaitingAgents();
+  const { data: usageRows } = useAgentUsage();
 
   // Check if it's a connection error (backend not running)
   const isOffline = error && (
@@ -45,6 +47,15 @@ export default function AgentsPage() {
     }
     return result;
   }, [status]);
+
+  // Convert usage rows to a record keyed by agent_id
+  const agentUsageMap = useMemo(() => {
+    const result: Record<string, AgentUsageRow> = {};
+    for (const row of usageRows ?? []) {
+      result[row.agent_id] = row;
+    }
+    return result;
+  }, [usageRows]);
 
   return (
     <div className="space-y-6">
@@ -83,6 +94,7 @@ export default function AgentsPage() {
         title="Board"
         agents={getBoardAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />
@@ -91,6 +103,7 @@ export default function AgentsPage() {
         title="Main PM"
         agents={getMainPm(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />
@@ -99,6 +112,7 @@ export default function AgentsPage() {
         title="Backend Cell"
         agents={getBackendAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={5}
       />
@@ -107,6 +121,7 @@ export default function AgentsPage() {
         title="Frontend Cell"
         agents={getFrontendAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={5}
       />
@@ -115,6 +130,7 @@ export default function AgentsPage() {
         title="UX/UI Cell"
         agents={getUxAgents(agents)}
         agentStatuses={agentStatuses}
+        agentUsage={agentUsageMap}
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />

--- a/panel/src/app/(dashboard)/metrics/page.tsx
+++ b/panel/src/app/(dashboard)/metrics/page.tsx
@@ -2,14 +2,30 @@
 
 import { useOrchestratorStatus } from "@/hooks/use-agents";
 import { useTasks } from "@/hooks/use-tasks";
+import {
+  useUsageSnapshot,
+  useUsageTimeSeries,
+  useAgentUsage,
+  useUsageSessions,
+  useModelUsage,
+} from "@/hooks/use-usage";
 import { TaskStatus, Team } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { OfflineState } from "@/components/ui/offline-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  UsageTimeSeriesChart,
+  ModelUsageDonut,
+  AgentUsageChart,
+  TeamUsageChart,
+  SessionsTable,
+} from "@/components/metrics";
 import {
   Activity,
   TrendingUp,
+  TrendingDown,
   Clock,
   AlertTriangle,
   Users,
@@ -18,6 +34,8 @@ import {
   RefreshCw,
   Zap,
   Timer,
+  Coins,
+  Sparkles,
 } from "lucide-react";
 
 interface MetricCardProps {
@@ -295,8 +313,236 @@ export default function MetricsPage() {
               ))}
             </div>
           </div>
+
+          {/* ─── Token Usage & Costs ─────────────────────────────────── */}
+          <TokenUsageCostsSection />
         </>
       )}
     </div>
+  );
+}
+
+// =============================================================================
+// TOKEN USAGE & COSTS SECTION
+// =============================================================================
+
+function TokenUsageCostsSection() {
+  const { data: snapshot, isLoading: loadingSnap } = useUsageSnapshot();
+  const { data: timeSeries, isLoading: loadingTS } = useUsageTimeSeries(24);
+  const { data: agentUsage, isLoading: loadingAgents } = useAgentUsage();
+  const { data: sessions, isLoading: loadingSessions } = useUsageSessions(100);
+  const { data: modelUsage, isLoading: loadingModels } = useModelUsage();
+
+  const weekTrend = snapshot
+    ? snapshot.cost_this_week - snapshot.cost_last_week
+    : 0;
+  const weekIsUp = weekTrend >= 0;
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold">Token Usage &amp; Costs</h2>
+
+      {/* Row 1 — Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        <SummaryCard
+          title="Tokens Today"
+          value={snapshot ? fmtTokens(snapshot.tokens_today) : undefined}
+          icon={<Zap className="h-4 w-4 text-yellow-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Cost Today"
+          value={snapshot ? "$" + snapshot.cost_today.toFixed(2) : undefined}
+          icon={<Coins className="h-4 w-4 text-green-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Cost This Week"
+          value={snapshot ? "$" + snapshot.cost_this_week.toFixed(2) : undefined}
+          icon={
+            weekIsUp ? (
+              <TrendingUp className="h-4 w-4 text-red-500" />
+            ) : (
+              <TrendingDown className="h-4 w-4 text-green-500" />
+            )
+          }
+          trend={
+            snapshot
+              ? {
+                  dir: weekIsUp ? "up" : "down",
+                  label:
+                    (weekIsUp ? "▲ " : "▼ ") +
+                    Math.abs(weekTrend).toFixed(2) +
+                    " vs last wk",
+                }
+              : undefined
+          }
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Active Sessions"
+          value={snapshot ? String(snapshot.active_sessions) : undefined}
+          icon={<Activity className="h-4 w-4 text-blue-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Cache Savings"
+          value={snapshot ? "$" + snapshot.cache_savings.toFixed(2) : undefined}
+          icon={<Sparkles className="h-4 w-4 text-purple-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Top Consumer"
+          value={snapshot?.top_consumer ?? undefined}
+          icon={<Users className="h-4 w-4 text-orange-500" />}
+          isLoading={loadingSnap}
+        />
+      </div>
+
+      {/* Row 2 — Time series + model donut */}
+      <div className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <UsageTimeSeriesChart data={timeSeries} isLoading={loadingTS} />
+        </div>
+        <ModelUsageDonut data={modelUsage} isLoading={loadingModels} />
+      </div>
+
+      {/* Row 3 — Agent bar + team bar */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <AgentUsageChart data={agentUsage} isLoading={loadingAgents} />
+        <TeamUsageChart data={agentUsage} isLoading={loadingAgents} />
+      </div>
+
+      {/* Row 4 — Projection + cache efficiency */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <ProjectionCard snapshot={snapshot} isLoading={loadingSnap} />
+        <CacheEfficiencyCard sessions={sessions} isLoading={loadingAgents || loadingSessions} />
+      </div>
+
+      {/* Row 5 — Sessions table */}
+      <SessionsTable data={sessions} isLoading={loadingSessions} />
+    </div>
+  );
+}
+
+// ─── Helper sub-components ────────────────────────────────────────────────────
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+interface SummaryCardProps {
+  title: string;
+  value: string | undefined;
+  icon: React.ReactNode;
+  trend?: { dir: "up" | "down"; label: string };
+  isLoading: boolean;
+}
+
+function SummaryCard({ title, value, icon, trend, isLoading }: SummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-7 w-24" />
+        ) : (
+          <>
+            <div className="text-2xl font-bold">{value ?? "—"}</div>
+            {trend && (
+              <p
+                className={
+                  "text-xs mt-1 " +
+                  (trend.dir === "up" ? "text-red-500" : "text-green-500")
+                }
+              >
+                {trend.label}
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+import type { TokenUsageSnapshot as TUS, UsageSession as US } from "@/types";
+
+interface ProjectionCardProps {
+  snapshot: TUS | undefined;
+  isLoading: boolean;
+}
+
+function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
+  const weeklyRun = snapshot
+    ? snapshot.cost_this_week / 7 * 30
+    : null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <TrendingUp className="h-4 w-4 text-blue-500" />
+          Monthly Projection
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-10 w-full" />
+        ) : (
+          <div>
+            <div className="text-3xl font-bold">
+              {weeklyRun != null ? "$" + weeklyRun.toFixed(2) : "—"}
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Based on this week&apos;s daily average
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface CacheEfficiencyCardProps {
+  sessions: US[] | undefined;
+  isLoading: boolean;
+}
+
+function CacheEfficiencyCard({ sessions, isLoading }: CacheEfficiencyCardProps) {
+  const totalCache = (sessions ?? []).reduce((s, r) => s + r.tokens_cache, 0);
+  const totalAll = (sessions ?? []).reduce(
+    (s, r) => s + r.tokens_input + r.tokens_output + r.tokens_cache,
+    0
+  );
+  const pct = totalAll > 0 ? (totalCache / totalAll) * 100 : 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-purple-500" />
+          Cache Efficiency
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-10 w-full" />
+        ) : (
+          <div>
+            <div className="text-3xl font-bold">{pct.toFixed(1)}%</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {fmtTokens(totalCache)} cached of {fmtTokens(totalAll)} total tokens
+            </p>
+            <Progress value={pct} className="mt-2" />
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/panel/src/app/(dashboard)/metrics/page.tsx
+++ b/panel/src/app/(dashboard)/metrics/page.tsx
@@ -3,11 +3,14 @@
 import { useOrchestratorStatus } from "@/hooks/use-agents";
 import { useTasks } from "@/hooks/use-tasks";
 import {
-  useUsageSnapshot,
+  useUsageSummary,
   useUsageTimeSeries,
   useAgentUsage,
-  useUsageSessions,
+  useTeamUsage,
   useModelUsage,
+  useUsageProjection,
+  useCacheEfficiency,
+  useUsageSessions,
 } from "@/hooks/use-usage";
 import { TaskStatus, Team } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -327,16 +330,16 @@ export default function MetricsPage() {
 // =============================================================================
 
 function TokenUsageCostsSection() {
-  const { data: snapshot, isLoading: loadingSnap } = useUsageSnapshot();
-  const { data: timeSeries, isLoading: loadingTS } = useUsageTimeSeries(24);
-  const { data: agentUsage, isLoading: loadingAgents } = useAgentUsage();
+  const { data: summary, isLoading: loadingSnap } = useUsageSummary("24h");
+  const { data: timeSeries, isLoading: loadingTS } = useUsageTimeSeries("24h");
+  const { data: agentUsage, isLoading: loadingAgents } = useAgentUsage("24h");
+  const { data: teamUsage, isLoading: loadingTeams } = useTeamUsage("24h");
   const { data: sessions, isLoading: loadingSessions } = useUsageSessions(100);
-  const { data: modelUsage, isLoading: loadingModels } = useModelUsage();
+  const { data: modelUsage, isLoading: loadingModels } = useModelUsage("24h");
+  const { data: projection, isLoading: loadingProj } = useUsageProjection();
+  const { data: cacheStats, isLoading: loadingCache } = useCacheEfficiency("24h");
 
-  const weekTrend = snapshot
-    ? snapshot.cost_this_week - snapshot.cost_last_week
-    : 0;
-  const weekIsUp = weekTrend >= 0;
+  const trendUp = (summary?.trend_pct ?? 0) >= 0;
 
   return (
     <div className="space-y-6">
@@ -345,57 +348,46 @@ function TokenUsageCostsSection() {
       {/* Row 1 — Summary cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
-          title="Tokens Today"
-          value={snapshot ? fmtTokens(snapshot.tokens_today) : undefined}
+          title="Tokens Input"
+          value={summary ? fmtTokens(summary.tokens_input) : undefined}
           icon={<Zap className="h-4 w-4 text-yellow-500" />}
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Cost Today"
-          value={snapshot ? "$" + snapshot.cost_today.toFixed(2) : undefined}
+          title="Tokens Output"
+          value={summary ? fmtTokens(summary.tokens_output) : undefined}
+          icon={<Zap className="h-4 w-4 text-blue-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Total Cost (24h)"
+          value={summary ? "$" + summary.total_cost_usd.toFixed(4) : undefined}
           icon={<Coins className="h-4 w-4 text-green-500" />}
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Cost This Week"
-          value={snapshot ? "$" + snapshot.cost_this_week.toFixed(2) : undefined}
+          title="Trend vs Prior"
+          value={summary ? (trendUp ? "+" : "") + summary.trend_pct.toFixed(1) + "%" : undefined}
           icon={
-            weekIsUp ? (
+            trendUp ? (
               <TrendingUp className="h-4 w-4 text-red-500" />
             ) : (
               <TrendingDown className="h-4 w-4 text-green-500" />
             )
           }
-          trend={
-            snapshot
-              ? {
-                  dir: weekIsUp ? "up" : "down",
-                  label:
-                    (weekIsUp ? "▲ " : "▼ ") +
-                    Math.abs(weekTrend).toFixed(2) +
-                    " vs last wk",
-                }
-              : undefined
-          }
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Active Sessions"
-          value={snapshot ? String(snapshot.active_sessions) : undefined}
+          title="Total Tokens"
+          value={summary ? fmtTokens(summary.total_tokens) : undefined}
           icon={<Activity className="h-4 w-4 text-blue-500" />}
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Cache Savings"
-          value={snapshot ? "$" + snapshot.cache_savings.toFixed(2) : undefined}
+          title="Cache Saved"
+          value={cacheStats ? "$" + cacheStats.cost_saved_by_cache_usd.toFixed(4) : undefined}
           icon={<Sparkles className="h-4 w-4 text-purple-500" />}
-          isLoading={loadingSnap}
-        />
-        <SummaryCard
-          title="Top Consumer"
-          value={snapshot?.top_consumer ?? undefined}
-          icon={<Users className="h-4 w-4 text-orange-500" />}
-          isLoading={loadingSnap}
+          isLoading={loadingCache}
         />
       </div>
 
@@ -410,16 +402,16 @@ function TokenUsageCostsSection() {
       {/* Row 3 — Agent bar + team bar */}
       <div className="grid gap-4 lg:grid-cols-2">
         <AgentUsageChart data={agentUsage} isLoading={loadingAgents} />
-        <TeamUsageChart data={agentUsage} isLoading={loadingAgents} />
+        <TeamUsageChart data={teamUsage} isLoading={loadingTeams} />
       </div>
 
       {/* Row 4 — Projection + cache efficiency */}
       <div className="grid gap-4 sm:grid-cols-2">
-        <ProjectionCard snapshot={snapshot} isLoading={loadingSnap} />
-        <CacheEfficiencyCard sessions={sessions} isLoading={loadingAgents || loadingSessions} />
+        <ProjectionCard projection={projection} isLoading={loadingProj} />
+        <CacheEfficiencyCard cacheStats={cacheStats} isLoading={loadingCache} />
       </div>
 
-      {/* Row 5 — Sessions table */}
+      {/* Row 5 — Sessions table (mock-mode only; empty in production) */}
       <SessionsTable data={sessions} isLoading={loadingSessions} />
     </div>
   );
@@ -471,18 +463,14 @@ function SummaryCard({ title, value, icon, trend, isLoading }: SummaryCardProps)
   );
 }
 
-import type { TokenUsageSnapshot as TUS, UsageSession as US } from "@/types";
+import type { UsageProjection as UP, CacheEfficiencyResponse as CER } from "@/types";
 
 interface ProjectionCardProps {
-  snapshot: TUS | undefined;
+  projection: UP | undefined;
   isLoading: boolean;
 }
 
-function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
-  const weeklyRun = snapshot
-    ? snapshot.cost_this_week / 7 * 30
-    : null;
-
+function ProjectionCard({ projection, isLoading }: ProjectionCardProps) {
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -497,10 +485,11 @@ function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
         ) : (
           <div>
             <div className="text-3xl font-bold">
-              {weeklyRun != null ? "$" + weeklyRun.toFixed(2) : "—"}
+              {projection != null ? "$" + projection.projected_monthly_cost_usd.toFixed(2) : "—"}
             </div>
             <p className="text-xs text-muted-foreground mt-1">
-              Based on this week&apos;s daily average
+              Based on {projection?.basis_days ?? 7}-day rolling average ($
+              {projection?.avg_daily_cost_usd.toFixed(4) ?? "—"}/day)
             </p>
           </div>
         )}
@@ -510,17 +499,12 @@ function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
 }
 
 interface CacheEfficiencyCardProps {
-  sessions: US[] | undefined;
+  cacheStats: CER | undefined;
   isLoading: boolean;
 }
 
-function CacheEfficiencyCard({ sessions, isLoading }: CacheEfficiencyCardProps) {
-  const totalCache = (sessions ?? []).reduce((s, r) => s + r.tokens_cache, 0);
-  const totalAll = (sessions ?? []).reduce(
-    (s, r) => s + r.tokens_input + r.tokens_output + r.tokens_cache,
-    0
-  );
-  const pct = totalAll > 0 ? (totalCache / totalAll) * 100 : 0;
+function CacheEfficiencyCard({ cacheStats, isLoading }: CacheEfficiencyCardProps) {
+  const pct = cacheStats ? cacheStats.cache_hit_rate * 100 : 0;
 
   return (
     <Card>
@@ -537,7 +521,8 @@ function CacheEfficiencyCard({ sessions, isLoading }: CacheEfficiencyCardProps) 
           <div>
             <div className="text-3xl font-bold">{pct.toFixed(1)}%</div>
             <p className="text-xs text-muted-foreground mt-1">
-              {fmtTokens(totalCache)} cached of {fmtTokens(totalAll)} total tokens
+              {cacheStats ? fmtTokens(cacheStats.tokens_cache_read) : "—"} cache reads ·
+              saved ${cacheStats?.cost_saved_by_cache_usd.toFixed(4) ?? "—"}
             </p>
             <Progress value={pct} className="mt-2" />
           </div>

--- a/panel/src/components/agents/agent-card.tsx
+++ b/panel/src/components/agents/agent-card.tsx
@@ -17,13 +17,15 @@ import { MoreHorizontal, Activity, Square } from "lucide-react";
 import { toast } from "sonner";
 import { AgentStateBadge } from "./agent-state-badge";
 import { SpawnAgentDialog } from "./spawn-agent-dialog";
+import type { AgentUsageRow } from "@/types";
 
 interface AgentCardProps {
   agent: AgentDefinition;
   agentStatus: AgentStatusResponse | null;
+  usageRow?: AgentUsageRow | null;
 }
 
-export function AgentCard({ agent, agentStatus }: AgentCardProps) {
+export function AgentCard({ agent, agentStatus, usageRow }: AgentCardProps) {
   const stopAgent = useStopAgent();
   const state = agentStatus?.state || "stopped";
   const isActive = ["running", "ready", "starting", "waiting_long"].includes(state);
@@ -99,6 +101,30 @@ export function AgentCard({ agent, agentStatus }: AgentCardProps) {
           <p className="text-xs text-red-500 mt-2">
             Errors: {agentStatus.error_count}
           </p>
+        )}
+        {usageRow && (
+          <div className="mt-3 pt-2 border-t">
+            <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
+              <span>
+                {usageRow.tokens_today >= 1_000
+                  ? (usageRow.tokens_today / 1_000).toFixed(1) + "K"
+                  : String(usageRow.tokens_today)}{" "}
+                tokens
+              </span>
+              <span className="font-medium text-foreground">
+                ${usageRow.cost_today.toFixed(2)}
+              </span>
+            </div>
+            <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-[var(--chart-1)]"
+                style={{
+                  width:
+                    Math.min(100, (usageRow.tokens_today / 30_000) * 100) + "%",
+                }}
+              />
+            </div>
+          </div>
         )}
       </CardContent>
     </Card>

--- a/panel/src/components/agents/agent-card.tsx
+++ b/panel/src/components/agents/agent-card.tsx
@@ -106,13 +106,13 @@ export function AgentCard({ agent, agentStatus, usageRow }: AgentCardProps) {
           <div className="mt-3 pt-2 border-t">
             <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
               <span>
-                {usageRow.tokens_today >= 1_000
-                  ? (usageRow.tokens_today / 1_000).toFixed(1) + "K"
-                  : String(usageRow.tokens_today)}{" "}
+                {usageRow.total_tokens >= 1_000
+                  ? (usageRow.total_tokens / 1_000).toFixed(1) + "K"
+                  : String(usageRow.total_tokens)}{" "}
                 tokens
               </span>
               <span className="font-medium text-foreground">
-                ${usageRow.cost_today.toFixed(2)}
+                ${usageRow.cost_usd.toFixed(4)}
               </span>
             </div>
             <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
@@ -120,7 +120,7 @@ export function AgentCard({ agent, agentStatus, usageRow }: AgentCardProps) {
                 className="h-full rounded-full bg-[var(--chart-1)]"
                 style={{
                   width:
-                    Math.min(100, (usageRow.tokens_today / 30_000) * 100) + "%",
+                    Math.min(100, (usageRow.total_tokens / 30_000) * 100) + "%",
                 }}
               />
             </div>

--- a/panel/src/components/agents/agent-grid.tsx
+++ b/panel/src/components/agents/agent-grid.tsx
@@ -1,4 +1,4 @@
-import { AgentStatusResponse } from "@/types";
+import { AgentStatusResponse, AgentUsageRow } from "@/types";
 import { AgentDefinition } from "@/lib/agent-definitions";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -8,6 +8,7 @@ interface AgentGridProps {
   title: string;
   agents: AgentDefinition[];
   agentStatuses: Record<string, AgentStatusResponse>;
+  agentUsage?: Record<string, AgentUsageRow>;
   isLoading: boolean;
   columns?: number;
 }
@@ -16,8 +17,9 @@ export function AgentGrid({
   title,
   agents,
   agentStatuses,
+  agentUsage,
   isLoading,
-  columns = 4
+  columns = 4,
 }: AgentGridProps) {
   const gridCols = {
     3: "md:grid-cols-3",
@@ -44,6 +46,7 @@ export function AgentGrid({
               key={agent.id}
               agent={agent}
               agentStatus={agentStatuses[agent.id] || null}
+              usageRow={agentUsage?.[agent.id] ?? null}
             />
           ))
         )}

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -11,6 +11,7 @@ import { QuickActionsBar } from "./quick-actions-bar";
 import { CeoApprovalQueue } from "./ceo-approval-queue";
 import type { Activity } from "./activity-item";
 import { Button } from "@/components/ui/button";
+import { UsageOverviewPanel } from "./usage-overview-panel";
 import { RefreshCw, Settings } from "lucide-react";
 import Link from "next/link";
 
@@ -61,13 +62,14 @@ export function CommandCenter() {
         <CeoApprovalQueue />
       </section>
 
-      {/* Metrics and Alerts Row */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Metrics, Alerts, and Usage Row */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <KeyMetricsPanel
           metrics={overview?.key_metrics}
           isLoading={loadingOverview}
         />
         <AuditorAlertsPanel alerts={flags} isLoading={loadingFlags} />
+        <UsageOverviewPanel />
       </div>
 
       {/* Blockers and Activity Row */}

--- a/panel/src/components/dashboard/index.ts
+++ b/panel/src/components/dashboard/index.ts
@@ -9,3 +9,4 @@ export { ActivityItem } from "./activity-item";
 export { QuickActionsBar } from "./quick-actions-bar";
 export { HealthIndicator } from "./health-indicator";
 export { CeoApprovalQueue } from "./ceo-approval-queue";
+export { UsageOverviewPanel } from "./usage-overview-panel";

--- a/panel/src/components/dashboard/usage-overview-panel.tsx
+++ b/panel/src/components/dashboard/usage-overview-panel.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUsageSnapshot } from "@/hooks/use-usage";
+import { Coins, TrendingUp, TrendingDown, Zap, Users, Sparkles } from "lucide-react";
+
+function fmt(n: number, decimals = 0): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return n.toFixed(decimals);
+}
+
+function fmtCost(n: number): string {
+  return "$" + n.toFixed(2);
+}
+
+interface MetricRowProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: React.ReactNode;
+}
+
+function MetricRow({ icon, label, value, sub }: MetricRowProps) {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="flex items-center gap-1">
+        <span className="font-semibold text-sm">{value}</span>
+        {sub}
+      </div>
+    </div>
+  );
+}
+
+export function UsageOverviewPanel() {
+  const { data: snapshot, isLoading } = useUsageSnapshot();
+
+  const weekTrend = snapshot
+    ? snapshot.cost_this_week - snapshot.cost_last_week
+    : 0;
+  const weekTrendPct = snapshot?.cost_last_week
+    ? Math.abs(weekTrend / snapshot.cost_last_week) * 100
+    : 0;
+  const weekIsUp = weekTrend >= 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Coins className="h-5 w-5" />
+          Token Usage &amp; Cost
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-6" />
+            ))}
+          </div>
+        ) : (
+          <div className="divide-y">
+            <MetricRow
+              icon={<Zap className="h-4 w-4" />}
+              label="Tokens today"
+              value={snapshot ? fmt(snapshot.tokens_today) : "—"}
+            />
+            <MetricRow
+              icon={<Coins className="h-4 w-4" />}
+              label="Cost today"
+              value={snapshot ? fmtCost(snapshot.cost_today) : "—"}
+            />
+            <MetricRow
+              icon={
+                weekIsUp ? (
+                  <TrendingUp className="h-4 w-4 text-red-500" />
+                ) : (
+                  <TrendingDown className="h-4 w-4 text-green-500" />
+                )
+              }
+              label="Cost this week"
+              value={snapshot ? fmtCost(snapshot.cost_this_week) : "—"}
+              sub={
+                snapshot ? (
+                  <span
+                    className={
+                      "text-xs " + (weekIsUp ? "text-red-500" : "text-green-500")
+                    }
+                  >
+                    {weekIsUp ? "▲" : "▼"} {weekTrendPct.toFixed(0)}%
+                  </span>
+                ) : undefined
+              }
+            />
+            <MetricRow
+              icon={<Users className="h-4 w-4" />}
+              label="Active sessions"
+              value={snapshot ? String(snapshot.active_sessions) : "—"}
+            />
+            <MetricRow
+              icon={<Sparkles className="h-4 w-4 text-yellow-500" />}
+              label="Cache savings"
+              value={snapshot ? fmtCost(snapshot.cache_savings) : "—"}
+            />
+            <MetricRow
+              icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
+              label="Top consumer"
+              value={snapshot?.top_consumer ?? "—"}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/dashboard/usage-overview-panel.tsx
+++ b/panel/src/components/dashboard/usage-overview-panel.tsx
@@ -2,8 +2,8 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useUsageSnapshot } from "@/hooks/use-usage";
-import { Coins, TrendingUp, TrendingDown, Zap, Users, Sparkles } from "lucide-react";
+import { useUsageSummary } from "@/hooks/use-usage";
+import { Coins, TrendingUp, TrendingDown, Zap, Activity } from "lucide-react";
 
 function fmt(n: number, decimals = 0): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
@@ -38,15 +38,9 @@ function MetricRow({ icon, label, value, sub }: MetricRowProps) {
 }
 
 export function UsageOverviewPanel() {
-  const { data: snapshot, isLoading } = useUsageSnapshot();
+  const { data: summary, isLoading } = useUsageSummary("24h");
 
-  const weekTrend = snapshot
-    ? snapshot.cost_this_week - snapshot.cost_last_week
-    : 0;
-  const weekTrendPct = snapshot?.cost_last_week
-    ? Math.abs(weekTrend / snapshot.cost_last_week) * 100
-    : 0;
-  const weekIsUp = weekTrend >= 0;
+  const trendUp = (summary?.trend_pct ?? 0) >= 0;
 
   return (
     <Card>
@@ -59,7 +53,7 @@ export function UsageOverviewPanel() {
       <CardContent>
         {isLoading ? (
           <div className="space-y-3">
-            {Array.from({ length: 6 }).map((_, i) => (
+            {Array.from({ length: 5 }).map((_, i) => (
               <Skeleton key={i} className="h-6" />
             ))}
           </div>
@@ -67,50 +61,41 @@ export function UsageOverviewPanel() {
           <div className="divide-y">
             <MetricRow
               icon={<Zap className="h-4 w-4" />}
-              label="Tokens today"
-              value={snapshot ? fmt(snapshot.tokens_today) : "—"}
+              label="Tokens (input)"
+              value={summary ? fmt(summary.tokens_input) : "—"}
+            />
+            <MetricRow
+              icon={<Zap className="h-4 w-4 text-muted-foreground" />}
+              label="Tokens (output)"
+              value={summary ? fmt(summary.tokens_output) : "—"}
             />
             <MetricRow
               icon={<Coins className="h-4 w-4" />}
-              label="Cost today"
-              value={snapshot ? fmtCost(snapshot.cost_today) : "—"}
+              label="Total cost"
+              value={summary ? fmtCost(summary.total_cost_usd) : "—"}
             />
             <MetricRow
               icon={
-                weekIsUp ? (
+                trendUp ? (
                   <TrendingUp className="h-4 w-4 text-red-500" />
                 ) : (
                   <TrendingDown className="h-4 w-4 text-green-500" />
                 )
               }
-              label="Cost this week"
-              value={snapshot ? fmtCost(snapshot.cost_this_week) : "—"}
+              label="Trend vs prior period"
+              value={summary ? (trendUp ? "+" : "") + summary.trend_pct.toFixed(1) + "%" : "—"}
               sub={
-                snapshot ? (
-                  <span
-                    className={
-                      "text-xs " + (weekIsUp ? "text-red-500" : "text-green-500")
-                    }
-                  >
-                    {weekIsUp ? "▲" : "▼"} {weekTrendPct.toFixed(0)}%
+                summary ? (
+                  <span className={"text-xs " + (trendUp ? "text-red-500" : "text-green-500")}>
+                    {trendUp ? "▲" : "▼"}
                   </span>
                 ) : undefined
               }
             />
             <MetricRow
-              icon={<Users className="h-4 w-4" />}
-              label="Active sessions"
-              value={snapshot ? String(snapshot.active_sessions) : "—"}
-            />
-            <MetricRow
-              icon={<Sparkles className="h-4 w-4 text-yellow-500" />}
-              label="Cache savings"
-              value={snapshot ? fmtCost(snapshot.cache_savings) : "—"}
-            />
-            <MetricRow
-              icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
-              label="Top consumer"
-              value={snapshot?.top_consumer ?? "—"}
+              icon={<Activity className="h-4 w-4 text-blue-500" />}
+              label="Period"
+              value={summary?.period ?? "—"}
             />
           </div>
         )}

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { AgentUsageRow } from "@/types";
+
+interface AgentUsageChartProps {
+  data: AgentUsageRow[] | undefined;
+  isLoading: boolean;
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(0) + "k";
+  return String(n);
+}
+
+export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
+  const chartData = [...(data ?? [])]
+    .sort((a, b) => b.tokens_today - a.tokens_today)
+    .slice(0, 10)
+    .map((row) => ({
+      name: row.agent_name,
+      Tokens: row.tokens_today,
+    }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Agent Tokens Today</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <BarChart
+              data={chartData}
+              margin={{ top: 4, right: 8, left: 0, bottom: 24 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 10 }}
+                angle={-30}
+                textAnchor="end"
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tickFormatter={fmtK}
+                tick={{ fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={36}
+              />
+              <Tooltip
+                formatter={(value) => [
+                  fmtK(typeof value === "number" ? value : 0),
+                  "Tokens",
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -25,11 +25,11 @@ function fmtK(n: number): string {
 
 export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
   const chartData = [...(data ?? [])]
-    .sort((a, b) => b.tokens_today - a.tokens_today)
+    .sort((a, b) => b.total_tokens - a.total_tokens)
     .slice(0, 10)
     .map((row) => ({
-      name: row.agent_name,
-      Tokens: row.tokens_today,
+      name: row.agent_slug,
+      Tokens: row.total_tokens,
     }));
 
   return (

--- a/panel/src/components/metrics/index.ts
+++ b/panel/src/components/metrics/index.ts
@@ -1,0 +1,5 @@
+export { UsageTimeSeriesChart } from "./usage-time-series-chart";
+export { ModelUsageDonut } from "./model-usage-donut";
+export { AgentUsageChart } from "./agent-usage-chart";
+export { TeamUsageChart } from "./team-usage-chart";
+export { SessionsTable } from "./sessions-table";

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ModelUsageSlice } from "@/types";
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+interface ModelUsageDonutProps {
+  data: ModelUsageSlice[] | undefined;
+  isLoading: boolean;
+}
+
+export function ModelUsageDonut({ data, isLoading }: ModelUsageDonutProps) {
+  const chartData = (data ?? []).map((s) => ({
+    name: s.model,
+    value: s.tokens,
+    cost: s.cost,
+    pct: s.percentage,
+  }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">By Model</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <PieChart>
+              <Pie
+                data={chartData}
+                cx="50%"
+                cy="50%"
+                innerRadius={52}
+                outerRadius={80}
+                dataKey="value"
+                paddingAngle={3}
+              >
+                {chartData.map((_, idx) => (
+                  <Cell
+                    key={idx}
+                    fill={CHART_COLORS[idx % CHART_COLORS.length]}
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                formatter={(value, name) => [
+                  (typeof value === "number" ? value : 0).toLocaleString() +
+                    " tokens",
+                  name,
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Legend wrapperStyle={{ fontSize: 11 }} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -28,9 +28,9 @@ interface ModelUsageDonutProps {
 export function ModelUsageDonut({ data, isLoading }: ModelUsageDonutProps) {
   const chartData = (data ?? []).map((s) => ({
     name: s.model,
-    value: s.tokens,
-    cost: s.cost,
-    pct: s.percentage,
+    value: s.total_tokens,
+    cost: s.cost_usd,
+    pct: s.pct_of_total,
   }));
 
   return (

--- a/panel/src/components/metrics/sessions-table.tsx
+++ b/panel/src/components/metrics/sessions-table.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronUp, ChevronDown } from "lucide-react";
+import type { UsageSession } from "@/types";
+
+const PAGE_SIZE = 10;
+
+type SortKey = keyof Pick<
+  UsageSession,
+  | "agent_name"
+  | "started_at"
+  | "total_tokens"
+  | "tokens_input"
+  | "tokens_output"
+  | "tokens_cache"
+  | "cost"
+  | "model"
+>;
+
+type SortDir = "asc" | "desc";
+
+interface Column {
+  key: SortKey;
+  label: string;
+}
+
+const COLUMNS: Column[] = [
+  { key: "agent_name", label: "Agent" },
+  { key: "model", label: "Model" },
+  { key: "started_at", label: "Started" },
+  { key: "total_tokens", label: "Total" },
+  { key: "tokens_input", label: "Input" },
+  { key: "tokens_output", label: "Output" },
+  { key: "tokens_cache", label: "Cache" },
+  { key: "cost", label: "Cost" },
+];
+
+function formatTime(ts: string): string {
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "k";
+  return String(n);
+}
+
+interface SessionsTableProps {
+  data: UsageSession[] | undefined;
+  isLoading: boolean;
+}
+
+export function SessionsTable({ data, isLoading }: SessionsTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("started_at");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [page, setPage] = useState(0);
+
+  const sorted = useMemo(() => {
+    const rows = [...(data ?? [])];
+    rows.sort((a, b) => {
+      const av = a[sortKey];
+      const bv = b[sortKey];
+      const cmp =
+        typeof av === "number" && typeof bv === "number"
+          ? av - bv
+          : String(av).localeCompare(String(bv));
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return rows;
+  }, [data, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const visible = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+    setPage(0);
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col) return <ChevronUp className="h-3 w-3 opacity-30 ml-1 inline" />;
+    return sortDir === "asc" ? (
+      <ChevronUp className="h-3 w-3 ml-1 inline" />
+    ) : (
+      <ChevronDown className="h-3 w-3 ml-1 inline" />
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Recent Sessions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+              <Skeleton key={i} className="h-8" />
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {COLUMNS.map((col) => (
+                      <TableHead
+                        key={col.key}
+                        className="cursor-pointer select-none text-xs whitespace-nowrap"
+                        onClick={() => toggleSort(col.key)}
+                      >
+                        {col.label}
+                        <SortIcon col={col.key} />
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visible.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={COLUMNS.length} className="text-center text-muted-foreground text-sm py-8">
+                        No sessions recorded yet
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    visible.map((s) => (
+                      <TableRow key={s.id}>
+                        <TableCell className="text-xs font-medium">{s.agent_name}</TableCell>
+                        <TableCell className="text-xs">{s.model}</TableCell>
+                        <TableCell className="text-xs">{formatTime(s.started_at)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.total_tokens)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.tokens_input)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.tokens_output)}</TableCell>
+                        <TableCell className="text-xs">{fmtK(s.tokens_cache)}</TableCell>
+                        <TableCell className="text-xs">${s.cost.toFixed(4)}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Pagination */}
+            <div className="flex items-center justify-between mt-3 pt-3 border-t text-sm">
+              <span className="text-muted-foreground text-xs">
+                {sorted.length === 0
+                  ? "No sessions"
+                  : `${page * PAGE_SIZE + 1}–${Math.min((page + 1) * PAGE_SIZE, sorted.length)} of ${sorted.length}`}
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                >
+                  Prev
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  disabled={page >= totalPages - 1}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/sessions-table.tsx
+++ b/panel/src/components/metrics/sessions-table.tsx
@@ -19,7 +19,7 @@ const PAGE_SIZE = 10;
 
 type SortKey = keyof Pick<
   UsageSession,
-  | "agent_name"
+  | "agent_slug"
   | "started_at"
   | "total_tokens"
   | "tokens_input"
@@ -37,7 +37,7 @@ interface Column {
 }
 
 const COLUMNS: Column[] = [
-  { key: "agent_name", label: "Agent" },
+  { key: "agent_slug", label: "Agent" },
   { key: "model", label: "Model" },
   { key: "started_at", label: "Started" },
   { key: "total_tokens", label: "Total" },
@@ -142,7 +142,7 @@ export function SessionsTable({ data, isLoading }: SessionsTableProps) {
                   ) : (
                     visible.map((s) => (
                       <TableRow key={s.id}>
-                        <TableCell className="text-xs font-medium">{s.agent_name}</TableCell>
+                        <TableCell className="text-xs font-medium">{s.agent_slug}</TableCell>
                         <TableCell className="text-xs">{s.model}</TableCell>
                         <TableCell className="text-xs">{formatTime(s.started_at)}</TableCell>
                         <TableCell className="text-xs">{fmtK(s.total_tokens)}</TableCell>

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { AgentUsageRow } from "@/types";
+
+interface TeamUsageChartProps {
+  data: AgentUsageRow[] | undefined;
+  isLoading: boolean;
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(0) + "k";
+  return String(n);
+}
+
+export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
+  // Aggregate tokens by team
+  const teamTotals = new Map<string, number>();
+  for (const row of data ?? []) {
+    const prev = teamTotals.get(row.team) ?? 0;
+    teamTotals.set(row.team, prev + row.tokens_today);
+  }
+
+  const chartData = [...teamTotals.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .map(([team, tokens]) => ({
+      name: team.replace(/_/g, " "),
+      Tokens: tokens,
+    }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Team Tokens Today</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <BarChart
+              data={chartData}
+              margin={{ top: 4, right: 8, left: 0, bottom: 8 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+              <XAxis
+                dataKey="name"
+                tick={{ fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tickFormatter={fmtK}
+                tick={{ fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={36}
+              />
+              <Tooltip
+                formatter={(value) => [
+                  fmtK(typeof value === "number" ? value : 0),
+                  "Tokens",
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Bar dataKey="Tokens" fill="var(--chart-2)" radius={[3, 3, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -11,10 +11,10 @@ import {
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { AgentUsageRow } from "@/types";
+import type { TeamUsageRow } from "@/types";
 
 interface TeamUsageChartProps {
-  data: AgentUsageRow[] | undefined;
+  data: TeamUsageRow[] | undefined;
   isLoading: boolean;
 }
 
@@ -24,24 +24,17 @@ function fmtK(n: number): string {
 }
 
 export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
-  // Aggregate tokens by team
-  const teamTotals = new Map<string, number>();
-  for (const row of data ?? []) {
-    const prev = teamTotals.get(row.team) ?? 0;
-    teamTotals.set(row.team, prev + row.tokens_today);
-  }
-
-  const chartData = [...teamTotals.entries()]
-    .sort(([, a], [, b]) => b - a)
-    .map(([team, tokens]) => ({
-      name: team.replace(/_/g, " "),
-      Tokens: tokens,
+  const chartData = [...(data ?? [])]
+    .sort((a, b) => b.total_tokens - a.total_tokens)
+    .map((row) => ({
+      name: row.team.replace(/_/g, " "),
+      Tokens: row.total_tokens,
     }));
 
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base">Team Tokens Today</CardTitle>
+        <CardTitle className="text-base">Team Tokens</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -19,9 +19,15 @@ interface UsageTimeSeriesChartProps {
   isLoading: boolean;
 }
 
-function formatHour(ts: string): string {
-  const d = new Date(ts);
-  return d.getHours().toString().padStart(2, "0") + ":00";
+function formatBucket(bucket: string): string {
+  const d = new Date(bucket);
+  // If the bucket has a non-zero time component it is an hourly bucket → show HH:00.
+  // Otherwise it is a daily bucket → show MM/DD.
+  const isHourly = d.getMinutes() === 0 && (d.getHours() !== 0 || bucket.includes("T"));
+  if (isHourly && d.getSeconds() === 0 && !bucket.endsWith("T00:00:00.000Z")) {
+    return d.getHours().toString().padStart(2, "0") + ":00";
+  }
+  return (d.getMonth() + 1) + "/" + d.getDate();
 }
 
 function fmtK(n: number): string {
@@ -31,10 +37,9 @@ function fmtK(n: number): string {
 
 export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartProps) {
   const chartData = (data ?? []).map((p) => ({
-    hour: formatHour(p.timestamp),
+    hour: formatBucket(p.bucket),
     Input: p.tokens_input,
     Output: p.tokens_output,
-    Cache: p.tokens_cache,
   }));
 
   return (
@@ -59,10 +64,6 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
                   <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
-                </linearGradient>
-                <linearGradient id="fillCache" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--chart-3)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--chart-3)" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
@@ -101,13 +102,6 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 stackId="1"
                 stroke="var(--chart-2)"
                 fill="url(#fillOutput)"
-              />
-              <Area
-                type="monotone"
-                dataKey="Cache"
-                stackId="1"
-                stroke="var(--chart-3)"
-                fill="url(#fillCache)"
               />
             </AreaChart>
           </ResponsiveContainer>

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { UsageTimePoint } from "@/types";
+
+interface UsageTimeSeriesChartProps {
+  data: UsageTimePoint[] | undefined;
+  isLoading: boolean;
+}
+
+function formatHour(ts: string): string {
+  const d = new Date(ts);
+  return d.getHours().toString().padStart(2, "0") + ":00";
+}
+
+function fmtK(n: number): string {
+  if (n >= 1_000) return (n / 1_000).toFixed(0) + "k";
+  return String(n);
+}
+
+export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartProps) {
+  const chartData = (data ?? []).map((p) => ({
+    hour: formatHour(p.timestamp),
+    Input: p.tokens_input,
+    Output: p.tokens_output,
+    Cache: p.tokens_cache,
+  }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Token Usage Over Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-52 w-full" />
+        ) : (
+          <ResponsiveContainer width="100%" height={208}>
+            <AreaChart
+              data={chartData}
+              margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id="fillInput" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0.1} />
+                </linearGradient>
+                <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
+                </linearGradient>
+                <linearGradient id="fillCache" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="var(--chart-3)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-3)" stopOpacity={0.1} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
+              <XAxis
+                dataKey="hour"
+                tick={{ fontSize: 10 }}
+                interval={3}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                tickFormatter={fmtK}
+                tick={{ fontSize: 10 }}
+                axisLine={false}
+                tickLine={false}
+                width={36}
+              />
+              <Tooltip
+                formatter={(value, name) => [
+                  fmtK(typeof value === "number" ? value : 0),
+                  name,
+                ]}
+                contentStyle={{ fontSize: 12 }}
+              />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Area
+                type="monotone"
+                dataKey="Input"
+                stackId="1"
+                stroke="var(--chart-1)"
+                fill="url(#fillInput)"
+              />
+              <Area
+                type="monotone"
+                dataKey="Output"
+                stackId="1"
+                stroke="var(--chart-2)"
+                fill="url(#fillOutput)"
+              />
+              <Area
+                type="monotone"
+                dataKey="Cache"
+                stackId="1"
+                stroke="var(--chart-3)"
+                fill="url(#fillCache)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/panel/src/hooks/index.ts
+++ b/panel/src/hooks/index.ts
@@ -33,3 +33,4 @@ export * from "./use-websocket";
 export * from "./use-journals";
 export * from "./use-projects";
 export * from "./use-work-sessions";
+export * from "./use-usage";

--- a/panel/src/hooks/use-usage.ts
+++ b/panel/src/hooks/use-usage.ts
@@ -2,12 +2,16 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { usageApi } from "@/lib/api/usage";
+import type { UsagePeriod } from "@/lib/api/usage";
 import type {
-  TokenUsageSnapshot,
+  UsageSummary,
   AgentUsageRow,
-  UsageSession,
-  UsageTimePoint,
+  TeamUsageRow,
   ModelUsageSlice,
+  UsageTimePoint,
+  UsageProjection,
+  CacheEfficiencyResponse,
+  UsageSession,
 } from "@/types";
 
 // =============================================================================
@@ -16,58 +20,93 @@ import type {
 
 export const usageKeys = {
   all: ["usage"] as const,
-  snapshot: () => [...usageKeys.all, "snapshot"] as const,
-  timeSeries: (hours: number) => [...usageKeys.all, "time-series", hours] as const,
-  agentUsage: () => [...usageKeys.all, "agents"] as const,
+  summary: (period: UsagePeriod) => [...usageKeys.all, "summary", period] as const,
+  timeSeries: (period: UsagePeriod) => [...usageKeys.all, "time-series", period] as const,
+  agentUsage: (period: UsagePeriod) => [...usageKeys.all, "by-agent", period] as const,
+  teamUsage: (period: UsagePeriod) => [...usageKeys.all, "by-team", period] as const,
+  modelUsage: (period: UsagePeriod) => [...usageKeys.all, "by-model", period] as const,
+  projection: () => [...usageKeys.all, "projection"] as const,
+  cacheEfficiency: (period: UsagePeriod) => [...usageKeys.all, "cache-efficiency", period] as const,
   sessions: (limit: number) => [...usageKeys.all, "sessions", limit] as const,
-  modelUsage: () => [...usageKeys.all, "models"] as const,
 };
 
 // =============================================================================
 // HOOKS
 // =============================================================================
 
-/** Snapshot of current-day usage totals (tokens, cost, sessions, cache) */
-export function useUsageSnapshot() {
-  return useQuery<TokenUsageSnapshot>({
-    queryKey: usageKeys.snapshot(),
-    queryFn: () => usageApi.getUsageSnapshot(),
+/** Aggregated usage summary (tokens_input, tokens_output, total_cost_usd, …) */
+export function useUsageSummary(period: UsagePeriod = "24h") {
+  return useQuery<UsageSummary>({
+    queryKey: usageKeys.summary(period),
+    queryFn: () => usageApi.getUsageSummary(period),
     refetchInterval: 60_000,
   });
 }
 
-/** Hourly time-series data for the stacked area chart */
-export function useUsageTimeSeries(hours: number = 24) {
+/** Bucketed time-series data for the stacked area chart */
+export function useUsageTimeSeries(period: UsagePeriod = "24h") {
   return useQuery<UsageTimePoint[]>({
-    queryKey: usageKeys.timeSeries(hours),
-    queryFn: () => usageApi.getUsageTimeSeries(hours),
+    queryKey: usageKeys.timeSeries(period),
+    queryFn: () => usageApi.getUsageTimeSeries(period),
     refetchInterval: 120_000,
   });
 }
 
 /** Per-agent usage rows for bar chart and agent card mini-bars */
-export function useAgentUsage() {
+export function useAgentUsage(period: UsagePeriod = "24h") {
   return useQuery<AgentUsageRow[]>({
-    queryKey: usageKeys.agentUsage(),
-    queryFn: () => usageApi.getAgentUsage(),
+    queryKey: usageKeys.agentUsage(period),
+    queryFn: () => usageApi.getAgentUsage(period),
     refetchInterval: 60_000,
   });
 }
 
-/** Recent inference sessions for the sessions table */
+/** Per-team usage rows from the dedicated by-team endpoint */
+export function useTeamUsage(period: UsagePeriod = "24h") {
+  return useQuery<TeamUsageRow[]>({
+    queryKey: usageKeys.teamUsage(period),
+    queryFn: () => usageApi.getTeamUsage(period),
+    refetchInterval: 60_000,
+  });
+}
+
+/** Per-model slices for the donut chart */
+export function useModelUsage(period: UsagePeriod = "24h") {
+  return useQuery<ModelUsageSlice[]>({
+    queryKey: usageKeys.modelUsage(period),
+    queryFn: () => usageApi.getModelUsage(period),
+    refetchInterval: 120_000,
+  });
+}
+
+/** Monthly cost projection based on 7-day rolling average */
+export function useUsageProjection() {
+  return useQuery<UsageProjection>({
+    queryKey: usageKeys.projection(),
+    queryFn: () => usageApi.getUsageProjection(),
+    refetchInterval: 300_000,
+  });
+}
+
+/** Cache efficiency stats */
+export function useCacheEfficiency(period: UsagePeriod = "24h") {
+  return useQuery<CacheEfficiencyResponse>({
+    queryKey: usageKeys.cacheEfficiency(period),
+    queryFn: () => usageApi.getCacheEfficiency(period),
+    refetchInterval: 120_000,
+  });
+}
+
+/**
+ * Recent inference sessions — mock-mode only.
+ *
+ * Returns an empty array in production (no real backend endpoint for sessions).
+ * The SessionsTable will display "No sessions recorded yet" gracefully.
+ */
 export function useUsageSessions(limit: number = 100) {
   return useQuery<UsageSession[]>({
     queryKey: usageKeys.sessions(limit),
     queryFn: () => usageApi.getUsageSessions(limit),
     refetchInterval: 30_000,
-  });
-}
-
-/** Per-model slices for the donut chart */
-export function useModelUsage() {
-  return useQuery<ModelUsageSlice[]>({
-    queryKey: usageKeys.modelUsage(),
-    queryFn: () => usageApi.getModelUsage(),
-    refetchInterval: 120_000,
   });
 }

--- a/panel/src/hooks/use-usage.ts
+++ b/panel/src/hooks/use-usage.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { usageApi } from "@/lib/api/usage";
+import type {
+  TokenUsageSnapshot,
+  AgentUsageRow,
+  UsageSession,
+  UsageTimePoint,
+  ModelUsageSlice,
+} from "@/types";
+
+// =============================================================================
+// QUERY KEYS
+// =============================================================================
+
+export const usageKeys = {
+  all: ["usage"] as const,
+  snapshot: () => [...usageKeys.all, "snapshot"] as const,
+  timeSeries: (hours: number) => [...usageKeys.all, "time-series", hours] as const,
+  agentUsage: () => [...usageKeys.all, "agents"] as const,
+  sessions: (limit: number) => [...usageKeys.all, "sessions", limit] as const,
+  modelUsage: () => [...usageKeys.all, "models"] as const,
+};
+
+// =============================================================================
+// HOOKS
+// =============================================================================
+
+/** Snapshot of current-day usage totals (tokens, cost, sessions, cache) */
+export function useUsageSnapshot() {
+  return useQuery<TokenUsageSnapshot>({
+    queryKey: usageKeys.snapshot(),
+    queryFn: () => usageApi.getUsageSnapshot(),
+    refetchInterval: 60_000,
+  });
+}
+
+/** Hourly time-series data for the stacked area chart */
+export function useUsageTimeSeries(hours: number = 24) {
+  return useQuery<UsageTimePoint[]>({
+    queryKey: usageKeys.timeSeries(hours),
+    queryFn: () => usageApi.getUsageTimeSeries(hours),
+    refetchInterval: 120_000,
+  });
+}
+
+/** Per-agent usage rows for bar chart and agent card mini-bars */
+export function useAgentUsage() {
+  return useQuery<AgentUsageRow[]>({
+    queryKey: usageKeys.agentUsage(),
+    queryFn: () => usageApi.getAgentUsage(),
+    refetchInterval: 60_000,
+  });
+}
+
+/** Recent inference sessions for the sessions table */
+export function useUsageSessions(limit: number = 100) {
+  return useQuery<UsageSession[]>({
+    queryKey: usageKeys.sessions(limit),
+    queryFn: () => usageApi.getUsageSessions(limit),
+    refetchInterval: 30_000,
+  });
+}
+
+/** Per-model slices for the donut chart */
+export function useModelUsage() {
+  return useQuery<ModelUsageSlice[]>({
+    queryKey: usageKeys.modelUsage(),
+    queryFn: () => usageApi.getModelUsage(),
+    refetchInterval: 120_000,
+  });
+}

--- a/panel/src/lib/api/index.ts
+++ b/panel/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 export { api, API_URL } from "./client";
+export { usageApi } from "./usage";
 export { tasksApi } from "./tasks";
 export { orchestratorApi } from "./orchestrator";
 export { channelsApi } from "./channels";

--- a/panel/src/lib/api/usage.ts
+++ b/panel/src/lib/api/usage.ts
@@ -1,74 +1,157 @@
 import api from "./client";
 import { isMockMode } from "@/lib/mock-data";
 import type {
-  TokenUsageSnapshot,
+  UsageSummary,
   AgentUsageRow,
-  UsageSession,
-  UsageTimePoint,
+  TeamUsageRow,
   ModelUsageSlice,
+  UsageTimePoint,
+  UsageProjection,
+  CacheEfficiencyResponse,
+  UsageSession,
 } from "@/types";
 
+export type UsagePeriod = "24h" | "7d" | "30d";
+
 // =============================================================================
-// MOCK DATA
+// MOCK DATA  — shapes must exactly match the real backend response schemas
 // =============================================================================
 
-function mockSnapshot(): TokenUsageSnapshot {
+function mockSummary(period: UsagePeriod = "24h"): UsageSummary {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
+  const base = 124_800 * scale;
   return {
-    tokens_today: 124_800,
-    cost_today: 3.74,
-    cost_this_week: 22.50,
-    cost_last_week: 18.20,
-    active_sessions: 3,
-    cache_savings: 1.25,
-    top_consumer: "be-dev-1",
+    tokens_input: Math.round(base * 0.55),
+    tokens_output: Math.round(base * 0.35),
+    total_tokens: base,
+    total_cost_usd: parseFloat((base * 0.000030).toFixed(6)),
+    trend_pct: 12.5,
+    period,
   };
 }
 
-function mockTimeSeries(): UsageTimePoint[] {
+function mockTimeSeries(period: UsagePeriod = "24h"): UsageTimePoint[] {
   const now = new Date();
-  return Array.from({ length: 24 }, (_, i) => {
+  const points = period === "24h" ? 24 : period === "7d" ? 7 : 30;
+  const step = period === "24h" ? "hour" : "day";
+  return Array.from({ length: points }, (_, i) => {
     const ts = new Date(now);
-    ts.setHours(now.getHours() - (23 - i), 0, 0, 0);
+    if (step === "hour") {
+      ts.setHours(now.getHours() - (points - 1 - i), 0, 0, 0);
+    } else {
+      ts.setDate(now.getDate() - (points - 1 - i));
+      ts.setHours(0, 0, 0, 0);
+    }
     const base = 3_000 + Math.round(Math.random() * 4_000);
+    const tokens_input = Math.round(base * 0.55);
+    const tokens_output = Math.round(base * 0.35);
+    const total_tokens = base;
     return {
-      timestamp: ts.toISOString(),
-      tokens_input: Math.round(base * 0.45),
-      tokens_output: Math.round(base * 0.35),
-      tokens_cache: Math.round(base * 0.20),
+      bucket: ts.toISOString(),
+      tokens_input,
+      tokens_output,
+      total_tokens,
+      cost_usd: parseFloat((total_tokens * 0.000030).toFixed(6)),
     };
   });
 }
 
-function mockAgentUsage(): AgentUsageRow[] {
+function mockAgentUsage(period: UsagePeriod = "24h"): AgentUsageRow[] {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
   const agents = [
-    { agent_id: "be-dev-1", agent_name: "BE-Dev-1", team: "backend" },
-    { agent_id: "be-dev-2", agent_name: "BE-Dev-2", team: "backend" },
-    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1", team: "frontend" },
-    { agent_id: "fe-dev-2", agent_name: "FE-Dev-2", team: "frontend" },
-    { agent_id: "ux-dev-1", agent_name: "UX-Dev-1", team: "ux_ui" },
-    { agent_id: "be-qa", agent_name: "BE-QA", team: "backend" },
-    { agent_id: "fe-qa", agent_name: "FE-QA", team: "frontend" },
-    { agent_id: "main-pm", agent_name: "Main-PM", team: "main_pm" },
+    { agent_slug: "be-dev-1" },
+    { agent_slug: "be-dev-2" },
+    { agent_slug: "fe-dev-1" },
+    { agent_slug: "fe-dev-2" },
+    { agent_slug: "ux-dev-1" },
+    { agent_slug: "be-qa" },
+    { agent_slug: "fe-qa" },
+    { agent_slug: "main-pm" },
   ];
-  return agents.map((a) => ({
-    ...a,
-    tokens_today: Math.round(5_000 + Math.random() * 25_000),
-    cost_today: parseFloat((0.15 + Math.random() * 0.75).toFixed(2)),
-    tokens_total: Math.round(50_000 + Math.random() * 200_000),
-  }));
+  const grand = agents.length * 15_000 * scale;
+  return agents.map((a) => {
+    const ti = Math.round((5_000 + Math.random() * 20_000) * scale);
+    const to_ = Math.round(ti * 0.65);
+    const total = ti + to_;
+    return {
+      agent_slug: a.agent_slug,
+      tokens_input: ti,
+      tokens_output: to_,
+      total_tokens: total,
+      cost_usd: parseFloat((total * 0.000030).toFixed(6)),
+      pct_of_total: parseFloat(((total / grand) * 100).toFixed(2)),
+    };
+  });
+}
+
+function mockTeamUsage(period: UsagePeriod = "24h"): TeamUsageRow[] {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
+  const teams = ["backend", "frontend", "ux_ui", "main_pm"];
+  const grand = teams.length * 50_000 * scale;
+  return teams.map((team) => {
+    const ti = Math.round((30_000 + Math.random() * 40_000) * scale);
+    const to_ = Math.round(ti * 0.65);
+    const total = ti + to_;
+    return {
+      team,
+      tokens_input: ti,
+      tokens_output: to_,
+      total_tokens: total,
+      cost_usd: parseFloat((total * 0.000030).toFixed(6)),
+      pct_of_total: parseFloat(((total / grand) * 100).toFixed(2)),
+    };
+  });
+}
+
+function mockModelUsage(period: UsagePeriod = "24h"): ModelUsageSlice[] {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
+  const models = [
+    { model: "claude-opus-4", share: 0.548 },
+    { model: "claude-sonnet-4", share: 0.346 },
+    { model: "claude-haiku-4", share: 0.106 },
+  ];
+  const base = 124_800 * scale;
+  return models.map((m) => {
+    const ti = Math.round(base * m.share * 0.55);
+    const to_ = Math.round(base * m.share * 0.35);
+    const total = Math.round(base * m.share);
+    return {
+      model: m.model,
+      tokens_input: ti,
+      tokens_output: to_,
+      total_tokens: total,
+      cost_usd: parseFloat((total * 0.000030).toFixed(6)),
+      pct_of_total: parseFloat((m.share * 100).toFixed(1)),
+    };
+  });
+}
+
+function mockProjection(): UsageProjection {
+  const total_cost_7d = parseFloat((124_800 * 7 * 0.000030).toFixed(6));
+  return {
+    total_cost_7d,
+    avg_daily_cost_usd: parseFloat((total_cost_7d / 7).toFixed(6)),
+    projected_monthly_cost_usd: parseFloat((total_cost_7d / 7 * 30).toFixed(4)),
+    basis_days: 7,
+  };
+}
+
+function mockCacheEfficiency(period: UsagePeriod = "24h"): CacheEfficiencyResponse {
+  return {
+    cache_hit_rate: 0.3142,
+    tokens_cache_read: 39_168,
+    tokens_cache_write: 12_480,
+    tokens_input: 85_632,
+    cost_saved_by_cache_usd: parseFloat((39_168 * (3.00 - 0.30) / 1_000_000).toFixed(6)),
+    period,
+  };
 }
 
 function mockSessions(): UsageSession[] {
   const models = ["claude-opus-4", "claude-sonnet-4", "claude-haiku-4"];
-  const agents = [
-    { agent_id: "be-dev-1", agent_name: "BE-Dev-1" },
-    { agent_id: "be-dev-2", agent_name: "BE-Dev-2" },
-    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1" },
-    { agent_id: "fe-qa", agent_name: "FE-QA" },
-    { agent_id: "main-pm", agent_name: "Main-PM" },
-  ];
+  const agentSlugs = ["be-dev-1", "be-dev-2", "fe-dev-1", "fe-qa", "main-pm"];
   return Array.from({ length: 35 }, (_, i) => {
-    const agent = agents[i % agents.length];
+    const agent_slug = agentSlugs[i % agentSlugs.length];
     const model = models[i % models.length];
     const input = Math.round(2_000 + Math.random() * 8_000);
     const output = Math.round(500 + Math.random() * 3_000);
@@ -77,8 +160,7 @@ function mockSessions(): UsageSession[] {
     const ended = i < 3 ? null : new Date(started.getTime() + Math.round(5 + Math.random() * 55) * 60_000);
     return {
       id: `session-mock-${i + 1}`,
-      agent_id: agent.agent_id,
-      agent_name: agent.agent_name,
+      agent_slug,
       started_at: started.toISOString(),
       ended_at: ended ? ended.toISOString() : null,
       tokens_input: input,
@@ -91,55 +173,82 @@ function mockSessions(): UsageSession[] {
   });
 }
 
-function mockModelUsage(): ModelUsageSlice[] {
-  return [
-    { model: "claude-opus-4", tokens: 68_400, cost: 2.05, percentage: 54.8 },
-    { model: "claude-sonnet-4", tokens: 43_200, cost: 1.30, percentage: 34.6 },
-    { model: "claude-haiku-4", tokens: 13_200, cost: 0.40, percentage: 10.6 },
-  ];
-}
-
 // =============================================================================
 // API OBJECT
 // =============================================================================
 
 export const usageApi = {
-  /** Current-day snapshot for the overview panel */
-  getUsageSnapshot: async (): Promise<TokenUsageSnapshot> => {
-    if (isMockMode()) return mockSnapshot();
-    const { data } = await api.get<TokenUsageSnapshot>("/usage/snapshot");
+  /** Aggregated token usage summary — GET /usage/summary?period= */
+  getUsageSummary: async (period: UsagePeriod = "24h"): Promise<UsageSummary> => {
+    if (isMockMode()) return mockSummary(period);
+    const { data } = await api.get<UsageSummary>("/usage/summary", {
+      params: { period },
+    });
     return data;
   },
 
-  /** Hourly time-series data for the stacked area chart */
-  getUsageTimeSeries: async (hours: number = 24): Promise<UsageTimePoint[]> => {
-    if (isMockMode()) return mockTimeSeries();
+  /** Bucketed time-series — GET /usage/time-series?period= */
+  getUsageTimeSeries: async (period: UsagePeriod = "24h"): Promise<UsageTimePoint[]> => {
+    if (isMockMode()) return mockTimeSeries(period);
     const { data } = await api.get<UsageTimePoint[]>("/usage/time-series", {
-      params: { hours },
+      params: { period },
     });
     return data;
   },
 
-  /** Per-agent usage rows for the bar chart and agent cards */
-  getAgentUsage: async (): Promise<AgentUsageRow[]> => {
-    if (isMockMode()) return mockAgentUsage();
-    const { data } = await api.get<AgentUsageRow[]>("/usage/agents");
+  /** Per-agent usage rows — GET /usage/by-agent?period= */
+  getAgentUsage: async (period: UsagePeriod = "24h"): Promise<AgentUsageRow[]> => {
+    if (isMockMode()) return mockAgentUsage(period);
+    const { data } = await api.get<AgentUsageRow[]>("/usage/by-agent", {
+      params: { period },
+    });
     return data;
   },
 
-  /** Recent inference sessions for the sessions table */
-  getUsageSessions: async (limit: number = 100): Promise<UsageSession[]> => {
+  /** Per-team usage rows — GET /usage/by-team?period= */
+  getTeamUsage: async (period: UsagePeriod = "24h"): Promise<TeamUsageRow[]> => {
+    if (isMockMode()) return mockTeamUsage(period);
+    const { data } = await api.get<TeamUsageRow[]>("/usage/by-team", {
+      params: { period },
+    });
+    return data;
+  },
+
+  /** Per-model usage slices — GET /usage/by-model?period= */
+  getModelUsage: async (period: UsagePeriod = "24h"): Promise<ModelUsageSlice[]> => {
+    if (isMockMode()) return mockModelUsage(period);
+    const { data } = await api.get<ModelUsageSlice[]>("/usage/by-model", {
+      params: { period },
+    });
+    return data;
+  },
+
+  /** Monthly cost projection — GET /usage/projection */
+  getUsageProjection: async (): Promise<UsageProjection> => {
+    if (isMockMode()) return mockProjection();
+    const { data } = await api.get<UsageProjection>("/usage/projection");
+    return data;
+  },
+
+  /** Cache efficiency stats — GET /usage/cache-efficiency?period= */
+  getCacheEfficiency: async (period: UsagePeriod = "24h"): Promise<CacheEfficiencyResponse> => {
+    if (isMockMode()) return mockCacheEfficiency(period);
+    const { data } = await api.get<CacheEfficiencyResponse>("/usage/cache-efficiency", {
+      params: { period },
+    });
+    return data;
+  },
+
+  /**
+   * Recent inference sessions — mock-mode only.
+   *
+   * The backend has no /usage/sessions endpoint.  In production this
+   * returns an empty array so SessionsTable shows a graceful "no data"
+   * state instead of throwing a 404.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getUsageSessions: async (_limit: number = 100): Promise<UsageSession[]> => {
     if (isMockMode()) return mockSessions();
-    const { data } = await api.get<UsageSession[]>("/usage/sessions", {
-      params: { limit },
-    });
-    return data;
-  },
-
-  /** Per-model usage slices for the donut chart */
-  getModelUsage: async (): Promise<ModelUsageSlice[]> => {
-    if (isMockMode()) return mockModelUsage();
-    const { data } = await api.get<ModelUsageSlice[]>("/usage/models");
-    return data;
+    return [];
   },
 };

--- a/panel/src/lib/api/usage.ts
+++ b/panel/src/lib/api/usage.ts
@@ -1,0 +1,145 @@
+import api from "./client";
+import { isMockMode } from "@/lib/mock-data";
+import type {
+  TokenUsageSnapshot,
+  AgentUsageRow,
+  UsageSession,
+  UsageTimePoint,
+  ModelUsageSlice,
+} from "@/types";
+
+// =============================================================================
+// MOCK DATA
+// =============================================================================
+
+function mockSnapshot(): TokenUsageSnapshot {
+  return {
+    tokens_today: 124_800,
+    cost_today: 3.74,
+    cost_this_week: 22.50,
+    cost_last_week: 18.20,
+    active_sessions: 3,
+    cache_savings: 1.25,
+    top_consumer: "be-dev-1",
+  };
+}
+
+function mockTimeSeries(): UsageTimePoint[] {
+  const now = new Date();
+  return Array.from({ length: 24 }, (_, i) => {
+    const ts = new Date(now);
+    ts.setHours(now.getHours() - (23 - i), 0, 0, 0);
+    const base = 3_000 + Math.round(Math.random() * 4_000);
+    return {
+      timestamp: ts.toISOString(),
+      tokens_input: Math.round(base * 0.45),
+      tokens_output: Math.round(base * 0.35),
+      tokens_cache: Math.round(base * 0.20),
+    };
+  });
+}
+
+function mockAgentUsage(): AgentUsageRow[] {
+  const agents = [
+    { agent_id: "be-dev-1", agent_name: "BE-Dev-1", team: "backend" },
+    { agent_id: "be-dev-2", agent_name: "BE-Dev-2", team: "backend" },
+    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1", team: "frontend" },
+    { agent_id: "fe-dev-2", agent_name: "FE-Dev-2", team: "frontend" },
+    { agent_id: "ux-dev-1", agent_name: "UX-Dev-1", team: "ux_ui" },
+    { agent_id: "be-qa", agent_name: "BE-QA", team: "backend" },
+    { agent_id: "fe-qa", agent_name: "FE-QA", team: "frontend" },
+    { agent_id: "main-pm", agent_name: "Main-PM", team: "main_pm" },
+  ];
+  return agents.map((a) => ({
+    ...a,
+    tokens_today: Math.round(5_000 + Math.random() * 25_000),
+    cost_today: parseFloat((0.15 + Math.random() * 0.75).toFixed(2)),
+    tokens_total: Math.round(50_000 + Math.random() * 200_000),
+  }));
+}
+
+function mockSessions(): UsageSession[] {
+  const models = ["claude-opus-4", "claude-sonnet-4", "claude-haiku-4"];
+  const agents = [
+    { agent_id: "be-dev-1", agent_name: "BE-Dev-1" },
+    { agent_id: "be-dev-2", agent_name: "BE-Dev-2" },
+    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1" },
+    { agent_id: "fe-qa", agent_name: "FE-QA" },
+    { agent_id: "main-pm", agent_name: "Main-PM" },
+  ];
+  return Array.from({ length: 35 }, (_, i) => {
+    const agent = agents[i % agents.length];
+    const model = models[i % models.length];
+    const input = Math.round(2_000 + Math.random() * 8_000);
+    const output = Math.round(500 + Math.random() * 3_000);
+    const cache = Math.round(100 + Math.random() * 1_000);
+    const started = new Date(Date.now() - (i + 1) * 12 * 60_000);
+    const ended = i < 3 ? null : new Date(started.getTime() + Math.round(5 + Math.random() * 55) * 60_000);
+    return {
+      id: `session-mock-${i + 1}`,
+      agent_id: agent.agent_id,
+      agent_name: agent.agent_name,
+      started_at: started.toISOString(),
+      ended_at: ended ? ended.toISOString() : null,
+      tokens_input: input,
+      tokens_output: output,
+      tokens_cache: cache,
+      total_tokens: input + output + cache,
+      cost: parseFloat(((input + output) * 0.00003 + cache * 0.000003).toFixed(4)),
+      model,
+    };
+  });
+}
+
+function mockModelUsage(): ModelUsageSlice[] {
+  return [
+    { model: "claude-opus-4", tokens: 68_400, cost: 2.05, percentage: 54.8 },
+    { model: "claude-sonnet-4", tokens: 43_200, cost: 1.30, percentage: 34.6 },
+    { model: "claude-haiku-4", tokens: 13_200, cost: 0.40, percentage: 10.6 },
+  ];
+}
+
+// =============================================================================
+// API OBJECT
+// =============================================================================
+
+export const usageApi = {
+  /** Current-day snapshot for the overview panel */
+  getUsageSnapshot: async (): Promise<TokenUsageSnapshot> => {
+    if (isMockMode()) return mockSnapshot();
+    const { data } = await api.get<TokenUsageSnapshot>("/usage/snapshot");
+    return data;
+  },
+
+  /** Hourly time-series data for the stacked area chart */
+  getUsageTimeSeries: async (hours: number = 24): Promise<UsageTimePoint[]> => {
+    if (isMockMode()) return mockTimeSeries();
+    const { data } = await api.get<UsageTimePoint[]>("/usage/time-series", {
+      params: { hours },
+    });
+    return data;
+  },
+
+  /** Per-agent usage rows for the bar chart and agent cards */
+  getAgentUsage: async (): Promise<AgentUsageRow[]> => {
+    if (isMockMode()) return mockAgentUsage();
+    const { data } = await api.get<AgentUsageRow[]>("/usage/agents");
+    return data;
+  },
+
+  /** Recent inference sessions for the sessions table */
+  getUsageSessions: async (limit: number = 100): Promise<UsageSession[]> => {
+    if (isMockMode()) return mockSessions();
+    const { data } = await api.get<UsageSession[]>("/usage/sessions", {
+      params: { limit },
+    });
+    return data;
+  },
+
+  /** Per-model usage slices for the donut chart */
+  getModelUsage: async (): Promise<ModelUsageSlice[]> => {
+    if (isMockMode()) return mockModelUsage();
+    const { data } = await api.get<ModelUsageSlice[]>("/usage/models");
+    return data;
+  },
+};

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -1255,35 +1255,84 @@ export interface CEORejectRequest {
 }
 
 // =============================================================================
-// TOKEN USAGE TYPES
+// TOKEN USAGE TYPES  (aligned to real backend: GET /api/usage/*)
 // =============================================================================
 
-/** Snapshot of current token usage totals for the overview panel */
-export interface TokenUsageSnapshot {
-  tokens_today: number;
-  cost_today: number;
-  cost_this_week: number;
-  cost_last_week: number;
-  active_sessions: number;
-  cache_savings: number;
-  top_consumer: string;
+/** Aggregated token and cost totals — GET /usage/summary?period=24h|7d|30d */
+export interface UsageSummary {
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  total_cost_usd: number;
+  trend_pct: number;
+  period: string;
 }
 
-/** Per-agent usage row for the agent bar chart and agent card mini-bar */
+/** Per-agent usage row — GET /usage/by-agent?period=24h|7d|30d */
 export interface AgentUsageRow {
-  agent_id: string;
-  agent_name: string;
-  tokens_today: number;
-  cost_today: number;
-  tokens_total: number;
-  team: string;
+  agent_slug: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+  pct_of_total: number;
 }
 
-/** Individual inference session for the sessions table */
+/** Per-team usage row — GET /usage/by-team?period=24h|7d|30d */
+export interface TeamUsageRow {
+  team: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+  pct_of_total: number;
+}
+
+/** Per-model usage slice — GET /usage/by-model?period=24h|7d|30d */
+export interface ModelUsageSlice {
+  model: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+  pct_of_total: number;
+}
+
+/** One data point in a token-usage time series — GET /usage/time-series?period=24h|7d|30d
+ *
+ * - 24h → hourly buckets; 7d / 30d → daily buckets
+ * - bucket is an ISO datetime string (from PostgreSQL date_trunc)
+ */
+export interface UsageTimePoint {
+  bucket: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+/** Monthly cost projection — GET /usage/projection */
+export interface UsageProjection {
+  total_cost_7d: number;
+  avg_daily_cost_usd: number;
+  projected_monthly_cost_usd: number;
+  basis_days: number;
+}
+
+/** Cache efficiency stats — GET /usage/cache-efficiency?period=24h|7d|30d */
+export interface CacheEfficiencyResponse {
+  cache_hit_rate: number;
+  tokens_cache_read: number;
+  tokens_cache_write: number;
+  tokens_input: number;
+  cost_saved_by_cache_usd: number;
+  period: string;
+}
+
+/** Individual inference session for the sessions table (mock-mode only — no real backend endpoint) */
 export interface UsageSession {
   id: string;
-  agent_id: string;
-  agent_name: string;
+  agent_slug: string;
   started_at: string;
   ended_at: string | null;
   tokens_input: number;
@@ -1292,20 +1341,4 @@ export interface UsageSession {
   total_tokens: number;
   cost: number;
   model: string;
-}
-
-/** One data point in a token-usage time series (hourly or daily) */
-export interface UsageTimePoint {
-  timestamp: string;
-  tokens_input: number;
-  tokens_output: number;
-  tokens_cache: number;
-}
-
-/** A model's share of overall token usage for the donut chart */
-export interface ModelUsageSlice {
-  model: string;
-  tokens: number;
-  cost: number;
-  percentage: number;
 }

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -1253,3 +1253,59 @@ export interface CEOApprovalRequest {
 export interface CEORejectRequest {
   notes: string; // Required for rejection
 }
+
+// =============================================================================
+// TOKEN USAGE TYPES
+// =============================================================================
+
+/** Snapshot of current token usage totals for the overview panel */
+export interface TokenUsageSnapshot {
+  tokens_today: number;
+  cost_today: number;
+  cost_this_week: number;
+  cost_last_week: number;
+  active_sessions: number;
+  cache_savings: number;
+  top_consumer: string;
+}
+
+/** Per-agent usage row for the agent bar chart and agent card mini-bar */
+export interface AgentUsageRow {
+  agent_id: string;
+  agent_name: string;
+  tokens_today: number;
+  cost_today: number;
+  tokens_total: number;
+  team: string;
+}
+
+/** Individual inference session for the sessions table */
+export interface UsageSession {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  started_at: string;
+  ended_at: string | null;
+  tokens_input: number;
+  tokens_output: number;
+  tokens_cache: number;
+  total_tokens: number;
+  cost: number;
+  model: string;
+}
+
+/** One data point in a token-usage time series (hourly or daily) */
+export interface UsageTimePoint {
+  timestamp: string;
+  tokens_input: number;
+  tokens_output: number;
+  tokens_cache: number;
+}
+
+/** A model's share of overall token usage for the donut chart */
+export interface ModelUsageSlice {
+  model: string;
+  tokens: number;
+  cost: number;
+  percentage: number;
+}

--- a/roboco/agent_sdk/models.py
+++ b/roboco/agent_sdk/models.py
@@ -202,3 +202,44 @@ class VerbCircuitStatus(BaseModel):
             "next gateway call."
         ),
     )
+
+
+# =============================================================================
+# TOKEN USAGE
+# =============================================================================
+
+
+class TokenReportRequest(BaseModel):
+    """Payload for POST /usage/report — reports token usage from a model call.
+
+    Counts are *additive*: the SDK accumulates them per session so multiple
+    report calls sum up correctly across tool invocations.
+    """
+
+    tokens_input: int = Field(default=0, description="Input / prompt tokens consumed")
+    tokens_output: int = Field(
+        default=0, description="Output / completion tokens generated"
+    )
+    tokens_cache_read: int = Field(
+        default=0, description="Prompt-cache read tokens (charged at reduced rate)"
+    )
+    tokens_cache_write: int = Field(
+        default=0, description="Prompt-cache write tokens"
+    )
+
+
+class TokenUsageStatus(BaseModel):
+    """Current cumulative token usage for this session (GET /usage/status)."""
+
+    tokens_input: int = Field(
+        default=0, description="Total input tokens accumulated this session"
+    )
+    tokens_output: int = Field(
+        default=0, description="Total output tokens accumulated this session"
+    )
+    tokens_cache_read: int = Field(
+        default=0, description="Total cache-read tokens this session"
+    )
+    tokens_cache_write: int = Field(
+        default=0, description="Total cache-write tokens this session"
+    )

--- a/roboco/agent_sdk/models.py
+++ b/roboco/agent_sdk/models.py
@@ -223,9 +223,7 @@ class TokenReportRequest(BaseModel):
     tokens_cache_read: int = Field(
         default=0, description="Prompt-cache read tokens (charged at reduced rate)"
     )
-    tokens_cache_write: int = Field(
-        default=0, description="Prompt-cache write tokens"
-    )
+    tokens_cache_write: int = Field(default=0, description="Prompt-cache write tokens")
 
 
 class TokenUsageStatus(BaseModel):

--- a/roboco/agent_sdk/server.py
+++ b/roboco/agent_sdk/server.py
@@ -35,6 +35,8 @@ from roboco.agent_sdk.models import (
     SendResponse,
     TerminalStatus,
     TerminalToolRecordRequest,
+    TokenReportRequest,
+    TokenUsageStatus,
     VerbAttemptRequest,
     VerbCircuitStatus,
 )
@@ -420,6 +422,11 @@ class _SessionState:
         self.verb_attempts: dict[tuple[str, str | None], deque[float]] = defaultdict(
             deque
         )
+        # Cumulative token usage for this session (reported via /usage/report)
+        self.tokens_input: int = 0
+        self.tokens_output: int = 0
+        self.tokens_cache_read: int = 0
+        self.tokens_cache_write: int = 0
 
     def reset(self) -> None:
         self._init_fields()
@@ -677,6 +684,54 @@ def _terminal_snapshot() -> TerminalStatus:
         had_terminal_recently=_state.had_terminal_recently(),
         stop_attempts=_state.stop_attempts,
         stop_allowance=_STOP_ALLOWANCE,
+    )
+
+
+# =============================================================================
+# TOKEN USAGE REPORTING
+# =============================================================================
+
+
+@app.post("/usage/report", response_model=TokenUsageStatus)
+async def usage_report(req: TokenReportRequest) -> TokenUsageStatus:
+    """Accumulate token usage counts for the current session.
+
+    Called by Claude Code hooks (e.g. PostToolUse) after each API call
+    to report the tokens consumed by that invocation. Counts are additive
+    — multiple calls sum up correctly across the session lifetime.
+    """
+    _state.tokens_input += req.tokens_input
+    _state.tokens_output += req.tokens_output
+    _state.tokens_cache_read += req.tokens_cache_read
+    _state.tokens_cache_write += req.tokens_cache_write
+
+    logger.debug(
+        "Token usage reported",
+        delta_input=req.tokens_input,
+        delta_output=req.tokens_output,
+        total_input=_state.tokens_input,
+        total_output=_state.tokens_output,
+    )
+
+    return _token_usage_snapshot()
+
+
+@app.get("/usage/status", response_model=TokenUsageStatus)
+async def usage_status() -> TokenUsageStatus:
+    """Return cumulative token usage totals for the current session.
+
+    The orchestrator sweeper calls this endpoint every ~60 s to record
+    snapshots and to finalize session rows when the container stops.
+    """
+    return _token_usage_snapshot()
+
+
+def _token_usage_snapshot() -> TokenUsageStatus:
+    return TokenUsageStatus(
+        tokens_input=_state.tokens_input,
+        tokens_output=_state.tokens_output,
+        tokens_cache_read=_state.tokens_cache_read,
+        tokens_cache_write=_state.tokens_cache_write,
     )
 
 

--- a/roboco/api/app.py
+++ b/roboco/api/app.py
@@ -36,6 +36,7 @@ from roboco.api.routes.provider import router as provider_router
 from roboco.api.routes.sessions import router as sessions_router
 from roboco.api.routes.stream import router as stream_router
 from roboco.api.routes.tasks import router as tasks_router
+from roboco.api.routes.usage import router as usage_router
 from roboco.api.routes.v1 import do as do_module
 from roboco.api.routes.v1 import flow_auditor as flow_auditor_module
 from roboco.api.routes.v1 import flow_board as flow_board_module
@@ -44,7 +45,6 @@ from roboco.api.routes.v1 import flow_dev as flow_dev_module
 from roboco.api.routes.v1 import flow_doc as flow_doc_module
 from roboco.api.routes.v1 import flow_main_pm as flow_main_pm_module
 from roboco.api.routes.v1 import flow_qa as flow_qa_module
-from roboco.api.routes.usage import router as usage_router
 from roboco.api.routes.work_session import router as work_session_router
 from roboco.api.websocket import router as ws_router
 from roboco.config import settings

--- a/roboco/api/app.py
+++ b/roboco/api/app.py
@@ -44,6 +44,7 @@ from roboco.api.routes.v1 import flow_dev as flow_dev_module
 from roboco.api.routes.v1 import flow_doc as flow_doc_module
 from roboco.api.routes.v1 import flow_main_pm as flow_main_pm_module
 from roboco.api.routes.v1 import flow_qa as flow_qa_module
+from roboco.api.routes.usage import router as usage_router
 from roboco.api.routes.work_session import router as work_session_router
 from roboco.api.websocket import router as ws_router
 from roboco.config import settings
@@ -338,6 +339,13 @@ def create_app() -> FastAPI:
         docs_router,
         prefix=f"{api_prefix}/docs",
         tags=["Documentation"],
+    )
+
+    # Token Usage Analytics
+    app.include_router(
+        usage_router,
+        prefix=f"{api_prefix}/usage",
+        tags=["Usage Analytics"],
     )
 
     # API v1 — intent-verb flow endpoints

--- a/roboco/api/routes/dashboard.py
+++ b/roboco/api/routes/dashboard.py
@@ -21,12 +21,14 @@ from roboco.api.schemas.dashboard import (
     CreateReportRequest,
     FlagSeverity,
     TeamHealth,
+    UsageSummary,
 )
 from roboco.models.base import Team
 from roboco.models.dashboard import CreateFlagParams
 from roboco.services.dashboard import get_dashboard_service
 from roboco.services.kanban import get_kanban_service
 from roboco.services.metrics import get_metrics_service
+from roboco.services.usage import get_usage_service
 
 router = APIRouter()
 
@@ -277,6 +279,7 @@ async def get_ceo_overview(
     - Roadmap progress
     """
     service = get_dashboard_service(db)
+    usage_svc = get_usage_service(db)
 
     health_list = await service.get_team_health_list()
     health_status = [
@@ -291,11 +294,22 @@ async def get_ceo_overview(
         for h in health_list
     ]
 
+    # Populate usage_summary from daily_usage_rollups for today
+    try:
+        today_usage = await usage_svc.get_today_summary()
+        usage_summary = UsageSummary(
+            tokens_today=today_usage["tokens_today"],
+            cost_today_usd=today_usage["cost_today_usd"],
+        )
+    except Exception:
+        usage_summary = UsageSummary(tokens_today=0, cost_today_usd=0.0)
+
     return CEOOverview(
         health_status=health_status,
         key_metrics=await service.get_key_metrics(),
         auditor_alerts=service.get_auditor_alerts(),
         roadmap_progress=await service.get_roadmap_progress(),
+        usage_summary=usage_summary,
     )
 
 

--- a/roboco/api/routes/usage.py
+++ b/roboco/api/routes/usage.py
@@ -5,7 +5,7 @@ Provides endpoints for querying token usage metrics across agents,
 teams, and models. Supports period-based queries (24h, 7d, 30d).
 """
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Query
 
@@ -16,6 +16,11 @@ router = APIRouter()
 
 _PeriodType = Literal["24h", "7d", "30d"]
 
+_PeriodQuery = Annotated[
+    _PeriodType,
+    Query(description="Time period: 24h, 7d, 30d"),
+]
+
 
 # =============================================================================
 # SUMMARY
@@ -25,7 +30,7 @@ _PeriodType = Literal["24h", "7d", "30d"]
 @router.get("/summary")
 async def get_usage_summary(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> dict[str, Any]:
     """Return aggregated token usage and cost for the given period.
 
@@ -48,7 +53,7 @@ async def get_usage_summary(
 @router.get("/time-series")
 async def get_usage_time_series(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return bucketed time-series data points.
 
@@ -70,7 +75,7 @@ async def get_usage_time_series(
 @router.get("/by-agent")
 async def get_usage_by_agent(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return per-agent token usage with pct_of_total.
 
@@ -83,7 +88,7 @@ async def get_usage_by_agent(
 @router.get("/by-team")
 async def get_usage_by_team(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return per-team token usage with pct_of_total.
 
@@ -96,7 +101,7 @@ async def get_usage_by_team(
 @router.get("/by-model")
 async def get_usage_by_model(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return per-model token usage with pct_of_total.
 
@@ -131,7 +136,7 @@ async def get_usage_projection(
 @router.get("/cache-efficiency")
 async def get_cache_efficiency(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> dict[str, Any]:
     """Return cache hit rate and estimated savings from prompt caching.
 

--- a/roboco/api/routes/usage.py
+++ b/roboco/api/routes/usage.py
@@ -1,0 +1,142 @@
+"""
+Token Usage Analytics API
+
+Provides endpoints for querying token usage metrics across agents,
+teams, and models. Supports period-based queries (24h, 7d, 30d).
+"""
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Query
+
+from roboco.api.deps import DbSession
+from roboco.services.usage import get_usage_service
+
+router = APIRouter()
+
+_PeriodType = Literal["24h", "7d", "30d"]
+
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+
+
+@router.get("/summary")
+async def get_usage_summary(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> dict[str, Any]:
+    """Return aggregated token usage and cost for the given period.
+
+    Response includes:
+    - tokens_input: total prompt tokens consumed
+    - tokens_output: total completion tokens generated
+    - total_tokens: sum of all token types
+    - total_cost_usd: estimated USD cost
+    - trend_pct: percent change vs. previous equivalent period
+    """
+    svc = get_usage_service(db)
+    return await svc.get_summary(period)
+
+
+# =============================================================================
+# TIME SERIES
+# =============================================================================
+
+
+@router.get("/time-series")
+async def get_usage_time_series(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return bucketed time-series data points.
+
+    - 24h → hourly buckets
+    - 7d / 30d → daily buckets
+
+    Each point has: bucket (ISO timestamp), tokens_input, tokens_output,
+    total_tokens, cost_usd.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_time_series(period)
+
+
+# =============================================================================
+# BREAKDOWN ENDPOINTS
+# =============================================================================
+
+
+@router.get("/by-agent")
+async def get_usage_by_agent(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return per-agent token usage with pct_of_total.
+
+    pct_of_total fields sum to approximately 100%.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_by_agent(period)
+
+
+@router.get("/by-team")
+async def get_usage_by_team(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return per-team token usage with pct_of_total.
+
+    pct_of_total fields sum to approximately 100%.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_by_team(period)
+
+
+@router.get("/by-model")
+async def get_usage_by_model(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> list[dict[str, Any]]:
+    """Return per-model token usage with pct_of_total.
+
+    pct_of_total fields sum to approximately 100%.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_by_model(period)
+
+
+# =============================================================================
+# PROJECTION
+# =============================================================================
+
+
+@router.get("/projection")
+async def get_usage_projection(
+    db: DbSession,
+) -> dict[str, Any]:
+    """Return projected monthly cost based on 7-day rolling average.
+
+    projected_monthly_cost_usd is computed from avg_daily_cost * 30.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_projection()
+
+
+# =============================================================================
+# CACHE EFFICIENCY
+# =============================================================================
+
+
+@router.get("/cache-efficiency")
+async def get_cache_efficiency(
+    db: DbSession,
+    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+) -> dict[str, Any]:
+    """Return cache hit rate and estimated savings from prompt caching.
+
+    - cache_hit_rate: fraction of input-like tokens served from cache
+    - cost_saved_by_cache_usd: estimated savings vs. full input pricing
+    """
+    svc = get_usage_service(db)
+    return await svc.get_cache_efficiency(period)

--- a/roboco/api/schemas/dashboard.py
+++ b/roboco/api/schemas/dashboard.py
@@ -78,6 +78,17 @@ class TeamHealth(BaseModel):
     completed_this_week: int
 
 
+class UsageSummary(BaseModel):
+    """Today's token usage summary for the CEO dashboard."""
+
+    tokens_today: int = Field(
+        default=0, description="Total tokens (input + output + cache) used today"
+    )
+    cost_today_usd: float = Field(
+        default=0.0, description="Estimated USD cost for today"
+    )
+
+
 class CEOOverview(BaseModel):
     """Complete CEO overview data."""
 
@@ -85,6 +96,10 @@ class CEOOverview(BaseModel):
     key_metrics: dict[str, Any]
     auditor_alerts: dict[str, Any]
     roadmap_progress: dict[str, Any]
+    usage_summary: UsageSummary | None = Field(
+        default=None,
+        description="Today's token usage and cost from daily_usage_rollups",
+    )
 
 
 class CreateFlagRequest(BaseModel):

--- a/roboco/billing/__init__.py
+++ b/roboco/billing/__init__.py
@@ -1,0 +1,8 @@
+"""Billing utilities for RoboCo.
+
+Provides token-cost calculation for Claude API models.
+"""
+
+from roboco.billing.pricing import calculate_cost
+
+__all__ = ["calculate_cost"]

--- a/roboco/billing/pricing.py
+++ b/roboco/billing/pricing.py
@@ -1,0 +1,95 @@
+"""
+Token pricing for Claude API models.
+
+Implements per-model USD cost calculation based on Anthropic's published
+pricing. All prices are in USD per 1 million tokens.
+
+Unknown model names return 0.0 without raising so callers don't need to
+guard against missing pricing data.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Per-model pricing table
+# Format: model_name_fragment → (input_usd_per_1m, output_usd_per_1m,
+#                                cache_read_usd_per_1m, cache_write_usd_per_1m)
+#
+# Cache read is charged at ~10 % of the input price.
+# Cache write is charged at ~25 % of the input price.
+#
+# Match on *substring* of model name so "claude-opus-4-6" and "opus" both
+# resolve to the same tier.
+# ---------------------------------------------------------------------------
+_PRICING: list[tuple[str, float, float, float, float]] = [
+    # (fragment, input/1M, output/1M, cache_read/1M, cache_write/1M)
+    # Opus 4 family
+    ("claude-opus-4", 15.00, 75.00, 1.50, 3.75),
+    # Sonnet 4 / 3.7 / 3.5 family
+    ("claude-sonnet-4", 3.00, 15.00, 0.30, 0.75),
+    ("claude-3-7-sonnet", 3.00, 15.00, 0.30, 0.75),
+    ("claude-3-5-sonnet", 3.00, 15.00, 0.30, 0.75),
+    # Haiku family
+    ("claude-haiku-4", 0.80, 4.00, 0.08, 0.20),
+    ("claude-haiku-3-5", 0.80, 4.00, 0.08, 0.20),
+    ("claude-3-5-haiku", 0.80, 4.00, 0.08, 0.20),
+    ("claude-haiku-3", 0.25, 1.25, 0.025, 0.0625),
+    # Short aliases used in ROLE_MODEL_MAP / MODEL_MAP
+    ("opus", 15.00, 75.00, 1.50, 3.75),
+    ("sonnet", 3.00, 15.00, 0.30, 0.75),
+    ("haiku", 0.80, 4.00, 0.08, 0.20),
+]
+
+_MILLION = 1_000_000.0
+
+
+def calculate_cost(
+    model: str,
+    tokens_input: int,
+    tokens_output: int,
+    tokens_cache_read: int = 0,
+    tokens_cache_write: int = 0,
+) -> float:
+    """Calculate the estimated USD cost for a model invocation.
+
+    Matches the model name against the known pricing table using substring
+    search (longest match wins).  Unknown models return 0.0 without raising.
+
+    Args:
+        model: Model name or short alias (e.g. ``"claude-sonnet-4-6"``,
+               ``"sonnet"``, ``"opus"``).
+        tokens_input: Number of input tokens (prompt / context).
+        tokens_output: Number of output tokens (completion).
+        tokens_cache_read: Prompt-cache read tokens (charged at reduced rate).
+        tokens_cache_write: Prompt-cache write tokens (charged at reduced rate).
+
+    Returns:
+        Estimated cost in USD as a float.  Returns 0.0 for unknown models
+        rather than raising.
+    """
+    if not model:
+        return 0.0
+
+    lower = model.lower()
+
+    # Find the best (longest fragment) match
+    best_fragment_len = 0
+    best_prices: tuple[float, float, float, float] | None = None
+
+    for fragment, inp_price, out_price, cr_price, cw_price in _PRICING:
+        if fragment in lower and len(fragment) > best_fragment_len:
+            best_fragment_len = len(fragment)
+            best_prices = (inp_price, out_price, cr_price, cw_price)
+
+    if best_prices is None:
+        return 0.0
+
+    inp_price, out_price, cr_price, cw_price = best_prices
+
+    cost = (
+        tokens_input * inp_price / _MILLION
+        + tokens_output * out_price / _MILLION
+        + tokens_cache_read * cr_price / _MILLION
+        + tokens_cache_write * cw_price / _MILLION
+    )
+    return round(cost, 8)

--- a/roboco/billing/pricing.py
+++ b/roboco/billing/pricing.py
@@ -5,10 +5,15 @@ Implements per-model USD cost calculation based on Anthropic's published
 pricing. All prices are in USD per 1 million tokens.
 
 Unknown model names return 0.0 without raising so callers don't need to
-guard against missing pricing data.
+guard against missing pricing data.  Self-hosted Ollama models always
+return 0.0 (no API cost) — matched by the ``ollama/`` prefix convention.
 """
 
 from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Per-model pricing table
@@ -24,20 +29,20 @@ from __future__ import annotations
 _PRICING: list[tuple[str, float, float, float, float]] = [
     # (fragment, input/1M, output/1M, cache_read/1M, cache_write/1M)
     # Opus 4 family
-    ("claude-opus-4", 15.00, 75.00, 1.50, 3.75),
+    ("claude-opus-4", 5.00, 25.00, 0.50, 6.25),
     # Sonnet 4 / 3.7 / 3.5 family
     ("claude-sonnet-4", 3.00, 15.00, 0.30, 0.75),
     ("claude-3-7-sonnet", 3.00, 15.00, 0.30, 0.75),
     ("claude-3-5-sonnet", 3.00, 15.00, 0.30, 0.75),
     # Haiku family
-    ("claude-haiku-4", 0.80, 4.00, 0.08, 0.20),
-    ("claude-haiku-3-5", 0.80, 4.00, 0.08, 0.20),
-    ("claude-3-5-haiku", 0.80, 4.00, 0.08, 0.20),
+    ("claude-haiku-4", 1.00, 5.00, 0.10, 1.25),
+    ("claude-haiku-3-5", 1.00, 5.00, 0.10, 1.25),
+    ("claude-3-5-haiku", 1.00, 5.00, 0.10, 1.25),
     ("claude-haiku-3", 0.25, 1.25, 0.025, 0.0625),
     # Short aliases used in ROLE_MODEL_MAP / MODEL_MAP
-    ("opus", 15.00, 75.00, 1.50, 3.75),
+    ("opus", 5.00, 25.00, 0.50, 6.25),
     ("sonnet", 3.00, 15.00, 0.30, 0.75),
-    ("haiku", 0.80, 4.00, 0.08, 0.20),
+    ("haiku", 1.00, 5.00, 0.10, 1.25),
 ]
 
 _MILLION = 1_000_000.0
@@ -54,6 +59,7 @@ def calculate_cost(
 
     Matches the model name against the known pricing table using substring
     search (longest match wins).  Unknown models return 0.0 without raising.
+    Self-hosted Ollama models (``ollama/`` prefix) always return 0.0.
 
     Args:
         model: Model name or short alias (e.g. ``"claude-sonnet-4-6"``,
@@ -72,6 +78,10 @@ def calculate_cost(
 
     lower = model.lower()
 
+    # Self-hosted Ollama models have no API cost.
+    if lower.startswith("ollama/"):
+        return 0.0
+
     # Find the best (longest fragment) match
     best_fragment_len = 0
     best_prices: tuple[float, float, float, float] | None = None
@@ -82,6 +92,7 @@ def calculate_cost(
             best_prices = (inp_price, out_price, cr_price, cw_price)
 
     if best_prices is None:
+        logger.warning("No pricing data found for model", model=model)
         return 0.0
 
     inp_price, out_price, cr_price, cw_price = best_prices

--- a/roboco/db/tables.py
+++ b/roboco/db/tables.py
@@ -11,7 +11,9 @@ from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
+    Date,
     DateTime,
     Enum,
     Float,
@@ -1814,6 +1816,148 @@ class GatewayTriggerTable(Base):
         Index("ix_gateway_triggers_task_id", "task_id"),
         Index("ix_gateway_triggers_created_at", "created_at"),
         Index("ix_gateway_triggers_kind_decision", "trigger_kind", "decision"),
+    )
+
+
+# =============================================================================
+# TOKEN USAGE TABLES
+# =============================================================================
+
+
+class AgentSpawnSessionTable(Base):
+    """Records each agent container spawn lifecycle.
+
+    Opened when the orchestrator successfully starts a container; closed
+    (ended_at set) when stop_agent() finishes.  Final token counts are
+    accumulated from the agent SDK's /usage/status endpoint.
+    """
+
+    __tablename__ = "agent_spawn_sessions"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    agent_slug: Mapped[str] = mapped_column(String(100), nullable=False)
+    team: Mapped[str] = mapped_column(String(50), nullable=False)
+    role: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    task_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # BIGINT — token counts can exceed INT32 for long sessions
+    tokens_input: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_output: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_cache_read: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    tokens_cache_write: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    exit_reason: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    estimated_cost_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # Relationship to snapshots (backref for convenience)
+    snapshots: Mapped[list["TokenUsageSnapshotTable"]] = relationship(
+        "TokenUsageSnapshotTable",
+        back_populates="session",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index("ix_agent_spawn_sessions_agent_slug", "agent_slug"),
+        Index("ix_agent_spawn_sessions_started_at", "started_at"),
+        Index("ix_agent_spawn_sessions_ended_at", "ended_at"),
+        Index("ix_agent_spawn_sessions_team", "team"),
+    )
+
+
+class TokenUsageSnapshotTable(Base):
+    """Periodic (every ~60 s) snapshot of cumulative token usage for an
+    active agent_spawn_session.
+
+    The sweeper inserts one row per active agent per sweep cycle when
+    token counts are non-zero.  Snapshots allow tracking how token usage
+    grows over session lifetime.
+    """
+
+    __tablename__ = "token_usage_snapshots"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    agent_spawn_session_id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent_spawn_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    snapshotted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    tokens_input: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_output: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_cache_read: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    tokens_cache_write: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+
+    session: Mapped["AgentSpawnSessionTable"] = relationship(
+        "AgentSpawnSessionTable", back_populates="snapshots"
+    )
+
+    __table_args__ = (
+        Index("ix_token_usage_snapshots_session_id", "agent_spawn_session_id"),
+        Index("ix_token_usage_snapshots_snapshotted_at", "snapshotted_at"),
+    )
+
+
+class DailyUsageRollupTable(Base):
+    """Pre-aggregated daily token usage per (date, agent_slug, team, model).
+
+    Populated by the orchestrator sweeper via an upsert query over
+    closed agent_spawn_sessions.  Unique constraint on the natural key
+    enables ON CONFLICT DO UPDATE so the sweep is idempotent.
+    """
+
+    __tablename__ = "daily_usage_rollups"
+
+    id: Mapped[UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    date: Mapped[Any] = mapped_column(Date, nullable=False)  # datetime.date
+    agent_slug: Mapped[str] = mapped_column(String(100), nullable=False)
+    team: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    tokens_input: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_output: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    tokens_cache_read: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    tokens_cache_write: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    total_cost_usd: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    session_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "date",
+            "agent_slug",
+            "team",
+            "model",
+            name="uq_daily_rollup_date_agent_team_model",
+        ),
+        Index("ix_daily_rollups_date", "date"),
+        Index("ix_daily_rollups_agent_slug", "agent_slug"),
     )
 
 

--- a/roboco/events/stream_bus.py
+++ b/roboco/events/stream_bus.py
@@ -236,15 +236,15 @@ class StreamEventBus:
         results = await self._redis.xreadgroup(
             self.group_name,
             self.consumer_name,
-            stream_dict,
+            stream_dict,  # type: ignore[arg-type]
             count=10,
             block=5000,
         )
         if not results:
             return
-        for stream_name, messages in results:
-            for message_id, data in messages:
-                await self._handle_message(stream_name, message_id, data)
+        for stream_name, messages in results:  # type: ignore[str-unpack]
+            for message_id, data in messages:  # type: ignore[str-unpack,union-attr]
+                await self._handle_message(stream_name, message_id, data)  # type: ignore[arg-type]
 
     async def _handle_response_error(
         self, exc: ResponseError, streams: list[str]
@@ -354,8 +354,8 @@ class StreamEventBus:
         )
         if not claimed:
             return 0
-        for claim_id, data in claimed:
-            await self._handle_message(stream, claim_id, data)
+        for claim_id, data in claimed:  # type: ignore[str-unpack]
+            await self._handle_message(stream, claim_id, data)  # type: ignore[arg-type]
         return 1
 
     async def _recover_stream(self, stream: str, idle_time_ms: int) -> int:
@@ -376,9 +376,9 @@ class StreamEventBus:
 
         recovered = 0
         for msg in pending_details:
-            if msg["time_since_delivered"] >= idle_time_ms:
+            if int(msg["time_since_delivered"]) >= idle_time_ms:
                 recovered += await self._claim_and_handle(
-                    stream, msg["message_id"], idle_time_ms
+                    stream, str(msg["message_id"]), idle_time_ms
                 )
         return recovered
 

--- a/roboco/events/stream_bus.py
+++ b/roboco/events/stream_bus.py
@@ -236,15 +236,15 @@ class StreamEventBus:
         results = await self._redis.xreadgroup(
             self.group_name,
             self.consumer_name,
-            stream_dict,  # type: ignore[arg-type]
+            stream_dict,
             count=10,
             block=5000,
         )
         if not results:
             return
-        for stream_name, messages in results:  # type: ignore[str-unpack]
-            for message_id, data in messages:  # type: ignore[str-unpack,union-attr]
-                await self._handle_message(stream_name, message_id, data)  # type: ignore[arg-type]
+        for stream_name, messages in results:
+            for message_id, data in messages:
+                await self._handle_message(stream_name, message_id, data)
 
     async def _handle_response_error(
         self, exc: ResponseError, streams: list[str]
@@ -354,8 +354,8 @@ class StreamEventBus:
         )
         if not claimed:
             return 0
-        for claim_id, data in claimed:  # type: ignore[str-unpack]
-            await self._handle_message(stream, claim_id, data)  # type: ignore[arg-type]
+        for claim_id, data in claimed:
+            await self._handle_message(stream, claim_id, data)
         return 1
 
     async def _recover_stream(self, stream: str, idle_time_ms: int) -> int:

--- a/roboco/models/runtime.py
+++ b/roboco/models/runtime.py
@@ -71,6 +71,10 @@ class AgentInstance:
     error_count: int = 0
     waiting_for: str | None = None  # For WAITING_LONG state
     waiting_context: dict[str, Any] = field(default_factory=dict)
+    # UUID of the agent_spawn_sessions row created at spawn time.
+    # Used by _finalize_spawn_session for a direct-by-id lookup instead of a
+    # fragile (agent_slug, ended_at IS NULL) query.
+    usage_session_id: UUID | None = None
 
     def __post_init__(self) -> None:
         if not self.id:

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -27,6 +27,7 @@ import httpx
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
+    from uuid import UUID
 
     from roboco.services.llm import AgentRoute
     from roboco.services.task import TaskService
@@ -68,6 +69,11 @@ AgentConfig = OrchestratorAgentConfig
 # Docker configuration
 AGENT_NETWORK = "roboco_default"
 AGENT_BASE_IMAGE = "roboco-agent-base"
+
+# Port on which each agent's Claude Code SDK server listens inside its container.
+# Referenced by write-hooks (_finalize_spawn_session, _sweep_token_snapshots,
+# _sweep_budget_exceeded) to build the SDK health/usage URL.
+SDK_PORT: int = 9000
 
 # The intake (prompter) agent: a single seeded, board-adjacent interviewer.
 # Unlike delivery agents it is never dispatched and runs ONE persistent
@@ -1383,8 +1389,11 @@ class AgentOrchestrator:
                 },
             )
 
-            # Record a token-usage session row in the DB (fire-and-forget).
-            await self._record_spawn_session(config, task_id)
+            # Record a token-usage session row in the DB and bind its UUID to
+            # the instance so _finalize_spawn_session can look it up directly.
+            usage_session_id = await self._record_spawn_session(config, task_id)
+            if usage_session_id is not None:
+                instance.usage_session_id = usage_session_id
 
             return instance
         except Exception as e:
@@ -2878,7 +2887,22 @@ class AgentOrchestrator:
         graceful: bool = True,
         exit_reason: str = "stopped",
     ) -> None:
-        """Stop an agent container."""
+        """Stop an agent container.
+
+        Finalization (the HTTP call to the agent SDK's /usage/status endpoint)
+        is performed BEFORE acquiring self._lock so that the network I/O does
+        not block other operations that need the lock.
+        """
+        # Finalize the spawn-session row before the container is removed so we
+        # can still query the SDK's /usage/status endpoint.  This must happen
+        # outside self._lock — the HTTP round-trip would otherwise hold the
+        # lock for the full network timeout.
+        instance = self._instances.get(agent_id)
+        if instance is None:
+            return
+        if instance.container_id:
+            await self._finalize_spawn_session(agent_id, exit_reason=exit_reason)
+
         async with self._lock:
             if agent_id not in self._instances:
                 return
@@ -2888,10 +2912,6 @@ class AgentOrchestrator:
             if instance.container_id:
                 instance.state = AgentState.STOPPING
                 container_name = f"roboco-agent-{agent_id}"
-
-                # Finalize the spawn-session row before the container is removed
-                # so we can still query the SDK's /usage/status endpoint.
-                await self._finalize_spawn_session(agent_id, exit_reason=exit_reason)
 
                 if graceful:
                     # Graceful stop with timeout
@@ -3034,11 +3054,13 @@ class AgentOrchestrator:
         self,
         config: "OrchestratorAgentConfig",
         task_id: str | None,
-    ) -> None:
+    ) -> "UUID | None":
         """Insert a row into agent_spawn_sessions after a successful spawn.
 
-        Errors are caught and logged; a missing session row must never block
-        the spawn path.
+        Returns the UUID of the created row so the caller can store it on
+        the AgentInstance for later direct-by-id lookup in
+        _finalize_spawn_session.  Returns None when the insert fails; a
+        missing session row must never block the spawn path.
         """
         try:
             from uuid import uuid4 as _uuid4
@@ -3050,10 +3072,11 @@ class AgentOrchestrator:
             team = get_agent_team(agent_slug) or "backend"
             role = get_agent_role(agent_slug) or "developer"
 
+            session_id = _uuid4()
             session_factory = get_session_factory()
             async with session_factory() as db:
                 row = AgentSpawnSessionTable(
-                    id=_uuid4(),
+                    id=session_id,
                     agent_slug=agent_slug,
                     team=team,
                     role=role,
@@ -3066,15 +3089,17 @@ class AgentOrchestrator:
                 logger.debug(
                     "Spawn session recorded",
                     agent_slug=agent_slug,
-                    session_id=str(row.id),
+                    session_id=str(session_id),
                     task_id=task_id,
                 )
+            return session_id
         except Exception as exc:
             logger.warning(
                 "Failed to record spawn session",
                 agent_slug=config.agent_id,
                 error=str(exc),
             )
+            return None
 
     async def _finalize_spawn_session(
         self,
@@ -3117,10 +3142,11 @@ class AgentOrchestrator:
                     error=str(sdk_exc),
                 )
 
-            # Look up the model from the running instance config
+            # Look up the model and usage_session_id from the running instance config.
             instance = self._instances.get(agent_id)
             if instance and instance.config:
                 model = instance.config.model or "unknown"
+            usage_session_id = instance.usage_session_id if instance else None
 
             cost = calculate_cost(
                 model=model,
@@ -3134,16 +3160,25 @@ class AgentOrchestrator:
             async with session_factory() as db:
                 from sqlalchemy import select, update
 
-                # Update the most recent open session for this agent
-                result = await db.execute(
-                    select(AgentSpawnSessionTable)
-                    .where(
-                        AgentSpawnSessionTable.agent_slug == agent_id,
-                        AgentSpawnSessionTable.ended_at.is_(None),
+                # Prefer a direct lookup by the session UUID captured at spawn
+                # time; fall back to the (agent_slug, ended_at IS NULL) query
+                # for instances that pre-date the usage_session_id field.
+                if usage_session_id is not None:
+                    result = await db.execute(
+                        select(AgentSpawnSessionTable).where(
+                            AgentSpawnSessionTable.id == usage_session_id
+                        )
                     )
-                    .order_by(AgentSpawnSessionTable.started_at.desc())
-                    .limit(1)
-                )
+                else:
+                    result = await db.execute(
+                        select(AgentSpawnSessionTable)
+                        .where(
+                            AgentSpawnSessionTable.agent_slug == agent_id,
+                            AgentSpawnSessionTable.ended_at.is_(None),
+                        )
+                        .order_by(AgentSpawnSessionTable.started_at.desc())
+                        .limit(1)
+                    )
                 session_row = result.scalar_one_or_none()
                 if session_row is not None:
                     await db.execute(
@@ -3290,7 +3325,10 @@ class AgentOrchestrator:
 
             session_factory = get_session_factory()
             async with session_factory() as db:
-                # Aggregate closed sessions by (date, agent_slug, team, model)
+                # Aggregate closed sessions by (date, agent_slug, team, model).
+                # Limit to the last 7 days to avoid re-aggregating all-time
+                # history on every sweep — older days are already stable.
+                rollup_window_start = datetime.now(UTC) - timedelta(days=7)
                 result = await db.execute(
                     select(
                         func.date(AgentSpawnSessionTable.started_at).label("date"),
@@ -3304,7 +3342,10 @@ class AgentOrchestrator:
                         func.sum(AgentSpawnSessionTable.estimated_cost_usd).label("total_cost_usd"),
                         func.count(AgentSpawnSessionTable.id).label("session_count"),
                     )
-                    .where(AgentSpawnSessionTable.ended_at.isnot(None))
+                    .where(
+                        AgentSpawnSessionTable.ended_at.isnot(None),
+                        AgentSpawnSessionTable.started_at >= rollup_window_start,
+                    )
                     .group_by(
                         func.date(AgentSpawnSessionTable.started_at),
                         AgentSpawnSessionTable.agent_slug,
@@ -3629,7 +3670,7 @@ Start by:
                     AgentState.WAITING_SHORT,
                 ):
                     continue
-                url = f"http://roboco-agent-{agent_id}:9000/budget/status"
+                url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/budget/status"
                 data = await self._fetch_budget_status(client, url, agent_id)
                 if data is None or not data.get("halt"):
                     continue

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -1382,6 +1382,10 @@ class AgentOrchestrator:
                     "model": config.model,
                 },
             )
+
+            # Record a token-usage session row in the DB (fire-and-forget).
+            await self._record_spawn_session(config, task_id)
+
             return instance
         except Exception as e:
             instance.state = AgentState.OFFLINE
@@ -2868,7 +2872,12 @@ class AgentOrchestrator:
     # AGENT STOPPING
     # =========================================================================
 
-    async def stop_agent(self, agent_id: str, graceful: bool = True) -> None:
+    async def stop_agent(
+        self,
+        agent_id: str,
+        graceful: bool = True,
+        exit_reason: str = "stopped",
+    ) -> None:
         """Stop an agent container."""
         async with self._lock:
             if agent_id not in self._instances:
@@ -2879,6 +2888,10 @@ class AgentOrchestrator:
             if instance.container_id:
                 instance.state = AgentState.STOPPING
                 container_name = f"roboco-agent-{agent_id}"
+
+                # Finalize the spawn-session row before the container is removed
+                # so we can still query the SDK's /usage/status endpoint.
+                await self._finalize_spawn_session(agent_id, exit_reason=exit_reason)
 
                 if graceful:
                     # Graceful stop with timeout
@@ -3012,6 +3025,354 @@ class AgentOrchestrator:
                 agent_id=agent_id,
                 error=str(e),
             )
+
+    # =========================================================================
+    # TOKEN USAGE INSTRUMENTATION
+    # =========================================================================
+
+    async def _record_spawn_session(
+        self,
+        config: "OrchestratorAgentConfig",
+        task_id: str | None,
+    ) -> None:
+        """Insert a row into agent_spawn_sessions after a successful spawn.
+
+        Errors are caught and logged; a missing session row must never block
+        the spawn path.
+        """
+        try:
+            from uuid import uuid4 as _uuid4
+
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable
+
+            agent_slug = config.agent_id
+            team = get_agent_team(agent_slug) or "backend"
+            role = get_agent_role(agent_slug) or "developer"
+
+            session_factory = get_session_factory()
+            async with session_factory() as db:
+                row = AgentSpawnSessionTable(
+                    id=_uuid4(),
+                    agent_slug=agent_slug,
+                    team=team,
+                    role=role,
+                    model=config.model or "unknown",
+                    task_id=task_id,
+                    started_at=datetime.now(UTC),
+                )
+                db.add(row)
+                await db.commit()
+                logger.debug(
+                    "Spawn session recorded",
+                    agent_slug=agent_slug,
+                    session_id=str(row.id),
+                    task_id=task_id,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Failed to record spawn session",
+                agent_slug=config.agent_id,
+                error=str(exc),
+            )
+
+    async def _finalize_spawn_session(
+        self,
+        agent_id: str,
+        exit_reason: str = "stopped",
+    ) -> None:
+        """Close the open agent_spawn_sessions row for this agent.
+
+        Fetches final token counts from the agent SDK's /usage/status endpoint,
+        calculates cost via pricing module, then updates the DB row with
+        ended_at, token totals, exit_reason, and estimated_cost_usd.
+        Errors are caught and logged — finalization must never block stop_agent.
+        """
+        try:
+            from roboco.billing.pricing import calculate_cost
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable
+
+            # Fetch final token counts from the agent's SDK
+            sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
+            tokens_input = 0
+            tokens_output = 0
+            tokens_cache_read = 0
+            tokens_cache_write = 0
+            model = "unknown"
+
+            try:
+                async with httpx.AsyncClient(timeout=3.0) as client:
+                    resp = await client.get(sdk_url)
+                    if resp.status_code == 200:
+                        data = resp.json()
+                        tokens_input = data.get("tokens_input", 0)
+                        tokens_output = data.get("tokens_output", 0)
+                        tokens_cache_read = data.get("tokens_cache_read", 0)
+                        tokens_cache_write = data.get("tokens_cache_write", 0)
+            except Exception as sdk_exc:
+                logger.debug(
+                    "Could not fetch final token counts from SDK",
+                    agent_id=agent_id,
+                    error=str(sdk_exc),
+                )
+
+            # Look up the model from the running instance config
+            instance = self._instances.get(agent_id)
+            if instance and instance.config:
+                model = instance.config.model or "unknown"
+
+            cost = calculate_cost(
+                model=model,
+                tokens_input=tokens_input,
+                tokens_output=tokens_output,
+                tokens_cache_read=tokens_cache_read,
+                tokens_cache_write=tokens_cache_write,
+            )
+
+            session_factory = get_session_factory()
+            async with session_factory() as db:
+                from sqlalchemy import select, update
+
+                # Update the most recent open session for this agent
+                result = await db.execute(
+                    select(AgentSpawnSessionTable)
+                    .where(
+                        AgentSpawnSessionTable.agent_slug == agent_id,
+                        AgentSpawnSessionTable.ended_at.is_(None),
+                    )
+                    .order_by(AgentSpawnSessionTable.started_at.desc())
+                    .limit(1)
+                )
+                session_row = result.scalar_one_or_none()
+                if session_row is not None:
+                    await db.execute(
+                        update(AgentSpawnSessionTable)
+                        .where(AgentSpawnSessionTable.id == session_row.id)
+                        .values(
+                            ended_at=datetime.now(UTC),
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                            tokens_cache_read=tokens_cache_read,
+                            tokens_cache_write=tokens_cache_write,
+                            exit_reason=exit_reason,
+                            estimated_cost_usd=cost,
+                        )
+                    )
+                    await db.commit()
+                    logger.debug(
+                        "Spawn session finalized",
+                        agent_id=agent_id,
+                        session_id=str(session_row.id),
+                        tokens_input=tokens_input,
+                        tokens_output=tokens_output,
+                        estimated_cost_usd=cost,
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Failed to finalize spawn session",
+                agent_id=agent_id,
+                error=str(exc),
+            )
+
+    async def _sweep_token_snapshots(self) -> None:
+        """Write a token_usage_snapshots row for each active agent with non-zero tokens.
+
+        Called from _run_sweep() every ~60 s. Also updates the cumulative
+        token counts on the open agent_spawn_sessions row so the DB reflects
+        current progress without waiting for session close.
+        Errors per-agent are caught so one bad agent doesn't abort the whole sweep.
+        """
+        if not self._instances:
+            return
+
+        try:
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable, TokenUsageSnapshotTable
+        except ImportError:
+            return
+
+        session_factory = get_session_factory()
+
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            for agent_id, instance in list(self._instances.items()):
+                if instance.state not in (
+                    AgentState.ACTIVE,
+                    AgentState.WAITING_SHORT,
+                ):
+                    continue
+
+                sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
+                try:
+                    resp = await client.get(sdk_url)
+                    if resp.status_code != 200:
+                        continue
+                    data = resp.json()
+                    tokens_input = data.get("tokens_input", 0)
+                    tokens_output = data.get("tokens_output", 0)
+                    tokens_cache_read = data.get("tokens_cache_read", 0)
+                    tokens_cache_write = data.get("tokens_cache_write", 0)
+
+                    # Skip agents with no token usage yet
+                    total = tokens_input + tokens_output + tokens_cache_read + tokens_cache_write
+                    if total == 0:
+                        continue
+
+                    async with session_factory() as db:
+                        from sqlalchemy import select, update
+
+                        # Find the open session row
+                        result = await db.execute(
+                            select(AgentSpawnSessionTable)
+                            .where(
+                                AgentSpawnSessionTable.agent_slug == agent_id,
+                                AgentSpawnSessionTable.ended_at.is_(None),
+                            )
+                            .order_by(AgentSpawnSessionTable.started_at.desc())
+                            .limit(1)
+                        )
+                        session_row = result.scalar_one_or_none()
+                        if session_row is None:
+                            continue
+
+                        # Insert snapshot
+                        from uuid import uuid4 as _uuid4
+                        snapshot = TokenUsageSnapshotTable(
+                            id=_uuid4(),
+                            agent_spawn_session_id=session_row.id,
+                            snapshotted_at=datetime.now(UTC),
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                            tokens_cache_read=tokens_cache_read,
+                            tokens_cache_write=tokens_cache_write,
+                        )
+                        db.add(snapshot)
+
+                        # Update cumulative totals on the session row
+                        await db.execute(
+                            update(AgentSpawnSessionTable)
+                            .where(AgentSpawnSessionTable.id == session_row.id)
+                            .values(
+                                tokens_input=tokens_input,
+                                tokens_output=tokens_output,
+                                tokens_cache_read=tokens_cache_read,
+                                tokens_cache_write=tokens_cache_write,
+                            )
+                        )
+                        await db.commit()
+
+                except Exception as agent_exc:
+                    logger.debug(
+                        "Token snapshot failed for agent",
+                        agent_id=agent_id,
+                        error=str(agent_exc),
+                    )
+
+    async def _sweep_daily_rollup(self) -> None:
+        """Upsert daily_usage_rollups from closed agent_spawn_sessions.
+
+        Groups ended sessions by (date, agent_slug, team, model) and sums
+        their token counts + cost. Uses a Python-side upsert to stay
+        compatible with asyncpg / SQLAlchemy without raw INSERT ... ON CONFLICT
+        dialect-specific SQL.
+        Errors are caught so a bad rollup doesn't abort the sweeper.
+        """
+        try:
+            from roboco.billing.pricing import calculate_cost
+            from roboco.db.base import get_session_factory
+            from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
+        except ImportError:
+            return
+
+        try:
+            from uuid import uuid4 as _uuid4
+            from sqlalchemy import func, select
+
+            session_factory = get_session_factory()
+            async with session_factory() as db:
+                # Aggregate closed sessions by (date, agent_slug, team, model)
+                result = await db.execute(
+                    select(
+                        func.date(AgentSpawnSessionTable.started_at).label("date"),
+                        AgentSpawnSessionTable.agent_slug,
+                        AgentSpawnSessionTable.team,
+                        AgentSpawnSessionTable.model,
+                        func.sum(AgentSpawnSessionTable.tokens_input).label("tokens_input"),
+                        func.sum(AgentSpawnSessionTable.tokens_output).label("tokens_output"),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_read).label("tokens_cache_read"),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_write).label("tokens_cache_write"),
+                        func.sum(AgentSpawnSessionTable.estimated_cost_usd).label("total_cost_usd"),
+                        func.count(AgentSpawnSessionTable.id).label("session_count"),
+                    )
+                    .where(AgentSpawnSessionTable.ended_at.isnot(None))
+                    .group_by(
+                        func.date(AgentSpawnSessionTable.started_at),
+                        AgentSpawnSessionTable.agent_slug,
+                        AgentSpawnSessionTable.team,
+                        AgentSpawnSessionTable.model,
+                    )
+                )
+                rows = result.fetchall()
+
+                for row in rows:
+                    date_val = row.date
+                    agent_slug = row.agent_slug
+                    team = row.team
+                    model = row.model
+
+                    # Look for existing rollup row
+                    existing_result = await db.execute(
+                        select(DailyUsageRollupTable).where(
+                            DailyUsageRollupTable.date == date_val,
+                            DailyUsageRollupTable.agent_slug == agent_slug,
+                            DailyUsageRollupTable.team == team,
+                            DailyUsageRollupTable.model == model,
+                        )
+                    )
+                    existing = existing_result.scalar_one_or_none()
+
+                    tokens_input = int(row.tokens_input or 0)
+                    tokens_output = int(row.tokens_output or 0)
+                    tokens_cache_read = int(row.tokens_cache_read or 0)
+                    tokens_cache_write = int(row.tokens_cache_write or 0)
+                    total_cost = float(row.total_cost_usd or 0.0)
+                    session_count = int(row.session_count or 0)
+
+                    if existing is not None:
+                        from sqlalchemy import update
+                        await db.execute(
+                            update(DailyUsageRollupTable)
+                            .where(DailyUsageRollupTable.id == existing.id)
+                            .values(
+                                tokens_input=tokens_input,
+                                tokens_output=tokens_output,
+                                tokens_cache_read=tokens_cache_read,
+                                tokens_cache_write=tokens_cache_write,
+                                total_cost_usd=total_cost,
+                                session_count=session_count,
+                            )
+                        )
+                    else:
+                        new_row = DailyUsageRollupTable(
+                            id=_uuid4(),
+                            date=date_val,
+                            agent_slug=agent_slug,
+                            team=team,
+                            model=model,
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                            tokens_cache_read=tokens_cache_read,
+                            tokens_cache_write=tokens_cache_write,
+                            total_cost_usd=total_cost,
+                            session_count=session_count,
+                        )
+                        db.add(new_row)
+
+                await db.commit()
+                logger.debug("Daily usage rollup complete", rows_processed=len(rows))
+
+        except Exception as exc:
+            logger.warning("Daily usage rollup failed", error=str(exc))
 
     async def restore_waiting_records(self) -> int:
         """Load persisted waiting records into memory on orchestrator start.
@@ -3211,6 +3572,11 @@ Start by:
         # container so the next dispatcher tick doesn't waste tokens on the
         # same session.
         await self._sweep_budget_exceeded()
+
+        # Token-usage instrumentation: snapshot active agents and roll up
+        # closed sessions into the daily aggregation table.
+        await self._sweep_token_snapshots()
+        await self._sweep_daily_rollup()
 
     @staticmethod
     async def _fetch_budget_status(

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3129,7 +3129,7 @@ class AgentOrchestrator:
             try:
                 async with httpx.AsyncClient(timeout=3.0) as client:
                     resp = await client.get(sdk_url)
-                    if resp.status_code == 200:
+                    if resp.status_code == http_status.HTTP_200_OK:
                         data = resp.json()
                         tokens_input = data.get("tokens_input", 0)
                         tokens_output = data.get("tokens_output", 0)
@@ -3240,7 +3240,7 @@ class AgentOrchestrator:
                 sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
                 try:
                     resp = await client.get(sdk_url)
-                    if resp.status_code != 200:
+                    if resp.status_code != http_status.HTTP_200_OK:
                         continue
                     data = resp.json()
                     tokens_input = data.get("tokens_input", 0)
@@ -3249,29 +3249,45 @@ class AgentOrchestrator:
                     tokens_cache_write = data.get("tokens_cache_write", 0)
 
                     # Skip agents with no token usage yet
-                    total = tokens_input + tokens_output + tokens_cache_read + tokens_cache_write
+                    total = (
+                        tokens_input
+                        + tokens_output
+                        + tokens_cache_read
+                        + tokens_cache_write
+                    )
                     if total == 0:
                         continue
 
                     async with session_factory() as db:
                         from sqlalchemy import select, update
 
-                        # Find the open session row
-                        result = await db.execute(
-                            select(AgentSpawnSessionTable)
-                            .where(
-                                AgentSpawnSessionTable.agent_slug == agent_id,
-                                AgentSpawnSessionTable.ended_at.is_(None),
+                        # Prefer a direct lookup by the session UUID captured at
+                        # spawn time; fall back to the agent_slug heuristic for
+                        # instances that pre-date the usage_session_id field.
+                        if instance.usage_session_id is not None:
+                            result = await db.execute(
+                                select(AgentSpawnSessionTable).where(
+                                    AgentSpawnSessionTable.id
+                                    == instance.usage_session_id
+                                )
                             )
-                            .order_by(AgentSpawnSessionTable.started_at.desc())
-                            .limit(1)
-                        )
+                        else:
+                            result = await db.execute(
+                                select(AgentSpawnSessionTable)
+                                .where(
+                                    AgentSpawnSessionTable.agent_slug == agent_id,
+                                    AgentSpawnSessionTable.ended_at.is_(None),
+                                )
+                                .order_by(AgentSpawnSessionTable.started_at.desc())
+                                .limit(1)
+                            )
                         session_row = result.scalar_one_or_none()
                         if session_row is None:
                             continue
 
                         # Insert snapshot
                         from uuid import uuid4 as _uuid4
+
                         snapshot = TokenUsageSnapshotTable(
                             id=_uuid4(),
                             agent_spawn_session_id=session_row.id,
@@ -3313,7 +3329,6 @@ class AgentOrchestrator:
         Errors are caught so a bad rollup doesn't abort the sweeper.
         """
         try:
-            from roboco.billing.pricing import calculate_cost
             from roboco.db.base import get_session_factory
             from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
         except ImportError:
@@ -3321,6 +3336,7 @@ class AgentOrchestrator:
 
         try:
             from uuid import uuid4 as _uuid4
+
             from sqlalchemy import func, select
 
             session_factory = get_session_factory()
@@ -3335,11 +3351,21 @@ class AgentOrchestrator:
                         AgentSpawnSessionTable.agent_slug,
                         AgentSpawnSessionTable.team,
                         AgentSpawnSessionTable.model,
-                        func.sum(AgentSpawnSessionTable.tokens_input).label("tokens_input"),
-                        func.sum(AgentSpawnSessionTable.tokens_output).label("tokens_output"),
-                        func.sum(AgentSpawnSessionTable.tokens_cache_read).label("tokens_cache_read"),
-                        func.sum(AgentSpawnSessionTable.tokens_cache_write).label("tokens_cache_write"),
-                        func.sum(AgentSpawnSessionTable.estimated_cost_usd).label("total_cost_usd"),
+                        func.sum(AgentSpawnSessionTable.tokens_input).label(
+                            "tokens_input"
+                        ),
+                        func.sum(AgentSpawnSessionTable.tokens_output).label(
+                            "tokens_output"
+                        ),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_read).label(
+                            "tokens_cache_read"
+                        ),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_write).label(
+                            "tokens_cache_write"
+                        ),
+                        func.sum(AgentSpawnSessionTable.estimated_cost_usd).label(
+                            "total_cost_usd"
+                        ),
                         func.count(AgentSpawnSessionTable.id).label("session_count"),
                     )
                     .where(
@@ -3381,6 +3407,7 @@ class AgentOrchestrator:
 
                     if existing is not None:
                         from sqlalchemy import update
+
                         await db.execute(
                             update(DailyUsageRollupTable)
                             .where(DailyUsageRollupTable.id == existing.id)

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -1,0 +1,435 @@
+"""
+Usage Analytics Service
+
+Provides token usage analytics over agent_spawn_sessions and
+daily_usage_rollups tables. Supports period-based queries (24h, 7d, 30d)
+and aggregation by agent, team, and model.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
+from roboco.services.base import BaseService
+
+
+def _parse_period(period: str) -> tuple[datetime, int]:
+    """Parse period string into (start_dt, hours).
+
+    Accepts '24h', '7d', '30d'. Defaults to 24h for unknown values.
+    Returns (start_datetime_utc, total_hours).
+    """
+    now = datetime.now(UTC)
+    if period == "7d":
+        return now - timedelta(days=7), 7 * 24
+    if period == "30d":
+        return now - timedelta(days=30), 30 * 24
+    # default 24h
+    return now - timedelta(hours=24), 24
+
+
+class UsageService(BaseService):
+    """Analytics service for token usage data."""
+
+    # =========================================================================
+    # SUMMARY
+    # =========================================================================
+
+    async def get_summary(self, period: str = "24h") -> dict[str, Any]:
+        """Return aggregated token and cost totals for the given period.
+
+        Queries daily_usage_rollups for whole-day periods; falls back to
+        agent_spawn_sessions for sub-day precision.
+
+        Returns dict with: tokens_input, tokens_output, total_tokens,
+        total_cost_usd, trend_pct.
+        """
+        start_dt, hours = _parse_period(period)
+
+        # Current period totals from closed sessions
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_usd"),
+            ).where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        row = result.one()
+        tokens_input = int(row.tokens_input or 0)
+        tokens_output = int(row.tokens_output or 0)
+        total_cost = float(row.total_cost_usd or 0.0)
+        total_tokens = tokens_input + tokens_output + int(row.tokens_cache_read or 0) + int(row.tokens_cache_write or 0)
+
+        # Previous period for trend calculation
+        prev_start = start_dt - timedelta(hours=hours)
+        prev_result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output), 0).label("total")
+            ).where(
+                AgentSpawnSessionTable.started_at >= prev_start,
+                AgentSpawnSessionTable.started_at < start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        prev_row = prev_result.one()
+        prev_total = int(prev_row.total or 0)
+
+        if prev_total > 0:
+            trend_pct = round((total_tokens - prev_total) / prev_total * 100, 1)
+        elif total_tokens > 0:
+            trend_pct = 100.0
+        else:
+            trend_pct = 0.0
+
+        return {
+            "tokens_input": tokens_input,
+            "tokens_output": tokens_output,
+            "total_tokens": total_tokens,
+            "total_cost_usd": round(total_cost, 6),
+            "trend_pct": trend_pct,
+            "period": period,
+        }
+
+    # =========================================================================
+    # TIME SERIES
+    # =========================================================================
+
+    async def get_time_series(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return bucketed time-series data points.
+
+        - 24h → hourly buckets
+        - 7d / 30d → daily buckets
+
+        Each point has: bucket (ISO string), tokens_input, tokens_output,
+        total_tokens, cost_usd.
+
+        total_tokens includes all 4 token types (input + output + cache_read +
+        cache_write) so it is consistent with get_summary()'s total_tokens
+        field — AC9 requires their sums to match for the same period.
+        """
+        start_dt, hours = _parse_period(period)
+
+        if period == "24h":
+            # Hourly buckets
+            trunc_fn = func.date_trunc("hour", AgentSpawnSessionTable.started_at)
+        else:
+            # Daily buckets
+            trunc_fn = func.date_trunc("day", AgentSpawnSessionTable.started_at)
+
+        result = await self.session.execute(
+            select(
+                trunc_fn.label("bucket"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(trunc_fn)
+            .order_by(trunc_fn)
+        )
+        rows = result.fetchall()
+
+        points = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            points.append(
+                {
+                    "bucket": r.bucket.isoformat() if r.bucket else None,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": ti + to_ + tcr + tcw,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                }
+            )
+        return points
+
+    # =========================================================================
+    # BY-AGENT
+    # =========================================================================
+
+    async def get_by_agent(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return per-agent token usage with pct_of_total."""
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                AgentSpawnSessionTable.agent_slug,
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(AgentSpawnSessionTable.agent_slug)
+            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+        )
+        rows = result.fetchall()
+
+        grand_total = sum(
+            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            for r in rows
+        )
+        items = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            total = ti + to_ + tcr + tcw
+            items.append(
+                {
+                    "agent_slug": r.agent_slug,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": total,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                }
+            )
+        return items
+
+    # =========================================================================
+    # BY-TEAM
+    # =========================================================================
+
+    async def get_by_team(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return per-team token usage with pct_of_total."""
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                AgentSpawnSessionTable.team,
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(AgentSpawnSessionTable.team)
+            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+        )
+        rows = result.fetchall()
+
+        grand_total = sum(
+            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            for r in rows
+        )
+        items = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            total = ti + to_ + tcr + tcw
+            items.append(
+                {
+                    "team": r.team,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": total,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                }
+            )
+        return items
+
+    # =========================================================================
+    # BY-MODEL
+    # =========================================================================
+
+    async def get_by_model(self, period: str = "24h") -> list[dict[str, Any]]:
+        """Return per-model token usage with pct_of_total."""
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                AgentSpawnSessionTable.model,
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+            )
+            .where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+            .group_by(AgentSpawnSessionTable.model)
+            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+        )
+        rows = result.fetchall()
+
+        grand_total = sum(
+            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            for r in rows
+        )
+        items = []
+        for r in rows:
+            ti = int(r.tokens_input or 0)
+            to_ = int(r.tokens_output or 0)
+            tcr = int(r.tokens_cache_read or 0)
+            tcw = int(r.tokens_cache_write or 0)
+            total = ti + to_ + tcr + tcw
+            items.append(
+                {
+                    "model": r.model,
+                    "tokens_input": ti,
+                    "tokens_output": to_,
+                    "total_tokens": total,
+                    "cost_usd": round(float(r.cost_usd or 0.0), 6),
+                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                }
+            )
+        return items
+
+    # =========================================================================
+    # PROJECTION
+    # =========================================================================
+
+    async def get_projection(self) -> dict[str, Any]:
+        """Return projected monthly cost based on 7-day rolling average.
+
+        Computes the average daily cost over the last 7 days and extrapolates
+        to 30 days.
+        """
+        seven_days_ago = datetime.now(UTC) - timedelta(days=7)
+
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_7d"),
+                func.coalesce(func.count(AgentSpawnSessionTable.id), 0).label("session_count"),
+            ).where(
+                AgentSpawnSessionTable.started_at >= seven_days_ago,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        row = result.one()
+        total_cost_7d = float(row.total_cost_7d or 0.0)
+        avg_daily_cost = total_cost_7d / 7.0
+        projected_monthly = avg_daily_cost * 30.0
+
+        return {
+            "total_cost_7d": round(total_cost_7d, 6),
+            "avg_daily_cost_usd": round(avg_daily_cost, 6),
+            "projected_monthly_cost_usd": round(projected_monthly, 4),
+            "basis_days": 7,
+        }
+
+    # =========================================================================
+    # CACHE EFFICIENCY
+    # =========================================================================
+
+    async def get_cache_efficiency(self, period: str = "24h") -> dict[str, Any]:
+        """Return cache hit rate and estimated savings from prompt caching.
+
+        cache_hit_rate = cache_read_tokens / (input_tokens + cache_read_tokens)
+        cost_saved = what cache reads would have cost at full input price
+                     minus what they actually cost at cache-read price.
+        """
+        start_dt, _ = _parse_period(period)
+
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+            ).where(
+                AgentSpawnSessionTable.started_at >= start_dt,
+                AgentSpawnSessionTable.ended_at.isnot(None),
+            )
+        )
+        row = result.one()
+        tokens_input = int(row.tokens_input or 0)
+        tokens_cache_read = int(row.tokens_cache_read or 0)
+        tokens_cache_write = int(row.tokens_cache_write or 0)
+
+        total_input_like = tokens_input + tokens_cache_read
+        cache_hit_rate = (
+            tokens_cache_read / total_input_like if total_input_like > 0 else 0.0
+        )
+
+        # Cost saved = (cache_read_tokens * full_input_rate) - actual_cache_read_cost
+        # Use sonnet as the baseline (most common model) for the aggregate estimate.
+        # The full input price for sonnet is $3/1M; cache read is $0.30/1M.
+        _MILLION = 1_000_000.0
+        _FULL_INPUT_PRICE = 3.00  # sonnet baseline, USD/1M
+        _CACHE_READ_PRICE = 0.30  # 10% of input
+        cost_at_full_price = tokens_cache_read * _FULL_INPUT_PRICE / _MILLION
+        cost_at_cache_price = tokens_cache_read * _CACHE_READ_PRICE / _MILLION
+        cost_saved = cost_at_full_price - cost_at_cache_price
+
+        return {
+            "cache_hit_rate": round(cache_hit_rate, 4),
+            "tokens_cache_read": tokens_cache_read,
+            "tokens_cache_write": tokens_cache_write,
+            "tokens_input": tokens_input,
+            "cost_saved_by_cache_usd": round(cost_saved, 6),
+            "period": period,
+        }
+
+    # =========================================================================
+    # TODAY'S USAGE (for CEO dashboard)
+    # =========================================================================
+
+    async def get_today_summary(self) -> dict[str, Any]:
+        """Return today's aggregated usage from daily_usage_rollups.
+
+        Used by the CEO dashboard to populate tokens_today and cost_today_usd.
+        Falls back to 0 values when no data exists for today.
+        """
+        today = date.today()
+
+        result = await self.session.execute(
+            select(
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_input), 0).label("tokens_input"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_output), 0).label("tokens_output"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_read), 0).label("tokens_cache_read"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(DailyUsageRollupTable.total_cost_usd), 0.0).label("total_cost_usd"),
+            ).where(DailyUsageRollupTable.date == today)
+        )
+        row = result.one()
+
+        tokens_today = (
+            int(row.tokens_input or 0)
+            + int(row.tokens_output or 0)
+            + int(row.tokens_cache_read or 0)
+            + int(row.tokens_cache_write or 0)
+        )
+
+        return {
+            "tokens_today": tokens_today,
+            "cost_today_usd": round(float(row.total_cost_usd or 0.0), 6),
+        }
+
+
+def get_usage_service(db: AsyncSession) -> UsageService:
+    """Factory function matching the pattern used by other services."""
+    return UsageService(db)

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -8,7 +8,7 @@ and aggregation by agent, team, and model.
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from sqlalchemy import func, select
@@ -70,11 +70,21 @@ class UsageService(BaseService):
         total_cost = float(row.total_cost_usd or 0.0)
         total_tokens = tokens_input + tokens_output + int(row.tokens_cache_read or 0) + int(row.tokens_cache_write or 0)
 
-        # Previous period for trend calculation
+        # Previous period for trend calculation.
+        # Sum all 4 token columns so the comparison is consistent with the
+        # current-period total_tokens (which also sums all 4 columns).
         prev_start = start_dt - timedelta(hours=hours)
         prev_result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output), 0).label("total")
+                func.coalesce(
+                    func.sum(
+                        AgentSpawnSessionTable.tokens_input
+                        + AgentSpawnSessionTable.tokens_output
+                        + AgentSpawnSessionTable.tokens_cache_read
+                        + AgentSpawnSessionTable.tokens_cache_write
+                    ),
+                    0,
+                ).label("total")
             ).where(
                 AgentSpawnSessionTable.started_at >= prev_start,
                 AgentSpawnSessionTable.started_at < start_dt,
@@ -115,7 +125,7 @@ class UsageService(BaseService):
 
         total_tokens includes all 4 token types (input + output + cache_read +
         cache_write) so it is consistent with get_summary()'s total_tokens
-        field — AC9 requires their sums to match for the same period.
+        field — the two sums must match for the same period.
         """
         start_dt, hours = _parse_period(period)
 
@@ -404,7 +414,7 @@ class UsageService(BaseService):
         Used by the CEO dashboard to populate tokens_today and cost_today_usd.
         Falls back to 0 values when no data exists for today.
         """
-        today = date.today()
+        today = datetime.now(UTC).date()
 
         result = await self.session.execute(
             select(

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -9,10 +9,12 @@ and aggregation by agent, team, and model.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
 from roboco.services.base import BaseService
@@ -54,11 +56,21 @@ class UsageService(BaseService):
         # Current period totals from closed sessions
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("total_cost_usd"),
             ).where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
@@ -68,7 +80,12 @@ class UsageService(BaseService):
         tokens_input = int(row.tokens_input or 0)
         tokens_output = int(row.tokens_output or 0)
         total_cost = float(row.total_cost_usd or 0.0)
-        total_tokens = tokens_input + tokens_output + int(row.tokens_cache_read or 0) + int(row.tokens_cache_write or 0)
+        total_tokens = (
+            tokens_input
+            + tokens_output
+            + int(row.tokens_cache_read or 0)
+            + int(row.tokens_cache_write or 0)
+        )
 
         # Previous period for trend calculation.
         # Sum all 4 token columns so the comparison is consistent with the
@@ -127,7 +144,7 @@ class UsageService(BaseService):
         cache_write) so it is consistent with get_summary()'s total_tokens
         field — the two sums must match for the same period.
         """
-        start_dt, hours = _parse_period(period)
+        start_dt, _hours = _parse_period(period)
 
         if period == "24h":
             # Hourly buckets
@@ -139,11 +156,21 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 trunc_fn.label("bucket"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
@@ -182,23 +209,41 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 AgentSpawnSessionTable.agent_slug,
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
             )
             .group_by(AgentSpawnSessionTable.agent_slug)
-            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+            .order_by(
+                func.sum(
+                    AgentSpawnSessionTable.tokens_input
+                    + AgentSpawnSessionTable.tokens_output
+                ).desc()
+            )
         )
         rows = result.fetchall()
 
         grand_total = sum(
-            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            int(r.tokens_input or 0)
+            + int(r.tokens_output or 0)
+            + int(r.tokens_cache_read or 0)
+            + int(r.tokens_cache_write or 0)
             for r in rows
         )
         items = []
@@ -215,7 +260,9 @@ class UsageService(BaseService):
                     "tokens_output": to_,
                     "total_tokens": total,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
-                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                    "pct_of_total": round(total / grand_total * 100, 2)
+                    if grand_total > 0
+                    else 0.0,
                 }
             )
         return items
@@ -231,23 +278,41 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 AgentSpawnSessionTable.team,
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
             )
             .group_by(AgentSpawnSessionTable.team)
-            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+            .order_by(
+                func.sum(
+                    AgentSpawnSessionTable.tokens_input
+                    + AgentSpawnSessionTable.tokens_output
+                ).desc()
+            )
         )
         rows = result.fetchall()
 
         grand_total = sum(
-            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            int(r.tokens_input or 0)
+            + int(r.tokens_output or 0)
+            + int(r.tokens_cache_read or 0)
+            + int(r.tokens_cache_write or 0)
             for r in rows
         )
         items = []
@@ -264,7 +329,9 @@ class UsageService(BaseService):
                     "tokens_output": to_,
                     "total_tokens": total,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
-                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                    "pct_of_total": round(total / grand_total * 100, 2)
+                    if grand_total > 0
+                    else 0.0,
                 }
             )
         return items
@@ -280,23 +347,41 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 AgentSpawnSessionTable.model,
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
             )
             .group_by(AgentSpawnSessionTable.model)
-            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+            .order_by(
+                func.sum(
+                    AgentSpawnSessionTable.tokens_input
+                    + AgentSpawnSessionTable.tokens_output
+                ).desc()
+            )
         )
         rows = result.fetchall()
 
         grand_total = sum(
-            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            int(r.tokens_input or 0)
+            + int(r.tokens_output or 0)
+            + int(r.tokens_cache_read or 0)
+            + int(r.tokens_cache_write or 0)
             for r in rows
         )
         items = []
@@ -313,7 +398,9 @@ class UsageService(BaseService):
                     "tokens_output": to_,
                     "total_tokens": total,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
-                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                    "pct_of_total": round(total / grand_total * 100, 2)
+                    if grand_total > 0
+                    else 0.0,
                 }
             )
         return items
@@ -332,8 +419,12 @@ class UsageService(BaseService):
 
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_7d"),
-                func.coalesce(func.count(AgentSpawnSessionTable.id), 0).label("session_count"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("total_cost_7d"),
+                func.coalesce(func.count(AgentSpawnSessionTable.id), 0).label(
+                    "session_count"
+                ),
             ).where(
                 AgentSpawnSessionTable.started_at >= seven_days_ago,
                 AgentSpawnSessionTable.ended_at.isnot(None),
@@ -366,10 +457,18 @@ class UsageService(BaseService):
 
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
             ).where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
@@ -418,11 +517,21 @@ class UsageService(BaseService):
 
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(DailyUsageRollupTable.total_cost_usd), 0.0).label("total_cost_usd"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(DailyUsageRollupTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(DailyUsageRollupTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(DailyUsageRollupTable.total_cost_usd), 0.0
+                ).label("total_cost_usd"),
             ).where(DailyUsageRollupTable.date == today)
         )
         row = result.one()

--- a/tests/integration/test_task_service_transitions.py
+++ b/tests/integration/test_task_service_transitions.py
@@ -623,9 +623,13 @@ async def test_ceo_reject_routes_coordination_task_to_main_pm(
 
     rejected = await svc.ceo_reject(task.id, reason="redo the API contract")
     assert rejected is not None
-    assert rejected.status == TaskStatus.NEEDS_REVISION
+    # A coordination root goes to PENDING (the Main PM's claim source), NOT
+    # needs_revision — that status is developer-claim-only and would deadlock
+    # the Main PM, which owns the root and must re-plan/re-delegate.
+    assert rejected.status == TaskStatus.PENDING
     assert rejected.team == Team.MAIN_PM
     assert rejected.assigned_to == main_pm_id
+    assert rejected.claimed_by is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/billing/test_pricing.py
+++ b/tests/unit/billing/test_pricing.py
@@ -1,0 +1,299 @@
+"""
+Unit tests for roboco.billing.pricing — calculate_cost().
+
+Covers:
+- Each model tier (opus, sonnet, haiku) with all 4 token types.
+- Unknown model name returns 0.0 without raising.
+- Empty model string returns 0.0 without raising.
+- Substring match correctness: longer fragment wins
+  (e.g. 'claude-sonnet-4-6' matches 'claude-sonnet-4' not bare 'sonnet').
+"""
+
+from __future__ import annotations
+
+import pytest
+from roboco.billing.pricing import calculate_cost
+
+# ---------------------------------------------------------------------------
+# Named constants (ruff PLR2004: magic values in comparisons must be named).
+# ---------------------------------------------------------------------------
+
+# Token counts
+_M = 1_000_000  # 1 million tokens
+
+# Pricing — per-1M USD, matches the _PRICING table in pricing.py
+_OPUS_INPUT = 15.00
+_OPUS_OUTPUT = 75.00
+_OPUS_CACHE_READ = 1.50
+_OPUS_CACHE_WRITE = 3.75
+
+_SONNET_INPUT = 3.00
+_SONNET_OUTPUT = 15.00
+_SONNET_CACHE_READ = 0.30
+_SONNET_CACHE_WRITE = 0.75
+
+_HAIKU_INPUT = 0.80
+_HAIKU_OUTPUT = 4.00
+_HAIKU_CACHE_READ = 0.08
+_HAIKU_CACHE_WRITE = 0.20
+
+_HAIKU3_INPUT = 0.25  # claude-haiku-3 is cheaper than haiku-3-5 / haiku-4
+
+# Tolerance for floating-point comparisons
+_TOL = 1e-4
+
+
+# ---------------------------------------------------------------------------
+# Opus tier
+# ---------------------------------------------------------------------------
+
+
+class TestOpusTier:
+    """claude-opus-4 family pricing."""
+
+    def test_input_only(self) -> None:
+        cost = calculate_cost("claude-opus-4-5", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _OPUS_INPUT) < _TOL
+
+    def test_output_only(self) -> None:
+        cost = calculate_cost("claude-opus-4-5", tokens_input=0, tokens_output=_M)
+        assert abs(cost - _OPUS_OUTPUT) < _TOL
+
+    def test_cache_read_only(self) -> None:
+        cost = calculate_cost(
+            "claude-opus-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_read=_M,
+        )
+        assert abs(cost - _OPUS_CACHE_READ) < _TOL
+
+    def test_cache_write_only(self) -> None:
+        cost = calculate_cost(
+            "claude-opus-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_write=_M,
+        )
+        assert abs(cost - _OPUS_CACHE_WRITE) < _TOL
+
+    def test_all_token_types(self) -> None:
+        cost = calculate_cost(
+            "claude-opus-4-5",
+            tokens_input=_M,
+            tokens_output=_M,
+            tokens_cache_read=_M,
+            tokens_cache_write=_M,
+        )
+        expected = _OPUS_INPUT + _OPUS_OUTPUT + _OPUS_CACHE_READ + _OPUS_CACHE_WRITE
+        assert abs(cost - expected) < _TOL
+
+    def test_short_alias(self) -> None:
+        """Bare 'opus' alias resolves to the opus tier."""
+        cost = calculate_cost("opus", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _OPUS_INPUT) < _TOL
+
+    def test_returns_float(self) -> None:
+        cost = calculate_cost("claude-opus-4", tokens_input=100, tokens_output=50)
+        assert isinstance(cost, float)
+
+
+# ---------------------------------------------------------------------------
+# Sonnet tier
+# ---------------------------------------------------------------------------
+
+
+class TestSonnetTier:
+    """claude-sonnet-4 family pricing."""
+
+    def test_input_only(self) -> None:
+        cost = calculate_cost("claude-sonnet-4-6", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _SONNET_INPUT) < _TOL
+
+    def test_output_only(self) -> None:
+        cost = calculate_cost("claude-sonnet-4-6", tokens_input=0, tokens_output=_M)
+        assert abs(cost - _SONNET_OUTPUT) < _TOL
+
+    def test_cache_read_only(self) -> None:
+        cost = calculate_cost(
+            "claude-sonnet-4-6",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_read=_M,
+        )
+        assert abs(cost - _SONNET_CACHE_READ) < _TOL
+
+    def test_cache_write_only(self) -> None:
+        cost = calculate_cost(
+            "claude-sonnet-4-6",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_write=_M,
+        )
+        assert abs(cost - _SONNET_CACHE_WRITE) < _TOL
+
+    def test_all_token_types(self) -> None:
+        cost = calculate_cost(
+            "claude-sonnet-4-6",
+            tokens_input=_M,
+            tokens_output=_M,
+            tokens_cache_read=_M,
+            tokens_cache_write=_M,
+        )
+        expected = (
+            _SONNET_INPUT + _SONNET_OUTPUT + _SONNET_CACHE_READ + _SONNET_CACHE_WRITE
+        )
+        assert abs(cost - expected) < _TOL
+
+    def test_short_alias(self) -> None:
+        """Bare 'sonnet' alias resolves to the sonnet tier."""
+        cost = calculate_cost("sonnet", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _SONNET_INPUT) < _TOL
+
+    def test_35_variant(self) -> None:
+        """claude-3-5-sonnet resolves to sonnet tier."""
+        cost = calculate_cost(
+            "claude-3-5-sonnet-20241022", tokens_input=_M, tokens_output=0
+        )
+        assert abs(cost - _SONNET_INPUT) < _TOL
+
+
+# ---------------------------------------------------------------------------
+# Haiku tier
+# ---------------------------------------------------------------------------
+
+
+class TestHaikuTier:
+    """claude-haiku family pricing."""
+
+    def test_input_only(self) -> None:
+        cost = calculate_cost("claude-haiku-4-5", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _HAIKU_INPUT) < _TOL
+
+    def test_output_only(self) -> None:
+        cost = calculate_cost("claude-haiku-4-5", tokens_input=0, tokens_output=_M)
+        assert abs(cost - _HAIKU_OUTPUT) < _TOL
+
+    def test_cache_read_only(self) -> None:
+        cost = calculate_cost(
+            "claude-haiku-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_read=_M,
+        )
+        assert abs(cost - _HAIKU_CACHE_READ) < _TOL
+
+    def test_cache_write_only(self) -> None:
+        cost = calculate_cost(
+            "claude-haiku-4-5",
+            tokens_input=0,
+            tokens_output=0,
+            tokens_cache_write=_M,
+        )
+        assert abs(cost - _HAIKU_CACHE_WRITE) < _TOL
+
+    def test_all_token_types(self) -> None:
+        cost = calculate_cost(
+            "claude-haiku-4-5",
+            tokens_input=_M,
+            tokens_output=_M,
+            tokens_cache_read=_M,
+            tokens_cache_write=_M,
+        )
+        expected = _HAIKU_INPUT + _HAIKU_OUTPUT + _HAIKU_CACHE_READ + _HAIKU_CACHE_WRITE
+        assert abs(cost - expected) < _TOL
+
+    def test_short_alias(self) -> None:
+        """Bare 'haiku' alias resolves to the haiku tier."""
+        cost = calculate_cost("haiku", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _HAIKU_INPUT) < _TOL
+
+    def test_haiku3_variant(self) -> None:
+        """claude-haiku-3 has lower pricing than haiku-3-5."""
+        cost = calculate_cost("claude-haiku-3", tokens_input=_M, tokens_output=0)
+        assert abs(cost - _HAIKU3_INPUT) < _TOL
+
+
+# ---------------------------------------------------------------------------
+# Unknown / edge cases — must return 0.0 without raising
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownModels:
+    def test_unknown_model_name_returns_zero(self) -> None:
+        cost = calculate_cost("gpt-4o", tokens_input=_M, tokens_output=_M)
+        assert cost == 0.0
+
+    def test_empty_string_returns_zero(self) -> None:
+        cost = calculate_cost("", tokens_input=_M, tokens_output=_M)
+        assert cost == 0.0
+
+    def test_gibberish_returns_zero(self) -> None:
+        cost = calculate_cost(
+            "totally-unknown-model-xyz", tokens_input=100, tokens_output=100
+        )
+        assert cost == 0.0
+
+    def test_zero_tokens_with_unknown_model_returns_zero(self) -> None:
+        cost = calculate_cost("unknown", tokens_input=0, tokens_output=0)
+        assert cost == 0.0
+
+    def test_does_not_raise_on_unknown_model(self) -> None:
+        """Must not raise regardless of token counts."""
+        try:
+            calculate_cost(
+                "not-a-claude-model",
+                tokens_input=999_999,
+                tokens_output=999_999,
+            )
+        except Exception as exc:
+            pytest.fail(f"calculate_cost raised unexpectedly: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Substring match correctness
+# ---------------------------------------------------------------------------
+
+# Named constants for the comparison floor/ceiling used in these tests.
+_ZERO_COST = 0.0
+_SONNET_CHEAPER_THAN_OPUS = True  # structural assertion in the test below
+
+
+class TestSubstringMatchPriority:
+    def test_claude_sonnet_4_resolves_non_zero(self) -> None:
+        """'claude-sonnet-4-6' must find a match (non-zero cost)."""
+        cost = calculate_cost("claude-sonnet-4-6", tokens_input=_M, tokens_output=0)
+        assert cost > _ZERO_COST
+
+    def test_haiku3_cheaper_than_haiku4(self) -> None:
+        """claude-haiku-3 is cheaper than claude-haiku-4 — longest-match wins."""
+        haiku3_cost = calculate_cost("claude-haiku-3", tokens_input=_M, tokens_output=0)
+        haiku4_cost = calculate_cost("claude-haiku-4", tokens_input=_M, tokens_output=0)
+        # haiku-3 ($0.25/1M) < haiku-4 ($0.80/1M)
+        assert haiku3_cost < haiku4_cost
+
+    def test_non_claude_model_returns_zero(self) -> None:
+        """A random non-Claude model must not match any Claude pricing entry."""
+        non_opus_cost = calculate_cost("llama-3-70b", tokens_input=_M, tokens_output=0)
+        assert non_opus_cost == _ZERO_COST
+
+    def test_opus_model_non_zero(self) -> None:
+        """Claude opus model resolves to non-zero cost."""
+        opus_cost = calculate_cost("claude-opus-4", tokens_input=_M, tokens_output=0)
+        assert opus_cost > _ZERO_COST
+
+    def test_zero_tokens_returns_zero_for_known_model(self) -> None:
+        """Known model with 0 tokens has 0 cost."""
+        cost = calculate_cost("claude-opus-4", tokens_input=0, tokens_output=0)
+        assert cost == _ZERO_COST
+
+    def test_case_insensitive_matching(self) -> None:
+        """Model name matching is case-insensitive."""
+        lower_cost = calculate_cost(
+            "claude-sonnet-4-6", tokens_input=1000, tokens_output=1000
+        )
+        upper_cost = calculate_cost(
+            "CLAUDE-SONNET-4-6", tokens_input=1000, tokens_output=1000
+        )
+        assert lower_cost == upper_cost
+        assert lower_cost > _ZERO_COST

--- a/tests/unit/billing/test_pricing.py
+++ b/tests/unit/billing/test_pricing.py
@@ -22,20 +22,20 @@ from roboco.billing.pricing import calculate_cost
 _M = 1_000_000  # 1 million tokens
 
 # Pricing — per-1M USD, matches the _PRICING table in pricing.py
-_OPUS_INPUT = 15.00
-_OPUS_OUTPUT = 75.00
-_OPUS_CACHE_READ = 1.50
-_OPUS_CACHE_WRITE = 3.75
+_OPUS_INPUT = 5.00
+_OPUS_OUTPUT = 25.00
+_OPUS_CACHE_READ = 0.50
+_OPUS_CACHE_WRITE = 6.25
 
 _SONNET_INPUT = 3.00
 _SONNET_OUTPUT = 15.00
 _SONNET_CACHE_READ = 0.30
 _SONNET_CACHE_WRITE = 0.75
 
-_HAIKU_INPUT = 0.80
-_HAIKU_OUTPUT = 4.00
-_HAIKU_CACHE_READ = 0.08
-_HAIKU_CACHE_WRITE = 0.20
+_HAIKU_INPUT = 1.00
+_HAIKU_OUTPUT = 5.00
+_HAIKU_CACHE_READ = 0.10
+_HAIKU_CACHE_WRITE = 1.25
 
 _HAIKU3_INPUT = 0.25  # claude-haiku-3 is cheaper than haiku-3-5 / haiku-4
 
@@ -269,7 +269,7 @@ class TestSubstringMatchPriority:
         """claude-haiku-3 is cheaper than claude-haiku-4 — longest-match wins."""
         haiku3_cost = calculate_cost("claude-haiku-3", tokens_input=_M, tokens_output=0)
         haiku4_cost = calculate_cost("claude-haiku-4", tokens_input=_M, tokens_output=0)
-        # haiku-3 ($0.25/1M) < haiku-4 ($0.80/1M)
+        # haiku-3 ($0.25/1M) < haiku-4 ($1.00/1M)
         assert haiku3_cost < haiku4_cost
 
     def test_non_claude_model_returns_zero(self) -> None:

--- a/tests/unit/runtime/test_orchestrator_write_hooks.py
+++ b/tests/unit/runtime/test_orchestrator_write_hooks.py
@@ -212,8 +212,12 @@ async def test_finalize_spawn_session_success_executes_select_and_update() -> No
     def _handler(_url: str) -> Any:
         return _mock_response(
             200,
-            {"tokens_input": 10, "tokens_output": 20,
-             "tokens_cache_read": 0, "tokens_cache_write": 0},
+            {
+                "tokens_input": 10,
+                "tokens_output": 20,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
         )
 
     session_row = MagicMock()
@@ -363,8 +367,12 @@ async def test_sweep_token_snapshots_skips_zero_token_agents() -> None:
     def _handler(_url: str) -> Any:
         return _mock_response(
             200,
-            {"tokens_input": 0, "tokens_output": 0,
-             "tokens_cache_read": 0, "tokens_cache_write": 0},
+            {
+                "tokens_input": 0,
+                "tokens_output": 0,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
         )
 
     added: list[Any] = []
@@ -401,8 +409,12 @@ async def test_sweep_token_snapshots_per_agent_error_does_not_abort_loop() -> No
             raise httpx.ConnectError("agent-1 unreachable")
         return _mock_response(
             200,
-            {"tokens_input": _LOOP_TI, "tokens_output": _LOOP_TO,
-             "tokens_cache_read": 0, "tokens_cache_write": 0},
+            {
+                "tokens_input": _LOOP_TI,
+                "tokens_output": _LOOP_TO,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
         )
 
     session_row = MagicMock()
@@ -423,3 +435,109 @@ async def test_sweep_token_snapshots_per_agent_error_does_not_abort_loop() -> No
     assert len(added) == 1
     assert added[0].tokens_input == _LOOP_TI
     assert added[0].tokens_output == _LOOP_TO
+
+
+# ---------------------------------------------------------------------------
+# _sweep_daily_rollup — inserts new row when none exists
+# ---------------------------------------------------------------------------
+
+# Token counts for the rollup test
+_ROLLUP_TI = 200
+_ROLLUP_TO = 300
+_ROLLUP_TCR = 20
+_ROLLUP_TCW = 10
+
+
+async def test_sweep_daily_rollup_inserts_new_row() -> None:
+    """When no existing DailyUsageRollupTable row exists, db.add() is called
+    with the correct aggregated token values."""
+    orch = _make_orchestrator()
+
+    # Build a fake aggregate result row
+    agg_row = MagicMock()
+    agg_row.date = "2026-06-10"
+    agg_row.agent_slug = _AGENT_ID
+    agg_row.team = "backend"
+    agg_row.model = "sonnet"
+    agg_row.tokens_input = _ROLLUP_TI
+    agg_row.tokens_output = _ROLLUP_TO
+    agg_row.tokens_cache_read = _ROLLUP_TCR
+    agg_row.tokens_cache_write = _ROLLUP_TCW
+    agg_row.total_cost_usd = 0.0
+    agg_row.session_count = 1
+
+    added: list[Any] = []
+    call_count = 0
+
+    @asynccontextmanager
+    async def _db_context() -> Any:
+        nonlocal call_count
+
+        db = MagicMock()
+        db.commit = AsyncMock()
+
+        def _add(obj: Any) -> None:
+            added.append(obj)
+
+        db.add = _add
+
+        async def _exec(_stmt: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # First call: aggregate SELECT — return one agg_row via fetchall()
+                result.fetchall = MagicMock(return_value=[agg_row])
+                result.scalar_one_or_none = MagicMock(return_value=None)
+            else:
+                # Second call: lookup SELECT for existing row — return None
+                result.fetchall = MagicMock(return_value=[])
+                result.scalar_one_or_none = MagicMock(return_value=None)
+            return result
+
+        db.execute = AsyncMock(side_effect=_exec)
+        yield db
+
+    with patch("roboco.db.base.get_session_factory", return_value=_db_context):
+        await orch._sweep_daily_rollup()
+
+    # Exactly one new DailyUsageRollupTable row must have been added
+    assert len(added) == 1
+    row = added[0]
+    assert row.tokens_input == _ROLLUP_TI
+    assert row.tokens_output == _ROLLUP_TO
+    assert row.tokens_cache_read == _ROLLUP_TCR
+    assert row.tokens_cache_write == _ROLLUP_TCW
+
+
+# ---------------------------------------------------------------------------
+# stop_agent — _finalize_spawn_session is awaited before acquiring the lock
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_agent_finalizes_before_lock() -> None:
+    """stop_agent awaits _finalize_spawn_session when the instance has a
+    running container_id (the finalization must happen before the lock)."""
+    orch = _make_orchestrator()
+    instance = _make_instance(_AGENT_ID)
+    instance.container_id = "abc123def456"  # non-None → finalize must be called
+    orch._instances[_AGENT_ID] = instance
+
+    finalized: list[str] = []
+
+    async def _fake_finalize(agent_id: str, exit_reason: str = "stopped") -> None:  # noqa: ARG001
+        finalized.append(agent_id)
+
+    # Stub out the Docker subprocess so stop_agent doesn't actually run Docker
+    mock_proc = MagicMock()
+    mock_proc.wait = AsyncMock()
+
+    with (
+        patch.object(orch, "_finalize_spawn_session", side_effect=_fake_finalize),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)),
+        patch.object(orch, "_remove_container", AsyncMock()),
+    ):
+        await orch.stop_agent(_AGENT_ID, graceful=True)
+
+    # _finalize_spawn_session must have been called exactly once with our agent id
+    assert finalized == [_AGENT_ID]

--- a/tests/unit/runtime/test_orchestrator_write_hooks.py
+++ b/tests/unit/runtime/test_orchestrator_write_hooks.py
@@ -1,0 +1,425 @@
+"""
+Unit tests for orchestrator write-hooks:
+    _finalize_spawn_session  — closes the agent_spawn_sessions DB row on stop
+    _sweep_token_snapshots   — polls active agents and upserts token snapshots
+
+These tests mock the httpx transport and the SQLAlchemy session factory so no
+real network or database is required.
+
+Coverage:
+  1. _finalize_spawn_session success — SDK returns token data → DB update
+     carries those exact values to calculate_cost and the UPDATE statement.
+  2. _finalize_spawn_session HTTP error — SDK unreachable → DB update proceeds
+     with all-zero token counts (finalization must not raise).
+  3. _sweep_token_snapshots active agent — non-zero tokens → snapshot row
+     inserted and session row updated.
+  4. _sweep_token_snapshots per-agent HTTP error — ConnectError on one agent
+     is caught; the sweep continues and the next agent is still processed.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import httpx
+from roboco.models.runtime import (
+    AgentInstance,
+    OrchestratorAgentConfig,
+    OrchestratorAgentState,
+)
+from roboco.runtime.orchestrator import AgentOrchestrator
+
+# ---------------------------------------------------------------------------
+# Module-level constants (ruff PLR2004: no magic values in comparisons)
+# ---------------------------------------------------------------------------
+
+_AGENT_ID = "be-dev-1"
+_AGENT_ID_2 = "be-dev-2"
+
+# Token counts used in success-path assertions
+_TI = 111  # tokens_input
+_TO = 222  # tokens_output
+_TCR = 33  # tokens_cache_read
+_TCW = 44  # tokens_cache_write
+
+# Token counts for the snapshot test
+_SNAP_TI = 50
+_SNAP_TO = 100
+_SNAP_TCR = 10
+_SNAP_TCW = 5
+
+# Token counts for the loop-continues test (agent-2)
+_LOOP_TI = 25
+_LOOP_TO = 75
+
+# Expected number of DB execute() calls for a normal finalize (SELECT + UPDATE)
+_FINALIZE_EXEC_CALLS = 2
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_orchestrator() -> AgentOrchestrator:
+    """Minimal AgentOrchestrator — no background tasks, no real DB."""
+    return AgentOrchestrator(mcp_config_dir=Path("/tmp"), project_root=Path("/tmp"))
+
+
+def _make_instance(
+    agent_id: str = _AGENT_ID,
+    usage_session_id: UUID | None = None,
+) -> AgentInstance:
+    """Return an ACTIVE AgentInstance with a running container."""
+    return AgentInstance(
+        agent_id=agent_id,
+        state=OrchestratorAgentState.ACTIVE,
+        container_id="abc123def456",
+        config=OrchestratorAgentConfig(
+            agent_id=agent_id,
+            blueprint_path=Path("/tmp/blueprint.md"),
+            model="sonnet",
+        ),
+        usage_session_id=usage_session_id,
+    )
+
+
+def _mock_response(
+    status: int = 200,
+    json_data: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Build a mock httpx.Response."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status
+    resp.json = MagicMock(return_value=json_data or {})
+    return resp
+
+
+def _make_db_factory(
+    session_row: Any = None,
+    add_list: list[Any] | None = None,
+    execute_list: list[Any] | None = None,
+) -> Any:
+    """Return a callable that acts like get_session_factory().
+
+    The returned callable, when called with no arguments, returns an async
+    context manager yielding a mock AsyncSession whose execute() returns a
+    result whose scalar_one_or_none() returns *session_row*.
+    """
+
+    @asynccontextmanager
+    async def _db_context() -> Any:
+        db = MagicMock()
+
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=session_row)
+
+        async def _exec(stmt: Any) -> MagicMock:
+            if execute_list is not None:
+                execute_list.append(stmt)
+            return result
+
+        db.execute = AsyncMock(side_effect=_exec)
+        db.commit = AsyncMock()
+
+        def _add(obj: Any) -> None:
+            if add_list is not None:
+                add_list.append(obj)
+
+        db.add = _add if add_list is not None else MagicMock()
+        yield db
+
+    return _db_context
+
+
+class _FakeHTTPClient:
+    """Drop-in replacement for ``httpx.AsyncClient`` in tests.
+
+    Accepts a *handler* callable ``(url: str) -> httpx.Response | raises``
+    that is invoked by ``get()``.  Supports the ``async with`` protocol.
+    """
+
+    def __init__(self, handler: Any, **_: Any) -> None:
+        self._handler = handler
+
+    async def __aenter__(self) -> _FakeHTTPClient:
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        pass
+
+    async def get(self, url: str, **_: Any) -> Any:
+        return self._handler(url)
+
+
+# ---------------------------------------------------------------------------
+# _finalize_spawn_session — success path
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_spawn_session_success_calls_calculate_cost() -> None:
+    """Token values returned by the SDK /usage/status are passed to calculate_cost.
+
+    This verifies the full data-flow: SDK response → token vars → cost calc.
+    """
+    orch = _make_orchestrator()
+    session_uuid = uuid4()
+    orch._instances[_AGENT_ID] = _make_instance(usage_session_id=session_uuid)
+
+    token_data = {
+        "tokens_input": _TI,
+        "tokens_output": _TO,
+        "tokens_cache_read": _TCR,
+        "tokens_cache_write": _TCW,
+    }
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(200, token_data)
+
+    session_row = MagicMock()
+    session_row.id = session_uuid
+    db_factory = _make_db_factory(session_row=session_row)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_handler)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+        patch("roboco.billing.pricing.calculate_cost", return_value=0.001) as mock_cost,
+    ):
+        await orch._finalize_spawn_session(_AGENT_ID, exit_reason="stopped")
+
+    mock_cost.assert_called_once_with(
+        model="sonnet",
+        tokens_input=_TI,
+        tokens_output=_TO,
+        tokens_cache_read=_TCR,
+        tokens_cache_write=_TCW,
+    )
+
+
+async def test_finalize_spawn_session_success_executes_select_and_update() -> None:
+    """When a session row exists the function calls execute() twice: SELECT + UPDATE."""
+    orch = _make_orchestrator()
+    session_uuid = uuid4()
+    orch._instances[_AGENT_ID] = _make_instance(usage_session_id=session_uuid)
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(
+            200,
+            {"tokens_input": 10, "tokens_output": 20,
+             "tokens_cache_read": 0, "tokens_cache_write": 0},
+        )
+
+    session_row = MagicMock()
+    session_row.id = session_uuid
+    execute_calls: list[Any] = []
+    db_factory = _make_db_factory(session_row=session_row, execute_list=execute_calls)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_handler)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+        patch("roboco.billing.pricing.calculate_cost", return_value=0.0),
+    ):
+        await orch._finalize_spawn_session(_AGENT_ID, exit_reason="completed")
+
+    # SELECT (find the row) + UPDATE (write the values) = 2 execute() calls
+    assert len(execute_calls) == _FINALIZE_EXEC_CALLS
+
+
+# ---------------------------------------------------------------------------
+# _finalize_spawn_session — HTTP-error path
+# ---------------------------------------------------------------------------
+
+
+async def test_finalize_spawn_session_http_error_uses_zero_tokens() -> None:
+    """When the SDK endpoint is unreachable, finalization uses zero tokens.
+
+    The function must not raise; cost must be calculated with all-zero counts.
+    """
+    orch = _make_orchestrator()
+    session_uuid = uuid4()
+    orch._instances[_AGENT_ID] = _make_instance(usage_session_id=session_uuid)
+
+    def _boom(_url: str) -> Any:
+        raise httpx.ConnectError("container not reachable")
+
+    session_row = MagicMock()
+    session_row.id = session_uuid
+    db_factory = _make_db_factory(session_row=session_row)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_boom)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+        patch("roboco.billing.pricing.calculate_cost", return_value=0.0) as mock_cost,
+    ):
+        # Must not raise even though the SDK is unreachable
+        await orch._finalize_spawn_session(_AGENT_ID, exit_reason="stopped")
+
+    mock_cost.assert_called_once_with(
+        model="sonnet",
+        tokens_input=0,
+        tokens_output=0,
+        tokens_cache_read=0,
+        tokens_cache_write=0,
+    )
+
+
+async def test_finalize_spawn_session_non_200_uses_zero_tokens() -> None:
+    """A non-200 SDK response results in zero-token finalization, no exception."""
+    orch = _make_orchestrator()
+    session_uuid = uuid4()
+    orch._instances[_AGENT_ID] = _make_instance(usage_session_id=session_uuid)
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(503)
+
+    session_row = MagicMock()
+    session_row.id = session_uuid
+    db_factory = _make_db_factory(session_row=session_row)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_handler)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+        patch("roboco.billing.pricing.calculate_cost", return_value=0.0) as mock_cost,
+    ):
+        await orch._finalize_spawn_session(_AGENT_ID, exit_reason="stopped")
+
+    mock_cost.assert_called_once_with(
+        model="sonnet",
+        tokens_input=0,
+        tokens_output=0,
+        tokens_cache_read=0,
+        tokens_cache_write=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _sweep_token_snapshots — active agent
+# ---------------------------------------------------------------------------
+
+
+async def test_sweep_token_snapshots_inserts_snapshot_for_active_agent() -> None:
+    """An active agent with non-zero tokens gets a snapshot row added to the DB."""
+    orch = _make_orchestrator()
+    instance = _make_instance(_AGENT_ID)
+    instance.state = OrchestratorAgentState.ACTIVE
+    orch._instances[_AGENT_ID] = instance
+
+    token_data = {
+        "tokens_input": _SNAP_TI,
+        "tokens_output": _SNAP_TO,
+        "tokens_cache_read": _SNAP_TCR,
+        "tokens_cache_write": _SNAP_TCW,
+    }
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(200, token_data)
+
+    session_row = MagicMock()
+    session_row.id = uuid4()
+    added: list[Any] = []
+    db_factory = _make_db_factory(session_row=session_row, add_list=added)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_handler)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+    ):
+        await orch._sweep_token_snapshots()
+
+    # Exactly one snapshot row must have been passed to db.add()
+    assert len(added) == 1
+    snap = added[0]
+    assert snap.tokens_input == _SNAP_TI
+    assert snap.tokens_output == _SNAP_TO
+    assert snap.tokens_cache_read == _SNAP_TCR
+    assert snap.tokens_cache_write == _SNAP_TCW
+
+
+async def test_sweep_token_snapshots_skips_zero_token_agents() -> None:
+    """An agent whose SDK reports all-zero tokens is skipped (no DB writes)."""
+    orch = _make_orchestrator()
+    instance = _make_instance(_AGENT_ID)
+    instance.state = OrchestratorAgentState.ACTIVE
+    orch._instances[_AGENT_ID] = instance
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(
+            200,
+            {"tokens_input": 0, "tokens_output": 0,
+             "tokens_cache_read": 0, "tokens_cache_write": 0},
+        )
+
+    added: list[Any] = []
+    db_factory = _make_db_factory(add_list=added)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_handler)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+    ):
+        await orch._sweep_token_snapshots()
+
+    assert added == []
+
+
+async def test_sweep_token_snapshots_per_agent_error_does_not_abort_loop() -> None:
+    """A ConnectError for one agent is caught; the next agent is still processed."""
+    orch = _make_orchestrator()
+
+    # Agent 1: HTTP error
+    inst1 = _make_instance(_AGENT_ID)
+    inst1.state = OrchestratorAgentState.ACTIVE
+    orch._instances[_AGENT_ID] = inst1
+
+    # Agent 2: success with non-zero tokens
+    inst2 = _make_instance(_AGENT_ID_2)
+    inst2.state = OrchestratorAgentState.ACTIVE
+    orch._instances[_AGENT_ID_2] = inst2
+
+    def _handler(url: str) -> Any:
+        if _AGENT_ID in url and _AGENT_ID_2 not in url:
+            raise httpx.ConnectError("agent-1 unreachable")
+        return _mock_response(
+            200,
+            {"tokens_input": _LOOP_TI, "tokens_output": _LOOP_TO,
+             "tokens_cache_read": 0, "tokens_cache_write": 0},
+        )
+
+    session_row = MagicMock()
+    session_row.id = uuid4()
+    added: list[Any] = []
+    db_factory = _make_db_factory(session_row=session_row, add_list=added)
+
+    def _client_cls(**_kw: Any) -> _FakeHTTPClient:
+        return _FakeHTTPClient(_handler)
+
+    with (
+        patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch("roboco.db.base.get_session_factory", return_value=db_factory),
+    ):
+        await orch._sweep_token_snapshots()
+
+    # Only agent-2's snapshot should be present; agent-1's error was caught.
+    assert len(added) == 1
+    assert added[0].tokens_input == _LOOP_TI
+    assert added[0].tokens_output == _LOOP_TO

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -12,6 +12,7 @@ verify the arithmetic / logic of each analytics method:
 
 from __future__ import annotations
 
+import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -223,9 +224,8 @@ class TestGetTimeSeries:
         for the same period.  The old implementation used ti + to_ (without
         cache), which violated this constraint whenever cache tokens were non-zero.
         """
-        import datetime
 
-        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.UTC)
         row = _make_row(
             bucket=bucket_dt,
             tokens_input=_TS_INPUT,
@@ -242,9 +242,8 @@ class TestGetTimeSeries:
     @pytest.mark.asyncio
     async def test_total_tokens_without_cache_still_correct(self) -> None:
         """When cache tokens are zero, total_tokens == tokens_input + tokens_output."""
-        import datetime
 
-        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.UTC)
         row = _make_row(
             bucket=bucket_dt,
             tokens_input=_TS_INPUT,
@@ -267,9 +266,8 @@ class TestGetTimeSeries:
     async def test_point_contains_required_fields(self) -> None:
         """Each time-series point must have bucket, tokens_input, tokens_output,
         total_tokens, and cost_usd fields."""
-        import datetime
 
-        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.UTC)
         row = _make_row(
             bucket=bucket_dt,
             tokens_input=100,
@@ -282,7 +280,13 @@ class TestGetTimeSeries:
         result = await svc.get_time_series("24h")
         assert len(result) == 1
         point = result[0]
-        for field in ("bucket", "tokens_input", "tokens_output", "total_tokens", "cost_usd"):
+        for field in (
+            "bucket",
+            "tokens_input",
+            "tokens_output",
+            "total_tokens",
+            "cost_usd",
+        ):
             assert field in point, f"Missing field: {field}"
 
 

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -199,7 +199,7 @@ class TestGetSummaryTrendPct:
 
 
 # ---------------------------------------------------------------------------
-# get_time_series — total_tokens includes all 4 token types (AC9 consistency)
+# get_time_series — total_tokens includes all 4 token types (summary consistency)
 # ---------------------------------------------------------------------------
 
 # Named constants for time-series tests
@@ -218,10 +218,10 @@ class TestGetTimeSeries:
     async def test_total_tokens_includes_cache_read_and_write(self) -> None:
         """total_tokens in each time-series point must include cache tokens.
 
-        This is the AC9 consistency requirement: time-series total_tokens must
-        sum to the same value as get_summary()'s total_tokens for the same
-        period.  The old implementation used ti + to_ (without cache), which
-        violated this constraint whenever cache tokens were non-zero.
+        This is the time-series / summary consistency requirement: time-series
+        total_tokens must sum to the same value as get_summary()'s total_tokens
+        for the same period.  The old implementation used ti + to_ (without
+        cache), which violated this constraint whenever cache tokens were non-zero.
         """
         import datetime
 
@@ -366,7 +366,7 @@ class TestGetByAgent:
 
     @pytest.mark.asyncio
     async def test_cache_tokens_included_in_total_tokens(self) -> None:
-        """total_tokens must include cache_read and cache_write (AC10 fix).
+        """total_tokens must include cache_read and cache_write.
 
         Without the fix, total would be 500+300=800 (input+output only).
         With the fix, total = 500+300+100+100 = 1000.
@@ -472,7 +472,7 @@ class TestGetByTeam:
 
     @pytest.mark.asyncio
     async def test_cache_tokens_included_in_total_tokens(self) -> None:
-        """total_tokens must include cache_read and cache_write (AC10 fix)."""
+        """total_tokens must include cache_read and cache_write."""
         _cache_read = 200
         _cache_write = 100
         _expected_total = 700 + 300 + _cache_read + _cache_write  # 1300
@@ -574,7 +574,7 @@ class TestGetByModel:
 
     @pytest.mark.asyncio
     async def test_cache_tokens_included_in_total_tokens(self) -> None:
-        """total_tokens must include cache_read and cache_write (AC10 fix)."""
+        """total_tokens must include cache_read and cache_write."""
         _cache_read = 300
         _cache_write = 100
         _expected_total = 600 + 600 + _cache_read + _cache_write  # 1600

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -1,0 +1,757 @@
+"""
+Unit tests for roboco.services.usage — UsageService analytics methods.
+
+These tests mock the SQLAlchemy AsyncSession.execute() boundary and
+verify the arithmetic / logic of each analytics method:
+
+- get_summary: trend_pct edge cases (prev=0, curr=0, both=0, prev>0)
+- get_by_agent/team/model: pct_of_total sums to 100%
+- get_projection: projected_monthly = avg_daily * 30
+- get_cache_efficiency: cache_hit_rate and cost_saved arithmetic
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from roboco.services.usage import UsageService
+
+# ---------------------------------------------------------------------------
+# Named constants (ruff PLR2004: magic values in comparisons must be named).
+# ---------------------------------------------------------------------------
+
+# Tolerance for floating-point arithmetic comparisons.
+_TOL = 0.001
+# Tolerance for percentage-sum assertions (rounding in pct_of_total).
+_PCT_TOL = 0.1
+
+# token count helpers
+_ZERO = 0
+_M = 1_000_000
+
+# Expected values for projection tests
+_COST_7D = 70.0
+_EXPECTED_AVG_DAILY = 10.0  # 70 / 7
+_EXPECTED_MONTHLY = 300.0  # 10 * 30
+_DAYS_BASIS = 7
+
+# Expected values for cache efficiency tests
+_CACHE_READ_TOKENS = 400
+_INPUT_TOKENS = 600
+_EXPECTED_HIT_RATE = 0.4  # 400 / (600 + 400)
+_FULL_INPUT_PRICE = 3.00  # sonnet baseline USD/1M
+_CACHE_READ_PRICE = 0.30
+_EXPECTED_COST_SAVED = _FULL_INPUT_PRICE - _CACHE_READ_PRICE  # = 2.70 per 1M
+
+# Expected trend_pct values
+_TREND_NONE = 0.0
+_TREND_NEW = 100.0  # curr > 0, prev == 0
+_TREND_DOUBLED = 200.0  # curr / prev = 3.0x → +200 %
+_TREND_HALVED = -50.0  # curr / prev = 0.5x → -50 %
+
+# Expected total_tokens when cache tokens are included
+_TOTAL_WITH_CACHE = 300  # 100+100+50+50
+
+# pct_of_total checks
+_FULL_PCT = 100.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(**kwargs: object) -> MagicMock:
+    """Return a MagicMock that mimics a SQLAlchemy Row with named attributes."""
+    row = MagicMock()
+    for k, v in kwargs.items():
+        setattr(row, k, v)
+    return row
+
+
+def _result_one(row: MagicMock) -> MagicMock:
+    """Return a mock execute() result whose .one() returns `row`."""
+    result = MagicMock()
+    result.one = MagicMock(return_value=row)
+    return result
+
+
+def _result_fetchall(rows: list[MagicMock]) -> MagicMock:
+    """Return a mock execute() result whose .fetchall() returns `rows`."""
+    result = MagicMock()
+    result.fetchall = MagicMock(return_value=rows)
+    return result
+
+
+def _service_with_execute(*return_values: object) -> UsageService:
+    """Build a UsageService whose session.execute() returns the provided
+    values in sequence (one per call)."""
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=list(return_values))
+    return UsageService(session)
+
+
+# ---------------------------------------------------------------------------
+# get_summary — trend_pct arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestGetSummaryTrendPct:
+    @pytest.mark.asyncio
+    async def test_both_zero_returns_zero_trend(self) -> None:
+        """When current and previous totals are both 0, trend_pct must be 0.0."""
+        current_row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.0,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert result["trend_pct"] == _TREND_NONE
+
+    @pytest.mark.asyncio
+    async def test_prev_zero_curr_positive_returns_100(self) -> None:
+        """When prev period is 0 but current is positive, trend_pct = 100.0."""
+        current_row = _make_row(
+            tokens_input=500,
+            tokens_output=500,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.01,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert result["trend_pct"] == _TREND_NEW
+
+    @pytest.mark.asyncio
+    async def test_positive_trend_calculation(self) -> None:
+        """trend_pct = (current - previous) / previous * 100 when prev > 0.
+
+        current = 1500 input + 1500 output = 3000; prev = 1000
+        → (3000 - 1000) / 1000 * 100 = 200.0
+        """
+        current_row = _make_row(
+            tokens_input=1500,
+            tokens_output=1500,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.1,
+        )
+        prev_row = _make_row(total=1000)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert abs(result["trend_pct"] - _TREND_DOUBLED) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_negative_trend_calculation(self) -> None:
+        """Negative trend when usage drops.
+
+        current = 250 + 250 = 500; prev = 1000
+        → (500 - 1000) / 1000 * 100 = -50.0
+        """
+        current_row = _make_row(
+            tokens_input=250,
+            tokens_output=250,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.01,
+        )
+        prev_row = _make_row(total=1000)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert abs(result["trend_pct"] - _TREND_HALVED) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total(self) -> None:
+        """total_tokens includes cache_read and cache_write tokens."""
+        current_row = _make_row(
+            tokens_input=100,
+            tokens_output=100,
+            tokens_cache_read=50,
+            tokens_cache_write=50,
+            total_cost_usd=0.005,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        assert result["total_tokens"] == _TOTAL_WITH_CACHE
+
+    @pytest.mark.asyncio
+    async def test_summary_contains_required_fields(self) -> None:
+        """Response dict must include all required summary fields."""
+        current_row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            total_cost_usd=0.0,
+        )
+        prev_row = _make_row(total=_ZERO)
+        svc = _service_with_execute(_result_one(current_row), _result_one(prev_row))
+        result = await svc.get_summary("24h")
+        for field in ("tokens_input", "tokens_output", "total_cost_usd", "trend_pct"):
+            assert field in result, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# get_time_series — total_tokens includes all 4 token types (AC9 consistency)
+# ---------------------------------------------------------------------------
+
+# Named constants for time-series tests
+_TS_INPUT = 100
+_TS_OUTPUT = 200
+_TS_CACHE_READ = 50
+_TS_CACHE_WRITE = 30
+# total = 100 + 200 + 50 + 30 = 380
+_TS_TOTAL_WITH_CACHE = 380
+# Without cache tokens (the old wrong formula): 100 + 200 = 300
+_TS_TOTAL_WITHOUT_CACHE = 300
+
+
+class TestGetTimeSeries:
+    @pytest.mark.asyncio
+    async def test_total_tokens_includes_cache_read_and_write(self) -> None:
+        """total_tokens in each time-series point must include cache tokens.
+
+        This is the AC9 consistency requirement: time-series total_tokens must
+        sum to the same value as get_summary()'s total_tokens for the same
+        period.  The old implementation used ti + to_ (without cache), which
+        violated this constraint whenever cache tokens were non-zero.
+        """
+        import datetime
+
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        row = _make_row(
+            bucket=bucket_dt,
+            tokens_input=_TS_INPUT,
+            tokens_output=_TS_OUTPUT,
+            tokens_cache_read=_TS_CACHE_READ,
+            tokens_cache_write=_TS_CACHE_WRITE,
+            cost_usd=0.01,
+        )
+        svc = _service_with_execute(_result_fetchall([row]))
+        result = await svc.get_time_series("24h")
+        assert len(result) == 1
+        assert result[0]["total_tokens"] == _TS_TOTAL_WITH_CACHE
+
+    @pytest.mark.asyncio
+    async def test_total_tokens_without_cache_still_correct(self) -> None:
+        """When cache tokens are zero, total_tokens == tokens_input + tokens_output."""
+        import datetime
+
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        row = _make_row(
+            bucket=bucket_dt,
+            tokens_input=_TS_INPUT,
+            tokens_output=_TS_OUTPUT,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            cost_usd=0.01,
+        )
+        svc = _service_with_execute(_result_fetchall([row]))
+        result = await svc.get_time_series("24h")
+        assert result[0]["total_tokens"] == _TS_INPUT + _TS_OUTPUT
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_empty_list(self) -> None:
+        svc = _service_with_execute(_result_fetchall([]))
+        result = await svc.get_time_series("24h")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_point_contains_required_fields(self) -> None:
+        """Each time-series point must have bucket, tokens_input, tokens_output,
+        total_tokens, and cost_usd fields."""
+        import datetime
+
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        row = _make_row(
+            bucket=bucket_dt,
+            tokens_input=100,
+            tokens_output=100,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+            cost_usd=0.01,
+        )
+        svc = _service_with_execute(_result_fetchall([row]))
+        result = await svc.get_time_series("24h")
+        assert len(result) == 1
+        point = result[0]
+        for field in ("bucket", "tokens_input", "tokens_output", "total_tokens", "cost_usd"):
+            assert field in point, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# get_by_agent — pct_of_total sums to 100%
+# ---------------------------------------------------------------------------
+
+
+class TestGetByAgent:
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100(self) -> None:
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=600,
+                tokens_output=400,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                agent_slug="be-dev-2",
+                tokens_input=300,
+                tokens_output=200,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.02,
+            ),
+            _make_row(
+                agent_slug="be-qa",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+    @pytest.mark.asyncio
+    async def test_empty_result_returns_empty_list(self) -> None:
+        svc = _service_with_execute(_result_fetchall([]))
+        result = await svc.get_by_agent("24h")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_single_agent_has_100_pct(self) -> None:
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=1000,
+                tokens_output=500,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.1,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        assert len(result) == 1
+        assert result[_ZERO]["pct_of_total"] == _FULL_PCT
+
+    @pytest.mark.asyncio
+    async def test_result_contains_agent_slug_field(self) -> None:
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent()
+        assert result[_ZERO]["agent_slug"] == "be-dev-1"
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self) -> None:
+        """total_tokens must include cache_read and cache_write (AC10 fix).
+
+        Without the fix, total would be 500+300=800 (input+output only).
+        With the fix, total = 500+300+100+100 = 1000.
+        """
+        _cache_read = 100
+        _cache_write = 100
+        _expected_total = 500 + 300 + _cache_read + _cache_write  # 1000
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=500,
+                tokens_output=300,
+                tokens_cache_read=_cache_read,
+                tokens_cache_write=_cache_write,
+                cost_usd=0.05,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        assert result[_ZERO]["total_tokens"] == _expected_total
+
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100_with_cache_tokens(self) -> None:
+        """pct_of_total still sums to 100% when agents have cache tokens."""
+        rows = [
+            _make_row(
+                agent_slug="be-dev-1",
+                tokens_input=400,
+                tokens_output=200,
+                tokens_cache_read=150,
+                tokens_cache_write=50,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                agent_slug="be-dev-2",
+                tokens_input=200,
+                tokens_output=100,
+                tokens_cache_read=75,
+                tokens_cache_write=25,
+                cost_usd=0.02,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_agent("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+
+# ---------------------------------------------------------------------------
+# get_by_team — pct_of_total sums to 100%
+# ---------------------------------------------------------------------------
+
+
+class TestGetByTeam:
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100(self) -> None:
+        rows = [
+            _make_row(
+                team="backend",
+                tokens_input=700,
+                tokens_output=300,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                team="frontend",
+                tokens_input=200,
+                tokens_output=200,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.02,
+            ),
+            _make_row(
+                team="uxui",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+    @pytest.mark.asyncio
+    async def test_result_contains_team_field(self) -> None:
+        rows = [
+            _make_row(
+                team="backend",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team()
+        assert result[_ZERO]["team"] == "backend"
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self) -> None:
+        """total_tokens must include cache_read and cache_write (AC10 fix)."""
+        _cache_read = 200
+        _cache_write = 100
+        _expected_total = 700 + 300 + _cache_read + _cache_write  # 1300
+        rows = [
+            _make_row(
+                team="backend",
+                tokens_input=700,
+                tokens_output=300,
+                tokens_cache_read=_cache_read,
+                tokens_cache_write=_cache_write,
+                cost_usd=0.05,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team("24h")
+        assert result[_ZERO]["total_tokens"] == _expected_total
+
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100_with_cache_tokens(self) -> None:
+        """pct_of_total still sums to 100% when teams have cache tokens."""
+        rows = [
+            _make_row(
+                team="backend",
+                tokens_input=600,
+                tokens_output=200,
+                tokens_cache_read=120,
+                tokens_cache_write=80,
+                cost_usd=0.05,
+            ),
+            _make_row(
+                team="frontend",
+                tokens_input=300,
+                tokens_output=100,
+                tokens_cache_read=60,
+                tokens_cache_write=40,
+                cost_usd=0.02,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_team("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+
+# ---------------------------------------------------------------------------
+# get_by_model — pct_of_total sums to 100%
+# ---------------------------------------------------------------------------
+
+
+class TestGetByModel:
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100(self) -> None:
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=600,
+                tokens_output=600,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.1,
+            ),
+            _make_row(
+                model="claude-haiku-4-5",
+                tokens_input=300,
+                tokens_output=300,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.02,
+            ),
+            _make_row(
+                model="claude-opus-4-5",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.04,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+    @pytest.mark.asyncio
+    async def test_result_contains_model_field(self) -> None:
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=100,
+                tokens_output=100,
+                tokens_cache_read=0,
+                tokens_cache_write=0,
+                cost_usd=0.01,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model()
+        assert result[_ZERO]["model"] == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self) -> None:
+        """total_tokens must include cache_read and cache_write (AC10 fix)."""
+        _cache_read = 300
+        _cache_write = 100
+        _expected_total = 600 + 600 + _cache_read + _cache_write  # 1600
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=600,
+                tokens_output=600,
+                tokens_cache_read=_cache_read,
+                tokens_cache_write=_cache_write,
+                cost_usd=0.1,
+            )
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model("24h")
+        assert result[_ZERO]["total_tokens"] == _expected_total
+
+    @pytest.mark.asyncio
+    async def test_pct_of_total_sums_to_100_with_cache_tokens(self) -> None:
+        """pct_of_total still sums to 100% when models have cache tokens."""
+        rows = [
+            _make_row(
+                model="claude-sonnet-4-6",
+                tokens_input=500,
+                tokens_output=500,
+                tokens_cache_read=200,
+                tokens_cache_write=100,
+                cost_usd=0.1,
+            ),
+            _make_row(
+                model="claude-haiku-4-5",
+                tokens_input=250,
+                tokens_output=250,
+                tokens_cache_read=100,
+                tokens_cache_write=50,
+                cost_usd=0.02,
+            ),
+        ]
+        svc = _service_with_execute(_result_fetchall(rows))
+        result = await svc.get_by_model("24h")
+        total_pct = sum(item["pct_of_total"] for item in result)
+        assert abs(total_pct - _FULL_PCT) < _PCT_TOL
+
+
+# ---------------------------------------------------------------------------
+# get_projection — formula: projected_monthly = (total_7d / 7) * 30
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjection:
+    @pytest.mark.asyncio
+    async def test_projection_formula_30_day_extrapolation(self) -> None:
+        """projected_monthly_cost_usd = (total_cost_7d / 7) * 30."""
+        row = _make_row(total_cost_7d=_COST_7D, session_count=10)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        assert abs(result["projected_monthly_cost_usd"] - _EXPECTED_MONTHLY) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_zero_cost_7d_gives_zero_projection(self) -> None:
+        row = _make_row(total_cost_7d=0.0, session_count=_ZERO)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        assert result["projected_monthly_cost_usd"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_avg_daily_cost_equals_total_over_7(self) -> None:
+        """avg_daily = total_7d / 7."""
+        row = _make_row(total_cost_7d=21.0, session_count=5)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        # 21 / 7 = 3.0 avg daily cost
+        _avg_daily_21 = 3.0
+        assert abs(result["avg_daily_cost_usd"] - _avg_daily_21) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_projection_contains_required_fields(self) -> None:
+        row = _make_row(total_cost_7d=7.0, session_count=3)
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_projection()
+        for field in (
+            "total_cost_7d",
+            "avg_daily_cost_usd",
+            "projected_monthly_cost_usd",
+            "basis_days",
+        ):
+            assert field in result, f"Missing field: {field}"
+        assert result["basis_days"] == _DAYS_BASIS
+
+
+# ---------------------------------------------------------------------------
+# get_cache_efficiency — hit rate and cost_saved arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestGetCacheEfficiency:
+    @pytest.mark.asyncio
+    async def test_cache_hit_rate_formula(self) -> None:
+        """cache_hit_rate = cache_read / (input + cache_read).
+
+        400 cache reads out of 400+600 total = 0.4
+        """
+        row = _make_row(
+            tokens_input=_INPUT_TOKENS,
+            tokens_output=_ZERO,
+            tokens_cache_read=_CACHE_READ_TOKENS,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert abs(result["cache_hit_rate"] - _EXPECTED_HIT_RATE) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_zero_input_tokens_gives_zero_hit_rate(self) -> None:
+        """When no input or cache_read tokens, hit rate is 0.0."""
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert result["cache_hit_rate"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_full_cache_hit_gives_rate_of_1(self) -> None:
+        """When all input-like tokens are cache reads, hit rate = 1.0."""
+        _full_rate = 1.0
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=1000,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert abs(result["cache_hit_rate"] - _full_rate) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_cost_saved_arithmetic(self) -> None:
+        """cost_saved = cache_read * (full_input_price - cache_read_price) / 1M.
+
+        Sonnet baseline: full=$3.00/1M, cache_read=$0.30/1M.
+        For 1M cache-read tokens: saved = 3.00 - 0.30 = 2.70.
+        """
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_M,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert abs(result["cost_saved_by_cache_usd"] - _EXPECTED_COST_SAVED) < _TOL
+
+    @pytest.mark.asyncio
+    async def test_zero_cache_reads_gives_zero_savings(self) -> None:
+        row = _make_row(
+            tokens_input=1000,
+            tokens_output=500,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        assert result["cost_saved_by_cache_usd"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_cache_efficiency_contains_required_fields(self) -> None:
+        row = _make_row(
+            tokens_input=_ZERO,
+            tokens_output=_ZERO,
+            tokens_cache_read=_ZERO,
+            tokens_cache_write=_ZERO,
+        )
+        svc = _service_with_execute(_result_one(row))
+        result = await svc.get_cache_efficiency("24h")
+        for field in ("cache_hit_rate", "cost_saved_by_cache_usd"):
+            assert field in result, f"Missing field: {field}"


### PR DESCRIPTION
## Objective

Instrument every agent spawn to capture LLM token usage in real time, persist it across three new database tables, expose it through 11 new API endpoints, and render it as interactive Recharts visualizations on the Metrics page and summary cards on the Dashboard — giving the CEO complete visibility into per-agent, per-team, per-model token consumption and costs.

## What This Builds

- Agent SDK usage capture — new /usage/report and /usage/status endpoints inside each agent container, extending _SessionState and BudgetStatus with input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, turns, and estimated_cost_usd fields
- Claude Code hook for usage reporting — a PostToolUse/SessionEnd hook injected via _generate_agent_settings at spawn time that parses stream-json usage data and POSTs it to localhost:9000/usage/report
- Model pricing constants — new roboco/models/pricing.py with per-model (opus/sonnet/haiku) input/output/cache-write/cache-read rates and an estimate_cost() calculator
- Three new database tables via migration 025 — agent_spawn_sessions (one row per container lifecycle with full token/cost/duration fields), token_usage_snapshots (60-second periodic snapshots from the sweeper), and daily_usage_rollups (materialized daily aggregates for fast queries)
- UsageService — new roboco/services/usage.py with session lifecycle methods (create/close/snapshot) and 10 aggregation queries: summary with trend comparison, time series, by-agent, by-team, by-model, session history, top sessions, cost projection, and cache efficiency
- 11 new API endpoints under /api/usage/ — summary, time-series, by-agent, by-team, by-model, sessions (paginated), sessions/top, agents/{slug}/sessions, projection, cache-efficiency, and dashboard-summary
- 12 new Pydantic response schemas in roboco/api/schemas/usage.py — UsageSummaryResponse, TimeSeriesPoint, UsageTimeSeriesResponse, AgentUsageResponse, TeamUsageResponse, ModelUsageResponse, SessionDetailResponse, CostProjectionResponse, CacheEfficiencyResponse, UsageDashboardSummary, and supporting types
- Orchestrator integration — create_spawn_session on agent spawn, record_usage_snapshot in the sweeper loop (every 60s), close_spawn_session on PostMortem/container stop, hourly rollup_daily background task, new usage_session_id field on AgentInstance
- Two new EventType entries (USAGE_SNAPSHOT, USAGE_SESSION_END) and WebSocket bridge subscriptions for real-time dashboard updates
- CEOOverview extension — add usage_summary field to the /dashboard/ceo response, populated by UsageService.get_usage_summary('24h')
- Frontend recharts dependency — pnpm add recharts, leveraging the existing --chart-1 through --chart-5 CSS custom properties already defined in globals.css
- Dashboard UsageOverviewPanel — new card panel in the CommandCenter's metrics row (expanded from 2-col to 3-col grid) showing tokens today, cost today, cost this week with trend, active sessions, cache savings, and top consumer agent
- Metrics page Token Usage & Costs section — 5 rows: (1) 6 summary MetricCards, (2) stacked AreaChart time series + PieChart model distribution in 2/3+1/3 split, (3) horizontal BarChart agent breakdown + vertical stacked BarChart team costs, (4) LineChart cost projection + donut CacheEfficiency, (5) sortable paginated SessionsTable
- 8 new chart components in panel/src/components/metrics/ — UsagePeriodSelector, UsageTimeSeriesChart, ModelDistributionChart, AgentUsageBarChart, TeamCostBarChart, CostProjectionCard, CacheEfficiencyCard, SessionsTable
- Usage TypeScript types, API module, and 11 TanStack Query hooks with query keys — useUsageSummary, useUsageTimeSeries, useUsageByAgent, useUsageByTeam, useUsageByModel, useUsageSessions, useAgentSessions, useTopSessions, useCostProjection, useCacheEfficiency, useUsageDashboardSummary
- Agents page enhancement — usage mini-bar on each agent card showing today's token count and cost, sourced from useUsageByAgent('24h') joined client-side by slug

## The Work

Board-led: the Board sets requirements and the Main PM delegates one subtask per cell.

**Backend** — Data capture layer — Agent SDK extension, Claude Code hook, and pricing model
- Extend _SessionState in roboco/agent_sdk/server.py with token accumulator fields (input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, turns, model, first_token_at, last_token_at) and a usage_by_turn list
- Add UsageReportRequest model to roboco/agent_sdk/models.py and new POST /usage/report endpoint that accumulates into _SessionState
- Add GET /usage/status endpoint returning current session token totals
- Extend BudgetStatus in roboco/agent_sdk/models.py with input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, turns, estimated_cost_usd, model fields
- Extend PostMortemRequest with input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, estimated_cost_usd, model fields
- Update /budget/status handler to include token data from _SessionState
- Update /journal/post_mortem handler to include token data in the journal entry content
- Create roboco/models/pricing.py with MODEL_PRICING dict (opus/sonnet/haiku rates for input, output, cache_write, cache_read per Mtok) and estimate_cost() function that resolves short names via MODEL_MAP

**Backend** — Persistence layer — migration, ORM tables, and UsageService
- Create migration 025_token_usage_tables.py with three tables: agent_spawn_sessions (UUID PK, agent_id FK, agent_slug, task_id FK, team enum, role, model, container_id, started_at, ended_at, duration_seconds, input/output/cache_creation/cache_read/total tokens as BigInteger, estimated_cost_usd Numeric(12,6), turns, tools_called, exit_reason, created_at), token_usage_snapshots (UUID PK, session_id FK CASCADE, agent_slug, token fields, cumulative_cost_usd, turns, recorded_at), daily_usage_rollups (UUID PK, date, agent_slug nullable, team nullable, model nullable, session_count, all token aggregates, total_cost_usd, avg_tokens_per_session, avg_cost_per_session, peak_concurrent_agents, total_duration_seconds) with UNIQUE on (date, agent_slug, team, model) NULLS NOT DISTINCT
- Add corresponding SQLAlchemy table classes to roboco/db/tables.py with all indexes: (agent_slug, started_at), (team, started_at), (model, started_at), (task_id), (started_at) on sessions; (session_id, recorded_at), (agent_slug, recorded_at) on snapshots; (date), (agent_slug, date), (team, date) on rollups
- Create roboco/services/usage.py with UsageService(BaseService) implementing: create_spawn_session(), close_spawn_session(), record_usage_snapshot(), get_usage_summary(period) with trend vs previous period, get_usage_time_series(period, granularity), get_usage_by_agent(period), get_usage_by_team(period), get_usage_by_model(period), get_agent_session_history(slug, limit, offset), get_top_sessions(period, limit, sort_by), get_cost_projection(days_ahead), get_cache_efficiency(period), get_dashboard_summary(), rollup_daily(date)

**Backend** — API layer — endpoints, schemas, orchestrator wiring, and real-time events
- Create roboco/api/schemas/usage.py with 12 Pydantic response schemas: UsageSummaryResponse, TimeSeriesPoint, UsageTimeSeriesResponse, AgentUsageResponse, TeamUsageResponse, ModelUsageResponse, SessionDetailResponse, CostProjectionResponse, CacheEfficiencyResponse, UsageDashboardSummary — all following project conventions (BaseModel, Field with descriptions, modern union syntax)
- Create roboco/api/routes/usage.py with router mounted at /api/usage/ containing 11 endpoints: GET /summary, GET /time-series, GET /by-agent, GET /by-team, GET /by-model, GET /sessions (paginated via ListResponse), GET /sessions/top, GET /agents/{slug}/sessions, GET /projection, GET /cache-efficiency, GET /dashboard-summary — all accepting period query param
- Wire orchestrator spawn_agent to call usage_service.create_spawn_session() after _fire_audit('agent.spawned'), storing session_id on AgentInstance (new usage_session_id field)
- Wire orchestrator _sweeper_loop to call usage_service.record_usage_snapshot() after reading /budget/status from each active agent, publishing USAGE_SNAPSHOT event
- Wire orchestrator stop_agent and post_mortem path to call usage_service.close_spawn_session() with final token totals, publishing USAGE_SESSION_END event
- Add _rollup_loop to orchestrator startup tasks running hourly to call usage_service.rollup_daily(date.today())
- Add USAGE_SNAPSHOT and USAGE_SESSION_END to EventType in roboco/models/events.py
- Subscribe to both new event types in roboco/api/websocket_bridge.py for real-time frontend updates
- Extend CEOOverview in roboco/api/schemas/dashboard.py with usage_summary: dict[str, Any] | None = None, and populate it in DashboardService.get_ceo_overview() via UsageService.get_dashboard_summary()

**Frontend** — Types, API client, hooks, and recharts installation
- Install recharts: pnpm add recharts
- Create panel/src/types/usage.ts with all TypeScript interfaces: UsageSummary, TimeSeriesPoint, UsageTimeSeries, AgentUsage, TeamUsage, ModelUsage, SessionDetail, CostProjection, CacheEfficiency, UsageDashboardSummary, and type aliases UsagePeriod, UsageGranularity, SessionSortBy
- Create panel/src/lib/api/usage.ts with usageApi object containing 11 methods matching the backend endpoints, export from panel/src/lib/api/index.ts
- Create panel/src/hooks/use-usage.ts with usageKeys query key factory and 11 TanStack Query hooks (useUsageSummary, useUsageTimeSeries, useUsageByAgent, useUsageByTeam, useUsageByModel, useUsageSessions, useAgentSessions, useTopSessions, useCostProjection, useCacheEfficiency, useUsageDashboardSummary) — 30s staleTime for real-time data, 60s refetchInterval matching sweeper cadence, 5min staleTime for projections. Export from panel/src/hooks/index.ts
- Re-export all usage types from panel/src/types/index.ts

**Frontend** — Dashboard integration — UsageOverviewPanel in CommandCenter
- Create panel/src/components/dashboard/usage-overview-panel.tsx — Card component matching KeyMetricsPanel structure (vertical space-y-3 metric rows) with 6 rows: Tokens Today (Zap icon, humanized number), Cost Today (DollarSign, USD format), Cost This Week (TrendingUp, with trend arrow colored green/red), Active Sessions (Activity, count), Cache Savings (Database, USD saved), Top Consumer (Crown, agent slug + token count). Uses useUsageDashboardSummary() hook, Skeleton loading state, '-' fallback
- Edit panel/src/components/dashboard/command-center.tsx — change the Metrics and Alerts row from grid-cols-1 lg:grid-cols-2 to grid-cols-1 lg:grid-cols-3, insert UsageOverviewPanel between KeyMetricsPanel and AuditorAlertsPanel

**Frontend** — Metrics page — full Token Usage & Costs section with 8 chart components
- Create panel/src/components/metrics/usage-period-selector.tsx — segmented tab control for 24h/7d/30d periods, uses shadcn Tabs or Button group with active state
- Create panel/src/components/metrics/usage-time-series-chart.tsx — Recharts AreaChart with three stacked areas (input tokens in --chart-2 blue, output tokens in --chart-1, cache tokens in --chart-4 amber), ResponsiveContainer, XAxis with time labels, YAxis with humanized token counts, Tooltip showing all values plus cost, uses useUsageTimeSeries(period, granularity auto-derived from period)
- Create panel/src/components/metrics/model-distribution-chart.tsx — Recharts PieChart donut with three segments (Opus --chart-1, Sonnet --chart-2, Haiku --chart-3), center label showing total cost, Legend below, uses useUsageByModel(period)
- Create panel/src/components/metrics/agent-usage-bar-chart.tsx — Recharts horizontal BarChart showing top 10 agents by total_tokens, bars colored by team, truncated agent names on Y-axis, token count on X-axis with humanized labels, uses useUsageByAgent(period)
- Create panel/src/components/metrics/team-cost-bar-chart.tsx — Recharts vertical BarChart with 5 team bars (Board, Main PM, Backend, Frontend, UX/UI), stacked by model tier within each bar, Y-axis in USD, uses useUsageByTeam(period) cross-referenced with useUsageByModel(period)
- Create panel/src/components/metrics/cost-projection-card.tsx — Card with mini Recharts LineChart showing daily cost trend (past 7d solid, next 30d dashed projection line), stat rows below: projected monthly cost, burn rate per hour, breakdown by model tier, uses useCostProjection()
- Create panel/src/components/metrics/cache-efficiency-card.tsx — Card with mini Recharts PieChart donut (cache hit vs miss), stat rows: hit rate percentage, cost saved USD, savings percentage, estimated cost without cache, uses useCacheEfficiency(period)
- Create panel/src/components/metrics/sessions-table.tsx — shadcn Table with sortable column headers (Agent, Task, Model, Duration, Input Tokens, Output Tokens, Cost, Exit Reason), pagination controls (10 per page), row expansion for full detail, uses useUsageSessions(params) with sort_by state
- Edit panel/src/app/(dashboard)/metrics/page.tsx — add UsagePeriod state via useState('24h'), add new section between Agent Status and Team Health containing: 6-col summary MetricCards row, 2/3+1/3 grid with UsageTimeSeriesChart and ModelDistributionChart, 2-col grid with AgentUsageBarChart and TeamCostBarChart, 2-col grid with CostProjectionCard and CacheEfficiencyCard, full-width SessionsTable. Wire all to useUsageSummary(period) for card data

**Frontend** — Agents page enhancement — per-agent usage mini-bars and real-time WebSocket
- Edit panel/src/app/(dashboard)/agents/page.tsx — inside each agent card, add a usage mini-bar row showing Zap icon + today's token count (humanized) + dot separator + cost (USD), data sourced from useUsageByAgent('24h') joined client-side by agent slug, show nothing if no data
- Add WebSocket subscription for USAGE_SNAPSHOT events to invalidate usage query keys on update, enabling near-real-time refresh of Metrics page charts and Dashboard cards without waiting for poll interval

## Notes

- Agents run claude CLI with --output-format stream-json inside Docker containers — the stream includes per-turn token usage but is currently never parsed. The capture hook bridges this gap by POSTing usage data to the Agent SDK server (localhost:9000) which already runs alongside claude in each container.
- The orchestrator's existing _sweeper_loop (60s interval) already polls each active agent's /budget/status — extending this to also capture token data means no new polling infrastructure is needed.
- The LLMUsage dataclass in roboco/models/llm.py, the AgentTable.metrics JSON column, and the --chart-1..5 CSS tokens in globals.css all exist as orphaned scaffolding — this feature finally wires them up.
- MODEL_MAP in roboco/models/runtime.py maps short names to full model IDs (opus→claude-opus-4-6, sonnet→claude-sonnet-4-6, haiku→claude-haiku-4-5-20251001) and ROLE_MODEL_MAP maps roles to tiers. The pricing module should use these for resolution.
- The daily_usage_rollups table uses nullable agent_slug/team/model columns with NULLS NOT DISTINCT unique constraint to store both per-dimension and system-wide rollups in the same table — NULL means 'all' for that dimension.
- The existing ExtractionService.extract_with_llm() is the only direct Anthropic SDK call in the orchestrator (uses Haiku for classification). Its response.usage should also be captured once the infrastructure exists.
- The Dashboard's CommandCenter currently uses a 2-column grid for KeyMetricsPanel + AuditorAlertsPanel — expanding to 3 columns keeps each panel compact while adding usage without displacing existing widgets.
- Token counts should be displayed humanized (1.2M, 847K, 3.1K) using a shared formatter utility to keep chart labels and card values consistent.

## Success Criteria

- Every agent spawn creates a row in agent_spawn_sessions with correct agent_slug, team, role, model, and started_at — verified by querying the table after a spawn
- The Agent SDK /usage/report endpoint accumulates token counts in _SessionState and /usage/status returns current session totals
- The orchestrator sweeper writes a token_usage_snapshots row every 60 seconds for each active agent with non-zero token counts
- On agent stop or PostMortem, the spawn session row is closed with final token totals, duration, exit_reason, and estimated_cost_usd calculated via the pricing module
- The daily_usage_rollups table is populated hourly by the rollup loop and contains correct aggregates matching the sum of closed sessions for each date/agent/team/model combination
- GET /api/usage/summary returns correct totals for each period (24h, 7d, 30d) with trend percentages comparing to the equivalent previous period
- GET /api/usage/time-series returns correctly bucketed data points (hourly for 24h, daily for 7d/30d) that sum to match the summary totals
- GET /api/usage/by-agent, /by-team, and /by-model each return breakdowns whose totals sum to the summary total and pct_of_total fields sum to ~100%
- GET /api/usage/projection returns a projected monthly cost based on 7-day rolling average that is within 5% of a manual calculation from the raw data
- GET /api/usage/cache-efficiency returns correct cache_hit_rate (read / (read + creation)) and cost_saved_by_cache matches the difference between estimated-without-cache and actual cost
- The Dashboard CommandCenter displays the UsageOverviewPanel in a 3-column grid alongside KeyMetricsPanel and AuditorAlertsPanel, showing tokens today, cost today, cost this week with trend arrow, active sessions, cache savings, and top consumer
- The Metrics page Token Usage & Costs section renders all 5 rows: summary cards, time series area chart + model donut, agent bar chart + team bar chart, projection + cache efficiency, and sessions table
- The UsageTimeSeriesChart renders a stacked area chart with distinct colors for input/output/cache tokens using the --chart-N CSS custom properties
- The SessionsTable supports sorting by each column header and paginates at 10 rows per page
- The Agents page shows a usage mini-bar on each agent card with today's token count and cost
- USAGE_SNAPSHOT and USAGE_SESSION_END WebSocket events trigger React Query cache invalidation so charts and cards update within seconds of new data arriving
- The CEOOverview response from GET /api/dashboard/ceo includes a usage_summary field with tokens_today and cost_today_usd populated from the usage service