### PR TITLE
[49bff06c] Frontend: Usage dashboard real-time rendering and polling fallback

### DIFF
--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -2,6 +2,7 @@
 
 import { useCeoOverview, useAuditorFlags, useRecentActivity } from "@/hooks/use-dashboard";
 import { useTasks } from "@/hooks/use-tasks";
+import { useUsageStore } from "@/store/usage-store";
 import { TeamHealthCards } from "./team-health-cards";
 import { KeyMetricsPanel } from "./key-metrics-panel";
 import { AuditorAlertsPanel } from "./auditor-alerts-panel";
@@ -16,10 +17,25 @@ import { RefreshCw, Settings } from "lucide-react";
 import Link from "next/link";
 
 export function CommandCenter() {
+  // WS-first data source: read live usage data from the store (populated by
+  // useRateLimitWebSocket whenever USAGE_UPDATE / USAGE_SNAPSHOT arrives on
+  // the /ws/system connection). Falls back to the polling hook when WS is
+  // not connected or no snapshot has been received yet.
+  const { wsState, usageData } = useUsageStore();
+  const wsConnected = wsState === "connected" && usageData !== null;
+
+  // Polling hook always runs (background refetch every 60 s) so the data is
+  // ready the moment WS disconnects.
   const { data: overview, isLoading: loadingOverview, refetch: refetchOverview } = useCeoOverview();
   const { data: flags, isLoading: loadingFlags } = useAuditorFlags({ resolved: false });
   const { data: tasks, isLoading: loadingTasks } = useTasks();
   const { data: activity, isLoading: loadingActivity } = useRecentActivity(24);
+
+  // key_metrics: prefer WS snapshot; fall back to polling
+  const keyMetrics = wsConnected
+    ? usageData.key_metrics
+    : overview?.key_metrics;
+  const isLoadingMetrics = wsConnected ? false : loadingOverview;
 
   const handleRefresh = () => {
     refetchOverview();
@@ -65,8 +81,9 @@ export function CommandCenter() {
       {/* Metrics, Alerts, and Usage Row */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <KeyMetricsPanel
-          metrics={overview?.key_metrics}
-          isLoading={loadingOverview}
+          metrics={keyMetrics}
+          isLoading={isLoadingMetrics}
+          wsState={wsState}
         />
         <AuditorAlertsPanel alerts={flags} isLoading={loadingFlags} />
         <UsageOverviewPanel />

--- a/panel/src/components/dashboard/key-metrics-panel.tsx
+++ b/panel/src/components/dashboard/key-metrics-panel.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TrendingUp, Clock, CheckCircle, Users, BarChart3 } from "lucide-react";
+import { TrendingUp, Clock, CheckCircle, Users, BarChart3, Wifi, WifiOff, Loader2 } from "lucide-react";
+import type { ConnectionState } from "@/lib/websocket/connection";
 
 interface KeyMetricsProps {
   metrics: Record<string, unknown> | undefined;
   isLoading: boolean;
+  /** Current /ws/system connection state, used to render the status badge */
+  wsState: ConnectionState;
 }
 
 interface MetricItem {
@@ -49,11 +53,48 @@ const METRIC_CONFIG: MetricItem[] = [
   },
 ];
 
-export function KeyMetricsPanel({ metrics, isLoading }: KeyMetricsProps) {
+/**
+ * Returns the badge variant props (className + icon + label) matching the
+ * AgentStreamViewer pattern.
+ */
+function getConnectionBadge(wsState: ConnectionState) {
+  switch (wsState) {
+    case "connected":
+      return {
+        className: "bg-green-500 text-white",
+        icon: <Wifi className="h-3 w-3 mr-1" />,
+        label: "Live",
+      };
+    case "connecting":
+    case "reconnecting":
+      return {
+        className: "bg-yellow-500 text-white",
+        icon: <Loader2 className="h-3 w-3 mr-1 animate-spin" />,
+        label: wsState === "reconnecting" ? "Reconnecting..." : "Connecting...",
+      };
+    case "disconnected":
+    default:
+      return {
+        className: "bg-gray-500 text-white",
+        icon: <WifiOff className="h-3 w-3 mr-1" />,
+        label: "Polling",
+      };
+  }
+}
+
+export function KeyMetricsPanel({ metrics, isLoading, wsState }: KeyMetricsProps) {
+  const badge = getConnectionBadge(wsState);
+
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-lg">Key Metrics</CardTitle>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Key Metrics</CardTitle>
+          <Badge className={badge.className}>
+            {badge.icon}
+            {badge.label}
+          </Badge>
+        </div>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -73,7 +114,7 @@ export function KeyMetricsPanel({ metrics, isLoading }: KeyMetricsProps) {
                     {m.icon}
                     {m.label}
                   </div>
-                  <span className="font-medium">
+                  <span className="font-medium transition-all duration-300 ease-in-out">
                     {value != null
                       ? m.format
                         ? m.format(value)

--- a/panel/src/hooks/use-rate-limit-websocket.ts
+++ b/panel/src/hooks/use-rate-limit-websocket.ts
@@ -3,13 +3,22 @@
 import { useEffect, useRef } from "react";
 import { useWebSocket } from "./use-websocket";
 import { useRateLimitStore } from "@/store/rate-limit-store";
+import { useUsageStore } from "@/store/usage-store";
 import type { RateLimitHitEvent, RateLimitLiftedEvent } from "@/types/rate-limits";
 
-interface RateLimitWsMessage {
+/**
+ * Unified shape for all messages arriving on the /ws/system endpoint.
+ * Fields are optional because different message types use different subsets.
+ */
+interface SystemWsMessage {
   type: string;
+  // Rate-limit fields (RATE_LIMIT_HIT / RATE_LIMIT_LIFTED)
   provider?: string;
   affectedAgents?: string[];
   retryAfterSeconds?: number;
+  // Usage fields (USAGE_UPDATE / USAGE_SNAPSHOT)
+  key_metrics?: Record<string, unknown>;
+  // Shared
   timestamp?: string;
 }
 
@@ -19,9 +28,18 @@ interface UseRateLimitWebSocketOptions {
 }
 
 /**
- * Subscribes to RATE_LIMIT_HIT and RATE_LIMIT_LIFTED WebSocket events and
- * dispatches them to the useRateLimitStore. Accepts an optional onReconnect
- * callback that fires when the connection recovers from a reconnecting state.
+ * Subscribes to the /ws/system WebSocket (single shared instance mounted in
+ * RateLimitBanner). Handles:
+ *
+ *  - RATE_LIMIT_HIT / RATE_LIMIT_LIFTED → dispatched to useRateLimitStore
+ *  - USAGE_UPDATE / USAGE_SNAPSHOT     → dispatched to useUsageStore
+ *
+ * Also syncs the live WebSocket connection state into useUsageStore so that
+ * other components (e.g. CommandCenter, KeyMetricsPanel) can read it without
+ * creating a second /ws/system connection.
+ *
+ * Accepts an optional onReconnect callback that fires when the connection
+ * recovers from a reconnecting state.
  */
 export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}) {
   const { onReconnect } = options;
@@ -30,11 +48,17 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
   // getWebSocketUrl() already supplies the "/ws" base, so the endpoint is just
   // the path (matching the agents/channels/notifications hooks). Passing
   // "/ws/system" here produced the doubled "/ws/ws/system" URL.
-  const { state, lastMessage } = useWebSocket<RateLimitWsMessage>(
+  const { state, lastMessage } = useWebSocket<SystemWsMessage>(
     "/system",
     undefined,
     true
   );
+
+  // Sync WS connection state into useUsageStore for cross-component visibility.
+  // This is the ONLY place wsState is written; no second useWebSocket call is needed.
+  useEffect(() => {
+    useUsageStore.getState().setWsState(state);
+  }, [state]);
 
   // Fire onReconnect when state transitions from reconnecting → connected
   useEffect(() => {
@@ -49,6 +73,7 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
     if (!lastMessage) return;
 
     const { hitRateLimit, liftRateLimit } = useRateLimitStore.getState();
+    const { setUsageData } = useUsageStore.getState();
 
     if (lastMessage.type === "RATE_LIMIT_HIT") {
       const event: RateLimitHitEvent = {
@@ -66,6 +91,14 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
         timestamp: lastMessage.timestamp ?? new Date().toISOString(),
       };
       liftRateLimit(event);
+    } else if (
+      lastMessage.type === "USAGE_UPDATE" ||
+      lastMessage.type === "USAGE_SNAPSHOT"
+    ) {
+      setUsageData({
+        key_metrics: lastMessage.key_metrics ?? {},
+        timestamp: lastMessage.timestamp,
+      });
     }
   }, [lastMessage]);
 

--- a/panel/src/store/index.ts
+++ b/panel/src/store/index.ts
@@ -1,3 +1,5 @@
 export { useUIStore } from "./ui-store";
 export { useNotificationStore } from "./notifications-store";
 export { useRateLimitStore } from "./rate-limit-store";
+export { useUsageStore } from "./usage-store";
+export type { UsageData } from "./usage-store";

--- a/panel/src/store/usage-store.ts
+++ b/panel/src/store/usage-store.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import type { ConnectionState } from "@/lib/websocket/connection";
+
+/**
+ * Usage data received from USAGE_UPDATE or USAGE_SNAPSHOT WebSocket messages
+ * on the /ws/system endpoint.
+ */
+export interface UsageData {
+  /** Key performance metrics (velocity, completion rate, active agents, etc.) */
+  key_metrics: Record<string, unknown>;
+  /** ISO timestamp of the snapshot */
+  timestamp?: string;
+}
+
+interface UsageState {
+  /** Most-recent usage data received over WebSocket; null until first message arrives */
+  usageData: UsageData | null;
+  /** Current /ws/system WebSocket connection state, synced by useRateLimitWebSocket */
+  wsState: ConnectionState;
+
+  // Actions
+  /** Overwrite usageData with the latest payload from the WebSocket */
+  setUsageData: (data: UsageData) => void;
+  /** Clear usageData (e.g. on intentional disconnect or reset) */
+  clearUsageData: () => void;
+  /** Update the cached WebSocket connection state */
+  setWsState: (state: ConnectionState) => void;
+}
+
+export const useUsageStore = create<UsageState>((set) => ({
+  usageData: null,
+  wsState: "disconnected",
+
+  setUsageData: (data) => set({ usageData: data }),
+  clearUsageData: () => set({ usageData: null }),
+  setWsState: (state) => set({ wsState: state }),
+}));


### PR DESCRIPTION
Wire the usage dashboard to receive real-time updates over the existing /ws/system WebSocket stream, with graceful fallback to HTTP polling. Goal: the Command Center (KeyMetricsPanel in command-center.tsx) and Metrics page (metrics/page.tsx) render WS-pushed usage data in real time when connected, and fall back seamlessly to react-query polling when /ws/system is unavailable. Constraints: (1) Use the existing useWebSocket("/system") hook and Zustand store pattern established by the rate-limit banner — no new client-side connection stack. (2) The backend event contract is: USAGE_UPDATE = {type, agent_id, task_id, input_tokens, output_tokens, model, timestamp}; USAGE_SNAPSHOT = {type, period, totals, cost_estimate, by_agent}. (3) HoM requires the real-time status indicator to follow the agent stream viewer badge pattern (green connected / yellow connecting / gray disconnected with Wifi/WifiOff icons) — do NOT introduce a new indicator style. (4) Fallback transition must be seamless: no data gaps, no UI flash, no jarring number jumps — only the badge changes color.