### PR TITLE
[2e0759e1] Fix pricing, provider-awareness, lint, write-path binding, tests, and PR description in PR #90 branch

### DIFF
--- a/roboco/agent_sdk/models.py
+++ b/roboco/agent_sdk/models.py
@@ -223,9 +223,7 @@ class TokenReportRequest(BaseModel):
     tokens_cache_read: int = Field(
         default=0, description="Prompt-cache read tokens (charged at reduced rate)"
     )
-    tokens_cache_write: int = Field(
-        default=0, description="Prompt-cache write tokens"
-    )
+    tokens_cache_write: int = Field(default=0, description="Prompt-cache write tokens")
 
 
 class TokenUsageStatus(BaseModel):

--- a/roboco/api/app.py
+++ b/roboco/api/app.py
@@ -36,6 +36,7 @@ from roboco.api.routes.provider import router as provider_router
 from roboco.api.routes.sessions import router as sessions_router
 from roboco.api.routes.stream import router as stream_router
 from roboco.api.routes.tasks import router as tasks_router
+from roboco.api.routes.usage import router as usage_router
 from roboco.api.routes.v1 import do as do_module
 from roboco.api.routes.v1 import flow_auditor as flow_auditor_module
 from roboco.api.routes.v1 import flow_board as flow_board_module
@@ -44,7 +45,6 @@ from roboco.api.routes.v1 import flow_dev as flow_dev_module
 from roboco.api.routes.v1 import flow_doc as flow_doc_module
 from roboco.api.routes.v1 import flow_main_pm as flow_main_pm_module
 from roboco.api.routes.v1 import flow_qa as flow_qa_module
-from roboco.api.routes.usage import router as usage_router
 from roboco.api.routes.work_session import router as work_session_router
 from roboco.api.websocket import router as ws_router
 from roboco.config import settings

--- a/roboco/api/routes/usage.py
+++ b/roboco/api/routes/usage.py
@@ -5,7 +5,7 @@ Provides endpoints for querying token usage metrics across agents,
 teams, and models. Supports period-based queries (24h, 7d, 30d).
 """
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Query
 
@@ -16,6 +16,11 @@ router = APIRouter()
 
 _PeriodType = Literal["24h", "7d", "30d"]
 
+_PeriodQuery = Annotated[
+    _PeriodType,
+    Query(description="Time period: 24h, 7d, 30d"),
+]
+
 
 # =============================================================================
 # SUMMARY
@@ -25,7 +30,7 @@ _PeriodType = Literal["24h", "7d", "30d"]
 @router.get("/summary")
 async def get_usage_summary(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> dict[str, Any]:
     """Return aggregated token usage and cost for the given period.
 
@@ -48,7 +53,7 @@ async def get_usage_summary(
 @router.get("/time-series")
 async def get_usage_time_series(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return bucketed time-series data points.
 
@@ -70,7 +75,7 @@ async def get_usage_time_series(
 @router.get("/by-agent")
 async def get_usage_by_agent(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return per-agent token usage with pct_of_total.
 
@@ -83,7 +88,7 @@ async def get_usage_by_agent(
 @router.get("/by-team")
 async def get_usage_by_team(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return per-team token usage with pct_of_total.
 
@@ -96,7 +101,7 @@ async def get_usage_by_team(
 @router.get("/by-model")
 async def get_usage_by_model(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> list[dict[str, Any]]:
     """Return per-model token usage with pct_of_total.
 
@@ -131,7 +136,7 @@ async def get_usage_projection(
 @router.get("/cache-efficiency")
 async def get_cache_efficiency(
     db: DbSession,
-    period: _PeriodType = Query(default="24h", description="Time period: 24h, 7d, 30d"),
+    period: _PeriodQuery = "24h",
 ) -> dict[str, Any]:
     """Return cache hit rate and estimated savings from prompt caching.
 

--- a/roboco/billing/pricing.py
+++ b/roboco/billing/pricing.py
@@ -5,10 +5,15 @@ Implements per-model USD cost calculation based on Anthropic's published
 pricing. All prices are in USD per 1 million tokens.
 
 Unknown model names return 0.0 without raising so callers don't need to
-guard against missing pricing data.
+guard against missing pricing data.  Self-hosted Ollama models always
+return 0.0 (no API cost) — matched by the ``ollama/`` prefix convention.
 """
 
 from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Per-model pricing table
@@ -24,20 +29,20 @@ from __future__ import annotations
 _PRICING: list[tuple[str, float, float, float, float]] = [
     # (fragment, input/1M, output/1M, cache_read/1M, cache_write/1M)
     # Opus 4 family
-    ("claude-opus-4", 15.00, 75.00, 1.50, 3.75),
+    ("claude-opus-4", 5.00, 25.00, 0.50, 6.25),
     # Sonnet 4 / 3.7 / 3.5 family
     ("claude-sonnet-4", 3.00, 15.00, 0.30, 0.75),
     ("claude-3-7-sonnet", 3.00, 15.00, 0.30, 0.75),
     ("claude-3-5-sonnet", 3.00, 15.00, 0.30, 0.75),
     # Haiku family
-    ("claude-haiku-4", 0.80, 4.00, 0.08, 0.20),
-    ("claude-haiku-3-5", 0.80, 4.00, 0.08, 0.20),
-    ("claude-3-5-haiku", 0.80, 4.00, 0.08, 0.20),
+    ("claude-haiku-4", 1.00, 5.00, 0.10, 1.25),
+    ("claude-haiku-3-5", 1.00, 5.00, 0.10, 1.25),
+    ("claude-3-5-haiku", 1.00, 5.00, 0.10, 1.25),
     ("claude-haiku-3", 0.25, 1.25, 0.025, 0.0625),
     # Short aliases used in ROLE_MODEL_MAP / MODEL_MAP
-    ("opus", 15.00, 75.00, 1.50, 3.75),
+    ("opus", 5.00, 25.00, 0.50, 6.25),
     ("sonnet", 3.00, 15.00, 0.30, 0.75),
-    ("haiku", 0.80, 4.00, 0.08, 0.20),
+    ("haiku", 1.00, 5.00, 0.10, 1.25),
 ]
 
 _MILLION = 1_000_000.0
@@ -54,6 +59,7 @@ def calculate_cost(
 
     Matches the model name against the known pricing table using substring
     search (longest match wins).  Unknown models return 0.0 without raising.
+    Self-hosted Ollama models (``ollama/`` prefix) always return 0.0.
 
     Args:
         model: Model name or short alias (e.g. ``"claude-sonnet-4-6"``,
@@ -72,6 +78,10 @@ def calculate_cost(
 
     lower = model.lower()
 
+    # Self-hosted Ollama models have no API cost.
+    if lower.startswith("ollama/"):
+        return 0.0
+
     # Find the best (longest fragment) match
     best_fragment_len = 0
     best_prices: tuple[float, float, float, float] | None = None
@@ -82,6 +92,7 @@ def calculate_cost(
             best_prices = (inp_price, out_price, cr_price, cw_price)
 
     if best_prices is None:
+        logger.warning("No pricing data found for model", model=model)
         return 0.0
 
     inp_price, out_price, cr_price, cw_price = best_prices

--- a/roboco/events/stream_bus.py
+++ b/roboco/events/stream_bus.py
@@ -236,15 +236,15 @@ class StreamEventBus:
         results = await self._redis.xreadgroup(
             self.group_name,
             self.consumer_name,
-            stream_dict,
+            stream_dict,  # type: ignore[arg-type]
             count=10,
             block=5000,
         )
         if not results:
             return
-        for stream_name, messages in results:
-            for message_id, data in messages:
-                await self._handle_message(stream_name, message_id, data)
+        for stream_name, messages in results:  # type: ignore[str-unpack]
+            for message_id, data in messages:  # type: ignore[str-unpack,union-attr]
+                await self._handle_message(stream_name, message_id, data)  # type: ignore[arg-type]
 
     async def _handle_response_error(
         self, exc: ResponseError, streams: list[str]
@@ -354,8 +354,8 @@ class StreamEventBus:
         )
         if not claimed:
             return 0
-        for claim_id, data in claimed:
-            await self._handle_message(stream, claim_id, data)
+        for claim_id, data in claimed:  # type: ignore[str-unpack]
+            await self._handle_message(stream, claim_id, data)  # type: ignore[arg-type]
         return 1
 
     async def _recover_stream(self, stream: str, idle_time_ms: int) -> int:
@@ -376,9 +376,9 @@ class StreamEventBus:
 
         recovered = 0
         for msg in pending_details:
-            if msg["time_since_delivered"] >= idle_time_ms:
+            if int(msg["time_since_delivered"]) >= idle_time_ms:
                 recovered += await self._claim_and_handle(
-                    stream, msg["message_id"], idle_time_ms
+                    stream, str(msg["message_id"]), idle_time_ms
                 )
         return recovered
 

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3129,7 +3129,7 @@ class AgentOrchestrator:
             try:
                 async with httpx.AsyncClient(timeout=3.0) as client:
                     resp = await client.get(sdk_url)
-                    if resp.status_code == 200:
+                    if resp.status_code == http_status.HTTP_200_OK:
                         data = resp.json()
                         tokens_input = data.get("tokens_input", 0)
                         tokens_output = data.get("tokens_output", 0)
@@ -3240,7 +3240,7 @@ class AgentOrchestrator:
                 sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
                 try:
                     resp = await client.get(sdk_url)
-                    if resp.status_code != 200:
+                    if resp.status_code != http_status.HTTP_200_OK:
                         continue
                     data = resp.json()
                     tokens_input = data.get("tokens_input", 0)
@@ -3249,29 +3249,45 @@ class AgentOrchestrator:
                     tokens_cache_write = data.get("tokens_cache_write", 0)
 
                     # Skip agents with no token usage yet
-                    total = tokens_input + tokens_output + tokens_cache_read + tokens_cache_write
+                    total = (
+                        tokens_input
+                        + tokens_output
+                        + tokens_cache_read
+                        + tokens_cache_write
+                    )
                     if total == 0:
                         continue
 
                     async with session_factory() as db:
                         from sqlalchemy import select, update
 
-                        # Find the open session row
-                        result = await db.execute(
-                            select(AgentSpawnSessionTable)
-                            .where(
-                                AgentSpawnSessionTable.agent_slug == agent_id,
-                                AgentSpawnSessionTable.ended_at.is_(None),
+                        # Prefer a direct lookup by the session UUID captured at
+                        # spawn time; fall back to the agent_slug heuristic for
+                        # instances that pre-date the usage_session_id field.
+                        if instance.usage_session_id is not None:
+                            result = await db.execute(
+                                select(AgentSpawnSessionTable).where(
+                                    AgentSpawnSessionTable.id
+                                    == instance.usage_session_id
+                                )
                             )
-                            .order_by(AgentSpawnSessionTable.started_at.desc())
-                            .limit(1)
-                        )
+                        else:
+                            result = await db.execute(
+                                select(AgentSpawnSessionTable)
+                                .where(
+                                    AgentSpawnSessionTable.agent_slug == agent_id,
+                                    AgentSpawnSessionTable.ended_at.is_(None),
+                                )
+                                .order_by(AgentSpawnSessionTable.started_at.desc())
+                                .limit(1)
+                            )
                         session_row = result.scalar_one_or_none()
                         if session_row is None:
                             continue
 
                         # Insert snapshot
                         from uuid import uuid4 as _uuid4
+
                         snapshot = TokenUsageSnapshotTable(
                             id=_uuid4(),
                             agent_spawn_session_id=session_row.id,
@@ -3313,7 +3329,6 @@ class AgentOrchestrator:
         Errors are caught so a bad rollup doesn't abort the sweeper.
         """
         try:
-            from roboco.billing.pricing import calculate_cost
             from roboco.db.base import get_session_factory
             from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
         except ImportError:
@@ -3321,6 +3336,7 @@ class AgentOrchestrator:
 
         try:
             from uuid import uuid4 as _uuid4
+
             from sqlalchemy import func, select
 
             session_factory = get_session_factory()
@@ -3335,11 +3351,21 @@ class AgentOrchestrator:
                         AgentSpawnSessionTable.agent_slug,
                         AgentSpawnSessionTable.team,
                         AgentSpawnSessionTable.model,
-                        func.sum(AgentSpawnSessionTable.tokens_input).label("tokens_input"),
-                        func.sum(AgentSpawnSessionTable.tokens_output).label("tokens_output"),
-                        func.sum(AgentSpawnSessionTable.tokens_cache_read).label("tokens_cache_read"),
-                        func.sum(AgentSpawnSessionTable.tokens_cache_write).label("tokens_cache_write"),
-                        func.sum(AgentSpawnSessionTable.estimated_cost_usd).label("total_cost_usd"),
+                        func.sum(AgentSpawnSessionTable.tokens_input).label(
+                            "tokens_input"
+                        ),
+                        func.sum(AgentSpawnSessionTable.tokens_output).label(
+                            "tokens_output"
+                        ),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_read).label(
+                            "tokens_cache_read"
+                        ),
+                        func.sum(AgentSpawnSessionTable.tokens_cache_write).label(
+                            "tokens_cache_write"
+                        ),
+                        func.sum(AgentSpawnSessionTable.estimated_cost_usd).label(
+                            "total_cost_usd"
+                        ),
                         func.count(AgentSpawnSessionTable.id).label("session_count"),
                     )
                     .where(
@@ -3381,6 +3407,7 @@ class AgentOrchestrator:
 
                     if existing is not None:
                         from sqlalchemy import update
+
                         await db.execute(
                             update(DailyUsageRollupTable)
                             .where(DailyUsageRollupTable.id == existing.id)

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -9,10 +9,12 @@ and aggregation by agent, team, and model.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
 
 from roboco.db.tables import AgentSpawnSessionTable, DailyUsageRollupTable
 from roboco.services.base import BaseService
@@ -54,11 +56,21 @@ class UsageService(BaseService):
         # Current period totals from closed sessions
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("total_cost_usd"),
             ).where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
@@ -68,7 +80,12 @@ class UsageService(BaseService):
         tokens_input = int(row.tokens_input or 0)
         tokens_output = int(row.tokens_output or 0)
         total_cost = float(row.total_cost_usd or 0.0)
-        total_tokens = tokens_input + tokens_output + int(row.tokens_cache_read or 0) + int(row.tokens_cache_write or 0)
+        total_tokens = (
+            tokens_input
+            + tokens_output
+            + int(row.tokens_cache_read or 0)
+            + int(row.tokens_cache_write or 0)
+        )
 
         # Previous period for trend calculation.
         # Sum all 4 token columns so the comparison is consistent with the
@@ -127,7 +144,7 @@ class UsageService(BaseService):
         cache_write) so it is consistent with get_summary()'s total_tokens
         field — the two sums must match for the same period.
         """
-        start_dt, hours = _parse_period(period)
+        start_dt, _hours = _parse_period(period)
 
         if period == "24h":
             # Hourly buckets
@@ -139,11 +156,21 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 trunc_fn.label("bucket"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
@@ -182,23 +209,41 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 AgentSpawnSessionTable.agent_slug,
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
             )
             .group_by(AgentSpawnSessionTable.agent_slug)
-            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+            .order_by(
+                func.sum(
+                    AgentSpawnSessionTable.tokens_input
+                    + AgentSpawnSessionTable.tokens_output
+                ).desc()
+            )
         )
         rows = result.fetchall()
 
         grand_total = sum(
-            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            int(r.tokens_input or 0)
+            + int(r.tokens_output or 0)
+            + int(r.tokens_cache_read or 0)
+            + int(r.tokens_cache_write or 0)
             for r in rows
         )
         items = []
@@ -215,7 +260,9 @@ class UsageService(BaseService):
                     "tokens_output": to_,
                     "total_tokens": total,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
-                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                    "pct_of_total": round(total / grand_total * 100, 2)
+                    if grand_total > 0
+                    else 0.0,
                 }
             )
         return items
@@ -231,23 +278,41 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 AgentSpawnSessionTable.team,
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
             )
             .group_by(AgentSpawnSessionTable.team)
-            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+            .order_by(
+                func.sum(
+                    AgentSpawnSessionTable.tokens_input
+                    + AgentSpawnSessionTable.tokens_output
+                ).desc()
+            )
         )
         rows = result.fetchall()
 
         grand_total = sum(
-            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            int(r.tokens_input or 0)
+            + int(r.tokens_output or 0)
+            + int(r.tokens_cache_read or 0)
+            + int(r.tokens_cache_write or 0)
             for r in rows
         )
         items = []
@@ -264,7 +329,9 @@ class UsageService(BaseService):
                     "tokens_output": to_,
                     "total_tokens": total,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
-                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                    "pct_of_total": round(total / grand_total * 100, 2)
+                    if grand_total > 0
+                    else 0.0,
                 }
             )
         return items
@@ -280,23 +347,41 @@ class UsageService(BaseService):
         result = await self.session.execute(
             select(
                 AgentSpawnSessionTable.model,
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("cost_usd"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("cost_usd"),
             )
             .where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
             )
             .group_by(AgentSpawnSessionTable.model)
-            .order_by(func.sum(AgentSpawnSessionTable.tokens_input + AgentSpawnSessionTable.tokens_output).desc())
+            .order_by(
+                func.sum(
+                    AgentSpawnSessionTable.tokens_input
+                    + AgentSpawnSessionTable.tokens_output
+                ).desc()
+            )
         )
         rows = result.fetchall()
 
         grand_total = sum(
-            int(r.tokens_input or 0) + int(r.tokens_output or 0) + int(r.tokens_cache_read or 0) + int(r.tokens_cache_write or 0)
+            int(r.tokens_input or 0)
+            + int(r.tokens_output or 0)
+            + int(r.tokens_cache_read or 0)
+            + int(r.tokens_cache_write or 0)
             for r in rows
         )
         items = []
@@ -313,7 +398,9 @@ class UsageService(BaseService):
                     "tokens_output": to_,
                     "total_tokens": total,
                     "cost_usd": round(float(r.cost_usd or 0.0), 6),
-                    "pct_of_total": round(total / grand_total * 100, 2) if grand_total > 0 else 0.0,
+                    "pct_of_total": round(total / grand_total * 100, 2)
+                    if grand_total > 0
+                    else 0.0,
                 }
             )
         return items
@@ -332,8 +419,12 @@ class UsageService(BaseService):
 
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0).label("total_cost_7d"),
-                func.coalesce(func.count(AgentSpawnSessionTable.id), 0).label("session_count"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.estimated_cost_usd), 0.0
+                ).label("total_cost_7d"),
+                func.coalesce(func.count(AgentSpawnSessionTable.id), 0).label(
+                    "session_count"
+                ),
             ).where(
                 AgentSpawnSessionTable.started_at >= seven_days_ago,
                 AgentSpawnSessionTable.ended_at.isnot(None),
@@ -366,10 +457,18 @@ class UsageService(BaseService):
 
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_cache_write), 0).label("tokens_cache_write"),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(AgentSpawnSessionTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(AgentSpawnSessionTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
             ).where(
                 AgentSpawnSessionTable.started_at >= start_dt,
                 AgentSpawnSessionTable.ended_at.isnot(None),
@@ -418,11 +517,21 @@ class UsageService(BaseService):
 
         result = await self.session.execute(
             select(
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_input), 0).label("tokens_input"),
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_output), 0).label("tokens_output"),
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_read), 0).label("tokens_cache_read"),
-                func.coalesce(func.sum(DailyUsageRollupTable.tokens_cache_write), 0).label("tokens_cache_write"),
-                func.coalesce(func.sum(DailyUsageRollupTable.total_cost_usd), 0.0).label("total_cost_usd"),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_input), 0).label(
+                    "tokens_input"
+                ),
+                func.coalesce(func.sum(DailyUsageRollupTable.tokens_output), 0).label(
+                    "tokens_output"
+                ),
+                func.coalesce(
+                    func.sum(DailyUsageRollupTable.tokens_cache_read), 0
+                ).label("tokens_cache_read"),
+                func.coalesce(
+                    func.sum(DailyUsageRollupTable.tokens_cache_write), 0
+                ).label("tokens_cache_write"),
+                func.coalesce(
+                    func.sum(DailyUsageRollupTable.total_cost_usd), 0.0
+                ).label("total_cost_usd"),
             ).where(DailyUsageRollupTable.date == today)
         )
         row = result.one()

--- a/tests/unit/billing/test_pricing.py
+++ b/tests/unit/billing/test_pricing.py
@@ -22,20 +22,20 @@ from roboco.billing.pricing import calculate_cost
 _M = 1_000_000  # 1 million tokens
 
 # Pricing — per-1M USD, matches the _PRICING table in pricing.py
-_OPUS_INPUT = 15.00
-_OPUS_OUTPUT = 75.00
-_OPUS_CACHE_READ = 1.50
-_OPUS_CACHE_WRITE = 3.75
+_OPUS_INPUT = 5.00
+_OPUS_OUTPUT = 25.00
+_OPUS_CACHE_READ = 0.50
+_OPUS_CACHE_WRITE = 6.25
 
 _SONNET_INPUT = 3.00
 _SONNET_OUTPUT = 15.00
 _SONNET_CACHE_READ = 0.30
 _SONNET_CACHE_WRITE = 0.75
 
-_HAIKU_INPUT = 0.80
-_HAIKU_OUTPUT = 4.00
-_HAIKU_CACHE_READ = 0.08
-_HAIKU_CACHE_WRITE = 0.20
+_HAIKU_INPUT = 1.00
+_HAIKU_OUTPUT = 5.00
+_HAIKU_CACHE_READ = 0.10
+_HAIKU_CACHE_WRITE = 1.25
 
 _HAIKU3_INPUT = 0.25  # claude-haiku-3 is cheaper than haiku-3-5 / haiku-4
 
@@ -269,7 +269,7 @@ class TestSubstringMatchPriority:
         """claude-haiku-3 is cheaper than claude-haiku-4 — longest-match wins."""
         haiku3_cost = calculate_cost("claude-haiku-3", tokens_input=_M, tokens_output=0)
         haiku4_cost = calculate_cost("claude-haiku-4", tokens_input=_M, tokens_output=0)
-        # haiku-3 ($0.25/1M) < haiku-4 ($0.80/1M)
+        # haiku-3 ($0.25/1M) < haiku-4 ($1.00/1M)
         assert haiku3_cost < haiku4_cost
 
     def test_non_claude_model_returns_zero(self) -> None:

--- a/tests/unit/runtime/test_orchestrator_write_hooks.py
+++ b/tests/unit/runtime/test_orchestrator_write_hooks.py
@@ -212,8 +212,12 @@ async def test_finalize_spawn_session_success_executes_select_and_update() -> No
     def _handler(_url: str) -> Any:
         return _mock_response(
             200,
-            {"tokens_input": 10, "tokens_output": 20,
-             "tokens_cache_read": 0, "tokens_cache_write": 0},
+            {
+                "tokens_input": 10,
+                "tokens_output": 20,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
         )
 
     session_row = MagicMock()
@@ -363,8 +367,12 @@ async def test_sweep_token_snapshots_skips_zero_token_agents() -> None:
     def _handler(_url: str) -> Any:
         return _mock_response(
             200,
-            {"tokens_input": 0, "tokens_output": 0,
-             "tokens_cache_read": 0, "tokens_cache_write": 0},
+            {
+                "tokens_input": 0,
+                "tokens_output": 0,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
         )
 
     added: list[Any] = []
@@ -401,8 +409,12 @@ async def test_sweep_token_snapshots_per_agent_error_does_not_abort_loop() -> No
             raise httpx.ConnectError("agent-1 unreachable")
         return _mock_response(
             200,
-            {"tokens_input": _LOOP_TI, "tokens_output": _LOOP_TO,
-             "tokens_cache_read": 0, "tokens_cache_write": 0},
+            {
+                "tokens_input": _LOOP_TI,
+                "tokens_output": _LOOP_TO,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
         )
 
     session_row = MagicMock()
@@ -423,3 +435,109 @@ async def test_sweep_token_snapshots_per_agent_error_does_not_abort_loop() -> No
     assert len(added) == 1
     assert added[0].tokens_input == _LOOP_TI
     assert added[0].tokens_output == _LOOP_TO
+
+
+# ---------------------------------------------------------------------------
+# _sweep_daily_rollup — inserts new row when none exists
+# ---------------------------------------------------------------------------
+
+# Token counts for the rollup test
+_ROLLUP_TI = 200
+_ROLLUP_TO = 300
+_ROLLUP_TCR = 20
+_ROLLUP_TCW = 10
+
+
+async def test_sweep_daily_rollup_inserts_new_row() -> None:
+    """When no existing DailyUsageRollupTable row exists, db.add() is called
+    with the correct aggregated token values."""
+    orch = _make_orchestrator()
+
+    # Build a fake aggregate result row
+    agg_row = MagicMock()
+    agg_row.date = "2026-06-10"
+    agg_row.agent_slug = _AGENT_ID
+    agg_row.team = "backend"
+    agg_row.model = "sonnet"
+    agg_row.tokens_input = _ROLLUP_TI
+    agg_row.tokens_output = _ROLLUP_TO
+    agg_row.tokens_cache_read = _ROLLUP_TCR
+    agg_row.tokens_cache_write = _ROLLUP_TCW
+    agg_row.total_cost_usd = 0.0
+    agg_row.session_count = 1
+
+    added: list[Any] = []
+    call_count = 0
+
+    @asynccontextmanager
+    async def _db_context() -> Any:
+        nonlocal call_count
+
+        db = MagicMock()
+        db.commit = AsyncMock()
+
+        def _add(obj: Any) -> None:
+            added.append(obj)
+
+        db.add = _add
+
+        async def _exec(_stmt: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # First call: aggregate SELECT — return one agg_row via fetchall()
+                result.fetchall = MagicMock(return_value=[agg_row])
+                result.scalar_one_or_none = MagicMock(return_value=None)
+            else:
+                # Second call: lookup SELECT for existing row — return None
+                result.fetchall = MagicMock(return_value=[])
+                result.scalar_one_or_none = MagicMock(return_value=None)
+            return result
+
+        db.execute = AsyncMock(side_effect=_exec)
+        yield db
+
+    with patch("roboco.db.base.get_session_factory", return_value=_db_context):
+        await orch._sweep_daily_rollup()
+
+    # Exactly one new DailyUsageRollupTable row must have been added
+    assert len(added) == 1
+    row = added[0]
+    assert row.tokens_input == _ROLLUP_TI
+    assert row.tokens_output == _ROLLUP_TO
+    assert row.tokens_cache_read == _ROLLUP_TCR
+    assert row.tokens_cache_write == _ROLLUP_TCW
+
+
+# ---------------------------------------------------------------------------
+# stop_agent — _finalize_spawn_session is awaited before acquiring the lock
+# ---------------------------------------------------------------------------
+
+
+async def test_stop_agent_finalizes_before_lock() -> None:
+    """stop_agent awaits _finalize_spawn_session when the instance has a
+    running container_id (the finalization must happen before the lock)."""
+    orch = _make_orchestrator()
+    instance = _make_instance(_AGENT_ID)
+    instance.container_id = "abc123def456"  # non-None → finalize must be called
+    orch._instances[_AGENT_ID] = instance
+
+    finalized: list[str] = []
+
+    async def _fake_finalize(agent_id: str, exit_reason: str = "stopped") -> None:  # noqa: ARG001
+        finalized.append(agent_id)
+
+    # Stub out the Docker subprocess so stop_agent doesn't actually run Docker
+    mock_proc = MagicMock()
+    mock_proc.wait = AsyncMock()
+
+    with (
+        patch.object(orch, "_finalize_spawn_session", side_effect=_fake_finalize),
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)),
+        patch.object(orch, "_remove_container", AsyncMock()),
+    ):
+        await orch.stop_agent(_AGENT_ID, graceful=True)
+
+    # _finalize_spawn_session must have been called exactly once with our agent id
+    assert finalized == [_AGENT_ID]

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -12,6 +12,7 @@ verify the arithmetic / logic of each analytics method:
 
 from __future__ import annotations
 
+import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -223,9 +224,8 @@ class TestGetTimeSeries:
         for the same period.  The old implementation used ti + to_ (without
         cache), which violated this constraint whenever cache tokens were non-zero.
         """
-        import datetime
 
-        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.UTC)
         row = _make_row(
             bucket=bucket_dt,
             tokens_input=_TS_INPUT,
@@ -242,9 +242,8 @@ class TestGetTimeSeries:
     @pytest.mark.asyncio
     async def test_total_tokens_without_cache_still_correct(self) -> None:
         """When cache tokens are zero, total_tokens == tokens_input + tokens_output."""
-        import datetime
 
-        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.UTC)
         row = _make_row(
             bucket=bucket_dt,
             tokens_input=_TS_INPUT,
@@ -267,9 +266,8 @@ class TestGetTimeSeries:
     async def test_point_contains_required_fields(self) -> None:
         """Each time-series point must have bucket, tokens_input, tokens_output,
         total_tokens, and cost_usd fields."""
-        import datetime
 
-        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.timezone.utc)
+        bucket_dt = datetime.datetime(2026, 6, 9, 12, 0, 0, tzinfo=datetime.UTC)
         row = _make_row(
             bucket=bucket_dt,
             tokens_input=100,
@@ -282,7 +280,13 @@ class TestGetTimeSeries:
         result = await svc.get_time_series("24h")
         assert len(result) == 1
         point = result[0]
-        for field in ("bucket", "tokens_input", "tokens_output", "total_tokens", "cost_usd"):
+        for field in (
+            "bucket",
+            "tokens_input",
+            "tokens_output",
+            "total_tokens",
+            "cost_usd",
+        ):
             assert field in point, f"Missing field: {field}"
 
 


### PR DESCRIPTION
Apply all 8 revision criteria identified in the PR #90 exhaustive review (2026-06-10). The work targets 4 files on the feature/main_pm/499f9eb1 branch. Your workspace already has this branch checked out.

## Exact changes required

### 1. roboco/billing/pricing.py — Pricing fixes + provider-awareness

**Fix Opus pricing (BLOCKER F-P1):**
- Line 27: `("claude-opus-4", 15.00, 75.00, 1.50, 3.75)` → `("claude-opus-4", 5.00, 25.00, 0.50, 6.25)`
- Line 38: `("opus", 15.00, 75.00, 1.50, 3.75)` → `("opus", 5.00, 25.00, 0.50, 6.25)`

**Fix Haiku pricing (F-P2):**
- Line 33: `("claude-haiku-4", 0.80, 4.00, 0.08, 0.20)` → `("claude-haiku-4", 1.00, 5.00, 0.10, 1.25)`
- Line 34: `("claude-haiku-3-5", 0.80, 4.00, 0.08, 0.20)` → `("claude-haiku-3-5", 1.00, 5.00, 0.10, 1.25)`
- Line 35: `("claude-3-5-haiku", 0.80, 4.00, 0.08, 0.20)` → `("claude-3-5-haiku", 1.00, 5.00, 0.10, 1.25)`
- Line 40: `("haiku", 0.80, 4.00, 0.08, 0.20)` → `("haiku", 1.00, 5.00, 0.10, 1.25)`

**Provider-awareness:** Add an `_OLLAMA_FREE` set for known self-hosted model name fragments and add a logger.warning call when no match is found for a non-empty model string. The safest minimal implementation: (a) add Ollama self-hosted model entries to `_PRICING` with all-zero rates so they return $0.0 intentionally (e.g., `("ollama/", 0.0, 0.0, 0.0, 0.0)` to match any `ollama/` prefix), and (b) replace the silent `return 0.0` at line 84-85 with a `logger.warning("Unknown model pricing, returning 0.0", model=model)` before returning 0.0. This satisfies: local Ollama=$0, warning on unpriced. For Ollama Cloud, add a note comment that cloud rates can be added when needed; for now the `ollama/` prefix entry covers local models at $0.

### 2. roboco/api/app.py — Import sort (F-R1, ruff I001 BLOCKER)

Move line 47 (`from roboco.api.routes.usage import router as usage_router`) to immediately before the `routes.v1` block — between the `tasks_router` import (currently line 38) and the first `v1` import (currently line 39). Result:
```python
from roboco.api.routes.tasks import router as tasks_router
from roboco.api.routes.usage import router as usage_router
from roboco.api.routes.v1 import do as do_module
```

### 3. roboco/runtime/orchestrator.py — Lint fixes + usage_session_id binding

**Fix F-R3 (unused import, ruff F401 gate failure):** Delete line 3316:
`from roboco.billing.pricing import calculate_cost`
from inside `_sweep_daily_rollup`. The function reads `total_cost = float(row.total_cost_usd or 0.0)` directly; it never calls `calculate_cost`.

**Fix F-R2 (isort violation, ruff I001 gate failure):** Lines 3323-3324 inside `_sweep_daily_rollup` have stdlib and third-party imports mixed. Add a blank line between them:
```python
from uuid import uuid4 as _uuid4

from sqlalchemy import func, select
```

**Fix F-B1 (usage_session_id binding):** In `_sweep_token_snapshots`, replace the heuristic-only SELECT (lines 3259-3268) with an id-first lookup with heuristic fallback:
```python
# Find the open session row — prefer bound usage_session_id, fall back to heuristic
if instance.usage_session_id is not None:
    result = await db.execute(
        select(AgentSpawnSessionTable)
        .where(AgentSpawnSessionTable.id == instance.usage_session_id)
    )
else:
    result = await db.execute(
        select(AgentSpawnSessionTable)
        .where(
            AgentSpawnSessionTable.agent_slug == agent_id,
            AgentSpawnSessionTable.ended_at.is_(None),
        )
        .order_by(AgentSpawnSessionTable.started_at.desc())
        .limit(1)
    )
```

### 4. tests/unit/runtime/test_orchestrator_write_hooks.py — New test coverage (F-T1, F-T2)

Add the following two test functions:

**test_sweep_daily_rollup_inserts_new_row (F-T1):** Mock `get_session_factory` with a DB that returns a populated `fetchall()` result and `scalar_one_or_none()` returning None (no existing row). Call `await orch._sweep_daily_rollup()`. Assert `db.add()` was called with a `DailyUsageRollupTable` instance carrying the expected summed token values. The mock `fetchall()` must return a list with one row that has `.date`, `.agent_slug`, `.team`, `.model`, `.tokens_input`, `.tokens_output`, `.tokens_cache_read`, `.tokens_cache_write`, `.total_cost_usd`, `.session_count` attributes.

**test_stop_agent_finalizes_before_lock (F-T2):** Register an ACTIVE instance in `orch._instances`. Patch `_finalize_spawn_session` as an AsyncMock. Also patch `asyncio.create_subprocess_exec` to return a mock with `wait` as an AsyncMock. Patch `roboco.db.base.get_session_factory` for the lock-holding DB ops. Call `await orch.stop_agent(_AGENT_ID, exit_reason="stopped")`. Assert that `orch._finalize_spawn_session` was awaited exactly once. The key invariant is that finalize is called before `async with self._lock` — verify this by checking finalize is called without the lock being held (the mock doesn't need to test lock state directly; calling without error is sufficient since the actual lock-ordering is a code-structure guarantee).

### 5. PR description correction (F-FQ1)

Update the PR #90 description (PR number 90) using the `pr_update` verb: remove all claims about `USAGE_SNAPSHOT`/`USAGE_SESSION_END` EventType entries, WebSocket bridge subscriptions, and "real-time within seconds." Replace with: "Usage dashboard polls every 30–120 seconds. WebSocket real-time events are not implemented in this PR; polling is the intentional design."

### 6. Final gate

Run `make quality` (or: `uv run ruff format . && uv run ruff check . && uv run mypy roboco/ && uv run pytest`) and verify zero errors before calling `i_am_done`.