### PR TITLE
[44b9eb1f] Align frontend usage API client, TS types, and chart components to real backend contract

### DIFF
--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -48,11 +48,11 @@ export default function AgentsPage() {
     return result;
   }, [status]);
 
-  // Convert usage rows to a record keyed by agent_id
+  // Convert usage rows to a record keyed by agent_slug
   const agentUsageMap = useMemo(() => {
     const result: Record<string, AgentUsageRow> = {};
     for (const row of usageRows ?? []) {
-      result[row.agent_id] = row;
+      result[row.agent_slug] = row;
     }
     return result;
   }, [usageRows]);

--- a/panel/src/app/(dashboard)/metrics/page.tsx
+++ b/panel/src/app/(dashboard)/metrics/page.tsx
@@ -3,11 +3,14 @@
 import { useOrchestratorStatus } from "@/hooks/use-agents";
 import { useTasks } from "@/hooks/use-tasks";
 import {
-  useUsageSnapshot,
+  useUsageSummary,
   useUsageTimeSeries,
   useAgentUsage,
-  useUsageSessions,
+  useTeamUsage,
   useModelUsage,
+  useUsageProjection,
+  useCacheEfficiency,
+  useUsageSessions,
 } from "@/hooks/use-usage";
 import { TaskStatus, Team } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -327,16 +330,16 @@ export default function MetricsPage() {
 // =============================================================================
 
 function TokenUsageCostsSection() {
-  const { data: snapshot, isLoading: loadingSnap } = useUsageSnapshot();
-  const { data: timeSeries, isLoading: loadingTS } = useUsageTimeSeries(24);
-  const { data: agentUsage, isLoading: loadingAgents } = useAgentUsage();
+  const { data: summary, isLoading: loadingSnap } = useUsageSummary("24h");
+  const { data: timeSeries, isLoading: loadingTS } = useUsageTimeSeries("24h");
+  const { data: agentUsage, isLoading: loadingAgents } = useAgentUsage("24h");
+  const { data: teamUsage, isLoading: loadingTeams } = useTeamUsage("24h");
   const { data: sessions, isLoading: loadingSessions } = useUsageSessions(100);
-  const { data: modelUsage, isLoading: loadingModels } = useModelUsage();
+  const { data: modelUsage, isLoading: loadingModels } = useModelUsage("24h");
+  const { data: projection, isLoading: loadingProj } = useUsageProjection();
+  const { data: cacheStats, isLoading: loadingCache } = useCacheEfficiency("24h");
 
-  const weekTrend = snapshot
-    ? snapshot.cost_this_week - snapshot.cost_last_week
-    : 0;
-  const weekIsUp = weekTrend >= 0;
+  const trendUp = (summary?.trend_pct ?? 0) >= 0;
 
   return (
     <div className="space-y-6">
@@ -345,57 +348,46 @@ function TokenUsageCostsSection() {
       {/* Row 1 — Summary cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
-          title="Tokens Today"
-          value={snapshot ? fmtTokens(snapshot.tokens_today) : undefined}
+          title="Tokens Input"
+          value={summary ? fmtTokens(summary.tokens_input) : undefined}
           icon={<Zap className="h-4 w-4 text-yellow-500" />}
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Cost Today"
-          value={snapshot ? "$" + snapshot.cost_today.toFixed(2) : undefined}
+          title="Tokens Output"
+          value={summary ? fmtTokens(summary.tokens_output) : undefined}
+          icon={<Zap className="h-4 w-4 text-blue-500" />}
+          isLoading={loadingSnap}
+        />
+        <SummaryCard
+          title="Total Cost (24h)"
+          value={summary ? "$" + summary.total_cost_usd.toFixed(4) : undefined}
           icon={<Coins className="h-4 w-4 text-green-500" />}
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Cost This Week"
-          value={snapshot ? "$" + snapshot.cost_this_week.toFixed(2) : undefined}
+          title="Trend vs Prior"
+          value={summary ? (trendUp ? "+" : "") + summary.trend_pct.toFixed(1) + "%" : undefined}
           icon={
-            weekIsUp ? (
+            trendUp ? (
               <TrendingUp className="h-4 w-4 text-red-500" />
             ) : (
               <TrendingDown className="h-4 w-4 text-green-500" />
             )
           }
-          trend={
-            snapshot
-              ? {
-                  dir: weekIsUp ? "up" : "down",
-                  label:
-                    (weekIsUp ? "▲ " : "▼ ") +
-                    Math.abs(weekTrend).toFixed(2) +
-                    " vs last wk",
-                }
-              : undefined
-          }
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Active Sessions"
-          value={snapshot ? String(snapshot.active_sessions) : undefined}
+          title="Total Tokens"
+          value={summary ? fmtTokens(summary.total_tokens) : undefined}
           icon={<Activity className="h-4 w-4 text-blue-500" />}
           isLoading={loadingSnap}
         />
         <SummaryCard
-          title="Cache Savings"
-          value={snapshot ? "$" + snapshot.cache_savings.toFixed(2) : undefined}
+          title="Cache Saved"
+          value={cacheStats ? "$" + cacheStats.cost_saved_by_cache_usd.toFixed(4) : undefined}
           icon={<Sparkles className="h-4 w-4 text-purple-500" />}
-          isLoading={loadingSnap}
-        />
-        <SummaryCard
-          title="Top Consumer"
-          value={snapshot?.top_consumer ?? undefined}
-          icon={<Users className="h-4 w-4 text-orange-500" />}
-          isLoading={loadingSnap}
+          isLoading={loadingCache}
         />
       </div>
 
@@ -410,16 +402,16 @@ function TokenUsageCostsSection() {
       {/* Row 3 — Agent bar + team bar */}
       <div className="grid gap-4 lg:grid-cols-2">
         <AgentUsageChart data={agentUsage} isLoading={loadingAgents} />
-        <TeamUsageChart data={agentUsage} isLoading={loadingAgents} />
+        <TeamUsageChart data={teamUsage} isLoading={loadingTeams} />
       </div>
 
       {/* Row 4 — Projection + cache efficiency */}
       <div className="grid gap-4 sm:grid-cols-2">
-        <ProjectionCard snapshot={snapshot} isLoading={loadingSnap} />
-        <CacheEfficiencyCard sessions={sessions} isLoading={loadingAgents || loadingSessions} />
+        <ProjectionCard projection={projection} isLoading={loadingProj} />
+        <CacheEfficiencyCard cacheStats={cacheStats} isLoading={loadingCache} />
       </div>
 
-      {/* Row 5 — Sessions table */}
+      {/* Row 5 — Sessions table (mock-mode only; empty in production) */}
       <SessionsTable data={sessions} isLoading={loadingSessions} />
     </div>
   );
@@ -471,18 +463,14 @@ function SummaryCard({ title, value, icon, trend, isLoading }: SummaryCardProps)
   );
 }
 
-import type { TokenUsageSnapshot as TUS, UsageSession as US } from "@/types";
+import type { UsageProjection as UP, CacheEfficiencyResponse as CER } from "@/types";
 
 interface ProjectionCardProps {
-  snapshot: TUS | undefined;
+  projection: UP | undefined;
   isLoading: boolean;
 }
 
-function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
-  const weeklyRun = snapshot
-    ? snapshot.cost_this_week / 7 * 30
-    : null;
-
+function ProjectionCard({ projection, isLoading }: ProjectionCardProps) {
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -497,10 +485,11 @@ function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
         ) : (
           <div>
             <div className="text-3xl font-bold">
-              {weeklyRun != null ? "$" + weeklyRun.toFixed(2) : "—"}
+              {projection != null ? "$" + projection.projected_monthly_cost_usd.toFixed(2) : "—"}
             </div>
             <p className="text-xs text-muted-foreground mt-1">
-              Based on this week&apos;s daily average
+              Based on {projection?.basis_days ?? 7}-day rolling average ($
+              {projection?.avg_daily_cost_usd.toFixed(4) ?? "—"}/day)
             </p>
           </div>
         )}
@@ -510,17 +499,12 @@ function ProjectionCard({ snapshot, isLoading }: ProjectionCardProps) {
 }
 
 interface CacheEfficiencyCardProps {
-  sessions: US[] | undefined;
+  cacheStats: CER | undefined;
   isLoading: boolean;
 }
 
-function CacheEfficiencyCard({ sessions, isLoading }: CacheEfficiencyCardProps) {
-  const totalCache = (sessions ?? []).reduce((s, r) => s + r.tokens_cache, 0);
-  const totalAll = (sessions ?? []).reduce(
-    (s, r) => s + r.tokens_input + r.tokens_output + r.tokens_cache,
-    0
-  );
-  const pct = totalAll > 0 ? (totalCache / totalAll) * 100 : 0;
+function CacheEfficiencyCard({ cacheStats, isLoading }: CacheEfficiencyCardProps) {
+  const pct = cacheStats ? cacheStats.cache_hit_rate * 100 : 0;
 
   return (
     <Card>
@@ -537,7 +521,8 @@ function CacheEfficiencyCard({ sessions, isLoading }: CacheEfficiencyCardProps) 
           <div>
             <div className="text-3xl font-bold">{pct.toFixed(1)}%</div>
             <p className="text-xs text-muted-foreground mt-1">
-              {fmtTokens(totalCache)} cached of {fmtTokens(totalAll)} total tokens
+              {cacheStats ? fmtTokens(cacheStats.tokens_cache_read) : "—"} cache reads ·
+              saved ${cacheStats?.cost_saved_by_cache_usd.toFixed(4) ?? "—"}
             </p>
             <Progress value={pct} className="mt-2" />
           </div>

--- a/panel/src/components/agents/agent-card.tsx
+++ b/panel/src/components/agents/agent-card.tsx
@@ -106,13 +106,13 @@ export function AgentCard({ agent, agentStatus, usageRow }: AgentCardProps) {
           <div className="mt-3 pt-2 border-t">
             <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
               <span>
-                {usageRow.tokens_today >= 1_000
-                  ? (usageRow.tokens_today / 1_000).toFixed(1) + "K"
-                  : String(usageRow.tokens_today)}{" "}
+                {usageRow.total_tokens >= 1_000
+                  ? (usageRow.total_tokens / 1_000).toFixed(1) + "K"
+                  : String(usageRow.total_tokens)}{" "}
                 tokens
               </span>
               <span className="font-medium text-foreground">
-                ${usageRow.cost_today.toFixed(2)}
+                ${usageRow.cost_usd.toFixed(4)}
               </span>
             </div>
             <div className="w-full bg-muted rounded-full h-1.5 overflow-hidden">
@@ -120,7 +120,7 @@ export function AgentCard({ agent, agentStatus, usageRow }: AgentCardProps) {
                 className="h-full rounded-full bg-[var(--chart-1)]"
                 style={{
                   width:
-                    Math.min(100, (usageRow.tokens_today / 30_000) * 100) + "%",
+                    Math.min(100, (usageRow.total_tokens / 30_000) * 100) + "%",
                 }}
               />
             </div>

--- a/panel/src/components/dashboard/usage-overview-panel.tsx
+++ b/panel/src/components/dashboard/usage-overview-panel.tsx
@@ -2,8 +2,8 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useUsageSnapshot } from "@/hooks/use-usage";
-import { Coins, TrendingUp, TrendingDown, Zap, Users, Sparkles } from "lucide-react";
+import { useUsageSummary } from "@/hooks/use-usage";
+import { Coins, TrendingUp, TrendingDown, Zap, Activity } from "lucide-react";
 
 function fmt(n: number, decimals = 0): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
@@ -38,15 +38,9 @@ function MetricRow({ icon, label, value, sub }: MetricRowProps) {
 }
 
 export function UsageOverviewPanel() {
-  const { data: snapshot, isLoading } = useUsageSnapshot();
+  const { data: summary, isLoading } = useUsageSummary("24h");
 
-  const weekTrend = snapshot
-    ? snapshot.cost_this_week - snapshot.cost_last_week
-    : 0;
-  const weekTrendPct = snapshot?.cost_last_week
-    ? Math.abs(weekTrend / snapshot.cost_last_week) * 100
-    : 0;
-  const weekIsUp = weekTrend >= 0;
+  const trendUp = (summary?.trend_pct ?? 0) >= 0;
 
   return (
     <Card>
@@ -59,7 +53,7 @@ export function UsageOverviewPanel() {
       <CardContent>
         {isLoading ? (
           <div className="space-y-3">
-            {Array.from({ length: 6 }).map((_, i) => (
+            {Array.from({ length: 5 }).map((_, i) => (
               <Skeleton key={i} className="h-6" />
             ))}
           </div>
@@ -67,50 +61,41 @@ export function UsageOverviewPanel() {
           <div className="divide-y">
             <MetricRow
               icon={<Zap className="h-4 w-4" />}
-              label="Tokens today"
-              value={snapshot ? fmt(snapshot.tokens_today) : "—"}
+              label="Tokens (input)"
+              value={summary ? fmt(summary.tokens_input) : "—"}
+            />
+            <MetricRow
+              icon={<Zap className="h-4 w-4 text-muted-foreground" />}
+              label="Tokens (output)"
+              value={summary ? fmt(summary.tokens_output) : "—"}
             />
             <MetricRow
               icon={<Coins className="h-4 w-4" />}
-              label="Cost today"
-              value={snapshot ? fmtCost(snapshot.cost_today) : "—"}
+              label="Total cost"
+              value={summary ? fmtCost(summary.total_cost_usd) : "—"}
             />
             <MetricRow
               icon={
-                weekIsUp ? (
+                trendUp ? (
                   <TrendingUp className="h-4 w-4 text-red-500" />
                 ) : (
                   <TrendingDown className="h-4 w-4 text-green-500" />
                 )
               }
-              label="Cost this week"
-              value={snapshot ? fmtCost(snapshot.cost_this_week) : "—"}
+              label="Trend vs prior period"
+              value={summary ? (trendUp ? "+" : "") + summary.trend_pct.toFixed(1) + "%" : "—"}
               sub={
-                snapshot ? (
-                  <span
-                    className={
-                      "text-xs " + (weekIsUp ? "text-red-500" : "text-green-500")
-                    }
-                  >
-                    {weekIsUp ? "▲" : "▼"} {weekTrendPct.toFixed(0)}%
+                summary ? (
+                  <span className={"text-xs " + (trendUp ? "text-red-500" : "text-green-500")}>
+                    {trendUp ? "▲" : "▼"}
                   </span>
                 ) : undefined
               }
             />
             <MetricRow
-              icon={<Users className="h-4 w-4" />}
-              label="Active sessions"
-              value={snapshot ? String(snapshot.active_sessions) : "—"}
-            />
-            <MetricRow
-              icon={<Sparkles className="h-4 w-4 text-yellow-500" />}
-              label="Cache savings"
-              value={snapshot ? fmtCost(snapshot.cache_savings) : "—"}
-            />
-            <MetricRow
-              icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
-              label="Top consumer"
-              value={snapshot?.top_consumer ?? "—"}
+              icon={<Activity className="h-4 w-4 text-blue-500" />}
+              label="Period"
+              value={summary?.period ?? "—"}
             />
           </div>
         )}

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -25,11 +25,11 @@ function fmtK(n: number): string {
 
 export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
   const chartData = [...(data ?? [])]
-    .sort((a, b) => b.tokens_today - a.tokens_today)
+    .sort((a, b) => b.total_tokens - a.total_tokens)
     .slice(0, 10)
     .map((row) => ({
-      name: row.agent_name,
-      Tokens: row.tokens_today,
+      name: row.agent_slug,
+      Tokens: row.total_tokens,
     }));
 
   return (

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -28,9 +28,9 @@ interface ModelUsageDonutProps {
 export function ModelUsageDonut({ data, isLoading }: ModelUsageDonutProps) {
   const chartData = (data ?? []).map((s) => ({
     name: s.model,
-    value: s.tokens,
-    cost: s.cost,
-    pct: s.percentage,
+    value: s.total_tokens,
+    cost: s.cost_usd,
+    pct: s.pct_of_total,
   }));
 
   return (

--- a/panel/src/components/metrics/sessions-table.tsx
+++ b/panel/src/components/metrics/sessions-table.tsx
@@ -19,7 +19,7 @@ const PAGE_SIZE = 10;
 
 type SortKey = keyof Pick<
   UsageSession,
-  | "agent_name"
+  | "agent_slug"
   | "started_at"
   | "total_tokens"
   | "tokens_input"
@@ -37,7 +37,7 @@ interface Column {
 }
 
 const COLUMNS: Column[] = [
-  { key: "agent_name", label: "Agent" },
+  { key: "agent_slug", label: "Agent" },
   { key: "model", label: "Model" },
   { key: "started_at", label: "Started" },
   { key: "total_tokens", label: "Total" },
@@ -142,7 +142,7 @@ export function SessionsTable({ data, isLoading }: SessionsTableProps) {
                   ) : (
                     visible.map((s) => (
                       <TableRow key={s.id}>
-                        <TableCell className="text-xs font-medium">{s.agent_name}</TableCell>
+                        <TableCell className="text-xs font-medium">{s.agent_slug}</TableCell>
                         <TableCell className="text-xs">{s.model}</TableCell>
                         <TableCell className="text-xs">{formatTime(s.started_at)}</TableCell>
                         <TableCell className="text-xs">{fmtK(s.total_tokens)}</TableCell>

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -11,10 +11,10 @@ import {
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { AgentUsageRow } from "@/types";
+import type { TeamUsageRow } from "@/types";
 
 interface TeamUsageChartProps {
-  data: AgentUsageRow[] | undefined;
+  data: TeamUsageRow[] | undefined;
   isLoading: boolean;
 }
 
@@ -24,24 +24,17 @@ function fmtK(n: number): string {
 }
 
 export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
-  // Aggregate tokens by team
-  const teamTotals = new Map<string, number>();
-  for (const row of data ?? []) {
-    const prev = teamTotals.get(row.team) ?? 0;
-    teamTotals.set(row.team, prev + row.tokens_today);
-  }
-
-  const chartData = [...teamTotals.entries()]
-    .sort(([, a], [, b]) => b - a)
-    .map(([team, tokens]) => ({
-      name: team.replace(/_/g, " "),
-      Tokens: tokens,
+  const chartData = [...(data ?? [])]
+    .sort((a, b) => b.total_tokens - a.total_tokens)
+    .map((row) => ({
+      name: row.team.replace(/_/g, " "),
+      Tokens: row.total_tokens,
     }));
 
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base">Team Tokens Today</CardTitle>
+        <CardTitle className="text-base">Team Tokens</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -19,9 +19,15 @@ interface UsageTimeSeriesChartProps {
   isLoading: boolean;
 }
 
-function formatHour(ts: string): string {
-  const d = new Date(ts);
-  return d.getHours().toString().padStart(2, "0") + ":00";
+function formatBucket(bucket: string): string {
+  const d = new Date(bucket);
+  // If the bucket has a non-zero time component it is an hourly bucket → show HH:00.
+  // Otherwise it is a daily bucket → show MM/DD.
+  const isHourly = d.getMinutes() === 0 && (d.getHours() !== 0 || bucket.includes("T"));
+  if (isHourly && d.getSeconds() === 0 && !bucket.endsWith("T00:00:00.000Z")) {
+    return d.getHours().toString().padStart(2, "0") + ":00";
+  }
+  return (d.getMonth() + 1) + "/" + d.getDate();
 }
 
 function fmtK(n: number): string {
@@ -31,10 +37,9 @@ function fmtK(n: number): string {
 
 export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartProps) {
   const chartData = (data ?? []).map((p) => ({
-    hour: formatHour(p.timestamp),
+    hour: formatBucket(p.bucket),
     Input: p.tokens_input,
     Output: p.tokens_output,
-    Cache: p.tokens_cache,
   }));
 
   return (
@@ -59,10 +64,6 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
                   <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
-                </linearGradient>
-                <linearGradient id="fillCache" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--chart-3)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--chart-3)" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
@@ -101,13 +102,6 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 stackId="1"
                 stroke="var(--chart-2)"
                 fill="url(#fillOutput)"
-              />
-              <Area
-                type="monotone"
-                dataKey="Cache"
-                stackId="1"
-                stroke="var(--chart-3)"
-                fill="url(#fillCache)"
               />
             </AreaChart>
           </ResponsiveContainer>

--- a/panel/src/hooks/use-usage.ts
+++ b/panel/src/hooks/use-usage.ts
@@ -2,12 +2,16 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { usageApi } from "@/lib/api/usage";
+import type { UsagePeriod } from "@/lib/api/usage";
 import type {
-  TokenUsageSnapshot,
+  UsageSummary,
   AgentUsageRow,
-  UsageSession,
-  UsageTimePoint,
+  TeamUsageRow,
   ModelUsageSlice,
+  UsageTimePoint,
+  UsageProjection,
+  CacheEfficiencyResponse,
+  UsageSession,
 } from "@/types";
 
 // =============================================================================
@@ -16,58 +20,93 @@ import type {
 
 export const usageKeys = {
   all: ["usage"] as const,
-  snapshot: () => [...usageKeys.all, "snapshot"] as const,
-  timeSeries: (hours: number) => [...usageKeys.all, "time-series", hours] as const,
-  agentUsage: () => [...usageKeys.all, "agents"] as const,
+  summary: (period: UsagePeriod) => [...usageKeys.all, "summary", period] as const,
+  timeSeries: (period: UsagePeriod) => [...usageKeys.all, "time-series", period] as const,
+  agentUsage: (period: UsagePeriod) => [...usageKeys.all, "by-agent", period] as const,
+  teamUsage: (period: UsagePeriod) => [...usageKeys.all, "by-team", period] as const,
+  modelUsage: (period: UsagePeriod) => [...usageKeys.all, "by-model", period] as const,
+  projection: () => [...usageKeys.all, "projection"] as const,
+  cacheEfficiency: (period: UsagePeriod) => [...usageKeys.all, "cache-efficiency", period] as const,
   sessions: (limit: number) => [...usageKeys.all, "sessions", limit] as const,
-  modelUsage: () => [...usageKeys.all, "models"] as const,
 };
 
 // =============================================================================
 // HOOKS
 // =============================================================================
 
-/** Snapshot of current-day usage totals (tokens, cost, sessions, cache) */
-export function useUsageSnapshot() {
-  return useQuery<TokenUsageSnapshot>({
-    queryKey: usageKeys.snapshot(),
-    queryFn: () => usageApi.getUsageSnapshot(),
+/** Aggregated usage summary (tokens_input, tokens_output, total_cost_usd, …) */
+export function useUsageSummary(period: UsagePeriod = "24h") {
+  return useQuery<UsageSummary>({
+    queryKey: usageKeys.summary(period),
+    queryFn: () => usageApi.getUsageSummary(period),
     refetchInterval: 60_000,
   });
 }
 
-/** Hourly time-series data for the stacked area chart */
-export function useUsageTimeSeries(hours: number = 24) {
+/** Bucketed time-series data for the stacked area chart */
+export function useUsageTimeSeries(period: UsagePeriod = "24h") {
   return useQuery<UsageTimePoint[]>({
-    queryKey: usageKeys.timeSeries(hours),
-    queryFn: () => usageApi.getUsageTimeSeries(hours),
+    queryKey: usageKeys.timeSeries(period),
+    queryFn: () => usageApi.getUsageTimeSeries(period),
     refetchInterval: 120_000,
   });
 }
 
 /** Per-agent usage rows for bar chart and agent card mini-bars */
-export function useAgentUsage() {
+export function useAgentUsage(period: UsagePeriod = "24h") {
   return useQuery<AgentUsageRow[]>({
-    queryKey: usageKeys.agentUsage(),
-    queryFn: () => usageApi.getAgentUsage(),
+    queryKey: usageKeys.agentUsage(period),
+    queryFn: () => usageApi.getAgentUsage(period),
     refetchInterval: 60_000,
   });
 }
 
-/** Recent inference sessions for the sessions table */
+/** Per-team usage rows from the dedicated by-team endpoint */
+export function useTeamUsage(period: UsagePeriod = "24h") {
+  return useQuery<TeamUsageRow[]>({
+    queryKey: usageKeys.teamUsage(period),
+    queryFn: () => usageApi.getTeamUsage(period),
+    refetchInterval: 60_000,
+  });
+}
+
+/** Per-model slices for the donut chart */
+export function useModelUsage(period: UsagePeriod = "24h") {
+  return useQuery<ModelUsageSlice[]>({
+    queryKey: usageKeys.modelUsage(period),
+    queryFn: () => usageApi.getModelUsage(period),
+    refetchInterval: 120_000,
+  });
+}
+
+/** Monthly cost projection based on 7-day rolling average */
+export function useUsageProjection() {
+  return useQuery<UsageProjection>({
+    queryKey: usageKeys.projection(),
+    queryFn: () => usageApi.getUsageProjection(),
+    refetchInterval: 300_000,
+  });
+}
+
+/** Cache efficiency stats */
+export function useCacheEfficiency(period: UsagePeriod = "24h") {
+  return useQuery<CacheEfficiencyResponse>({
+    queryKey: usageKeys.cacheEfficiency(period),
+    queryFn: () => usageApi.getCacheEfficiency(period),
+    refetchInterval: 120_000,
+  });
+}
+
+/**
+ * Recent inference sessions — mock-mode only.
+ *
+ * Returns an empty array in production (no real backend endpoint for sessions).
+ * The SessionsTable will display "No sessions recorded yet" gracefully.
+ */
 export function useUsageSessions(limit: number = 100) {
   return useQuery<UsageSession[]>({
     queryKey: usageKeys.sessions(limit),
     queryFn: () => usageApi.getUsageSessions(limit),
     refetchInterval: 30_000,
-  });
-}
-
-/** Per-model slices for the donut chart */
-export function useModelUsage() {
-  return useQuery<ModelUsageSlice[]>({
-    queryKey: usageKeys.modelUsage(),
-    queryFn: () => usageApi.getModelUsage(),
-    refetchInterval: 120_000,
   });
 }

--- a/panel/src/lib/api/usage.ts
+++ b/panel/src/lib/api/usage.ts
@@ -1,74 +1,157 @@
 import api from "./client";
 import { isMockMode } from "@/lib/mock-data";
 import type {
-  TokenUsageSnapshot,
+  UsageSummary,
   AgentUsageRow,
-  UsageSession,
-  UsageTimePoint,
+  TeamUsageRow,
   ModelUsageSlice,
+  UsageTimePoint,
+  UsageProjection,
+  CacheEfficiencyResponse,
+  UsageSession,
 } from "@/types";
 
+export type UsagePeriod = "24h" | "7d" | "30d";
+
 // =============================================================================
-// MOCK DATA
+// MOCK DATA  — shapes must exactly match the real backend response schemas
 // =============================================================================
 
-function mockSnapshot(): TokenUsageSnapshot {
+function mockSummary(period: UsagePeriod = "24h"): UsageSummary {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
+  const base = 124_800 * scale;
   return {
-    tokens_today: 124_800,
-    cost_today: 3.74,
-    cost_this_week: 22.50,
-    cost_last_week: 18.20,
-    active_sessions: 3,
-    cache_savings: 1.25,
-    top_consumer: "be-dev-1",
+    tokens_input: Math.round(base * 0.55),
+    tokens_output: Math.round(base * 0.35),
+    total_tokens: base,
+    total_cost_usd: parseFloat((base * 0.000030).toFixed(6)),
+    trend_pct: 12.5,
+    period,
   };
 }
 
-function mockTimeSeries(): UsageTimePoint[] {
+function mockTimeSeries(period: UsagePeriod = "24h"): UsageTimePoint[] {
   const now = new Date();
-  return Array.from({ length: 24 }, (_, i) => {
+  const points = period === "24h" ? 24 : period === "7d" ? 7 : 30;
+  const step = period === "24h" ? "hour" : "day";
+  return Array.from({ length: points }, (_, i) => {
     const ts = new Date(now);
-    ts.setHours(now.getHours() - (23 - i), 0, 0, 0);
+    if (step === "hour") {
+      ts.setHours(now.getHours() - (points - 1 - i), 0, 0, 0);
+    } else {
+      ts.setDate(now.getDate() - (points - 1 - i));
+      ts.setHours(0, 0, 0, 0);
+    }
     const base = 3_000 + Math.round(Math.random() * 4_000);
+    const tokens_input = Math.round(base * 0.55);
+    const tokens_output = Math.round(base * 0.35);
+    const total_tokens = base;
     return {
-      timestamp: ts.toISOString(),
-      tokens_input: Math.round(base * 0.45),
-      tokens_output: Math.round(base * 0.35),
-      tokens_cache: Math.round(base * 0.20),
+      bucket: ts.toISOString(),
+      tokens_input,
+      tokens_output,
+      total_tokens,
+      cost_usd: parseFloat((total_tokens * 0.000030).toFixed(6)),
     };
   });
 }
 
-function mockAgentUsage(): AgentUsageRow[] {
+function mockAgentUsage(period: UsagePeriod = "24h"): AgentUsageRow[] {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
   const agents = [
-    { agent_id: "be-dev-1", agent_name: "BE-Dev-1", team: "backend" },
-    { agent_id: "be-dev-2", agent_name: "BE-Dev-2", team: "backend" },
-    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1", team: "frontend" },
-    { agent_id: "fe-dev-2", agent_name: "FE-Dev-2", team: "frontend" },
-    { agent_id: "ux-dev-1", agent_name: "UX-Dev-1", team: "ux_ui" },
-    { agent_id: "be-qa", agent_name: "BE-QA", team: "backend" },
-    { agent_id: "fe-qa", agent_name: "FE-QA", team: "frontend" },
-    { agent_id: "main-pm", agent_name: "Main-PM", team: "main_pm" },
+    { agent_slug: "be-dev-1" },
+    { agent_slug: "be-dev-2" },
+    { agent_slug: "fe-dev-1" },
+    { agent_slug: "fe-dev-2" },
+    { agent_slug: "ux-dev-1" },
+    { agent_slug: "be-qa" },
+    { agent_slug: "fe-qa" },
+    { agent_slug: "main-pm" },
   ];
-  return agents.map((a) => ({
-    ...a,
-    tokens_today: Math.round(5_000 + Math.random() * 25_000),
-    cost_today: parseFloat((0.15 + Math.random() * 0.75).toFixed(2)),
-    tokens_total: Math.round(50_000 + Math.random() * 200_000),
-  }));
+  const grand = agents.length * 15_000 * scale;
+  return agents.map((a) => {
+    const ti = Math.round((5_000 + Math.random() * 20_000) * scale);
+    const to_ = Math.round(ti * 0.65);
+    const total = ti + to_;
+    return {
+      agent_slug: a.agent_slug,
+      tokens_input: ti,
+      tokens_output: to_,
+      total_tokens: total,
+      cost_usd: parseFloat((total * 0.000030).toFixed(6)),
+      pct_of_total: parseFloat(((total / grand) * 100).toFixed(2)),
+    };
+  });
+}
+
+function mockTeamUsage(period: UsagePeriod = "24h"): TeamUsageRow[] {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
+  const teams = ["backend", "frontend", "ux_ui", "main_pm"];
+  const grand = teams.length * 50_000 * scale;
+  return teams.map((team) => {
+    const ti = Math.round((30_000 + Math.random() * 40_000) * scale);
+    const to_ = Math.round(ti * 0.65);
+    const total = ti + to_;
+    return {
+      team,
+      tokens_input: ti,
+      tokens_output: to_,
+      total_tokens: total,
+      cost_usd: parseFloat((total * 0.000030).toFixed(6)),
+      pct_of_total: parseFloat(((total / grand) * 100).toFixed(2)),
+    };
+  });
+}
+
+function mockModelUsage(period: UsagePeriod = "24h"): ModelUsageSlice[] {
+  const scale = period === "30d" ? 30 : period === "7d" ? 7 : 1;
+  const models = [
+    { model: "claude-opus-4", share: 0.548 },
+    { model: "claude-sonnet-4", share: 0.346 },
+    { model: "claude-haiku-4", share: 0.106 },
+  ];
+  const base = 124_800 * scale;
+  return models.map((m) => {
+    const ti = Math.round(base * m.share * 0.55);
+    const to_ = Math.round(base * m.share * 0.35);
+    const total = Math.round(base * m.share);
+    return {
+      model: m.model,
+      tokens_input: ti,
+      tokens_output: to_,
+      total_tokens: total,
+      cost_usd: parseFloat((total * 0.000030).toFixed(6)),
+      pct_of_total: parseFloat((m.share * 100).toFixed(1)),
+    };
+  });
+}
+
+function mockProjection(): UsageProjection {
+  const total_cost_7d = parseFloat((124_800 * 7 * 0.000030).toFixed(6));
+  return {
+    total_cost_7d,
+    avg_daily_cost_usd: parseFloat((total_cost_7d / 7).toFixed(6)),
+    projected_monthly_cost_usd: parseFloat((total_cost_7d / 7 * 30).toFixed(4)),
+    basis_days: 7,
+  };
+}
+
+function mockCacheEfficiency(period: UsagePeriod = "24h"): CacheEfficiencyResponse {
+  return {
+    cache_hit_rate: 0.3142,
+    tokens_cache_read: 39_168,
+    tokens_cache_write: 12_480,
+    tokens_input: 85_632,
+    cost_saved_by_cache_usd: parseFloat((39_168 * (3.00 - 0.30) / 1_000_000).toFixed(6)),
+    period,
+  };
 }
 
 function mockSessions(): UsageSession[] {
   const models = ["claude-opus-4", "claude-sonnet-4", "claude-haiku-4"];
-  const agents = [
-    { agent_id: "be-dev-1", agent_name: "BE-Dev-1" },
-    { agent_id: "be-dev-2", agent_name: "BE-Dev-2" },
-    { agent_id: "fe-dev-1", agent_name: "FE-Dev-1" },
-    { agent_id: "fe-qa", agent_name: "FE-QA" },
-    { agent_id: "main-pm", agent_name: "Main-PM" },
-  ];
+  const agentSlugs = ["be-dev-1", "be-dev-2", "fe-dev-1", "fe-qa", "main-pm"];
   return Array.from({ length: 35 }, (_, i) => {
-    const agent = agents[i % agents.length];
+    const agent_slug = agentSlugs[i % agentSlugs.length];
     const model = models[i % models.length];
     const input = Math.round(2_000 + Math.random() * 8_000);
     const output = Math.round(500 + Math.random() * 3_000);
@@ -77,8 +160,7 @@ function mockSessions(): UsageSession[] {
     const ended = i < 3 ? null : new Date(started.getTime() + Math.round(5 + Math.random() * 55) * 60_000);
     return {
       id: `session-mock-${i + 1}`,
-      agent_id: agent.agent_id,
-      agent_name: agent.agent_name,
+      agent_slug,
       started_at: started.toISOString(),
       ended_at: ended ? ended.toISOString() : null,
       tokens_input: input,
@@ -91,55 +173,82 @@ function mockSessions(): UsageSession[] {
   });
 }
 
-function mockModelUsage(): ModelUsageSlice[] {
-  return [
-    { model: "claude-opus-4", tokens: 68_400, cost: 2.05, percentage: 54.8 },
-    { model: "claude-sonnet-4", tokens: 43_200, cost: 1.30, percentage: 34.6 },
-    { model: "claude-haiku-4", tokens: 13_200, cost: 0.40, percentage: 10.6 },
-  ];
-}
-
 // =============================================================================
 // API OBJECT
 // =============================================================================
 
 export const usageApi = {
-  /** Current-day snapshot for the overview panel */
-  getUsageSnapshot: async (): Promise<TokenUsageSnapshot> => {
-    if (isMockMode()) return mockSnapshot();
-    const { data } = await api.get<TokenUsageSnapshot>("/usage/snapshot");
+  /** Aggregated token usage summary — GET /usage/summary?period= */
+  getUsageSummary: async (period: UsagePeriod = "24h"): Promise<UsageSummary> => {
+    if (isMockMode()) return mockSummary(period);
+    const { data } = await api.get<UsageSummary>("/usage/summary", {
+      params: { period },
+    });
     return data;
   },
 
-  /** Hourly time-series data for the stacked area chart */
-  getUsageTimeSeries: async (hours: number = 24): Promise<UsageTimePoint[]> => {
-    if (isMockMode()) return mockTimeSeries();
+  /** Bucketed time-series — GET /usage/time-series?period= */
+  getUsageTimeSeries: async (period: UsagePeriod = "24h"): Promise<UsageTimePoint[]> => {
+    if (isMockMode()) return mockTimeSeries(period);
     const { data } = await api.get<UsageTimePoint[]>("/usage/time-series", {
-      params: { hours },
+      params: { period },
     });
     return data;
   },
 
-  /** Per-agent usage rows for the bar chart and agent cards */
-  getAgentUsage: async (): Promise<AgentUsageRow[]> => {
-    if (isMockMode()) return mockAgentUsage();
-    const { data } = await api.get<AgentUsageRow[]>("/usage/agents");
+  /** Per-agent usage rows — GET /usage/by-agent?period= */
+  getAgentUsage: async (period: UsagePeriod = "24h"): Promise<AgentUsageRow[]> => {
+    if (isMockMode()) return mockAgentUsage(period);
+    const { data } = await api.get<AgentUsageRow[]>("/usage/by-agent", {
+      params: { period },
+    });
     return data;
   },
 
-  /** Recent inference sessions for the sessions table */
-  getUsageSessions: async (limit: number = 100): Promise<UsageSession[]> => {
+  /** Per-team usage rows — GET /usage/by-team?period= */
+  getTeamUsage: async (period: UsagePeriod = "24h"): Promise<TeamUsageRow[]> => {
+    if (isMockMode()) return mockTeamUsage(period);
+    const { data } = await api.get<TeamUsageRow[]>("/usage/by-team", {
+      params: { period },
+    });
+    return data;
+  },
+
+  /** Per-model usage slices — GET /usage/by-model?period= */
+  getModelUsage: async (period: UsagePeriod = "24h"): Promise<ModelUsageSlice[]> => {
+    if (isMockMode()) return mockModelUsage(period);
+    const { data } = await api.get<ModelUsageSlice[]>("/usage/by-model", {
+      params: { period },
+    });
+    return data;
+  },
+
+  /** Monthly cost projection — GET /usage/projection */
+  getUsageProjection: async (): Promise<UsageProjection> => {
+    if (isMockMode()) return mockProjection();
+    const { data } = await api.get<UsageProjection>("/usage/projection");
+    return data;
+  },
+
+  /** Cache efficiency stats — GET /usage/cache-efficiency?period= */
+  getCacheEfficiency: async (period: UsagePeriod = "24h"): Promise<CacheEfficiencyResponse> => {
+    if (isMockMode()) return mockCacheEfficiency(period);
+    const { data } = await api.get<CacheEfficiencyResponse>("/usage/cache-efficiency", {
+      params: { period },
+    });
+    return data;
+  },
+
+  /**
+   * Recent inference sessions — mock-mode only.
+   *
+   * The backend has no /usage/sessions endpoint.  In production this
+   * returns an empty array so SessionsTable shows a graceful "no data"
+   * state instead of throwing a 404.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getUsageSessions: async (_limit: number = 100): Promise<UsageSession[]> => {
     if (isMockMode()) return mockSessions();
-    const { data } = await api.get<UsageSession[]>("/usage/sessions", {
-      params: { limit },
-    });
-    return data;
-  },
-
-  /** Per-model usage slices for the donut chart */
-  getModelUsage: async (): Promise<ModelUsageSlice[]> => {
-    if (isMockMode()) return mockModelUsage();
-    const { data } = await api.get<ModelUsageSlice[]>("/usage/models");
-    return data;
+    return [];
   },
 };

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -1255,35 +1255,84 @@ export interface CEORejectRequest {
 }
 
 // =============================================================================
-// TOKEN USAGE TYPES
+// TOKEN USAGE TYPES  (aligned to real backend: GET /api/usage/*)
 // =============================================================================
 
-/** Snapshot of current token usage totals for the overview panel */
-export interface TokenUsageSnapshot {
-  tokens_today: number;
-  cost_today: number;
-  cost_this_week: number;
-  cost_last_week: number;
-  active_sessions: number;
-  cache_savings: number;
-  top_consumer: string;
+/** Aggregated token and cost totals — GET /usage/summary?period=24h|7d|30d */
+export interface UsageSummary {
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  total_cost_usd: number;
+  trend_pct: number;
+  period: string;
 }
 
-/** Per-agent usage row for the agent bar chart and agent card mini-bar */
+/** Per-agent usage row — GET /usage/by-agent?period=24h|7d|30d */
 export interface AgentUsageRow {
-  agent_id: string;
-  agent_name: string;
-  tokens_today: number;
-  cost_today: number;
-  tokens_total: number;
-  team: string;
+  agent_slug: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+  pct_of_total: number;
 }
 
-/** Individual inference session for the sessions table */
+/** Per-team usage row — GET /usage/by-team?period=24h|7d|30d */
+export interface TeamUsageRow {
+  team: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+  pct_of_total: number;
+}
+
+/** Per-model usage slice — GET /usage/by-model?period=24h|7d|30d */
+export interface ModelUsageSlice {
+  model: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+  pct_of_total: number;
+}
+
+/** One data point in a token-usage time series — GET /usage/time-series?period=24h|7d|30d
+ *
+ * - 24h → hourly buckets; 7d / 30d → daily buckets
+ * - bucket is an ISO datetime string (from PostgreSQL date_trunc)
+ */
+export interface UsageTimePoint {
+  bucket: string;
+  tokens_input: number;
+  tokens_output: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+/** Monthly cost projection — GET /usage/projection */
+export interface UsageProjection {
+  total_cost_7d: number;
+  avg_daily_cost_usd: number;
+  projected_monthly_cost_usd: number;
+  basis_days: number;
+}
+
+/** Cache efficiency stats — GET /usage/cache-efficiency?period=24h|7d|30d */
+export interface CacheEfficiencyResponse {
+  cache_hit_rate: number;
+  tokens_cache_read: number;
+  tokens_cache_write: number;
+  tokens_input: number;
+  cost_saved_by_cache_usd: number;
+  period: string;
+}
+
+/** Individual inference session for the sessions table (mock-mode only — no real backend endpoint) */
 export interface UsageSession {
   id: string;
-  agent_id: string;
-  agent_name: string;
+  agent_slug: string;
   started_at: string;
   ended_at: string | null;
   tokens_input: number;
@@ -1292,20 +1341,4 @@ export interface UsageSession {
   total_tokens: number;
   cost: number;
   model: string;
-}
-
-/** One data point in a token-usage time series (hourly or daily) */
-export interface UsageTimePoint {
-  timestamp: string;
-  tokens_input: number;
-  tokens_output: number;
-  tokens_cache: number;
-}
-
-/** A model's share of overall token usage for the donut chart */
-export interface ModelUsageSlice {
-  model: string;
-  tokens: number;
-  cost: number;
-  percentage: number;
 }


### PR DESCRIPTION
The backend team has fully implemented the /usage analytics API (see /data/workspaces/roboco-api/backend/be-dev-1/roboco/services/usage.py and roboco/api/routes/usage.py). The frontend was built against a different earlier draft. You need to update the following files in panel/src/:

**1. src/types/index.ts — Update TS interfaces:**
- Replace `TokenUsageSnapshot` → `UsageSummary` with fields: `tokens_input`, `tokens_output`, `total_tokens`, `total_cost_usd`, `trend_pct`, `period`
- Replace `AgentUsageRow` → fields: `agent_slug`, `tokens_input`, `tokens_output`, `total_tokens`, `cost_usd`, `pct_of_total`
- Replace `UsageTimePoint` → fields: `bucket` (ISO string, NOT `timestamp`), `tokens_input`, `tokens_output`, `total_tokens`, `cost_usd`
- Add `TeamUsageRow`: `team`, `tokens_input`, `tokens_output`, `total_tokens`, `cost_usd`, `pct_of_total`
- Add `UsageProjection`: `total_cost_7d`, `avg_daily_cost_usd`, `projected_monthly_cost_usd`, `basis_days`
- Add `CacheEfficiency`: `cache_hit_rate`, `tokens_cache_read`, `tokens_cache_write`, `tokens_input`, `cost_saved_by_cache_usd`, `period`
- Keep `ModelUsageSlice` but update fields to: `model`, `tokens_input`, `tokens_output`, `total_tokens`, `cost_usd`, `pct_of_total`
- Remove `UsageSession` (no backend endpoint for sessions)

**2. src/lib/api/usage.ts — Rewrite usageApi:**
- Map each method to the correct real endpoint:
  - `getUsageSummary(period)` → GET `/usage/summary?period=<period>` (period: '24h'|'7d'|'30d', default '24h')
  - `getTimeSeries(period)` → GET `/usage/time-series?period=<period>`
  - `getByAgent(period)` → GET `/usage/by-agent?period=<period>`
  - `getByTeam(period)` → GET `/usage/by-team?period=<period>`
  - `getByModel(period)` → GET `/usage/by-model?period=<period>`
  - `getProjection()` → GET `/usage/projection`
  - `getCacheEfficiency(period)` → GET `/usage/cache-efficiency?period=<period>`
- Remove: `getUsageSnapshot`, `getAgentUsage`, `getUsageSessions`, `getModelUsage`
- Update ALL mock generators to produce data matching the real backend response shapes (same field names, same types)

**3. src/components/metrics/usage-time-series-chart.tsx:**
- Change all references from `p.timestamp` → `p.bucket` for x-axis labels
- Update prop type from `UsageTimePoint[]` to the updated interface
- Remove `tokens_cache` references (split into `tokens_input`/`tokens_output`/`total_tokens` from backend)

**4. src/components/metrics/agent-usage-chart.tsx:**
- Change `row.agent_id` / `row.agent_name` → `row.agent_slug` (used as both key and label)
- Change `row.tokens_today` → `row.total_tokens` (or tokens_input for breakdown)
- Update sorting and data access

**5. src/components/metrics/team-usage-chart.tsx:**
- Currently aggregates AgentUsageRow[] by `row.team`. Rewrite to accept `TeamUsageRow[]` directly (from /usage/by-team)
- Update prop type

**6. src/components/metrics/model-usage-donut.tsx:**
- Update field access: `s.cost` → `s.cost_usd`, `s.tokens` → `s.total_tokens`, `s.percentage` → `s.pct_of_total`

**7. src/components/metrics/sessions-table.tsx:**
- The /usage/sessions backend endpoint does NOT exist. Remove or stub out the sessions API call.
- Option A (preferred): Adapt SessionsTable to accept `AgentUsageRow[]` or `TeamUsageRow[]` and show a per-agent breakdown instead
- Option B: Replace with an empty/disabled state with a clear TODO comment explaining the missing endpoint
- Either is acceptable; ensure no 404 is thrown in production mode

**8. Find and update any page/hook files** that call the old API methods (likely under src/app/ or src/hooks/) to use the new method names and `period` param instead of `hours`.

**Before i_am_done:**
- Run `pnpm typecheck` — must pass with zero errors
- Run `pnpm lint` — must pass
- Verify mock data generators return data in the same shape as real API responses
- Confirm no component references the old field names (timestamp, agent_id, tokens_today, cost_today, hours query param)

**Key reference files (read these first):**
- Backend service: `/data/workspaces/roboco-api/backend/be-dev-1/roboco/services/usage.py`
- Backend routes: `/data/workspaces/roboco-api/backend/be-dev-1/roboco/api/routes/usage.py`
- Frontend API client: `panel/src/lib/api/usage.ts`
- Frontend types: `panel/src/types/index.ts` (search for TokenUsageSnapshot)
- Chart components: `panel/src/components/metrics/`