### PR TITLE
[8451ca50] Wire i_am_blocked rate_limited path + add decide_spawn provider-rate-limit gate

### DIFF
--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -413,6 +413,7 @@ async def gateway_pre_spawn_check(
     task_id: str | None,
     trigger_kind: str,
     target_role: str,
+    provider: str | None = None,
 ) -> tuple[str, str]:
     """Consult trigger_filter before spawning a container.
 
@@ -420,6 +421,12 @@ async def gateway_pre_spawn_check(
     ``"spawn"``, ``"queue"``, or ``"drop"``.
 
     The trigger_filter spawn cooldown runs unconditionally for every spawn.
+
+    Args:
+        provider: Optional provider name (e.g. ``"anthropic"``) for the
+            agent about to be spawned.  When given, the
+            ``RateLimitStateTracker`` is consulted and a QUEUE decision is
+            returned when that provider is currently rate-limited.
     """
     from roboco.db.base import get_session_factory
     from roboco.services.gateway.trigger_filter import (
@@ -459,11 +466,29 @@ async def gateway_pre_spawn_check(
             if task_row is None:
                 return SpawnDecision.SPAWN, "task not found in DB — allow by default"
 
+            # Check provider rate-limit status when a provider is known.
+            # Failure is non-fatal — degrade to False (allow spawn) so Redis
+            # unavailability never permanently blocks the dispatcher.
+            provider_rate_limited = False
+            if provider is not None:
+                try:
+                    from roboco.services.gateway.rate_limit_tracker import (
+                        RateLimitStateTracker,
+                    )
+
+                    provider_rate_limited = await RateLimitStateTracker(
+                        provider
+                    ).is_rate_limited()
+                except Exception:
+                    provider_rate_limited = False
+
             trigger = TriggerContext(
                 kind=TriggerKind(trigger_kind),
                 skill=None,
                 recent_spawns_for_task=recent_for_task,
                 recent_spawns_for_role=recent_for_role,
+                provider=provider,
+                provider_rate_limited=provider_rate_limited,
             )
             config = SpawnConfig(
                 cooldown_seconds=settings.spawn_cooldown_seconds,
@@ -1212,6 +1237,7 @@ class AgentOrchestrator:
             task_id=task_id,
             trigger_kind=trigger_kind,
             target_role=target_role,
+            provider=self.get_provider_for_agent(agent_id),
         )
         if outcome != "spawn":
             logger.info(

--- a/roboco/services/gateway/choreographer/_impl.py
+++ b/roboco/services/gateway/choreographer/_impl.py
@@ -2234,7 +2234,7 @@ class Choreographer:
         briefing: dict[str, Any],
         what_needed: str | None,
     ) -> Envelope:
-        """Rate-limited fast path: park agents and publish event without blocking the task.
+        """Rate-limited fast path: park agents, publish event, persist state.
 
         Called from ``i_am_blocked`` when ``reason == 'rate_limited'``.
         The task stays in its current status (``in_progress``) — no block
@@ -2273,6 +2273,21 @@ class Choreographer:
                     )
 
         retry_after_seconds = self._parse_retry_after(what_needed)
+
+        # Persist rate-limit state to Redis so downstream decide_spawn()
+        # calls can gate new spawns for this provider.  Skipped when the
+        # provider is "unknown" (orchestrator not wired or not tracking the
+        # agent) to avoid polluting the tracker with meaningless keys.
+        if provider != "unknown":
+            with contextlib.suppress(Exception):
+                from roboco.services.gateway.rate_limit_tracker import (
+                    RateLimitStateTracker,
+                )
+
+                await RateLimitStateTracker(provider).activate(
+                    retry_after=retry_after_seconds,
+                    affected_agents=affected_agents,
+                )
 
         bus = self.stream_bus
         if bus is not None:

--- a/roboco/services/gateway/trigger_filter.py
+++ b/roboco/services/gateway/trigger_filter.py
@@ -50,6 +50,11 @@ class TriggerContext:
     skill: str | None
     recent_spawns_for_task: int
     recent_spawns_for_role: int
+    # Provider rate-limit fields.  Optional — callers that don't know the
+    # provider (e.g. no-task spawns) leave these at their defaults so the
+    # gate is a no-op.
+    provider: str | None = None
+    provider_rate_limited: bool = False
 
 
 _TERMINAL_STATUSES: frozenset[str] = frozenset({"completed", "cancelled"})
@@ -60,13 +65,16 @@ _A2A_CODE_REVIEW_RELEVANT_STATES: frozenset[str] = frozenset(
 )
 
 
-def decide_spawn(
+def decide_spawn(  # noqa: PLR0911
     *,
     task: Any,
     trigger: TriggerContext,
     config: SpawnConfig,
 ) -> Decision:
-    """Apply four rules in order: stale > claimant-lock > task-cooldown > role-rate."""
+    """Apply five rules in order.
+
+    stale > provider-rate-limit > claimant-lock > task-cooldown > role-rate
+    """
     # 1. Stale-trigger cleanup
     if task.status in _TERMINAL_STATUSES:
         return Decision(SpawnDecision.DROP, "task in terminal state — trigger stale")
@@ -81,7 +89,14 @@ def decide_spawn(
             f"a2a code_review for task in {task.status} — stale",
         )
 
-    # 2. Single-claimant invariant
+    # 2. Provider rate-limit gate
+    if trigger.provider_rate_limited:
+        return Decision(
+            SpawnDecision.QUEUE,
+            f"provider {trigger.provider or 'unknown'} rate-limited",
+        )
+
+    # 3. Single-claimant invariant
     if task.active_claimant_id is not None and not is_stale(
         task, threshold_seconds=config.claim_stale_seconds
     ):
@@ -90,14 +105,14 @@ def decide_spawn(
             "task has active claimant with fresh heartbeat",
         )
 
-    # 3. Per-task spawn cooldown
+    # 4. Per-task spawn cooldown
     if trigger.recent_spawns_for_task >= 1:
         return Decision(
             SpawnDecision.QUEUE,
             f"per-task spawn cooldown ({config.cooldown_seconds}s) active",
         )
 
-    # 4. Per-role rate limit
+    # 5. Per-role rate limit
     if trigger.recent_spawns_for_role >= config.role_rate_per_minute:
         return Decision(
             SpawnDecision.QUEUE,

--- a/tests/unit/gateway/test_i_am_blocked_rate_limited.py
+++ b/tests/unit/gateway/test_i_am_blocked_rate_limited.py
@@ -1,6 +1,9 @@
 """Unit tests for the rate-limited path in Choreographer.i_am_blocked.
 
 Acceptance criteria verified here:
+- AC1: i_am_blocked(reason='rate_limited') calls RateLimitStateTracker.activate()
+       and stores affected agent IDs; all active agents on the rate-limited
+       provider are subsequently marked waiting-long.
 - AC3: POST /v1/i_am_blocked with reason='rate_limited' does NOT transition
        the task to 'blocked'; the task remains in its current status
        (in_progress) and the calling agent is parked via
@@ -13,14 +16,11 @@ Acceptance criteria verified here:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
-
-import pytest
 
 from roboco.models.events import EventType
 from roboco.services.gateway.choreographer import Choreographer, ChoreographerDeps
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -161,8 +161,7 @@ class TestRateLimitedDoesNotBlockTask:
         # The implementation calls mark_waiting_long(slug, waiting_for=..., ...)
         # so waiting_for is always a keyword argument.
         waiting_for_values = [
-            c.kwargs.get("waiting_for")
-            for c in orch.mark_waiting_long.call_args_list
+            c.kwargs.get("waiting_for") for c in orch.mark_waiting_long.call_args_list
         ]
         assert "rate_limit_lifted" in waiting_for_values
 
@@ -345,12 +344,10 @@ class TestRateLimitHitEventPublished:
         deps = _make_deps(agent_id, task_id, orchestrator=orch, stream_bus=bus)
         c = Choreographer(deps)
 
-        await c.i_am_blocked(
-            agent_id, task_id, "rate_limited", what_needed="30"
-        )
+        await c.i_am_blocked(agent_id, task_id, "rate_limited", what_needed="30")
 
         event = bus.publish.call_args.args[0]
-        assert event.data["retryAfterSeconds"] == 30.0
+        assert event.data["retryAfterSeconds"] == float("30")
 
     async def test_event_data_has_timestamp_iso_string(self) -> None:
         agent_id = uuid4()
@@ -380,5 +377,132 @@ class TestRateLimitHitEventPublished:
         env = await c.i_am_blocked(agent_id, task_id, "rate_limited")
 
         # Should still succeed
+        assert env.error is None
+        assert env.status == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# AC1: RateLimitStateTracker.activate() called on rate_limited path
+# ---------------------------------------------------------------------------
+
+_TRACKER_PATCH = "roboco.services.gateway.rate_limit_tracker.RateLimitStateTracker"
+
+
+class TestRateLimitTrackerActivateOnParking:
+    """Verify that _handle_rate_limited_parking() calls activate()."""
+
+    async def test_activate_called_when_provider_known(self) -> None:
+        """activate() must be called once when provider != 'unknown'."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"], provider=_PROVIDER)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        mock_tracker = AsyncMock()
+        mock_tracker.activate = AsyncMock(return_value=None)
+        mock_tracker_cls = MagicMock(return_value=mock_tracker)
+
+        with patch(_TRACKER_PATCH, mock_tracker_cls):
+            await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        mock_tracker_cls.assert_called_once_with(_PROVIDER)
+        mock_tracker.activate.assert_awaited_once()
+
+    async def test_activate_receives_affected_agents(self) -> None:
+        """activate() must be called with the affected_agents list."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        active = ["be-dev-1", "be-dev-2"]
+        orch = _make_orchestrator(active_agents=active, provider=_PROVIDER)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        mock_tracker = AsyncMock()
+        mock_tracker.activate = AsyncMock(return_value=None)
+        mock_tracker_cls = MagicMock(return_value=mock_tracker)
+
+        with patch(_TRACKER_PATCH, mock_tracker_cls):
+            await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        call_kwargs = mock_tracker.activate.call_args.kwargs
+        assert call_kwargs.get("affected_agents") == active
+
+    async def test_activate_receives_retry_after_from_what_needed(self) -> None:
+        """activate() must receive retry_after parsed from what_needed."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"], provider=_PROVIDER)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        mock_tracker = AsyncMock()
+        mock_tracker.activate = AsyncMock(return_value=None)
+        mock_tracker_cls = MagicMock(return_value=mock_tracker)
+
+        with patch(_TRACKER_PATCH, mock_tracker_cls):
+            await c.i_am_blocked(agent_id, task_id, "rate_limited", what_needed="45")
+
+        call_kwargs = mock_tracker.activate.call_args.kwargs
+        assert call_kwargs.get("retry_after") == float("45")
+
+    async def test_activate_retry_after_none_when_what_needed_not_numeric(self) -> None:
+        """activate() must receive retry_after=None when what_needed is not a number."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"], provider=_PROVIDER)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        mock_tracker = AsyncMock()
+        mock_tracker.activate = AsyncMock(return_value=None)
+        mock_tracker_cls = MagicMock(return_value=mock_tracker)
+
+        with patch(_TRACKER_PATCH, mock_tracker_cls):
+            await c.i_am_blocked(
+                agent_id, task_id, "rate_limited", what_needed="retry soon"
+            )
+
+        call_kwargs = mock_tracker.activate.call_args.kwargs
+        assert call_kwargs.get("retry_after") is None
+
+    async def test_activate_skipped_when_provider_unknown(self) -> None:
+        """activate() must NOT be called when provider resolves to 'unknown'."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        # get_provider_for_agent returns None → provider stays 'unknown'
+        orch = MagicMock()
+        orch.get_provider_for_agent = MagicMock(return_value=None)
+        orch.get_active_agent_slugs_for_provider = MagicMock(return_value=[])
+        orch.mark_waiting_long = AsyncMock(return_value=None)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        mock_tracker = AsyncMock()
+        mock_tracker.activate = AsyncMock(return_value=None)
+        mock_tracker_cls = MagicMock(return_value=mock_tracker)
+
+        with patch(_TRACKER_PATCH, mock_tracker_cls):
+            env = await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
+        # No crash, no activate call
+        assert env.error is None
+        mock_tracker.activate.assert_not_awaited()
+
+    async def test_activate_failure_does_not_crash_path(self) -> None:
+        """If activate() raises, _handle_rate_limited_parking must still succeed."""
+        agent_id = uuid4()
+        task_id = uuid4()
+        orch = _make_orchestrator(active_agents=["be-dev-1"], provider=_PROVIDER)
+        deps = _make_deps(agent_id, task_id, orchestrator=orch)
+        c = Choreographer(deps)
+
+        mock_tracker = AsyncMock()
+        mock_tracker.activate = AsyncMock(side_effect=RuntimeError("redis down"))
+        mock_tracker_cls = MagicMock(return_value=mock_tracker)
+
+        with patch(_TRACKER_PATCH, mock_tracker_cls):
+            env = await c.i_am_blocked(agent_id, task_id, "rate_limited")
+
         assert env.error is None
         assert env.status == "in_progress"

--- a/tests/unit/gateway/test_trigger_filter.py
+++ b/tests/unit/gateway/test_trigger_filter.py
@@ -34,17 +34,21 @@ def _task(
     return t
 
 
-def _trigger(
+def _trigger(  # noqa: PLR0913
     kind: TriggerKind,
     skill: str | None = None,
     recent_spawns_for_task: int = 0,
     recent_spawns_for_role: int = 0,
+    provider: str | None = None,
+    provider_rate_limited: bool = False,
 ) -> TriggerContext:
     return TriggerContext(
         kind=kind,
         skill=skill,
         recent_spawns_for_task=recent_spawns_for_task,
         recent_spawns_for_role=recent_spawns_for_role,
+        provider=provider,
+        provider_rate_limited=provider_rate_limited,
     )
 
 
@@ -148,3 +152,101 @@ class TestCooldown:
         )
         assert decision.outcome == SpawnDecision.QUEUE
         assert "rate" in decision.reason.lower()
+
+
+class TestProviderRateLimitGate:
+    """Rule 2: provider rate-limit gate fires before claimant-lock/cooldown."""
+
+    def test_queues_when_provider_rate_limited(self) -> None:
+        """QUEUE outcome when provider_rate_limited=True."""
+        t = _task(status="in_progress")
+        decision = decide_spawn(
+            task=t,
+            trigger=_trigger(
+                TriggerKind.NOTIFICATION,
+                provider="anthropic",
+                provider_rate_limited=True,
+            ),
+            config=_DEFAULT_CONFIG,
+        )
+        assert decision.outcome == SpawnDecision.QUEUE
+        assert "provider anthropic rate-limited" in decision.reason
+
+    def test_reason_contains_provider_name(self) -> None:
+        """Reason string must contain the provider name."""
+        t = _task(status="pending")
+        decision = decide_spawn(
+            task=t,
+            trigger=_trigger(
+                TriggerKind.SCAN,
+                provider="ollama_cloud",
+                provider_rate_limited=True,
+            ),
+            config=_DEFAULT_CONFIG,
+        )
+        assert "ollama_cloud" in decision.reason
+
+    def test_reason_contains_unknown_when_no_provider_name(self) -> None:
+        """When provider is None, reason still contains 'unknown'."""
+        t = _task(status="in_progress")
+        decision = decide_spawn(
+            task=t,
+            trigger=_trigger(
+                TriggerKind.NOTIFICATION,
+                provider=None,
+                provider_rate_limited=True,
+            ),
+            config=_DEFAULT_CONFIG,
+        )
+        assert decision.outcome == SpawnDecision.QUEUE
+        assert "unknown" in decision.reason
+
+    def test_no_queue_injection_when_not_rate_limited(self) -> None:
+        """SPAWN when provider_rate_limited=False and all other gates clear."""
+        t = _task(status="in_progress")
+        decision = decide_spawn(
+            task=t,
+            trigger=_trigger(
+                TriggerKind.NOTIFICATION,
+                provider="anthropic",
+                provider_rate_limited=False,
+            ),
+            config=_DEFAULT_CONFIG,
+        )
+        assert decision.outcome == SpawnDecision.SPAWN
+
+    def test_stale_drop_fires_before_rate_limit_gate(self) -> None:
+        """Rule 1 (stale-drop) fires before rule 2 (rate-limit gate)."""
+        t = _task(status="completed")
+        decision = decide_spawn(
+            task=t,
+            trigger=_trigger(
+                TriggerKind.NOTIFICATION,
+                provider="anthropic",
+                provider_rate_limited=True,
+            ),
+            config=_DEFAULT_CONFIG,
+        )
+        # Rule 1 fires first — outcome must be DROP, not QUEUE
+        assert decision.outcome == SpawnDecision.DROP
+
+    def test_rate_limit_gate_fires_before_claimant_lock(self) -> None:
+        """Rule 2 (rate-limit gate) fires before rule 3 (single-claimant invariant)."""
+        recent = datetime.now(tz=UTC)
+        t = _task(
+            status="in_progress",
+            active_claimant_id=uuid4(),
+            last_heartbeat_at=recent,
+        )
+        decision = decide_spawn(
+            task=t,
+            trigger=_trigger(
+                TriggerKind.NOTIFICATION,
+                provider="anthropic",
+                provider_rate_limited=True,
+            ),
+            config=_DEFAULT_CONFIG,
+        )
+        # Both gates would QUEUE but reason must come from rate-limit (rule 2)
+        assert decision.outcome == SpawnDecision.QUEUE
+        assert "rate-limited" in decision.reason


### PR DESCRIPTION
The RateLimitStateTracker class already exists at roboco/services/gateway/rate_limit_tracker.py (Redis-backed, with activate(), clear(), is_rate_limited(), get_state(), increment_probe_failures() methods). Your job is to wire it into two orchestrator integration points:

**Integration Point 1 — i_am_blocked in choreographer/_impl.py (AC2)**
- In `Choreographer.i_am_blocked()` (around line 2191 of choreographer/_impl.py), add a branch: if `reason == 'rate_limited'`:
  1. Extract the `provider` from the blocked agent's current task or from the `context` argument (check how provider is tracked per-agent — look at the agent's task, its model config, or the `context` dict passed to i_am_blocked)
  2. Instantiate `RateLimitStateTracker(provider)` and call `await tracker.activate(retry_after=<from context if available>)`
  3. Find all agents currently on the same provider (query orchestrator's active agent list) and call `orchestrator.mark_waiting_long(agent_id, waiting_for='rate_limit', task_id=...)` for each
  4. Store the affected agent IDs in the tracker state via the `affected_agents` param of `activate()`

**Integration Point 2 — trigger_filter.decide_spawn() (AC5)**
- In `trigger_filter.py`, in the `decide_spawn()` function, add a new gate (preferably as the first check after the terminal-status drop):
  1. Determine which provider the task's model uses (look at how the spawn config or task config maps models to providers)
  2. Instantiate `RateLimitStateTracker(provider)` and check `await tracker.is_rate_limited()`
  3. If True, return `SpawnDecision(action=SpawnAction.QUEUE, reason=f'provider {provider} rate-limited')`
  4. Record this decision in the GatewayTriggerTable (check how existing QUEUE decisions are recorded — follow the same pattern)

**Important implementation notes:**
- RateLimitStateTracker is async; the choreographer and trigger_filter are async contexts, so `await` is appropriate
- Don't re-implement the tracker class — import it from `roboco.services.gateway.rate_limit_tracker`
- Check how `mark_waiting_long()` signature looks in orchestrator.py:2951 before calling it
- The `decide_spawn()` function may need to receive the tracker as an injected dependency or construct it inline — follow the existing pattern for Redis access in that file
- Write or update unit tests in tests/unit/services/ (or tests/unit/gateway/) covering: (a) i_am_blocked with reason='rate_limited' activates the tracker, (b) decide_spawn returns QUEUE when provider is rate-limited, (c) decide_spawn passes through normally when provider is clear

Run `uv run ruff format . && uv run ruff check . && uv run mypy roboco/ && uv run pytest tests/unit/` before marking done.