### PR TITLE
[462e52b2] Frontend: Persistent rate-limit banner, store, and WebSocket integration

### DIFF
--- a/panel/src/app/(dashboard)/layout.tsx
+++ b/panel/src/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { Sidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import { ScrollRestoration } from "@/components/scroll-restoration";
+import { RateLimitBanner } from "@/components/rate-limit/rate-limit-banner";
 
 export default function DashboardLayout({
   children,
@@ -13,6 +14,7 @@ export default function DashboardLayout({
       <Sidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header />
+        <RateLimitBanner />
         <main className="flex-1 overflow-auto bg-muted/30 p-6">
           <Suspense fallback={null}>
             <ScrollRestoration />

--- a/panel/src/components/rate-limit/rate-limit-banner.tsx
+++ b/panel/src/components/rate-limit/rate-limit-banner.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { AlertTriangle } from "lucide-react";
+import { useRateLimitStore } from "@/store/rate-limit-store";
+import { useRateLimitSync } from "@/hooks/use-rate-limit-sync";
+import { useRateLimitWebSocket } from "@/hooks/use-rate-limit-websocket";
+import type { RateLimitEntry } from "@/types/rate-limits";
+
+// =============================================================================
+// Countdown row for a single rate-limited provider
+// =============================================================================
+
+function computeSecondsLeft(resumeAt: string): number {
+  return Math.max(
+    0,
+    Math.ceil((new Date(resumeAt).getTime() - Date.now()) / 1000)
+  );
+}
+
+function RateLimitRow({ entry }: { entry: RateLimitEntry }) {
+  const resumeAt = entry.resumeAt;
+  const [secondsLeft, setSecondsLeft] = useState(() =>
+    computeSecondsLeft(resumeAt)
+  );
+
+  useEffect(() => {
+    // Tick every second; re-runs when resumeAt changes (re-hit same provider)
+    const id = setInterval(() => {
+      setSecondsLeft(computeSecondsLeft(resumeAt));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [resumeAt]);
+
+  const agentCount = entry.affectedAgents.length;
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 bg-amber-50 border-b border-amber-300 last:border-b-0">
+      <AlertTriangle className="h-4 w-4 text-amber-600 shrink-0" />
+      <span className="text-sm font-medium text-amber-900">
+        {entry.provider}
+      </span>
+      {agentCount > 0 && (
+        <span className="text-sm text-amber-700">
+          {agentCount} agent{agentCount !== 1 ? "s" : ""} affected
+        </span>
+      )}
+      <span className="text-sm text-amber-700">
+        {secondsLeft}s
+      </span>
+      <span className="text-sm text-amber-800 font-medium ml-auto">
+        operations paused — resuming automatically
+      </span>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main banner component
+// =============================================================================
+
+export function RateLimitBanner() {
+  const limits = useRateLimitStore((state) => state.limits);
+
+  // Sync hook — calls GET /api/system/rate-limits on mount and exposes sync()
+  const { sync } = useRateLimitSync();
+
+  // Called when the WS reconnects — re-sync state from API
+  const handleReconnect = useCallback(() => {
+    void sync();
+  }, [sync]);
+
+  // WS hook — subscribes to RATE_LIMIT_HIT / RATE_LIMIT_LIFTED events
+  useRateLimitWebSocket({ onReconnect: handleReconnect });
+
+  // Nothing to show when no providers are rate-limited
+  if (limits.size === 0) {
+    return null;
+  }
+
+  const entries = Array.from(limits.values());
+
+  return (
+    <div
+      className="border-b border-amber-300 bg-amber-50"
+      role="alert"
+      aria-live="polite"
+      aria-label="Rate limit notifications"
+    >
+      {entries.map((entry) => (
+        <RateLimitRow key={entry.provider} entry={entry} />
+      ))}
+    </div>
+  );
+}

--- a/panel/src/hooks/index.ts
+++ b/panel/src/hooks/index.ts
@@ -1,4 +1,6 @@
 export * from "./use-tasks";
+export * from "./use-rate-limit-websocket";
+export * from "./use-rate-limit-sync";
 export * from "./use-agents";
 export * from "./use-channels";
 export * from "./use-notifications";

--- a/panel/src/hooks/use-rate-limit-sync.ts
+++ b/panel/src/hooks/use-rate-limit-sync.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useCallback } from "react";
+import { rateLimitsApi } from "@/lib/api/rate-limits";
+import { useRateLimitStore } from "@/store/rate-limit-store";
+
+/**
+ * Calls GET /api/system/rate-limits on mount and passes results to syncFromApi.
+ * Is a no-op (with console.warn) when the endpoint is unavailable.
+ * Also exposes a sync() function that can be called on WS reconnect.
+ */
+export function useRateLimitSync() {
+  const { syncFromApi } = useRateLimitStore();
+
+  const sync = useCallback(async () => {
+    try {
+      const response = await rateLimitsApi.getRateLimits();
+      syncFromApi(response);
+    } catch (err) {
+      // Endpoint unavailable — treat as no-op per acceptance criteria
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      if (status === 404) {
+        console.warn("[rate-limits] GET /api/system/rate-limits returned 404 — endpoint not available");
+      } else {
+        console.warn("[rate-limits] GET /api/system/rate-limits unavailable:", err);
+      }
+    }
+  }, [syncFromApi]);
+
+  // Sync on mount
+  useEffect(() => {
+    void sync();
+  }, [sync]);
+
+  return { sync };
+}

--- a/panel/src/hooks/use-rate-limit-websocket.ts
+++ b/panel/src/hooks/use-rate-limit-websocket.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useWebSocket } from "./use-websocket";
+import { useRateLimitStore } from "@/store/rate-limit-store";
+import type { RateLimitHitEvent, RateLimitLiftedEvent } from "@/types/rate-limits";
+
+interface RateLimitWsMessage {
+  type: string;
+  provider?: string;
+  affectedAgents?: string[];
+  retryAfterSeconds?: number;
+  timestamp?: string;
+}
+
+interface UseRateLimitWebSocketOptions {
+  /** Called when the WebSocket reconnects after a disconnect */
+  onReconnect?: () => void;
+}
+
+/**
+ * Subscribes to RATE_LIMIT_HIT and RATE_LIMIT_LIFTED WebSocket events and
+ * dispatches them to the useRateLimitStore. Accepts an optional onReconnect
+ * callback that fires when the connection recovers from a reconnecting state.
+ */
+export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}) {
+  const { onReconnect } = options;
+  const prevStateRef = useRef<string | null>(null);
+
+  const { state, lastMessage } = useWebSocket<RateLimitWsMessage>(
+    "/ws/system",
+    undefined,
+    true
+  );
+
+  // Fire onReconnect when state transitions from reconnecting → connected
+  useEffect(() => {
+    if (prevStateRef.current === "reconnecting" && state === "connected") {
+      onReconnect?.();
+    }
+    prevStateRef.current = state;
+  }, [state, onReconnect]);
+
+  // Handle incoming WS messages
+  useEffect(() => {
+    if (!lastMessage) return;
+
+    const { hitRateLimit, liftRateLimit } = useRateLimitStore.getState();
+
+    if (lastMessage.type === "RATE_LIMIT_HIT") {
+      const event: RateLimitHitEvent = {
+        type: "RATE_LIMIT_HIT",
+        provider: lastMessage.provider ?? "unknown",
+        affectedAgents: lastMessage.affectedAgents ?? [],
+        retryAfterSeconds: lastMessage.retryAfterSeconds ?? 60,
+        timestamp: lastMessage.timestamp ?? new Date().toISOString(),
+      };
+      hitRateLimit(event);
+    } else if (lastMessage.type === "RATE_LIMIT_LIFTED") {
+      const event: RateLimitLiftedEvent = {
+        type: "RATE_LIMIT_LIFTED",
+        provider: lastMessage.provider ?? "unknown",
+        timestamp: lastMessage.timestamp ?? new Date().toISOString(),
+      };
+      liftRateLimit(event);
+    }
+  }, [lastMessage]);
+
+  return { wsState: state };
+}

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -1,5 +1,17 @@
 import axios, { AxiosInstance, AxiosError } from "axios";
+import { toast } from "sonner";
 import { API_URL, CEO_AGENT_ID, CEO_ROLE } from "@/lib/constants";
+import { useRateLimitStore } from "@/store/rate-limit-store";
+import type { RateLimitHitEvent } from "@/types/rate-limits";
+
+// Custom Axios config extension for retry tracking
+declare module "axios" {
+  interface InternalAxiosRequestConfig {
+    _retryCount?: number;
+  }
+}
+
+const RATE_LIMIT_MAX_RETRIES = 3;
 
 // Create axios instance with default config
 const api: AxiosInstance = axios.create({
@@ -46,6 +58,46 @@ api.interceptors.response.use(
     const method = error.config?.method?.toUpperCase();
     const errorData = error.response?.data as Record<string, unknown> | undefined;
     const errorDetail = errorData?.detail || error.message;
+
+    // -------------------------------------------------------------------------
+    // 429 Rate-limit handling — FIRST side-effect, before any other logic
+    // -------------------------------------------------------------------------
+    if (status === 429) {
+      const retryAfterHeader = error.response?.headers?.["retry-after"];
+      const retryAfterSeconds = retryAfterHeader ? parseInt(String(retryAfterHeader), 10) : 60;
+      const safeRetryAfter = isNaN(retryAfterSeconds) ? 60 : retryAfterSeconds;
+
+      // Extract provider from custom header or fall back to URL path heuristics
+      const providerHeader = error.response?.headers?.["x-provider"];
+      const urlProvider = url
+        ? (["anthropic", "openai", "ollama"].find((p) => url.includes(p)) ?? "unknown")
+        : "unknown";
+      const provider = (providerHeader as string | undefined) ?? urlProvider;
+
+      // Dispatch to store as first side-effect
+      const hitEvent: RateLimitHitEvent = {
+        type: "RATE_LIMIT_HIT",
+        provider,
+        affectedAgents: [],
+        retryAfterSeconds: safeRetryAfter,
+        timestamp: new Date().toISOString(),
+      };
+      useRateLimitStore.getState().hitRateLimit(hitEvent);
+
+      // Track retry count; retry the request until exhausted, then toast
+      const retryCount = (error.config?._retryCount ?? 0) + 1;
+      if (error.config) {
+        error.config._retryCount = retryCount;
+        if (retryCount < RATE_LIMIT_MAX_RETRIES) {
+          // Retry the request — interceptor re-runs on each subsequent 429
+          return api(error.config);
+        }
+      }
+      // Retries exhausted — notify the user via Sonner toast
+      toast.warning(
+        `Rate limited by ${provider}. The system has paused operations and will resume automatically in ~${safeRetryAfter}s.`
+      );
+    }
 
     // Log comprehensive error info
     console.error(`[API] ✗ ${method} ${url}`, {

--- a/panel/src/lib/api/rate-limits.ts
+++ b/panel/src/lib/api/rate-limits.ts
@@ -1,0 +1,18 @@
+import api from "./client";
+import type { RateLimitApiResponse } from "@/types/rate-limits";
+import { isMockMode } from "@/lib/mock-data";
+
+export const rateLimitsApi = {
+  /**
+   * GET /api/system/rate-limits — fetch active rate limits on page load or WS reconnect.
+   * Returns empty list in mock mode (rate limits are a real-backend-only concern).
+   */
+  getRateLimits: async (): Promise<RateLimitApiResponse> => {
+    if (isMockMode()) {
+      console.warn("[rate-limits] isMockMode: skipping GET /api/system/rate-limits");
+      return { entries: [] };
+    }
+    const { data } = await api.get<RateLimitApiResponse>("/system/rate-limits");
+    return data;
+  },
+};

--- a/panel/src/store/index.ts
+++ b/panel/src/store/index.ts
@@ -1,2 +1,3 @@
 export { useUIStore } from "./ui-store";
 export { useNotificationStore } from "./notifications-store";
+export { useRateLimitStore } from "./rate-limit-store";

--- a/panel/src/store/rate-limit-store.ts
+++ b/panel/src/store/rate-limit-store.ts
@@ -1,0 +1,53 @@
+import { create } from "zustand";
+import type {
+  RateLimitEntry,
+  RateLimitHitEvent,
+  RateLimitLiftedEvent,
+  RateLimitApiResponse,
+} from "@/types/rate-limits";
+
+interface RateLimitState {
+  /** Active rate limits keyed by provider name */
+  limits: Map<string, RateLimitEntry>;
+
+  // Actions
+  hitRateLimit: (event: RateLimitHitEvent) => void;
+  liftRateLimit: (event: RateLimitLiftedEvent) => void;
+  syncFromApi: (response: RateLimitApiResponse) => void;
+}
+
+export const useRateLimitStore = create<RateLimitState>((set) => ({
+  limits: new Map<string, RateLimitEntry>(),
+
+  hitRateLimit: (event: RateLimitHitEvent) =>
+    set((state) => {
+      const next = new Map(state.limits);
+      const entry: RateLimitEntry = {
+        provider: event.provider,
+        affectedAgents: event.affectedAgents,
+        hitAt: event.timestamp,
+        resumeAt: new Date(
+          new Date(event.timestamp).getTime() + event.retryAfterSeconds * 1000
+        ).toISOString(),
+        retryAfterSeconds: event.retryAfterSeconds,
+      };
+      next.set(event.provider, entry);
+      return { limits: next };
+    }),
+
+  liftRateLimit: (event: RateLimitLiftedEvent) =>
+    set((state) => {
+      const next = new Map(state.limits);
+      next.delete(event.provider);
+      return { limits: next };
+    }),
+
+  syncFromApi: (response: RateLimitApiResponse) =>
+    set(() => {
+      const next = new Map<string, RateLimitEntry>();
+      for (const entry of response.entries) {
+        next.set(entry.provider, entry);
+      }
+      return { limits: next };
+    }),
+}));

--- a/panel/src/types/rate-limits.ts
+++ b/panel/src/types/rate-limits.ts
@@ -1,0 +1,53 @@
+// =============================================================================
+// RATE LIMIT TYPES
+// =============================================================================
+
+/**
+ * Represents an active rate-limit entry for a provider.
+ * Stored in the Zustand store keyed by provider name.
+ */
+export interface RateLimitEntry {
+  /** The AI provider that is rate-limited (e.g. "anthropic", "openai") */
+  provider: string;
+  /** Agent slugs affected by this rate limit */
+  affectedAgents: string[];
+  /** ISO timestamp when the rate limit was hit */
+  hitAt: string;
+  /** ISO timestamp when the rate limit is expected to lift (hitAt + retryAfterSeconds) */
+  resumeAt: string;
+  /** How many seconds until operations resume */
+  retryAfterSeconds: number;
+}
+
+/**
+ * WebSocket event emitted when a rate limit is triggered.
+ */
+export interface RateLimitHitEvent {
+  type: "RATE_LIMIT_HIT";
+  /** The AI provider being rate-limited */
+  provider: string;
+  /** Agent slugs affected */
+  affectedAgents: string[];
+  /** How many seconds to wait before retrying */
+  retryAfterSeconds: number;
+  /** ISO timestamp of the event */
+  timestamp: string;
+}
+
+/**
+ * WebSocket event emitted when a rate limit is cleared.
+ */
+export interface RateLimitLiftedEvent {
+  type: "RATE_LIMIT_LIFTED";
+  /** The AI provider whose rate limit has been lifted */
+  provider: string;
+  /** ISO timestamp of the event */
+  timestamp: string;
+}
+
+/**
+ * Response shape from GET /api/system/rate-limits
+ */
+export interface RateLimitApiResponse {
+  entries: RateLimitEntry[];
+}


### PR DESCRIPTION
Goal: Give the CEO real-time visibility into provider rate limits via a persistent amber banner in the panel, with automatic appearance/dismissal driven by backend WebSocket events and an HTTP sync endpoint.

Constraints and context from HoM review (these are MUST-HAVES, not suggestions):
- This is the FIRST persistent banner component in the panel — it sets the design precedent for future operational banners (provider outage, maintenance mode, etc.).
- Banner copy: show (a) provider name, (b) affected agent count, (c) live countdown to estimated_lift_at, (d) explicit 'operations paused — resuming automatically' status. Example: 'Anthropic rate limited — 4 agents paused, resuming in ~45s'.
- Banner visual: Amber/warning color (NOT red/error — system is handling it). Fixed position between nav and content. Stack with shared container when both providers are limited simultaneously.
- Banner appearance SLA: must render within 2 seconds of backend detection.
- Banner is NOT user-dismissible — it represents operational state. Auto-dismiss on RATE_LIMIT_LIFTED event.
- Zustand rate-limit store fed by BOTH WebSocket (RATE_LIMIT_HIT/RATE_LIMIT_LIFTED events) and Axios 429 interceptor — both paths write same store, no dual-state bugs.
- Sonner error toast on exhausted retries with specific copy: 'Rate limited by {Provider}. The system has paused operations and will resume automatically in ~{N}s.'
- Page load/reconnect sync via GET /api/system/rate-limits — banner must reappear immediately from HTTP response, not wait for WebSocket.
- The Axios 429 interceptor is the first side-effect in the API client error path — document it as a pattern.