### PR TITLE
[4112cd34] RateLimitError class and 5-retry exponential backoff at all LLM call sites

### DIFF
--- a/roboco/api/middleware.py
+++ b/roboco/api/middleware.py
@@ -41,6 +41,7 @@ from roboco.services.base import (
 from roboco.services.base import (
     ValidationError as ServiceValidationError,
 )
+from roboco.services.exceptions import RateLimitError
 
 logger = structlog.get_logger()
 
@@ -227,6 +228,42 @@ async def service_exception_handler(request: Request, exc: Exception) -> JSONRes
     )
 
 
+async def rate_limit_exception_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    """Handle :class:`~roboco.services.exceptions.RateLimitError`.
+
+    Returns HTTP 429 with a ``Retry-After`` response header (when available)
+    and a structured JSON body so API consumers can back off gracefully.
+    """
+    rl_exc = cast("RateLimitError", exc)
+    correlation_id = getattr(request.state, "correlation_id", None)
+
+    logger.warning(
+        "LLM rate limit exhausted",
+        provider=rl_exc.provider,
+        retry_after=rl_exc.retry_after,
+    )
+
+    content: dict = {
+        "error": "rate_limit_exceeded",
+        "provider": rl_exc.provider,
+        "message": str(rl_exc),
+    }
+    if correlation_id:
+        content["correlation_id"] = correlation_id
+
+    headers: dict[str, str] = {}
+    if rl_exc.retry_after is not None:
+        headers["Retry-After"] = str(int(rl_exc.retry_after))
+
+    return JSONResponse(
+        status_code=429,
+        content=content,
+        headers=headers,
+    )
+
+
 async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Handle unexpected exceptions."""
     correlation_id = getattr(request.state, "correlation_id", None)
@@ -376,6 +413,7 @@ def setup_middleware(app: FastAPI) -> None:
     app.add_exception_handler(HTTPException, http_exception_handler)
     app.add_exception_handler(RobocoError, roboco_exception_handler)
     app.add_exception_handler(ServiceError, service_exception_handler)
+    app.add_exception_handler(RateLimitError, rate_limit_exception_handler)
     app.add_exception_handler(Exception, generic_exception_handler)
 
     # Middleware (added in reverse order due to LIFO)

--- a/roboco/services/exceptions.py
+++ b/roboco/services/exceptions.py
@@ -1,0 +1,81 @@
+"""
+LLM Service Exceptions
+
+Shared exception types and helpers for LLM provider rate-limit handling.
+Importable from a single location as required by the acceptance criteria.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Maximum number of retries on HTTP 429 / provider RateLimitError.
+MAX_RATE_LIMIT_RETRIES: int = 5
+
+#: HTTP status code for rate limiting.
+HTTP_TOO_MANY_REQUESTS: int = 429
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RateLimitError(Exception):
+    """Raised when an LLM provider returns a 429 rate-limit response after all retries.
+
+    Attributes:
+        provider:    Name of the provider that rate-limited us (``"anthropic"`` /
+                     ``"ollama"``).
+        retry_after: The last ``Retry-After`` value seen (in seconds), or ``None``
+                     if the header was absent.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        retry_after: float | None = None,
+    ) -> None:
+        self.provider = provider
+        self.retry_after = retry_after
+        msg = f"Rate limit exceeded for provider '{provider}'"
+        if retry_after is not None:
+            msg += f"; retry after {retry_after:.1f}s"
+        super().__init__(msg)
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"RateLimitError("
+            f"provider={self.provider!r}, retry_after={self.retry_after!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_retry_after_header(response: httpx.Response) -> float | None:
+    """Extract the ``Retry-After`` header from an httpx response as seconds.
+
+    The header is treated as a plain integer/float number of seconds.  HTTP-date
+    format is not supported (LLM providers invariably use numeric values).
+
+    Returns:
+        Number of seconds to wait, or ``None`` if the header is absent or cannot
+        be parsed as a number.
+    """
+    header = response.headers.get("retry-after")
+    if not header:
+        return None
+    try:
+        return float(header)
+    except (ValueError, TypeError):
+        return None

--- a/roboco/services/extraction.py
+++ b/roboco/services/extraction.py
@@ -312,6 +312,51 @@ class ExtractionService:
 
         return best_type, confidence, matches
 
+    async def _call_anthropic_with_retry(self, client: Any, prompt: str) -> Any:
+        """Call Anthropic messages.create with up to MAX_RATE_LIMIT_RETRIES on 429.
+
+        Raises RateLimitError when all retries are exhausted.
+        """
+        import asyncio
+
+        import anthropic as anthropic_mod
+
+        from roboco.services.exceptions import MAX_RATE_LIMIT_RETRIES, RateLimitError
+
+        last_retry_after: float | None = None
+        for rl_attempt in range(MAX_RATE_LIMIT_RETRIES):
+            try:
+                return await client.messages.create(
+                    model="claude-3-haiku-20240307",  # Fast, cheap
+                    max_tokens=2000,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+            except anthropic_mod.RateLimitError as exc:
+                try:
+                    header = exc.response.headers.get("retry-after")
+                    last_retry_after = float(header) if header else None
+                except (AttributeError, TypeError, ValueError):
+                    last_retry_after = None
+                backoff = (
+                    last_retry_after
+                    if last_retry_after is not None
+                    else float(2**rl_attempt)
+                )
+                self.log.warning(
+                    "Anthropic rate limited (429), retrying",
+                    provider="anthropic",
+                    attempt=rl_attempt + 1,
+                    max_retries=MAX_RATE_LIMIT_RETRIES,
+                    backoff_duration=backoff,
+                )
+                if rl_attempt < MAX_RATE_LIMIT_RETRIES - 1:
+                    await asyncio.sleep(backoff)
+                else:
+                    raise RateLimitError(
+                        provider="anthropic", retry_after=last_retry_after
+                    ) from exc
+        raise RateLimitError(provider="anthropic", retry_after=last_retry_after)
+
     async def extract_with_llm(self, ctx: ExtractionContext) -> ExtractionResult:
         """
         Extract messages using LLM classification.
@@ -319,11 +364,14 @@ class ExtractionService:
         This is more accurate but slower and more expensive.
         Falls back to pattern matching if LLM unavailable.
         Uses TOON format for token-efficient communication.
+        Retries up to MAX_RATE_LIMIT_RETRIES times on 429/RateLimitError,
+        respecting the Retry-After header when present.
         """
         from anthropic import AsyncAnthropic
 
         from roboco.config import settings
         from roboco.llm import ToonAdapter
+        from roboco.services.exceptions import RateLimitError
 
         toon = ToonAdapter()
 
@@ -348,11 +396,7 @@ action,Creating file utils.py,0.95
 
 Output only valid TOON, no other text."""
 
-            response = await client.messages.create(
-                model="claude-3-haiku-20240307",  # Fast, cheap for classification
-                max_tokens=2000,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            response = await self._call_anthropic_with_retry(client, prompt)
 
             # Parse response using TOON (falls back to JSON)
             # Extract text from first TextBlock content
@@ -398,6 +442,8 @@ Output only valid TOON, no other text."""
                 session_id=ctx.session_id,
             )
 
+        except RateLimitError:
+            raise
         except Exception as e:
             # Fall back to pattern matching
             self.log.warning("LLM extraction failed, using patterns", error=str(e))

--- a/roboco/services/optimal_brain/indexes/base.py
+++ b/roboco/services/optimal_brain/indexes/base.py
@@ -17,6 +17,12 @@ from piragi.types import Citation, Document
 
 from roboco.config import settings
 from roboco.models.optimal import IndexType, SearchOutcome, SearchResult
+from roboco.services.exceptions import (
+    HTTP_TOO_MANY_REQUESTS,
+    MAX_RATE_LIMIT_RETRIES,
+    RateLimitError,
+    parse_retry_after_header,
+)
 
 # Apply piragi runtime patches (chunker tokenizer) BEFORE importing piragi
 # itself anywhere in the plugin stack. Importing for side effects only.
@@ -918,19 +924,25 @@ class BaseIndexPlugin(ABC):
         Returns:
             Tuple of (answer, citations). Returns ("", []) on failure
             to allow OptimalService to continue to next index.
+
+        The Ollama LLM call is retried up to MAX_RATE_LIMIT_RETRIES times on
+        HTTP 429, respecting the Retry-After header.  The vector-search phase
+        is NOT retried and still runs inside the 15-second index timeout.
         """
         import asyncio
 
         import httpx
 
-        # Per-index timeout to prevent one slow index from blocking everything
+        # Per-index timeout to prevent one slow index from blocking everything.
+        # Applied to the search phase only; LLM retries run outside this timeout.
         INDEX_TIMEOUT = 15.0
 
         search_results: list[SearchResult] = []
+        prompt: str = ""
 
+        # ---- Search phase (inside timeout) -----------------------------------
         try:
             async with asyncio.timeout(INDEX_TIMEOUT):
-                # First get context using our properly async search
                 logger.info(
                     "ask() starting search",
                     index_type=self.index_type.value,
@@ -947,14 +959,11 @@ class BaseIndexPlugin(ABC):
                 )
 
                 if not search_results:
-                    # Return empty to continue to next index
                     return "", []
 
-                # Build context for LLM
+                # Build context and prompt while still inside the timeout
                 context_texts = [r.content for r in search_results]
                 context = "\n\n---\n\n".join(context_texts)
-
-                # Build prompt
                 prompt = (
                     "You are a technical knowledge base assistant. "
                     "Based on the context, provide a thorough, actionable answer.\n\n"
@@ -969,14 +978,28 @@ class BaseIndexPlugin(ABC):
                     "Detailed Answer:"
                 )
 
-                # Call LLM via Ollama API (async HTTP)
-                llm_url = f"{self.config.llm_base_url}/chat/completions"
-                logger.info(
-                    "ask() calling LLM",
-                    index_type=self.index_type.value,
-                    llm_url=llm_url,
-                    model=self.config.llm_model,
-                )
+        except (TimeoutError, httpx.TimeoutException, Exception) as e:
+            logger.warning(
+                "Index ask() search phase failed",
+                index_type=self.index_type.value,
+                error_type=type(e).__name__,
+                error=str(e) if not isinstance(e, TimeoutError) else "timed out",
+            )
+            return "", search_results
+
+        # ---- LLM call phase with 429 retry (outside index timeout) -----------
+        llm_url = f"{self.config.llm_base_url}/chat/completions"
+        logger.info(
+            "ask() calling LLM",
+            index_type=self.index_type.value,
+            llm_url=llm_url,
+            model=self.config.llm_model,
+        )
+
+        last_rl_retry_after: float | None = None
+
+        for rl_attempt in range(MAX_RATE_LIMIT_RETRIES):
+            try:
                 async with httpx.AsyncClient(timeout=60.0) as client:
                     resp = await client.post(
                         llm_url,
@@ -987,44 +1010,46 @@ class BaseIndexPlugin(ABC):
                             "options": {"num_ctx": 8192},
                         },
                     )
-                    if resp.is_success:
-                        data = resp.json()
-                        answer_text = data["choices"][0]["message"]["content"]
-                        # Extract answer from think tags if needed
-                        answer_text = self._extract_from_think_tags(answer_text)
-                        return answer_text, search_results
-                    else:
-                        logger.warning(
-                            "LLM call failed in ask",
-                            index_type=self.index_type.value,
-                            status=resp.status_code,
-                            error=resp.text[:200] if resp.text else "no error text",
-                        )
-                        # Return empty to let service aggregate and synthesize
-                        return "", search_results
+            except (httpx.TimeoutException, Exception) as e:
+                logger.warning(
+                    "LLM call failed in ask (non-429)",
+                    index_type=self.index_type.value,
+                    error=str(e),
+                )
+                return "", search_results
 
-        except TimeoutError:
-            logger.warning(
-                "Index ask() timed out",
-                index_type=self.index_type.value,
-                timeout=INDEX_TIMEOUT,
-            )
-            # Return search results even on timeout - service can aggregate them
-            return "", search_results
-        except httpx.TimeoutException:
-            logger.warning(
-                "LLM HTTP call timed out in ask",
-                index_type=self.index_type.value,
-            )
-            return "", search_results
-        except Exception as e:
-            logger.warning(
-                "RAG query failed",
-                index_type=self.index_type.value,
-                error=str(e),
-            )
-            # Return whatever search results we have for aggregation
-            return "", search_results
+            if resp.status_code == HTTP_TOO_MANY_REQUESTS:
+                retry_after = parse_retry_after_header(resp)
+                last_rl_retry_after = retry_after
+                backoff = (
+                    retry_after if retry_after is not None else float(2**rl_attempt)
+                )
+                logger.warning(
+                    "Ollama rate limited (429), retrying",
+                    provider="ollama",
+                    attempt=rl_attempt + 1,
+                    max_retries=MAX_RATE_LIMIT_RETRIES,
+                    backoff_duration=backoff,
+                )
+                if rl_attempt < MAX_RATE_LIMIT_RETRIES - 1:
+                    await asyncio.sleep(backoff)
+                continue
+
+            if resp.is_success:
+                data = resp.json()
+                answer_text = data["choices"][0]["message"]["content"]
+                answer_text = self._extract_from_think_tags(answer_text)
+                return answer_text, search_results
+            else:
+                logger.warning(
+                    "LLM call failed in ask",
+                    index_type=self.index_type.value,
+                    status=resp.status_code,
+                    error=resp.text[:200] if resp.text else "no error text",
+                )
+                return "", search_results
+
+        raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     async def count(self) -> int:
         """Get the number of documents in the index."""

--- a/roboco/services/optimal_brain/mentor.py
+++ b/roboco/services/optimal_brain/mentor.py
@@ -32,6 +32,12 @@ from roboco.models.optimal import (
     MentorResponse,
     SearchResult,
 )
+from roboco.services.exceptions import (
+    HTTP_TOO_MANY_REQUESTS,
+    MAX_RATE_LIMIT_RETRIES,
+    RateLimitError,
+    parse_retry_after_header,
+)
 
 logger = structlog.get_logger()
 
@@ -683,7 +689,12 @@ class MentorService:
         agent_profile: AgentProfile | None,
         journal_context: list[dict[str, Any]],
     ) -> str:
-        """Synthesize a personalized answer using LLM."""
+        """Synthesize a personalized answer using LLM.
+
+        Retries the Ollama call up to MAX_RATE_LIMIT_RETRIES times on HTTP 429,
+        respecting the Retry-After header.  Each individual attempt is bounded by
+        a 120-second asyncio timeout so a slow model cannot block the loop.
+        """
         import asyncio
 
         if not sources and not journal_context:
@@ -709,52 +720,73 @@ class MentorService:
             question, sources, conversation_context, agent_profile, journal_context
         )
 
-        # Call LLM
-        try:
-            async with asyncio.timeout(120.0):
-                async with httpx.AsyncClient(timeout=120.0) as client:
-                    response = await client.post(
-                        f"{settings.local_llm_base_url}/chat/completions",
-                        json={
-                            "model": settings.local_llm_model,
-                            "messages": [
-                                {"role": "system", "content": system_prompt},
-                                {"role": "user", "content": user_prompt},
-                            ],
-                            "max_tokens": 4096,
-                            "temperature": 0.5,
-                            "options": {"num_ctx": 8192},
-                        },
+        llm_url = f"{settings.local_llm_base_url}/chat/completions"
+        payload = {
+            "model": settings.local_llm_model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "max_tokens": 4096,
+            "temperature": 0.5,
+            "options": {"num_ctx": 8192},
+        }
+
+        last_rl_retry_after: float | None = None
+
+        for rl_attempt in range(MAX_RATE_LIMIT_RETRIES):
+            # Each attempt gets its own 120-second timeout
+            try:
+                async with asyncio.timeout(120.0):
+                    async with httpx.AsyncClient(timeout=120.0) as client:
+                        response = await client.post(llm_url, json=payload)
+            except (TimeoutError, httpx.TimeoutException):
+                logger.warning("LLM call timed out in mentor (120s)")
+                return self._fallback_answer(sources, agent_profile)
+            except Exception as e:
+                logger.warning("LLM call failed in mentor", error=str(e))
+                return self._fallback_answer(sources, agent_profile)
+
+            if response.status_code == HTTP_TOO_MANY_REQUESTS:
+                retry_after = parse_retry_after_header(response)
+                last_rl_retry_after = retry_after
+                backoff = (
+                    retry_after if retry_after is not None else float(2**rl_attempt)
+                )
+                logger.warning(
+                    "Ollama rate limited (429), retrying",
+                    provider="ollama",
+                    attempt=rl_attempt + 1,
+                    max_retries=MAX_RATE_LIMIT_RETRIES,
+                    backoff_duration=backoff,
+                )
+                if rl_attempt < MAX_RATE_LIMIT_RETRIES - 1:
+                    await asyncio.sleep(backoff)
+                continue
+
+            if response.is_success:
+                data = response.json()
+                raw_answer: str = data["choices"][0]["message"]["content"]
+                answer = self._extract_answer(raw_answer)
+
+                if not answer:
+                    logger.warning(
+                        "LLM response empty after extraction",
+                        model=settings.local_llm_model,
+                        original_length=len(raw_answer),
                     )
+                    return self._fallback_answer(sources, agent_profile)
 
-                    if response.is_success:
-                        data = response.json()
-                        raw_answer: str = data["choices"][0]["message"]["content"]
-                        answer = self._extract_answer(raw_answer)
+                return answer
+            else:
+                logger.warning(
+                    "LLM call failed in mentor",
+                    status=response.status_code,
+                    error=response.text[:200],
+                )
+                return self._fallback_answer(sources, agent_profile)
 
-                        if not answer:
-                            logger.warning(
-                                "LLM response empty after extraction",
-                                model=settings.local_llm_model,
-                                original_length=len(raw_answer),
-                            )
-                            return self._fallback_answer(sources, agent_profile)
-
-                        return answer
-                    else:
-                        logger.warning(
-                            "LLM call failed in mentor",
-                            status=response.status_code,
-                            error=response.text[:200],
-                        )
-                        return self._fallback_answer(sources, agent_profile)
-
-        except (TimeoutError, httpx.TimeoutException):
-            logger.warning("LLM call timed out in mentor (60s)")
-            return self._fallback_answer(sources, agent_profile)
-        except Exception as e:
-            logger.warning("LLM call failed in mentor", error=str(e))
-            return self._fallback_answer(sources, agent_profile)
+        raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     def _extract_answer(self, text: str) -> str:
         """Extract answer from LLM response, handling think tags."""

--- a/roboco/services/optimal_brain/ollama_embedder.py
+++ b/roboco/services/optimal_brain/ollama_embedder.py
@@ -22,12 +22,20 @@ from piragi.types import Chunk
 
 from roboco.config import settings
 from roboco.logging import get_logger
+from roboco.services.exceptions import (
+    HTTP_TOO_MANY_REQUESTS,
+    RateLimitError,
+    parse_retry_after_header,
+)
 
 logger = get_logger(__name__)
 
-# Retry configuration
+# Retry configuration — ConnectError / Timeout (existing, unchanged)
 MAX_RETRIES = 3
 RETRY_DELAY_BASE = 0.5  # seconds, exponential backoff
+
+# Retry configuration — HTTP 429 / RateLimitError (new outer loop)
+RATE_LIMIT_MAX_RETRIES = 5
 
 # Parallel processing configuration
 MAX_CONCURRENT_BATCHES = 4  # Number of batches to process in parallel
@@ -304,7 +312,15 @@ class OllamaEmbedder:
         query: str,
         task_instruction: str | None = None,
     ) -> list[float]:
-        """Generate embedding for a single query with retry logic."""
+        """Generate embedding for a single query.
+
+        Retry behaviour (two independent concerns, non-overlapping):
+        - ConnectError / TimeoutException: up to MAX_RETRIES=3 attempts with
+          0.5/1/2 s exponential backoff (existing behaviour, unchanged).
+        - HTTP 429 (rate limit): outer loop up to RATE_LIMIT_MAX_RETRIES=5,
+          respecting Retry-After header.  A 429 response does NOT trigger the
+          ConnectError path.
+        """
         _ = task_instruction
 
         # Check cache first
@@ -313,79 +329,154 @@ class OllamaEmbedder:
             return cached
 
         client = self._get_sync_client()
-        last_error: Exception | None = None
+        last_rl_retry_after: float | None = None
 
-        for attempt in range(MAX_RETRIES):
-            try:
-                response = client.post(
-                    f"{self.base_url}/api/embed",
-                    json={"model": self.model, "input": query},
-                )
-                embeddings = self._handle_embed_response(response, input_count=1)
-                result = embeddings[0]
-                self._cache.put(query, result)
-                return result
+        for rl_attempt in range(RATE_LIMIT_MAX_RETRIES):
+            got_429 = False
+            last_error: Exception | None = None
 
-            except httpx.ConnectError as e:
-                last_error = OllamaConnectionError(
-                    f"Cannot connect to Ollama at {self.base_url}: {e}"
-                )
-            except httpx.TimeoutException as e:
-                last_error = OllamaConnectionError(f"Ollama request timed out: {e}")
-            except (OllamaModelError, OllamaEmbedderError):
-                raise
-            except Exception as e:
-                last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+            # --- inner loop: ConnectError / Timeout (unchanged) ---
+            for attempt in range(MAX_RETRIES):
+                try:
+                    response = client.post(
+                        f"{self.base_url}/api/embed",
+                        json={"model": self.model, "input": query},
+                    )
+                    # 429 check — must NOT enter the ConnectError path
+                    if response.status_code == HTTP_TOO_MANY_REQUESTS:
+                        retry_after = parse_retry_after_header(response)
+                        last_rl_retry_after = retry_after
+                        backoff = (
+                            retry_after
+                            if retry_after is not None
+                            else float(2**rl_attempt)
+                        )
+                        logger.warning(
+                            "Ollama rate limited (429), retrying",
+                            provider="ollama",
+                            attempt=rl_attempt + 1,
+                            max_retries=RATE_LIMIT_MAX_RETRIES,
+                            backoff_duration=backoff,
+                        )
+                        got_429 = True
+                        break  # break inner loop; outer loop will sleep + retry
 
-            if attempt < MAX_RETRIES - 1:
-                delay = RETRY_DELAY_BASE * (2**attempt)
-                logger.warning(
-                    "Ollama embed_query retry",
-                    attempt=attempt + 1,
-                    delay=delay,
-                    error=str(last_error),
-                )
-                time.sleep(delay)
+                    embeddings = self._handle_embed_response(response, input_count=1)
+                    result = embeddings[0]
+                    self._cache.put(query, result)
+                    return result
 
-        raise last_error or OllamaEmbedderError("Max retries exceeded")
+                except httpx.ConnectError as e:
+                    last_error = OllamaConnectionError(
+                        f"Cannot connect to Ollama at {self.base_url}: {e}"
+                    )
+                except httpx.TimeoutException as e:
+                    last_error = OllamaConnectionError(f"Ollama request timed out: {e}")
+                except (OllamaModelError, OllamaEmbedderError):
+                    raise
+                except Exception as e:
+                    last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+
+                if attempt < MAX_RETRIES - 1:
+                    delay = RETRY_DELAY_BASE * (2**attempt)
+                    logger.warning(
+                        "Ollama embed_query retry",
+                        attempt=attempt + 1,
+                        delay=delay,
+                        error=str(last_error),
+                    )
+                    time.sleep(delay)
+            # --- end inner loop ---
+
+            if not got_429:
+                # ConnectError / Timeout exhausted — same behaviour as before
+                raise last_error or OllamaEmbedderError("Max retries exceeded")
+
+            # 429: sleep and try again (outer loop)
+            backoff = (
+                last_rl_retry_after
+                if last_rl_retry_after is not None
+                else float(2**rl_attempt)
+            )
+            if rl_attempt < RATE_LIMIT_MAX_RETRIES - 1:
+                time.sleep(backoff)
+
+        raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     def _embed_batch_sync(
         self, client: httpx.Client, batch: list[str], batch_index: int
     ) -> list[list[float]]:
-        """Embed a single batch synchronously with retry logic."""
-        last_error: Exception | None = None
+        """Embed a single batch synchronously.
 
-        for attempt in range(MAX_RETRIES):
-            try:
-                response = client.post(
-                    f"{self.base_url}/api/embed",
-                    json={"model": self.model, "input": batch},
-                )
-                return self._handle_embed_response(response, input_count=len(batch))
+        Same two-concern retry composition as :meth:`embed_query`:
+        inner ConnectError/Timeout loop (unchanged) + outer 429 loop.
+        """
+        last_rl_retry_after: float | None = None
 
-            except httpx.ConnectError as e:
-                last_error = OllamaConnectionError(
-                    f"Cannot connect to Ollama at {self.base_url}: {e}"
-                )
-            except httpx.TimeoutException as e:
-                last_error = OllamaConnectionError(f"Ollama request timed out: {e}")
-            except (OllamaModelError, OllamaEmbedderError):
-                raise
-            except Exception as e:
-                last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+        for rl_attempt in range(RATE_LIMIT_MAX_RETRIES):
+            got_429 = False
+            last_error: Exception | None = None
 
-            if attempt < MAX_RETRIES - 1:
-                delay = RETRY_DELAY_BASE * (2**attempt)
-                logger.warning(
-                    "Ollama embed_documents retry",
-                    attempt=attempt + 1,
-                    batch_index=batch_index,
-                    delay=delay,
-                    error=str(last_error),
-                )
-                time.sleep(delay)
+            for attempt in range(MAX_RETRIES):
+                try:
+                    response = client.post(
+                        f"{self.base_url}/api/embed",
+                        json={"model": self.model, "input": batch},
+                    )
+                    if response.status_code == HTTP_TOO_MANY_REQUESTS:
+                        retry_after = parse_retry_after_header(response)
+                        last_rl_retry_after = retry_after
+                        backoff = (
+                            retry_after
+                            if retry_after is not None
+                            else float(2**rl_attempt)
+                        )
+                        logger.warning(
+                            "Ollama rate limited (429), retrying",
+                            provider="ollama",
+                            attempt=rl_attempt + 1,
+                            max_retries=RATE_LIMIT_MAX_RETRIES,
+                            backoff_duration=backoff,
+                        )
+                        got_429 = True
+                        break
 
-        raise last_error or OllamaEmbedderError("Max retries exceeded")
+                    return self._handle_embed_response(response, input_count=len(batch))
+
+                except httpx.ConnectError as e:
+                    last_error = OllamaConnectionError(
+                        f"Cannot connect to Ollama at {self.base_url}: {e}"
+                    )
+                except httpx.TimeoutException as e:
+                    last_error = OllamaConnectionError(f"Ollama request timed out: {e}")
+                except (OllamaModelError, OllamaEmbedderError):
+                    raise
+                except Exception as e:
+                    last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+
+                if attempt < MAX_RETRIES - 1:
+                    delay = RETRY_DELAY_BASE * (2**attempt)
+                    logger.warning(
+                        "Ollama embed_documents retry",
+                        attempt=attempt + 1,
+                        batch_index=batch_index,
+                        delay=delay,
+                        error=str(last_error),
+                    )
+                    time.sleep(delay)
+
+            if not got_429:
+                raise last_error or OllamaEmbedderError("Max retries exceeded")
+
+            backoff = (
+                last_rl_retry_after
+                if last_rl_retry_after is not None
+                else float(2**rl_attempt)
+            )
+            if rl_attempt < RATE_LIMIT_MAX_RETRIES - 1:
+                time.sleep(backoff)
+
+        raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     def _partition_cached_documents(
         self, documents: list[str]
@@ -464,49 +555,90 @@ class OllamaEmbedder:
         batch: list[str],
         batch_index: int,
     ) -> list[list[float]]:
-        """Embed a single batch with semaphore-limited concurrency."""
+        """Embed a single batch with semaphore-limited concurrency.
+
+        Same two-concern retry composition as :meth:`embed_query`:
+        inner ConnectError/Timeout loop (unchanged) + outer 429 loop (async).
+        """
         semaphore = self._get_semaphore()
 
         async with semaphore:
-            last_error: Exception | None = None
+            last_rl_retry_after: float | None = None
 
-            for attempt in range(MAX_RETRIES):
-                try:
-                    logger.debug(
-                        "Parallel embed batch",
-                        batch_index=batch_index,
-                        batch_size=len(batch),
-                        attempt=attempt,
-                    )
-                    response = await client.post(
-                        f"{self.base_url}/api/embed",
-                        json={"model": self.model, "input": batch},
-                    )
-                    return self._handle_embed_response(response, input_count=len(batch))
+            for rl_attempt in range(RATE_LIMIT_MAX_RETRIES):
+                got_429 = False
+                last_error: Exception | None = None
 
-                except httpx.ConnectError as e:
-                    last_error = OllamaConnectionError(
-                        f"Cannot connect to Ollama at {self.base_url}: {e}"
-                    )
-                except httpx.TimeoutException as e:
-                    last_error = OllamaConnectionError(f"Ollama request timed out: {e}")
-                except (OllamaModelError, OllamaEmbedderError):
-                    raise
-                except Exception as e:
-                    last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+                for attempt in range(MAX_RETRIES):
+                    try:
+                        logger.debug(
+                            "Parallel embed batch",
+                            batch_index=batch_index,
+                            batch_size=len(batch),
+                            attempt=attempt,
+                        )
+                        response = await client.post(
+                            f"{self.base_url}/api/embed",
+                            json={"model": self.model, "input": batch},
+                        )
+                        if response.status_code == HTTP_TOO_MANY_REQUESTS:
+                            retry_after = parse_retry_after_header(response)
+                            last_rl_retry_after = retry_after
+                            backoff = (
+                                retry_after
+                                if retry_after is not None
+                                else float(2**rl_attempt)
+                            )
+                            logger.warning(
+                                "Ollama rate limited (429), retrying",
+                                provider="ollama",
+                                attempt=rl_attempt + 1,
+                                max_retries=RATE_LIMIT_MAX_RETRIES,
+                                backoff_duration=backoff,
+                            )
+                            got_429 = True
+                            break
 
-                if attempt < MAX_RETRIES - 1:
-                    delay = RETRY_DELAY_BASE * (2**attempt)
-                    logger.warning(
-                        "Parallel embed batch retry",
-                        batch_index=batch_index,
-                        attempt=attempt + 1,
-                        delay=delay,
-                        error=str(last_error),
-                    )
-                    await asyncio.sleep(delay)
+                        return self._handle_embed_response(
+                            response, input_count=len(batch)
+                        )
 
-            raise last_error or OllamaEmbedderError("Max retries exceeded")
+                    except httpx.ConnectError as e:
+                        last_error = OllamaConnectionError(
+                            f"Cannot connect to Ollama at {self.base_url}: {e}"
+                        )
+                    except httpx.TimeoutException as e:
+                        last_error = OllamaConnectionError(
+                            f"Ollama request timed out: {e}"
+                        )
+                    except (OllamaModelError, OllamaEmbedderError):
+                        raise
+                    except Exception as e:
+                        last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+
+                    if attempt < MAX_RETRIES - 1:
+                        delay = RETRY_DELAY_BASE * (2**attempt)
+                        logger.warning(
+                            "Parallel embed batch retry",
+                            batch_index=batch_index,
+                            attempt=attempt + 1,
+                            delay=delay,
+                            error=str(last_error),
+                        )
+                        await asyncio.sleep(delay)
+
+                if not got_429:
+                    raise last_error or OllamaEmbedderError("Max retries exceeded")
+
+                backoff = (
+                    last_rl_retry_after
+                    if last_rl_retry_after is not None
+                    else float(2**rl_attempt)
+                )
+                if rl_attempt < RATE_LIMIT_MAX_RETRIES - 1:
+                    await asyncio.sleep(backoff)
+
+            raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     async def _run_parallel_batches(
         self, batches: list[list[str]]
@@ -650,49 +782,93 @@ class OllamaEmbedder:
         return chunks
 
     async def aembed_query(self, query: str) -> list[float]:
-        """Async version of embed_query with retry logic and caching."""
+        """Async version of embed_query with retry logic and caching.
+
+        Same two-concern retry composition as :meth:`embed_query`:
+        inner ConnectError/Timeout loop (unchanged) + outer 429 loop (async).
+        """
         # Check cache first
         cached = self._cache.get(query)
         if cached is not None:
             return cached
 
-        last_error: Exception | None = None
+        last_rl_retry_after: float | None = None
 
-        for attempt in range(MAX_RETRIES):
-            # Create fresh client each attempt to avoid event loop issues
-            async with self._create_async_client() as client:
-                try:
-                    response = await client.post(
-                        f"{self.base_url}/api/embed",
-                        json={"model": self.model, "input": query},
+        for rl_attempt in range(RATE_LIMIT_MAX_RETRIES):
+            got_429 = False
+            last_error: Exception | None = None
+
+            for attempt in range(MAX_RETRIES):
+                # Create fresh client each attempt to avoid event loop issues
+                async with self._create_async_client() as client:
+                    try:
+                        response = await client.post(
+                            f"{self.base_url}/api/embed",
+                            json={"model": self.model, "input": query},
+                        )
+                        if response.status_code == HTTP_TOO_MANY_REQUESTS:
+                            retry_after = parse_retry_after_header(response)
+                            last_rl_retry_after = retry_after
+                            backoff = (
+                                retry_after
+                                if retry_after is not None
+                                else float(2**rl_attempt)
+                            )
+                            logger.warning(
+                                "Ollama rate limited (429), retrying",
+                                provider="ollama",
+                                attempt=rl_attempt + 1,
+                                max_retries=RATE_LIMIT_MAX_RETRIES,
+                                backoff_duration=backoff,
+                            )
+                            got_429 = True
+                            break
+
+                        embeddings = self._handle_embed_response(
+                            response, input_count=1
+                        )
+                        result = embeddings[0]
+                        self._cache.put(query, result)
+                        return result
+
+                    except httpx.ConnectError as e:
+                        last_error = OllamaConnectionError(
+                            f"Cannot connect to Ollama at {self.base_url}: {e}"
+                        )
+                    except httpx.TimeoutException as e:
+                        last_error = OllamaConnectionError(
+                            f"Ollama request timed out: {e}"
+                        )
+                    except (OllamaModelError, OllamaEmbedderError):
+                        raise
+                    except Exception as e:
+                        last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+
+                if got_429:
+                    break  # exit inner loop cleanly
+
+                if attempt < MAX_RETRIES - 1:
+                    delay = RETRY_DELAY_BASE * (2**attempt)
+                    logger.warning(
+                        "Ollama aembed_query retry",
+                        attempt=attempt + 1,
+                        delay=delay,
+                        error=str(last_error),
                     )
-                    embeddings = self._handle_embed_response(response, input_count=1)
-                    result = embeddings[0]
-                    self._cache.put(query, result)
-                    return result
+                    await asyncio.sleep(delay)
 
-                except httpx.ConnectError as e:
-                    last_error = OllamaConnectionError(
-                        f"Cannot connect to Ollama at {self.base_url}: {e}"
-                    )
-                except httpx.TimeoutException as e:
-                    last_error = OllamaConnectionError(f"Ollama request timed out: {e}")
-                except (OllamaModelError, OllamaEmbedderError):
-                    raise
-                except Exception as e:
-                    last_error = OllamaEmbedderError(f"Unexpected error: {e}")
+            if not got_429:
+                raise last_error or OllamaEmbedderError("Max retries exceeded")
 
-            if attempt < MAX_RETRIES - 1:
-                delay = RETRY_DELAY_BASE * (2**attempt)
-                logger.warning(
-                    "Ollama aembed_query retry",
-                    attempt=attempt + 1,
-                    delay=delay,
-                    error=str(last_error),
-                )
-                await asyncio.sleep(delay)
+            backoff = (
+                last_rl_retry_after
+                if last_rl_retry_after is not None
+                else float(2**rl_attempt)
+            )
+            if rl_attempt < RATE_LIMIT_MAX_RETRIES - 1:
+                await asyncio.sleep(backoff)
 
-        raise last_error or OllamaEmbedderError("Max retries exceeded")
+        raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     async def aembed_documents(
         self, documents: list[str], batch_size: int = DEFAULT_BATCH_SIZE

--- a/roboco/services/optimal_brain/validator.py
+++ b/roboco/services/optimal_brain/validator.py
@@ -19,6 +19,12 @@ import structlog
 
 from roboco.config import settings
 from roboco.models.optimal import SearchResult, ValidationResult
+from roboco.services.exceptions import (
+    HTTP_TOO_MANY_REQUESTS,
+    MAX_RATE_LIMIT_RETRIES,
+    RateLimitError,
+    parse_retry_after_header,
+)
 
 logger = structlog.get_logger()
 
@@ -492,6 +498,10 @@ class ValidatorService:
         """
         Use LLM to validate context against standards.
 
+        Retries the Ollama call up to MAX_RATE_LIMIT_RETRIES times on HTTP 429,
+        respecting the Retry-After header.  Each attempt is bounded by
+        LLM_TIMEOUT_SECONDS so a single slow call cannot block the retry loop.
+
         Returns:
             Tuple of (violations, warnings)
         """
@@ -512,41 +522,63 @@ RELEVANT STANDARDS:
 Analyze the context and identify any violations of the standards above.
 Return your analysis as JSON."""
 
-        try:
-            async with asyncio.timeout(LLM_TIMEOUT_SECONDS):
-                async with httpx.AsyncClient(timeout=LLM_TIMEOUT_SECONDS) as client:
-                    response = await client.post(
-                        f"{settings.local_llm_base_url}/chat/completions",
-                        json={
-                            "model": settings.local_llm_model,
-                            "messages": [
-                                {"role": "system", "content": VALIDATION_SYSTEM_PROMPT},
-                                {"role": "user", "content": user_prompt},
-                            ],
-                            "max_tokens": 2048,
-                            "temperature": 0.1,  # Low temp for consistent analysis
-                            "options": {"num_ctx": 8192},
-                        },
-                    )
+        llm_url = f"{settings.local_llm_base_url}/chat/completions"
+        payload = {
+            "model": settings.local_llm_model,
+            "messages": [
+                {"role": "system", "content": VALIDATION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            "max_tokens": 2048,
+            "temperature": 0.1,  # Low temp for consistent analysis
+            "options": {"num_ctx": 8192},
+        }
 
-                    if response.is_success:
-                        data = response.json()
-                        raw_response = data["choices"][0]["message"]["content"]
-                        return self._parse_llm_response(raw_response)
-                    else:
-                        logger.warning(
-                            "LLM validation call failed",
-                            status=response.status_code,
-                            error=response.text[:200],
-                        )
-                        raise RuntimeError(f"LLM call failed: {response.status_code}")
+        last_rl_retry_after: float | None = None
 
-        except TimeoutError:
-            logger.warning("LLM validation timed out")
-            raise
-        except httpx.TimeoutException:
-            logger.warning("LLM validation HTTP timeout")
-            raise
+        for rl_attempt in range(MAX_RATE_LIMIT_RETRIES):
+            # Each attempt gets its own timeout — raises if the call hangs
+            try:
+                async with asyncio.timeout(LLM_TIMEOUT_SECONDS):
+                    async with httpx.AsyncClient(timeout=LLM_TIMEOUT_SECONDS) as client:
+                        response = await client.post(llm_url, json=payload)
+            except TimeoutError:
+                logger.warning("LLM validation timed out")
+                raise
+            except httpx.TimeoutException:
+                logger.warning("LLM validation HTTP timeout")
+                raise
+
+            if response.status_code == HTTP_TOO_MANY_REQUESTS:
+                retry_after = parse_retry_after_header(response)
+                last_rl_retry_after = retry_after
+                backoff = (
+                    retry_after if retry_after is not None else float(2**rl_attempt)
+                )
+                logger.warning(
+                    "Ollama rate limited (429), retrying",
+                    provider="ollama",
+                    attempt=rl_attempt + 1,
+                    max_retries=MAX_RATE_LIMIT_RETRIES,
+                    backoff_duration=backoff,
+                )
+                if rl_attempt < MAX_RATE_LIMIT_RETRIES - 1:
+                    await asyncio.sleep(backoff)
+                continue
+
+            if response.is_success:
+                data = response.json()
+                raw_response = data["choices"][0]["message"]["content"]
+                return self._parse_llm_response(raw_response)
+            else:
+                logger.warning(
+                    "LLM validation call failed",
+                    status=response.status_code,
+                    error=response.text[:200],
+                )
+                raise RuntimeError(f"LLM call failed: {response.status_code}")
+
+        raise RateLimitError(provider="ollama", retry_after=last_rl_retry_after)
 
     def _build_standards_context(self, standards: list[SearchResult]) -> str:
         """Build a formatted string of standards for the LLM."""

--- a/tests/unit/services/test_rate_limit_retry.py
+++ b/tests/unit/services/test_rate_limit_retry.py
@@ -1,0 +1,691 @@
+"""
+Unit tests for rate-limit retry behaviour across all LLM call sites.
+
+Covers acceptance criteria:
+- 5-retry exhaustion raises RateLimitError
+- Retry-After header drives the sleep duration
+- Partial retries then success returns the correct result
+- ConnectError / TimeoutException in OllamaEmbedder does NOT trigger the 429
+  retry path (the two concerns are composed without double-retrying)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import anthropic as anthropic_mod
+import httpx
+import pytest
+import pytest_asyncio  # noqa: F401 - registers asyncio mode
+
+# ---------------------------------------------------------------------------
+# Ensure piragi stubs are present before the optimal_brain modules are imported
+# ---------------------------------------------------------------------------
+
+_PIRAGI_STUB_NAMES = (
+    "piragi",
+    "piragi.types",
+    "piragi.stores",
+    "piragi.stores.postgres",
+    "piragi.chunking",
+    "piragi.semantic_chunking",
+)
+
+
+def _stub_piragi() -> None:
+    mock = MagicMock()
+    for name in _PIRAGI_STUB_NAMES:
+        if name not in sys.modules:
+            mod = types.ModuleType(name)
+            mod.__dict__.update(
+                {
+                    "AsyncRagi": mock,
+                    "Citation": mock,
+                    "Document": mock,
+                    "Chunk": mock,
+                    "PostgresStore": mock,
+                }
+            )
+            sys.modules[name] = mod
+
+
+_stub_piragi()
+
+# ---------------------------------------------------------------------------
+# Module imports (after stubs are injected)
+# ---------------------------------------------------------------------------
+
+from roboco.models.extraction import ExtractionContext  # noqa: E402
+from roboco.models.optimal import IndexType  # noqa: E402
+from roboco.services.exceptions import (  # noqa: E402
+    MAX_RATE_LIMIT_RETRIES,
+    RateLimitError,
+    parse_retry_after_header,
+)
+from roboco.services.extraction import ExtractionService  # noqa: E402
+from roboco.services.optimal_brain.indexes.journals import (  # noqa: E402
+    JournalsIndexPlugin,
+)
+from roboco.services.optimal_brain.mentor import MentorService  # noqa: E402
+from roboco.services.optimal_brain.ollama_embedder import (  # noqa: E402
+    MAX_RETRIES,
+    OllamaConnectionError,
+    OllamaEmbedder,
+)
+from roboco.services.optimal_brain.validator import ValidatorService  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_RETRY_AFTER_FLOAT = 30.0
+_RETRY_AFTER_FLOAT_2 = 2.5
+_RETRY_AFTER_7 = 7.0
+_RETRY_AFTER_9 = 9.0
+_RETRY_AFTER_12 = 12.0
+_RETRY_AFTER_5 = 5.0
+_EMBED_DIM = 4  # zero-vector dimension in test responses
+_CALLS_2RL_1_SUCCESS = 3  # 2 rate-limit errors then 1 success
+
+_EMBED_PATH = (
+    "roboco.services.optimal_brain.ollama_embedder.OllamaEmbedder._create_async_client"
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    status_code: int,
+    body: Any = None,
+    retry_after: str | None = None,
+) -> httpx.Response:
+    """Build a minimal httpx.Response for use in mocks."""
+    headers: dict[str, str] = {}
+    if retry_after is not None:
+        headers["retry-after"] = retry_after
+    content = json.dumps(body or {}).encode()
+    return httpx.Response(
+        status_code=status_code,
+        headers=headers,
+        content=content,
+    )
+
+
+def _success_embed_response(n: int = 1) -> httpx.Response:
+    """Return a valid Ollama /api/embed response with *n* zero-vectors."""
+    body = {"embeddings": [[0.0] * _EMBED_DIM] * n}
+    return _make_response(200, body)
+
+
+def _429_response(retry_after: str | None = None) -> httpx.Response:
+    return _make_response(429, {"error": "rate limited"}, retry_after=retry_after)
+
+
+def _make_async_client_mock(post_return: Any = None) -> AsyncMock:
+    """Return an async context manager mock exposing `.post`."""
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    if post_return is not None:
+        client.post = AsyncMock(return_value=post_return)
+    return client
+
+
+def _make_extraction_context() -> ExtractionContext:
+    return ExtractionContext(
+        content="This is a test message that is long enough.",
+        agent_id=uuid4(),
+        channel_id=uuid4(),
+        session_id=uuid4(),
+        group_id=uuid4(),
+    )
+
+
+def _make_anthropic_rl_exc(
+    retry_after: str | None = None,
+) -> anthropic_mod.RateLimitError:
+    """Build a minimal anthropic.RateLimitError."""
+    fake_resp = MagicMock()
+    fake_resp.headers = {} if retry_after is None else {"retry-after": retry_after}
+    return anthropic_mod.RateLimitError(
+        message="rate limit",
+        response=fake_resp,
+        body={},
+    )
+
+
+def _make_journal_plugin() -> JournalsIndexPlugin:
+    """Create a minimal JournalsIndexPlugin without initialising piragi."""
+    plugin = JournalsIndexPlugin.__new__(JournalsIndexPlugin)
+    plugin._config = MagicMock()
+    plugin._config.llm_base_url = "http://ollama-test:11434/v1"
+    plugin._config.llm_model = "glm-5:cloud"
+    plugin._ragi = MagicMock()
+    plugin._initialized = True
+    return plugin
+
+
+def _make_search_outcome(content: str = "context text") -> Any:
+    mock_outcome = MagicMock()
+    mock_outcome.success = True
+    mock_outcome.results = [
+        MagicMock(content=content, source="src", score=0.9, index_type=None)
+    ]
+    return mock_outcome
+
+
+def _make_sources() -> list[Any]:
+    return [
+        MagicMock(content="ctx", source="s", score=0.9, index_type=IndexType.JOURNALS)
+    ]
+
+
+def _make_standards() -> list[Any]:
+    s = MagicMock()
+    s.content = "### PY-001: Use Type Hints\nMust add return type annotations."
+    return [s]
+
+
+# ===========================================================================
+# 1. parse_retry_after_header
+# ===========================================================================
+
+
+class TestParseRetryAfterHeader:
+    def test_integer_seconds(self) -> None:
+        resp = _429_response(retry_after="30")
+        assert parse_retry_after_header(resp) == _RETRY_AFTER_FLOAT
+
+    def test_float_seconds(self) -> None:
+        resp = _429_response(retry_after="2.5")
+        assert parse_retry_after_header(resp) == _RETRY_AFTER_FLOAT_2
+
+    def test_missing_header_returns_none(self) -> None:
+        resp = _make_response(429)
+        assert parse_retry_after_header(resp) is None
+
+    def test_non_numeric_returns_none(self) -> None:
+        resp = _429_response(retry_after="Wed, 21 Oct 2015 07:28:00 GMT")
+        assert parse_retry_after_header(resp) is None
+
+
+# ===========================================================================
+# 2. RateLimitError class
+# ===========================================================================
+
+
+class TestRateLimitError:
+    def test_fields(self) -> None:
+        err = RateLimitError(provider="anthropic", retry_after=_RETRY_AFTER_FLOAT)
+        assert err.provider == "anthropic"
+        assert err.retry_after == _RETRY_AFTER_FLOAT
+
+    def test_message_includes_provider(self) -> None:
+        err = RateLimitError(provider="ollama")
+        assert "ollama" in str(err)
+
+    def test_message_includes_retry_after_when_set(self) -> None:
+        err = RateLimitError(provider="ollama", retry_after=15.0)
+        assert "15" in str(err)
+
+    def test_none_retry_after(self) -> None:
+        err = RateLimitError(provider="anthropic", retry_after=None)
+        assert err.retry_after is None
+
+
+# ===========================================================================
+# 3. OllamaEmbedder - async path (aembed_query)
+# ===========================================================================
+
+
+class TestOllamaEmbedderAembed:
+    """Tests for the async aembed_query method."""
+
+    def _make_embedder(self) -> OllamaEmbedder:
+        return OllamaEmbedder(base_url="http://ollama-test:11434")
+
+    async def test_five_consecutive_429s_raise_rate_limit_error(self) -> None:
+        """After MAX_RATE_LIMIT_RETRIES attempts all 429 -> RateLimitError."""
+        embedder = self._make_embedder()
+        mock_c = _make_async_client_mock(post_return=_429_response())
+
+        with (
+            patch(_EMBED_PATH, return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            await embedder.aembed_query("hello")
+
+        assert exc_info.value.provider == "ollama"
+        assert mock_c.post.call_count == MAX_RATE_LIMIT_RETRIES
+
+    async def test_retry_after_header_respected_as_sleep_duration(self) -> None:
+        """Retry-After: 7 -> asyncio.sleep(7.0) on each inter-attempt gap."""
+        embedder = self._make_embedder()
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(secs: float) -> None:
+            sleep_calls.append(secs)
+
+        mock_c = _make_async_client_mock(post_return=_429_response(retry_after="7"))
+
+        with (
+            patch(_EMBED_PATH, return_value=mock_c),
+            patch("asyncio.sleep", side_effect=_fake_sleep),
+            pytest.raises(RateLimitError),
+        ):
+            await embedder.aembed_query("hello")
+
+        assert all(s == _RETRY_AFTER_7 for s in sleep_calls)
+        assert len(sleep_calls) == MAX_RATE_LIMIT_RETRIES - 1
+
+    async def test_partial_retries_then_success(self) -> None:
+        """Two 429s then a 200 -> returns the embedding list."""
+        embedder = self._make_embedder()
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(
+            side_effect=[
+                _429_response(),
+                _429_response(),
+                _success_embed_response(),
+            ]
+        )
+
+        with (
+            patch(_EMBED_PATH, return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await embedder.aembed_query("hello")
+
+        assert isinstance(result, list)
+        assert len(result) == _EMBED_DIM
+
+    async def test_connect_error_does_not_trigger_429_retry_path(
+        self,
+    ) -> None:
+        """ConnectError -> OllamaConnectionError after MAX_RETRIES=3, not 5."""
+        embedder = self._make_embedder()
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+
+        with (
+            patch(_EMBED_PATH, return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(OllamaConnectionError),
+        ):
+            await embedder.aembed_query("hello")
+
+        assert mock_c.post.call_count == MAX_RETRIES
+
+    async def test_timeout_does_not_trigger_429_retry_path(self) -> None:
+        """TimeoutException -> OllamaConnectionError after MAX_RETRIES=3."""
+        embedder = self._make_embedder()
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+
+        with (
+            patch(_EMBED_PATH, return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(OllamaConnectionError),
+        ):
+            await embedder.aembed_query("hello")
+
+        assert mock_c.post.call_count == MAX_RETRIES
+
+
+# ===========================================================================
+# 4. OllamaEmbedder - sync path (embed_query)
+# ===========================================================================
+
+
+class TestOllamaEmbedderSync:
+    """Tests for the synchronous embed_query method."""
+
+    def _make_embedder(self) -> OllamaEmbedder:
+        return OllamaEmbedder(base_url="http://ollama-test:11434")
+
+    def test_five_consecutive_429s_raise_rate_limit_error(self) -> None:
+        embedder = self._make_embedder()
+        mock_client = MagicMock()
+        mock_client.post.return_value = _429_response()
+
+        with (
+            patch.object(embedder, "_get_sync_client", return_value=mock_client),
+            patch("time.sleep"),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            embedder.embed_query("hello")
+
+        assert exc_info.value.provider == "ollama"
+        assert mock_client.post.call_count == MAX_RATE_LIMIT_RETRIES
+
+    def test_retry_after_header_respected_as_sleep_duration(self) -> None:
+        embedder = self._make_embedder()
+        sleep_calls: list[float] = []
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = _429_response(retry_after="9")
+
+        with (
+            patch.object(embedder, "_get_sync_client", return_value=mock_client),
+            patch("time.sleep", side_effect=sleep_calls.append),
+            pytest.raises(RateLimitError),
+        ):
+            embedder.embed_query("hello")
+
+        assert all(s == _RETRY_AFTER_9 for s in sleep_calls)
+        assert len(sleep_calls) == MAX_RATE_LIMIT_RETRIES - 1
+
+    def test_partial_retries_then_success(self) -> None:
+        embedder = self._make_embedder()
+        mock_client = MagicMock()
+        mock_client.post.side_effect = [_429_response(), _success_embed_response()]
+
+        with (
+            patch.object(embedder, "_get_sync_client", return_value=mock_client),
+            patch("time.sleep"),
+        ):
+            result = embedder.embed_query("hello")
+
+        assert isinstance(result, list)
+
+    def test_connect_error_does_not_trigger_rate_limit_retry(self) -> None:
+        embedder = self._make_embedder()
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+
+        with (
+            patch.object(embedder, "_get_sync_client", return_value=mock_client),
+            patch("time.sleep"),
+            pytest.raises(OllamaConnectionError),
+        ):
+            embedder.embed_query("hello")
+
+        assert mock_client.post.call_count == MAX_RETRIES
+
+
+# ===========================================================================
+# 5. OllamaEmbedder - _embed_batch_sync
+# ===========================================================================
+
+
+class TestOllamaEmbedBatchSync:
+    def _make_embedder(self) -> OllamaEmbedder:
+        return OllamaEmbedder(base_url="http://ollama-test:11434")
+
+    def test_five_429s_raise_rate_limit_error(self) -> None:
+        embedder = self._make_embedder()
+        mock_client = MagicMock()
+        mock_client.post.return_value = _429_response()
+
+        with patch("time.sleep"), pytest.raises(RateLimitError):
+            embedder._embed_batch_sync(mock_client, ["a", "b"], batch_index=0)
+
+        assert mock_client.post.call_count == MAX_RATE_LIMIT_RETRIES
+
+    def test_connect_error_raises_connection_error_not_rate_limit(self) -> None:
+        embedder = self._make_embedder()
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+
+        with patch("time.sleep"), pytest.raises(OllamaConnectionError):
+            embedder._embed_batch_sync(mock_client, ["a"], batch_index=0)
+
+        assert mock_client.post.call_count == MAX_RETRIES
+
+
+# ===========================================================================
+# 6. extraction.py - Anthropic rate-limit retry
+# ===========================================================================
+
+
+class TestExtractionAnthropicRetry:
+    """Tests for ExtractionService.extract_with_llm Anthropic retry logic.
+
+    AsyncAnthropic is imported *inside* extract_with_llm, so we patch at the
+    anthropic module level. The client is NOT used as a context manager there.
+    """
+
+    async def test_five_rate_limit_errors_raises_rate_limit_error(self) -> None:
+        """RateLimitError raised 5 times -> our RateLimitError propagated."""
+        svc = ExtractionService()
+        api_exc = _make_anthropic_rl_exc(retry_after="5")
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(side_effect=api_exc)
+
+        with (
+            patch("anthropic.AsyncAnthropic") as mock_cls,
+            patch("roboco.config.settings") as mock_settings,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            mock_cls.return_value = mock_client
+            mock_settings.anthropic_api_key = "test-key"
+            await svc.extract_with_llm(_make_extraction_context())
+
+        assert exc_info.value.provider == "anthropic"
+        assert mock_client.messages.create.call_count == MAX_RATE_LIMIT_RETRIES
+
+    async def test_retry_after_header_drives_sleep_duration(self) -> None:
+        """Retry-After: 12 -> asyncio.sleep(12) called on each gap."""
+        svc = ExtractionService()
+        sleep_calls: list[float] = []
+        api_exc = _make_anthropic_rl_exc(retry_after="12")
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(side_effect=api_exc)
+
+        async def _fake_sleep(secs: float) -> None:
+            sleep_calls.append(secs)
+
+        with (
+            patch("anthropic.AsyncAnthropic") as mock_cls,
+            patch("roboco.config.settings") as mock_settings,
+            patch("asyncio.sleep", side_effect=_fake_sleep),
+            pytest.raises(RateLimitError),
+        ):
+            mock_cls.return_value = mock_client
+            mock_settings.anthropic_api_key = "test-key"
+            await svc.extract_with_llm(_make_extraction_context())
+
+        assert all(s == _RETRY_AFTER_12 for s in sleep_calls)
+        assert len(sleep_calls) == MAX_RATE_LIMIT_RETRIES - 1
+
+    async def test_partial_rate_limit_then_success_returns_result(self) -> None:
+        """Two RateLimitErrors then success -> result returned, no raise."""
+        svc = ExtractionService()
+        api_exc = _make_anthropic_rl_exc()
+
+        text_block = MagicMock()
+        text_block.text = "[N,]{type,content,confidence}:\nreasoning,Hello world,0.9"
+        success_response = MagicMock()
+        success_response.content = [text_block]
+
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(
+            side_effect=[api_exc, api_exc, success_response]
+        )
+
+        raised = False
+        with (
+            patch("anthropic.AsyncAnthropic") as mock_cls,
+            patch("roboco.config.settings") as mock_settings,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_cls.return_value = mock_client
+            mock_settings.anthropic_api_key = "test-key"
+            try:
+                result = await svc.extract_with_llm(_make_extraction_context())
+                assert result is not None
+            except RateLimitError:
+                raised = True
+
+        assert not raised, "RateLimitError raised even though 3rd attempt succeeded"
+        assert mock_client.messages.create.call_count == _CALLS_2RL_1_SUCCESS
+
+
+# ===========================================================================
+# 7. indexes/base.py - BaseIndexPlugin.ask() LLM 429 retry
+# ===========================================================================
+
+
+class TestIndexAsk429Retry:
+    """Tests for the LLM call in BaseIndexPlugin.ask()."""
+
+    async def test_ask_raises_rate_limit_after_five_429s(self) -> None:
+        plugin = _make_journal_plugin()
+        mock_c = _make_async_client_mock(post_return=_429_response())
+
+        with (
+            patch.object(
+                plugin, "search", AsyncMock(return_value=_make_search_outcome())
+            ),
+            patch("httpx.AsyncClient", return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            await plugin.ask("what is X")
+
+        assert exc_info.value.provider == "ollama"
+        assert mock_c.post.call_count == MAX_RATE_LIMIT_RETRIES
+
+    async def test_ask_partial_retry_then_success(self) -> None:
+        plugin = _make_journal_plugin()
+        success_body = {"choices": [{"message": {"content": "Here is the answer."}}]}
+        success_resp = _make_response(200, success_body)
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(side_effect=[_429_response(), success_resp])
+
+        with (
+            patch.object(
+                plugin, "search", AsyncMock(return_value=_make_search_outcome())
+            ),
+            patch("httpx.AsyncClient", return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            answer, results = await plugin.ask("what is X")
+
+        assert answer == "Here is the answer."
+        assert results is not None
+
+
+# ===========================================================================
+# 8. mentor.py - MentorService._synthesize_answer() 429 retry
+# ===========================================================================
+
+
+class TestMentorSynthesizeAnswer429:
+    async def test_raises_rate_limit_after_five_429s(self) -> None:
+        mentor = MentorService()
+        mentor._optimal_service = MagicMock()
+        mock_c = _make_async_client_mock(post_return=_429_response())
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            await mentor._synthesize_answer(
+                question="test",
+                sources=_make_sources(),
+                conversation_context="",
+                agent_profile=None,
+                journal_context=[],
+            )
+
+        assert exc_info.value.provider == "ollama"
+        assert mock_c.post.call_count == MAX_RATE_LIMIT_RETRIES
+
+    async def test_partial_retry_then_success(self) -> None:
+        mentor = MentorService()
+        mentor._optimal_service = MagicMock()
+        success_body = {"choices": [{"message": {"content": "Great answer."}}]}
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(
+            side_effect=[_429_response(), _make_response(200, success_body)]
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            answer = await mentor._synthesize_answer(
+                question="test",
+                sources=_make_sources(),
+                conversation_context="",
+                agent_profile=None,
+                journal_context=[],
+            )
+
+        assert answer == "Great answer."
+
+
+# ===========================================================================
+# 9. validator.py - ValidatorService._validate_with_llm() 429 retry
+# ===========================================================================
+
+
+class TestValidatorLLMRetry:
+    async def test_raises_rate_limit_after_five_429s(self) -> None:
+        validator = ValidatorService()
+        validator._optimal_service = MagicMock()
+        validator._llm_available = True
+        mock_c = _make_async_client_mock(post_return=_429_response())
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(RateLimitError) as exc_info,
+        ):
+            await validator._validate_with_llm(
+                action_type="create_endpoint",
+                context="def foo(): pass",
+                standards=_make_standards(),
+            )
+
+        assert exc_info.value.provider == "ollama"
+        assert mock_c.post.call_count == MAX_RATE_LIMIT_RETRIES
+
+    async def test_partial_retry_then_success(self) -> None:
+        validator = ValidatorService()
+        validator._optimal_service = MagicMock()
+        validator._llm_available = True
+        success_content = '{"violations": [], "summary": "ok"}'
+        success_body = {"choices": [{"message": {"content": success_content}}]}
+        mock_c = AsyncMock()
+        mock_c.__aenter__ = AsyncMock(return_value=mock_c)
+        mock_c.__aexit__ = AsyncMock(return_value=False)
+        mock_c.post = AsyncMock(
+            side_effect=[_429_response(), _make_response(200, success_body)]
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_c),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            violations, warnings = await validator._validate_with_llm(
+                action_type="create_endpoint",
+                context="def foo(): pass",
+                standards=_make_standards(),
+            )
+
+        assert violations == []
+        assert warnings == []


### PR DESCRIPTION
Implement a shared `RateLimitError` exception class and a 5-retry exponential-backoff helper that respects the `Retry-After` header, then apply it to all 5 LLM call sites.

**Scope:**
1. **`RateLimitError` exception** — define in `roboco/services/exceptions.py` (or `roboco/core/exceptions.py` if that already exists; check first). Fields: `provider: str`, `retry_after: float | None`, `message: str`. Importable from a single shared location.

2. **Retry helper** — a reusable async function (or decorator) `retry_on_rate_limit(coro_fn, max_retries=5)` that:
   - Catches HTTP 429 responses (for httpx) and `anthropic.RateLimitError` (for the Anthropic SDK).
   - Reads `Retry-After` from the response headers (seconds as float; default to `min(2^attempt * base, 60)` when absent).
   - Sleeps `Retry-After` seconds then retries.
   - After 5 exhausted retries, raises `RateLimitError(provider=..., retry_after=<last header value>)`.

3. **`roboco/services/extraction.py`** — wrap the `extract_with_llm()` Anthropic call with the retry helper. On `RateLimitError` propagate upward (caller gets a 429 response with `Retry-After` header).

4. **`roboco/services/optimal_brain/ollama_embedder.py`** — add 429 detection inside the existing retry loops (ConnectError/TimeoutException already handled). The 429 retry must **compose without double-retrying**: if the inner loop catches `ConnectError`, it retries via the existing path; if the inner loop gets a 429, it should use the same backoff helper. Do NOT create a second outer retry loop — integrate the 429 check into the existing `for attempt in range(MAX_RETRIES)` pattern (but increase MAX_RETRIES to 5 for 429 paths).

5. **`roboco/services/optimal_brain/indexes/base.py`** — wrap the LLM HTTP call in `ask()` with the retry helper.

6. **`roboco/services/optimal_brain/mentor.py`** — wrap `_synthesize_answer()` LLM call with the retry helper.

7. **`roboco/services/optimal_brain/validator.py`** — wrap `_validate_with_llm()` LLM call with the retry helper.

**Key constraints:**
- Existing `OllamaEmbedder` `ConnectError`/`TimeoutException` retry logic (3 attempts, 0.5/1/2s backoff) must be preserved exactly as-is.
- For httpx-based Ollama calls: a 429 status code on the response object is the trigger.
- For the Anthropic SDK call in `extraction.py`: catch `anthropic.RateLimitError` (the SDK raises this natively) OR check for HTTP 429 if using raw HTTP.
- Always log a warning when a retry is triggered: `logger.warning("Rate limit hit on %s, retry %d/%d, backing off %.1fs", provider, attempt, max_retries, delay)`.
- After all retries exhausted, raise `RateLimitError`; the HTTP layer (FastAPI exception handler or the calling endpoint) must convert this to a `429 Too Many Requests` response with `Retry-After: <seconds>` header.

**Tests required (in `tests/`):**
- `test_rate_limit_retry.py`: mock Anthropic 429 → assert 5 retries then `RateLimitError`; mock Retry-After header present → assert sleep durations match; mock first 3 calls 429 then success → assert caller gets result.
- `test_ollama_embedder_retry.py` (or extend existing): mock 429 on embed call → assert retries; verify ConnectError still retried via existing path without interference.
- At least one test per call site (extraction, indexes/base, mentor, validator) that verifies `RateLimitError` is raised on exhaustion.