### PR TITLE
[18107054] Redis rate-limit state tracker + i_am_blocked rate_limited path (AC2)

### DIFF
--- a/roboco/api/deps.py
+++ b/roboco/api/deps.py
@@ -504,6 +504,15 @@ async def get_choreographer(
     db_session: DbSession,
 ) -> Choreographer:
     """Build a Choreographer with all service dependencies wired up."""
+    from roboco.events.stream_bus import get_stream_event_bus
+
+    # Inject the orchestrator (if initialised) and the stream event bus
+    # so the rate-limited i_am_blocked path can park agents and publish events.
+    # Both are None-safe in ChoreographerDeps — passing None is the same as
+    # omitting the field, so the choreographer degrades gracefully when the
+    # orchestrator has not been initialised yet (e.g. during startup).
+    orch: AgentOrchestrator | None = _ServiceHolder.orchestrator
+    bus = get_stream_event_bus() if _ServiceHolder.orchestrator is not None else None
     return Choreographer(
         ChoreographerDeps(
             task=TaskService(db_session),
@@ -515,6 +524,8 @@ async def get_choreographer(
             evidence_repo=EvidenceRepo(db_session),
             messaging=MessagingService(db_session),
             product=ProductService(db_session),
+            orchestrator=orch,
+            stream_bus=bus,
         )
     )
 

--- a/roboco/models/events.py
+++ b/roboco/models/events.py
@@ -65,6 +65,9 @@ class EventType(StrEnum):
     BLOCKER_REPORTED = "blocker.reported"
     BLOCKER_RESOLVED = "blocker.resolved"
 
+    # Rate-limit events
+    RATE_LIMIT_HIT = "rate_limit.hit"
+
     # Question events
     QUESTION_ASKED = "question.asked"
     QUESTION_ANSWERED = "question.answered"

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3047,6 +3047,44 @@ class AgentOrchestrator:
             )
 
     # =========================================================================
+    # PROVIDER QUERY HELPERS (used by the choreographer rate-limit path)
+    # =========================================================================
+
+    def get_provider_for_agent(self, agent_slug: str) -> str | None:
+        """Return the ``provider_type`` for a currently-tracked agent, or None.
+
+        Reads the in-memory ``_instances`` dict so this is synchronous and
+        O(1).  Returns None when the agent is not tracked or has no config.
+
+        Args:
+            agent_slug: The agent slug (e.g. ``"be-dev-1"``).
+        """
+        instance = self._instances.get(agent_slug)
+        if instance is None or instance.config is None:
+            return None
+        return instance.config.provider_type
+
+    def get_active_agent_slugs_for_provider(self, provider: str) -> list[str]:
+        """Return slugs of all active agents currently using ``provider``.
+
+        "Active" means the instance's state is ACTIVE or STARTING (i.e.
+        the container is running or spinning up — not IDLE, WAITING_LONG,
+        STOPPING, or OFFLINE).
+
+        Args:
+            provider: Provider type string, e.g. ``"anthropic"`` or
+                      ``"ollama_cloud"``.
+        """
+        active_states = {AgentState.ACTIVE, AgentState.STARTING}
+        return [
+            slug
+            for slug, inst in self._instances.items()
+            if inst.state in active_states
+            and inst.config is not None
+            and inst.config.provider_type == provider
+        ]
+
+    # =========================================================================
     # TOKEN USAGE INSTRUMENTATION
     # =========================================================================
 

--- a/roboco/services/gateway/choreographer/_impl.py
+++ b/roboco/services/gateway/choreographer/_impl.py
@@ -219,6 +219,17 @@ class ChoreographerDeps:
     # callsites / tests that don't exercise Product routing don't have to plumb
     # it in; when None, delegate falls back to parent-project inheritance.
     product: Any = None
+    # Orchestrator access for the rate-limited i_am_blocked path.
+    # Implements get_provider_for_agent(slug) -> str | None,
+    # get_active_agent_slugs_for_provider(provider) -> list[str], and
+    # async mark_waiting_long(slug, waiting_for, task_id, context).
+    # Optional: when None the parking step is skipped (e.g. in unit tests
+    # that don't need to verify orchestrator interactions).
+    orchestrator: Any = None
+    # StreamEventBus for publishing RATE_LIMIT_HIT events.
+    # Optional so existing callsites that don't exercise the rate-limit path
+    # don't have to plumb it in.
+    stream_bus: Any = None
 
 
 @dataclass(frozen=True)
@@ -359,6 +370,14 @@ class Choreographer:
     @property
     def product(self) -> Any:
         return self._deps.product
+
+    @property
+    def orchestrator(self) -> Any:
+        return self._deps.orchestrator
+
+    @property
+    def stream_bus(self) -> Any:
+        return self._deps.stream_bus
 
     async def _touch(self, task_id: UUID | None) -> None:
         """Best-effort heartbeat write; silent on missing task."""
@@ -2188,6 +2207,99 @@ class Choreographer:
             )
         return updated, None
 
+    @staticmethod
+    def _parse_retry_after(what_needed: str | None) -> float | None:
+        """Extract a retry-after seconds value from ``what_needed``, or None.
+
+        Agents may embed the Retry-After seconds in the ``what_needed``
+        field as a numeric string (e.g. ``"30"`` or ``"60.5"``). This
+        helper tries to parse it; any non-numeric or absent value returns
+        ``None``, which maps to the nullable ``retryAfterSeconds`` in the
+        RATE_LIMIT_HIT event.
+        """
+        if what_needed is None:
+            return None
+        try:
+            return float(what_needed.strip())
+        except (ValueError, AttributeError):
+            return None
+
+    async def _handle_rate_limited_parking(
+        self,
+        agent_id: UUID,
+        task_id: UUID,
+        t: Any,
+        agent: Any,
+        role_str: str,
+        briefing: dict[str, Any],
+        what_needed: str | None,
+    ) -> Envelope:
+        """Rate-limited fast path: park agents and publish event without blocking the task.
+
+        Called from ``i_am_blocked`` when ``reason == 'rate_limited'``.
+        The task stays in its current status (``in_progress``) — no block
+        transition occurs. Instead, every orchestrator-tracked active agent
+        sharing the same provider as the calling agent is parked via
+        ``mark_waiting_long(waiting_for='rate_limit_lifted')``.  A
+        ``RATE_LIMIT_HIT`` event is published so downstream consumers (the
+        orchestrator backpressure layer, the panel) can react.
+        """
+        from roboco.models.events import Event, EventType
+
+        agent_slug: str | None = (
+            getattr(agent, "slug", None) if agent is not None else None
+        )
+
+        provider: str = "unknown"
+        affected_agents: list[str] = []
+
+        orch = self.orchestrator
+        if orch is not None and agent_slug is not None:
+            with contextlib.suppress(Exception):
+                prov = orch.get_provider_for_agent(agent_slug)
+                if prov:
+                    provider = prov
+            with contextlib.suppress(Exception):
+                affected_agents = list(
+                    orch.get_active_agent_slugs_for_provider(provider)
+                )
+            for slug in affected_agents:
+                with contextlib.suppress(Exception):
+                    await orch.mark_waiting_long(
+                        slug,
+                        waiting_for="rate_limit_lifted",
+                        task_id=str(task_id),
+                        context={"provider": provider, "triggered_by": agent_slug},
+                    )
+
+        retry_after_seconds = self._parse_retry_after(what_needed)
+
+        bus = self.stream_bus
+        if bus is not None:
+            event = Event(
+                type=EventType.RATE_LIMIT_HIT,
+                data={
+                    "provider": provider,
+                    "affectedAgents": affected_agents,
+                    "retryAfterSeconds": retry_after_seconds,
+                    "timestamp": datetime.now(UTC).isoformat(),
+                },
+                source_agent=str(agent_id),
+            )
+            with contextlib.suppress(Exception):
+                await bus.publish(event)
+
+        await self._touch(task_id)
+        return Envelope.ok(
+            status=str(t.status),
+            task_id=str(task_id),
+            next=(
+                "agent parked waiting for rate_limit_lifted; "
+                "will be respawned when the limit clears"
+            ),
+            context_briefing=briefing,
+        ).with_introspection(task=t, role=role_str)
+
     async def i_am_blocked(
         self,
         agent_id: UUID,
@@ -2202,8 +2314,15 @@ class Choreographer:
         membership (developer/qa/documenter) and the source-status
         constraint of the composed ``block`` action (in_progress only).
         After the spec gate accepts, the journal:struggle entry is written
-        from the verb body, then ``VerbRunner.run_intent("i_am_blocked", ...)``
-        dispatches the (block,) atomic chain wrapped in a savepoint.
+        from the verb body, then either:
+
+        - ``reason == 'rate_limited'``: the task is **not** transitioned to
+          ``blocked``; instead every active agent on the same provider is
+          parked via ``mark_waiting_long(waiting_for='rate_limit_lifted')``
+          and a ``RATE_LIMIT_HIT`` event is published.
+        - any other reason: ``VerbRunner.run_intent("i_am_blocked", ...)``
+          dispatches the ``(block,)`` atomic chain wrapped in a savepoint,
+          transitioning the task to ``blocked``.
         """
         t = await self.task.get(task_id)
         if t is None:
@@ -2253,6 +2372,20 @@ class Choreographer:
             task_id=task_id,
             content=self._build_struggle_body(reason, blocker_type, what_needed),
         )
+
+        # Rate-limited fast path: skip the block state transition and park
+        # all affected agents instead.
+        if reason.strip().lower() == "rate_limited":
+            return await self._handle_rate_limited_parking(
+                agent_id=agent_id,
+                task_id=task_id,
+                t=t,
+                agent=agent,
+                role_str=role_str,
+                briefing=briefing,
+                what_needed=what_needed,
+            )
+
         t, rejection = await self._run_i_am_blocked_intent(
             agent_id, task_id, t, agent, spec_ctx, role_str, briefing
         )

--- a/roboco/services/gateway/rate_limit_tracker.py
+++ b/roboco/services/gateway/rate_limit_tracker.py
@@ -1,0 +1,130 @@
+"""Redis-backed rate-limit state tracker for the agent gateway.
+
+State is persisted in Redis as a JSON blob keyed by provider name.
+Because it is backed by Redis rather than process memory, state survives
+a process restart and a *new* ``RateLimitStateTracker`` instance pointing
+at the same Redis URL will read the same values — satisfying the
+cross-reconnection persistence requirement.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import redis.asyncio as redis
+
+from roboco.config import settings
+
+
+class RateLimitStateTracker:
+    """Track rate-limit state for a single AI provider in Redis.
+
+    Usage
+    -----
+    tracker = RateLimitStateTracker("anthropic")
+    await tracker.activate(retry_after=60.0, affected_agents=["be-dev-1"])
+    assert await tracker.is_rate_limited()
+
+    A second instance that uses the same Redis URL and provider name
+    will observe the same state — no in-process singleton required.
+    """
+
+    _KEY_PREFIX: str = "roboco:rate_limit:"
+
+    def __init__(self, provider: str, redis_url: str | None = None) -> None:
+        """Construct a tracker for *provider*.
+
+        Args:
+            provider:  Logical provider name, e.g. ``"anthropic"`` or
+                       ``"ollama_cloud"``.  Used as part of the Redis key.
+            redis_url: Override the Redis URL (defaults to
+                       ``settings.redis_url``).
+        """
+        self._provider = provider
+        self._redis_url = redis_url or settings.redis_url
+        self._redis: redis.Redis | None = None  # type: ignore[type-arg]
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _conn(self) -> redis.Redis:  # type: ignore[type-arg]
+        """Return a (lazy-connected) redis.asyncio.Redis client."""
+        if self._redis is None:
+            self._redis = redis.from_url(self._redis_url)
+        return self._redis
+
+    def _key(self) -> str:
+        """Redis key for this provider's state blob."""
+        return f"{self._KEY_PREFIX}{self._provider}:state"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def activate(
+        self,
+        retry_after: float | None = None,
+        affected_agents: list[str] | None = None,
+    ) -> None:
+        """Mark the provider as rate-limited.
+
+        Args:
+            retry_after:      Seconds until the provider should accept new
+                              requests, or ``None`` if unknown.
+            affected_agents:  Agent slugs that were active when the limit
+                              was hit (informational; stored in state).
+        """
+        r = await self._conn()
+        state: dict[str, Any] = {
+            "rate_limited": True,
+            "activated_at": datetime.now(UTC).isoformat(),
+            "retry_after": retry_after,
+            "affected_agents": affected_agents or [],
+            "probe_failures": 0,
+        }
+        await r.set(self._key(), json.dumps(state))
+
+    async def clear(self) -> None:
+        """Remove rate-limit state for this provider."""
+        r = await self._conn()
+        await r.delete(self._key())
+
+    async def is_rate_limited(self) -> bool:
+        """Return ``True`` if the provider is currently rate-limited."""
+        state = await self.get_state()
+        return bool(state.get("rate_limited", False))
+
+    async def get_state(self) -> dict[str, Any]:
+        """Return the stored state dict, or ``{}`` if none exists."""
+        r = await self._conn()
+        raw = await r.get(self._key())
+        if raw is None:
+            return {}
+        decoded: str = raw.decode() if isinstance(raw, bytes) else str(raw)
+        result: dict[str, Any] = json.loads(decoded)
+        return result
+
+    async def increment_probe_failures(self) -> int:
+        """Increment the probe-failure counter and return the new value.
+
+        The probe-failure counter tracks how many successive connectivity
+        probes have failed since the rate limit was activated.  The
+        orchestrator uses this to decide whether to keep waiting or give
+        up entirely.
+        """
+        r = await self._conn()
+        state = await self.get_state()
+        new_count: int = state.get("probe_failures", 0) + 1
+        state["probe_failures"] = new_count
+        await r.set(self._key(), json.dumps(state))
+        return new_count
+
+    async def reset_probe_failures(self) -> None:
+        """Reset the probe-failure counter to 0."""
+        r = await self._conn()
+        state = await self.get_state()
+        state["probe_failures"] = 0
+        await r.set(self._key(), json.dumps(state))

--- a/tests/unit/gateway/test_i_am_blocked_rate_limited.py
+++ b/tests/unit/gateway/test_i_am_blocked_rate_limited.py
@@ -1,0 +1,384 @@
+"""Unit tests for the rate-limited path in Choreographer.i_am_blocked.
+
+Acceptance criteria verified here:
+- AC3: POST /v1/i_am_blocked with reason='rate_limited' does NOT transition
+       the task to 'blocked'; the task remains in its current status
+       (in_progress) and the calling agent is parked via
+       mark_waiting_long(waiting_for='rate_limit_lifted').
+- AC4: mark_waiting_long is called for every orchestrator-tracked active agent
+       sharing the affected provider — call count equals active agent count.
+- AC5: A RATE_LIMIT_HIT event is published to the StreamEventBus with fields
+       provider, affectedAgents, retryAfterSeconds, and timestamp.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, call
+from uuid import uuid4
+
+import pytest
+
+from roboco.models.events import EventType
+from roboco.services.gateway.choreographer import Choreographer, ChoreographerDeps
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ACTIVE_AGENTS = ["be-dev-1", "be-dev-2", "be-qa"]
+_PROVIDER = "anthropic"
+
+
+def _make_evidence_repo() -> AsyncMock:
+    repo = AsyncMock()
+    for method in (
+        "list_unread_a2a",
+        "list_unread_mentions",
+        "list_pending_notifications",
+        "task_metadata_gaps",
+        "recent_team_activity",
+        "blockers_in_lane",
+        "journal_highlights_for_task",
+    ):
+        getattr(repo, method).return_value = []
+    return repo
+
+
+def _make_task_svc(agent_id: object, task_id: object) -> AsyncMock:
+    t = MagicMock(
+        id=task_id,
+        status="in_progress",
+        assigned_to=agent_id,
+        pre_block_state=None,
+        task_type="code",
+        team="backend",
+        # Avoid issues with spec iteration in claim guards
+        dependency_ids=[],
+        # acceptance_criteria needed by some paths
+        acceptance_criteria=[],
+        quick_context=None,
+    )
+    task_svc = AsyncMock()
+    task_svc.session = MagicMock()
+    task_svc.session.begin_nested = MagicMock(
+        return_value=MagicMock(
+            __aenter__=AsyncMock(return_value=None),
+            __aexit__=AsyncMock(return_value=False),
+        )
+    )
+    task_svc.get.return_value = t
+    task_svc.agent_for.return_value = MagicMock(
+        id=agent_id,
+        role="developer",
+        team="backend",
+        slug="be-dev-1",  # calling agent's slug
+    )
+    return task_svc
+
+
+def _make_orchestrator(
+    active_agents: list[str] | None = None,
+    provider: str = _PROVIDER,
+) -> MagicMock:
+    """Build a synchronous/async orchestrator mock."""
+    agents = active_agents if active_agents is not None else _ACTIVE_AGENTS
+    orch = MagicMock()
+    orch.get_provider_for_agent = MagicMock(return_value=provider)
+    orch.get_active_agent_slugs_for_provider = MagicMock(return_value=agents)
+    orch.mark_waiting_long = AsyncMock(return_value=None)
+    return orch
+
+
+def _make_stream_bus() -> AsyncMock:
+    bus = AsyncMock()
+    bus.publish = AsyncMock(return_value="msg-id-1")
+    return bus
+
+
+def _make_deps(
+    agent_id: object,
+    task_id: object,
+    orchestrator: MagicMock | None = None,
+    stream_bus: AsyncMock | None = None,
+) -> ChoreographerDeps:
+    return ChoreographerDeps(
+        task=_make_task_svc(agent_id, task_id),
+        work_session=AsyncMock(),
+        git=AsyncMock(),
+        a2a=AsyncMock(),
+        journal=AsyncMock(),
+        audit=AsyncMock(),
+        evidence_repo=_make_evidence_repo(),
+        orchestrator=orchestrator,
+        stream_bus=stream_bus,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3: Task stays in in_progress, agent parked via mark_waiting_long
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitedDoesNotBlockTask:
+    async def test_task_status_remains_in_progress(self) -> None:
+        """reason='rate_limited' must NOT transition the task to 'blocked'."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        env = await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        assert env.error is None
+        assert env.status == "in_progress"
+
+    async def test_verb_runner_block_action_not_called(self) -> None:
+        """The `block` action (task.escalate) must NOT run on rate_limited path."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        deps = _make_deps(agent_id, task_id)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        # The VerbRunner calls task.escalate for the normal block path.
+        # In the rate-limited path this must NOT happen.
+        deps.task.escalate.assert_not_awaited()
+
+    async def test_calling_agent_parked_via_mark_waiting_long(self) -> None:
+        """mark_waiting_long must be called with waiting_for='rate_limit_lifted'."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"])
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        # Verify that at least one mark_waiting_long call uses the right reason.
+        # The implementation calls mark_waiting_long(slug, waiting_for=..., ...)
+        # so waiting_for is always a keyword argument.
+        waiting_for_values = [
+            c.kwargs.get("waiting_for")
+            for c in orch.mark_waiting_long.call_args_list
+        ]
+        assert "rate_limit_lifted" in waiting_for_values
+
+    async def test_case_insensitive_reason_match(self) -> None:
+        """reason='Rate_Limited' (any case) should trigger the special path."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"])
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        env = await c.i_am_blocked(agent_id, task_id, "Rate_Limited")
+
+        assert env.error is None
+        assert env.status == "in_progress"
+
+    async def test_struggle_journal_still_written(self) -> None:
+        """journal.write_struggle must still be written on the rate_limited path."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        deps = _make_deps(agent_id, task_id)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        deps.journal.write_struggle.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# AC4: mark_waiting_long called for every active agent on affected provider
+# ---------------------------------------------------------------------------
+
+
+class TestMarkWaitingLongCallCount:
+    async def test_call_count_equals_active_agent_count(self) -> None:
+        """mark_waiting_long must be called once per active agent."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        active = ["be-dev-1", "be-dev-2", "be-dev-3"]
+        orch = _make_orchestrator(active_agents=active)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        assert orch.mark_waiting_long.call_count == len(active)
+
+    async def test_call_count_with_single_active_agent(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"])
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        assert orch.mark_waiting_long.call_count == 1
+
+    async def test_no_calls_when_no_active_agents(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=[])
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        assert orch.mark_waiting_long.call_count == 0
+
+    async def test_no_calls_when_orchestrator_is_none(self) -> None:
+        """When orchestrator is not wired in, no parking happens but no crash."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        deps = _make_deps(agent_id, task_id, orchestrator=None)
+        c = Choreographer(deps)
+
+        env = await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        # Should still succeed; no orchestrator = no parking
+        assert env.error is None
+        assert env.status == "in_progress"
+
+    async def test_mark_waiting_long_receives_waiting_for_arg(self) -> None:
+        """Every mark_waiting_long call must carry waiting_for='rate_limit_lifted'."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        active = ["be-dev-1", "be-qa"]
+        orch = _make_orchestrator(active_agents=active)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        for c_args in orch.mark_waiting_long.call_args_list:
+            # mark_waiting_long(slug, waiting_for=..., ...) — waiting_for is a kwarg
+            assert c_args.kwargs.get("waiting_for") == "rate_limit_lifted"
+
+
+# ---------------------------------------------------------------------------
+# AC5: RATE_LIMIT_HIT event published with correct payload structure
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitHitEventPublished:
+    async def test_stream_bus_publish_called_once(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        bus.publish.assert_awaited_once()
+
+    async def test_event_type_is_rate_limit_hit(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        event = bus.publish.call_args.args[0]
+        assert event.type == EventType.RATE_LIMIT_HIT
+
+    async def test_event_data_has_provider_field(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(provider="anthropic")
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        event = bus.publish.call_args.args[0]
+        assert "provider" in event.data
+        assert event.data["provider"] == "anthropic"
+
+    async def test_event_data_has_affected_agents_list(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        active = ["be-dev-1", "be-dev-2"]
+        orch = _make_orchestrator(active_agents=active)
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        event = bus.publish.call_args.args[0]
+        assert "affectedAgents" in event.data
+        assert isinstance(event.data["affectedAgents"], list)
+        assert event.data["affectedAgents"] == active
+
+    async def test_event_data_has_retry_after_seconds_null_by_default(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        event = bus.publish.call_args.args[0]
+        assert "retryAfterSeconds" in event.data
+        assert event.data["retryAfterSeconds"] is None
+
+    async def test_event_data_retry_after_parsed_from_what_needed(self) -> None:
+        """If what_needed is a numeric string, it becomes retryAfterSeconds."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(
+            agent_id, task_id, "rate_limited", what_needed="30"
+        )
+
+        event = bus.publish.call_args.args[0]
+        assert event.data["retryAfterSeconds"] == 30.0
+
+    async def test_event_data_has_timestamp_iso_string(self) -> None:
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        bus = _make_stream_bus()
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
+        c = Choreographer(deps)
+
+        await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        event = bus.publish.call_args.args[0]
+        assert "timestamp" in event.data
+        # ISO string: must be a non-empty string
+        ts = event.data["timestamp"]
+        assert isinstance(ts, str) and len(ts) > 0
+
+    async def test_no_publish_when_stream_bus_is_none(self) -> None:
+        """When stream_bus is not wired in, no publish is attempted."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator()
+        # stream_bus=None: no bus
+        deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=None)
+        c = Choreographer(deps)
+
+        env = await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        # Should still succeed
+        assert env.error is None
+        assert env.status == "in_progress"

--- a/tests/unit/services/test_rate_limit_tracker.py
+++ b/tests/unit/services/test_rate_limit_tracker.py
@@ -1,0 +1,244 @@
+"""Unit tests for RateLimitStateTracker.
+
+These tests use mock Redis clients (no real Redis server required) to
+verify the state-management logic.  The cross-reconnection persistence
+test constructs *two* RateLimitStateTracker instances that share the
+same mock Redis store, proving that state written by one instance is
+visible to a fresh instance.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from roboco.services.gateway.rate_limit_tracker import RateLimitStateTracker
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_redis_mock(initial_store: dict[str, Any] | None = None) -> AsyncMock:
+    """Build an async Redis mock backed by a plain dict.
+
+    The mock supports ``get``, ``set``, and ``delete`` with the same
+    semantics as the real redis.asyncio.Redis client.
+    """
+    # Use the dict AS-IS (no copy) so that two mocks sharing the same
+    # dict object see each other's writes and deletes — this is what the
+    # cross-reconnection persistence tests rely on.
+    store: dict[str, Any] = initial_store if initial_store is not None else {}
+
+    async def _get(key: str) -> bytes | None:
+        val = store.get(key)
+        if val is None:
+            return None
+        if isinstance(val, bytes):
+            return val
+        return str(val).encode()
+
+    async def _set(key: str, value: Any) -> None:
+        store[key] = value
+
+    async def _delete(key: str) -> int:
+        return 1 if store.pop(key, None) is not None else 0
+
+    mock = AsyncMock()
+    mock.get = AsyncMock(side_effect=_get)
+    mock.set = AsyncMock(side_effect=_set)
+    mock.delete = AsyncMock(side_effect=_delete)
+    # Stash the backing store so tests can inspect raw state
+    mock._store = store
+    return mock
+
+
+def _make_tracker(
+    provider: str = "anthropic",
+    redis_mock: AsyncMock | None = None,
+) -> RateLimitStateTracker:
+    """Build a tracker with an injected mock Redis client."""
+    tracker = RateLimitStateTracker(provider=provider, redis_url="redis://unused")
+    if redis_mock is not None:
+        tracker._redis = redis_mock  # type: ignore[assignment]
+    return tracker
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic operations
+# ---------------------------------------------------------------------------
+
+
+class TestActivateAndRead:
+    async def test_is_rate_limited_false_by_default(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        assert await tracker.is_rate_limited() is False
+
+    async def test_get_state_empty_by_default(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        assert await tracker.get_state() == {}
+
+    async def test_activate_sets_rate_limited_true(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate()
+        assert await tracker.is_rate_limited() is True
+
+    async def test_activate_stores_retry_after(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate(retry_after=30.0)
+        state = await tracker.get_state()
+        assert state["retry_after"] == 30.0
+
+    async def test_activate_stores_affected_agents(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate(affected_agents=["be-dev-1", "be-dev-2"])
+        state = await tracker.get_state()
+        assert state["affected_agents"] == ["be-dev-1", "be-dev-2"]
+
+    async def test_activate_initialises_probe_failures_zero(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate()
+        state = await tracker.get_state()
+        assert state["probe_failures"] == 0
+
+    async def test_clear_removes_state(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate()
+        await tracker.clear()
+        assert await tracker.is_rate_limited() is False
+        assert await tracker.get_state() == {}
+
+
+class TestProbeFailures:
+    async def test_increment_starts_from_zero(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate()
+        count = await tracker.increment_probe_failures()
+        assert count == 1
+
+    async def test_increment_accumulates(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate()
+        await tracker.increment_probe_failures()
+        await tracker.increment_probe_failures()
+        count = await tracker.increment_probe_failures()
+        assert count == 3
+
+    async def test_reset_sets_zero(self) -> None:
+        mock = _make_redis_mock()
+        tracker = _make_tracker(redis_mock=mock)
+        await tracker.activate()
+        await tracker.increment_probe_failures()
+        await tracker.increment_probe_failures()
+        await tracker.reset_probe_failures()
+        state = await tracker.get_state()
+        assert state["probe_failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: cross-reconnection persistence
+# ---------------------------------------------------------------------------
+#
+# AC2: "State persists across client reconnection: a test writes state via
+# activate(), creates a new RateLimitStateTracker instance pointing at the
+# same Redis URL, calls is_rate_limited() and get_state() and gets back the
+# same values — proving state survives a process restart."
+#
+# We simulate this by sharing the same backing dict between two mock Redis
+# clients — one injected into the first tracker and one injected into the
+# second.  Both clients read from and write to the same dict, so the second
+# tracker "sees" everything the first wrote.
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistsAcrossReconnection:
+    async def test_is_rate_limited_survives_reconnection(self) -> None:
+        shared_store: dict[str, Any] = {}
+
+        # First "connection": write rate-limit state
+        mock_a = _make_redis_mock(initial_store=shared_store)
+        tracker_a = _make_tracker(provider="anthropic", redis_mock=mock_a)
+        await tracker_a.activate(retry_after=60.0, affected_agents=["be-dev-1"])
+
+        # The mock writes into shared_store directly (our _set stores raw).
+        # We need to seed the second mock from the same backing store.
+        # Because mock_a._store IS shared_store (same dict object), we only
+        # need to give mock_b access to the same dict.
+        mock_b = _make_redis_mock(initial_store=mock_a._store)
+        tracker_b = RateLimitStateTracker(
+            provider="anthropic", redis_url="redis://unused"
+        )
+        tracker_b._redis = mock_b  # type: ignore[assignment]
+
+        assert await tracker_b.is_rate_limited() is True
+
+    async def test_get_state_survives_reconnection(self) -> None:
+        shared_store: dict[str, Any] = {}
+
+        mock_a = _make_redis_mock(initial_store=shared_store)
+        tracker_a = _make_tracker(provider="anthropic", redis_mock=mock_a)
+        await tracker_a.activate(retry_after=45.0, affected_agents=["be-dev-2"])
+
+        mock_b = _make_redis_mock(initial_store=mock_a._store)
+        tracker_b = RateLimitStateTracker(
+            provider="anthropic", redis_url="redis://unused"
+        )
+        tracker_b._redis = mock_b  # type: ignore[assignment]
+
+        state = await tracker_b.get_state()
+        assert state["rate_limited"] is True
+        assert state["retry_after"] == 45.0
+        assert state["affected_agents"] == ["be-dev-2"]
+
+    async def test_clear_via_first_instance_visible_to_second(self) -> None:
+        shared_store: dict[str, Any] = {}
+
+        mock_a = _make_redis_mock(initial_store=shared_store)
+        tracker_a = _make_tracker(provider="anthropic", redis_mock=mock_a)
+        await tracker_a.activate()
+
+        # Second instance points at the same store
+        mock_b = _make_redis_mock(initial_store=mock_a._store)
+        tracker_b = RateLimitStateTracker(
+            provider="anthropic", redis_url="redis://unused"
+        )
+        tracker_b._redis = mock_b  # type: ignore[assignment]
+
+        # Write clear via tracker_a
+        await tracker_a.clear()
+
+        # tracker_b observes the cleared state
+        assert await tracker_b.is_rate_limited() is False
+        assert await tracker_b.get_state() == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests: different providers are isolated
+# ---------------------------------------------------------------------------
+
+
+class TestProviderIsolation:
+    async def test_activating_one_provider_does_not_affect_another(self) -> None:
+        store: dict[str, Any] = {}
+        mock_a = _make_redis_mock(initial_store=store)
+        mock_b = _make_redis_mock(initial_store=store)
+
+        tracker_anthropic = _make_tracker(provider="anthropic", redis_mock=mock_a)
+        tracker_ollama = _make_tracker(provider="ollama_cloud", redis_mock=mock_b)
+
+        await tracker_anthropic.activate()
+        assert await tracker_anthropic.is_rate_limited() is True
+        assert await tracker_ollama.is_rate_limited() is False


### PR DESCRIPTION
Implement the foundational Redis-backed RateLimitStateTracker and wire it into the i_am_blocked flow, covering AC2 of the orchestrator rate-limit backpressure layer.

**What to build:**

1. **`roboco/services/gateway/rate_limit_tracker.py`** (new file):
   - `RateLimitStateTracker` class using `redis.asyncio` (same import as `stream_bus.py`)
   - Redis key pattern: `roboco:rate_limit:{provider}` storing a JSON object, 24h TTL
   - Async methods:
     - `activate(provider: str, retry_after_secs: float | None, affected_agents: list[str]) -> None` — sets hit_at (now), estimated_lift_at (now + retry_after_secs or +300), affected_agents, consecutive_probe_failures=0
     - `clear(provider: str) -> None` — deletes the Redis key
     - `is_rate_limited(provider: str) -> bool` — key exists?
     - `get_state() -> list[dict]` — returns all active rate-limit entries as list of dicts with keys: provider, affected_agents, hit_at (ISO), estimated_lift_at (ISO), retry_after_seconds, consecutive_probe_failures
     - `increment_probe_failures(provider: str) -> int` — increments counter in Redis, returns new count
     - `reset_probe_failures(provider: str) -> None` — resets counter to 0 in Redis

2. **Modify `roboco/services/gateway/choreographer/_impl.py`** (i_am_blocked handler):
   - Before the existing `spec_module.can_invoke_intent` gate: check if `reason == 'rate_limited'`
   - If rate_limited: skip the normal block-task transition entirely
   - Extract provider from the `what_needed` parameter or task metadata (use `'unknown'` if not determinable)
   - Extract `retry_after_secs` from `what_needed` if present (it may be passed as a float string)
   - Call `rate_limit_tracker.activate(provider, retry_after_secs, [agent_id])` 
   - Look up all active agents (from orchestrator._instances or equivalent) that share the same provider; call `orchestrator.mark_waiting_long(other_agent_id, waiting_for='rate_limit_lifted', task_id=other_agent_task_id, context={'provider': provider})` for each
   - Also call `mark_waiting_long` for the calling agent itself
   - Publish a `RATE_LIMIT_HIT` event via `stream_bus.publish(...)` with payload matching `RateLimitHitEvent` from `panel/src/types/rate-limits.ts`: `{type: 'RATE_LIMIT_HIT', provider, affectedAgents: [...], retryAfterSeconds, timestamp}`
   - Return a success envelope (status='rate_limit_activated', do NOT return a block envelope)

**Key files to read first:**
- `roboco/services/gateway/choreographer/_impl.py` — i_am_blocked method (~line 2191)
- `roboco/runtime/orchestrator.py` — mark_waiting_long (~line 2951), _instances dict, AgentState enum
- `roboco/events/stream_bus.py` — publish() method, Event class
- `roboco/services/exceptions.py` — RateLimitError.provider, retry_after fields
- `panel/src/types/rate-limits.ts` — RateLimitHitEvent shape (provider, affectedAgents, retryAfterSeconds, timestamp)

**Tests required:**
- Unit test: `activate()` writes to Redis and `is_rate_limited()` returns True; state round-trips through a fresh client instance (restart-survival test)
- Unit test: `i_am_blocked(reason='rate_limited')` does NOT call the block-task verb and does NOT change task status to blocked
- Unit test: `mark_waiting_long` is called for all affected agents including the caller
- Unit test: `stream_bus.publish` is called with RATE_LIMIT_HIT event carrying correct fields

Run before submitting: `uv run ruff format . && uv run ruff check . && uv run mypy roboco/ && uv run pytest`