### PR TITLE
[a75df123] Backend: WebSocket usage event infrastructure

### DIFF
--- a/roboco/api/websocket_bridge.py
+++ b/roboco/api/websocket_bridge.py
@@ -144,6 +144,20 @@ async def _handle_rate_limit_event(event: Event) -> None:
     await manager.broadcast_system({"type": ws_type, **event.data})
 
 
+async def _handle_usage_event(event: Event) -> None:
+    """Forward USAGE_UPDATE/SNAPSHOT events to operator system WS clients.
+
+    Both event types carry all the fields the panel needs directly in
+    ``event.data``; we pass them through tagged with ``event.type.value``
+    so the panel can distinguish per-agent updates from aggregate snapshots.
+    """
+    await manager.broadcast_system({"type": event.type.value, **event.data})
+    logger.debug(
+        "Usage event forwarded to system WebSocket",
+        event_type=event.type.value,
+    )
+
+
 def register_websocket_bridge_handlers() -> None:
     """
     Register event handlers that forward events to WebSocket clients.
@@ -171,6 +185,10 @@ def register_websocket_bridge_handlers() -> None:
     # Rate-limit lifecycle -> system WebSocket (panel banner)
     bus.subscribe(EventType.RATE_LIMIT_HIT, _handle_rate_limit_event)
     bus.subscribe(EventType.RATE_LIMIT_LIFTED, _handle_rate_limit_event)
+
+    # Usage events -> system WebSocket (panel dashboard)
+    bus.subscribe(EventType.USAGE_UPDATE, _handle_usage_event)
+    bus.subscribe(EventType.USAGE_SNAPSHOT, _handle_usage_event)
 
     logger.info("WebSocket bridge handlers registered")
 

--- a/roboco/models/events.py
+++ b/roboco/models/events.py
@@ -69,6 +69,10 @@ class EventType(StrEnum):
     RATE_LIMIT_HIT = "rate_limit.hit"
     RATE_LIMIT_LIFTED = "rate_limit.lifted"
 
+    # Usage events
+    USAGE_UPDATE = "usage.update"
+    USAGE_SNAPSHOT = "usage.snapshot"
+
     # Question events
     QUESTION_ASKED = "question.asked"
     QUESTION_ANSWERED = "question.answered"

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3316,13 +3316,16 @@ class AgentOrchestrator:
                 error=str(exc),
             )
 
-    async def _sweep_token_snapshots(self) -> None:
+    async def _sweep_token_snapshots(self) -> None:  # noqa: PLR0915
         """Write a token_usage_snapshots row for each active agent with non-zero tokens.
 
         Called from _run_sweep() every ~60 s. Also updates the cumulative
         token counts on the open agent_spawn_sessions row so the DB reflects
         current progress without waiting for session close.
         Errors per-agent are caught so one bad agent doesn't abort the whole sweep.
+
+        Additionally publishes USAGE_UPDATE events per agent (throttled to at most
+        one per 5-second window) and a USAGE_SNAPSHOT aggregate after the loop.
         """
         if not self._instances:
             return
@@ -3334,6 +3337,12 @@ class AgentOrchestrator:
             return
 
         session_factory = get_session_factory()
+
+        # Accumulators for the post-loop USAGE_SNAPSHOT event.
+        _usage_by_agent: list[dict[str, Any]] = []
+        _usage_total_input = 0
+        _usage_total_output = 0
+        _usage_total_cost = 0.0
 
         async with httpx.AsyncClient(timeout=3.0) as client:
             for agent_id, instance in list(self._instances.items()):
@@ -3363,6 +3372,9 @@ class AgentOrchestrator:
                     )
                     if total == 0:
                         continue
+
+                    # Resolve model for cost estimation and event data.
+                    _model = instance.config.model if instance.config else "unknown"
 
                     async with session_factory() as db:
                         from sqlalchemy import select, update
@@ -3418,12 +3430,65 @@ class AgentOrchestrator:
                         )
                         await db.commit()
 
+                    # Publish USAGE_UPDATE event for this agent (throttled).
+                    with contextlib.suppress(Exception):
+                        from roboco.events import get_event_bus
+                        from roboco.services.usage_events import publish_usage_update
+
+                        await publish_usage_update(
+                            bus=get_event_bus(),
+                            agent_id=agent_id,
+                            task_id=instance.current_task_id,
+                            input_tokens=tokens_input,
+                            output_tokens=tokens_output,
+                            model=_model,
+                        )
+
+                    # Accumulate per-agent data for the aggregate snapshot.
+                    with contextlib.suppress(Exception):
+                        from roboco.billing.pricing import calculate_cost
+
+                        agent_cost = calculate_cost(
+                            model=_model,
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                        )
+                        _usage_by_agent.append(
+                            {
+                                "agent_id": agent_id,
+                                "input_tokens": tokens_input,
+                                "output_tokens": tokens_output,
+                                "model": _model,
+                                "cost_estimate": agent_cost,
+                            }
+                        )
+                        _usage_total_input += tokens_input
+                        _usage_total_output += tokens_output
+                        _usage_total_cost += agent_cost
+
                 except Exception as agent_exc:
                     logger.debug(
                         "Token snapshot failed for agent",
                         agent_id=agent_id,
                         error=str(agent_exc),
                     )
+
+        # Publish a USAGE_SNAPSHOT aggregate if any active agents had token data.
+        if _usage_by_agent:
+            with contextlib.suppress(Exception):
+                from roboco.events import get_event_bus
+                from roboco.services.usage_events import publish_usage_snapshot
+
+                await publish_usage_snapshot(
+                    bus=get_event_bus(),
+                    period="60s",
+                    totals={
+                        "input_tokens": _usage_total_input,
+                        "output_tokens": _usage_total_output,
+                    },
+                    cost_estimate=_usage_total_cost,
+                    by_agent=_usage_by_agent,
+                )
 
     async def _sweep_daily_rollup(self) -> None:
         """Upsert daily_usage_rollups from closed agent_spawn_sessions.

--- a/roboco/services/usage_events.py
+++ b/roboco/services/usage_events.py
@@ -1,0 +1,132 @@
+"""
+Usage Event Publisher
+
+Throttled helpers for publishing USAGE_UPDATE and USAGE_SNAPSHOT events
+to the StreamEventBus.  Consumed by the orchestrator token sweep and
+forwarded to /ws/system WebSocket clients via the websocket_bridge.
+
+Throttle window: one USAGE_UPDATE publish per agent per 5-second window.
+Subsequent calls within the window are silently dropped so a frequent
+sweep loop cannot flood the event bus or WebSocket clients.
+
+USAGE_SNAPSHOT is always published (no per-agent throttle) — it is an
+aggregate and published at most once per sweep cycle.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from roboco.events.stream_bus import StreamEventBus
+
+_THROTTLE_WINDOW_SECONDS: float = 5.0
+
+
+class _UsageThrottle:
+    """Per-agent last-publish timestamp tracker.
+
+    Uses ``time.monotonic()`` so clock adjustments (NTP, DST) don't cause
+    spurious suppressions or double-fires.
+    """
+
+    def __init__(self, window: float = _THROTTLE_WINDOW_SECONDS) -> None:
+        self._window = window
+        self._last: dict[str, float] = {}
+
+    def should_publish(self, agent_id: str) -> bool:
+        """Return True if the agent is outside the throttle window.
+
+        Also records the current monotonic time as the new *last published*
+        timestamp when it returns True, so the caller does not need to call a
+        separate ``record()`` method.
+        """
+        now = time.monotonic()
+        if now - self._last.get(agent_id, 0.0) >= self._window:
+            self._last[agent_id] = now
+            return True
+        return False
+
+
+# Module-level singleton — shared across all callers in this process.
+_throttle = _UsageThrottle()
+
+
+async def publish_usage_update(  # noqa: PLR0913
+    bus: StreamEventBus,
+    agent_id: str,
+    task_id: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    model: str,
+    timestamp: datetime | None = None,
+) -> bool:
+    """Publish a USAGE_UPDATE event if the per-agent throttle window has elapsed.
+
+    Args:
+        bus: The StreamEventBus to publish on.
+        agent_id: Agent slug (e.g. ``"be-dev-1"``).
+        task_id: The agent's current task UUID string, or None.
+        input_tokens: Cumulative input-token count for this session.
+        output_tokens: Cumulative output-token count for this session.
+        model: Model name (e.g. ``"claude-sonnet-4-6"``).
+        timestamp: Override publish timestamp; defaults to ``datetime.now(UTC)``.
+
+    Returns:
+        True if the event was published; False if suppressed by the throttle.
+    """
+    if not _throttle.should_publish(agent_id):
+        return False
+
+    from roboco.models.events import Event, EventType  # lazy — avoids circular import
+
+    event = Event(
+        type=EventType.USAGE_UPDATE,
+        data={
+            "agent_id": agent_id,
+            "task_id": task_id,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "model": model,
+            "timestamp": (timestamp or datetime.now(UTC)).isoformat(),
+        },
+    )
+    await bus.publish(event)
+    return True
+
+
+async def publish_usage_snapshot(  # noqa: PLR0913
+    bus: StreamEventBus,
+    period: str,
+    totals: dict[str, Any],
+    cost_estimate: float,
+    by_agent: list[dict[str, Any]],
+    timestamp: datetime | None = None,
+) -> None:
+    """Publish a USAGE_SNAPSHOT aggregate event (no throttle).
+
+    Args:
+        bus: The StreamEventBus to publish on.
+        period: Human-readable period label (e.g. ``"60s"``).
+        totals: ``{"input_tokens": int, "output_tokens": int}`` aggregate.
+        cost_estimate: Estimated USD cost for the snapshot period.
+        by_agent: Per-agent breakdown list; each item is a dict with keys
+            ``agent_id``, ``input_tokens``, ``output_tokens``, ``model``,
+            and ``cost_estimate``.
+        timestamp: Override publish timestamp; defaults to ``datetime.now(UTC)``.
+    """
+    from roboco.models.events import Event, EventType  # lazy — avoids circular import
+
+    event = Event(
+        type=EventType.USAGE_SNAPSHOT,
+        data={
+            "period": period,
+            "totals": totals,
+            "cost_estimate": cost_estimate,
+            "by_agent": by_agent,
+            "timestamp": (timestamp or datetime.now(UTC)).isoformat(),
+        },
+    )
+    await bus.publish(event)

--- a/tests/unit/api/test_websocket_bridge.py
+++ b/tests/unit/api/test_websocket_bridge.py
@@ -17,6 +17,7 @@ from roboco.api.websocket_bridge import (
     _handle_notification_sent,
     _handle_rate_limit_event,
     _handle_session_event,
+    _handle_usage_event,
     register_websocket_bridge_handlers,
     start_websocket_bridge,
 )
@@ -292,12 +293,74 @@ async def test_handle_rate_limit_ignores_unrelated_event() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _handle_usage_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_usage_update_broadcasts_to_system() -> None:
+    """USAGE_UPDATE event → broadcast_system with type=usage.update + data fields."""
+    event = _evt(
+        EventType.USAGE_UPDATE,
+        {
+            "agent_id": "be-dev-1",
+            "task_id": "task-abc",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "model": "claude-sonnet-4-6",
+            "timestamp": "2026-06-11T00:00:00+00:00",
+        },
+    )
+    with patch("roboco.api.websocket_bridge.manager") as mgr:
+        mgr.broadcast_system = AsyncMock()
+        await _handle_usage_event(event)
+    mgr.broadcast_system.assert_awaited_once()
+    msg = mgr.broadcast_system.await_args.args[0]
+    assert msg["type"] == "usage.update"
+    assert msg["agent_id"] == "be-dev-1"
+    assert msg["input_tokens"] == 100  # noqa: PLR2004
+    assert msg["output_tokens"] == 50  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_handle_usage_snapshot_broadcasts_to_system() -> None:
+    """USAGE_SNAPSHOT event → broadcast_system with type=usage.snapshot + aggregate."""
+    event = _evt(
+        EventType.USAGE_SNAPSHOT,
+        {
+            "period": "60s",
+            "totals": {"input_tokens": 500, "output_tokens": 200},
+            "cost_estimate": 0.0025,
+            "by_agent": [
+                {
+                    "agent_id": "be-dev-1",
+                    "input_tokens": 500,
+                    "output_tokens": 200,
+                    "model": "sonnet",
+                    "cost_estimate": 0.0025,
+                }
+            ],
+            "timestamp": "2026-06-11T00:01:00+00:00",
+        },
+    )
+    with patch("roboco.api.websocket_bridge.manager") as mgr:
+        mgr.broadcast_system = AsyncMock()
+        await _handle_usage_event(event)
+    mgr.broadcast_system.assert_awaited_once()
+    msg = mgr.broadcast_system.await_args.args[0]
+    assert msg["type"] == "usage.snapshot"
+    assert msg["period"] == "60s"
+    assert msg["totals"]["input_tokens"] == 500  # noqa: PLR2004
+    assert len(msg["by_agent"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # Registration + start
 # ---------------------------------------------------------------------------
 
 
 def test_register_websocket_bridge_handlers_subscribes_all_event_types() -> None:
-    """Registration wires up notification + session + agent event handlers."""
+    """Registration wires up all handler categories, including usage events."""
 
     class _FakeBus:
         def __init__(self) -> None:
@@ -310,7 +373,7 @@ def test_register_websocket_bridge_handlers_subscribes_all_event_types() -> None
     with patch("roboco.api.websocket_bridge.get_event_bus", return_value=fake):
         register_websocket_bridge_handlers()
     types = [t for t, _ in fake.subscribed]
-    # All 10 expected event types appear at least once.
+    # All 14 expected event types appear at least once.
     assert EventType.NOTIFICATION_SENT in types
     assert EventType.NOTIFICATION_ACKED in types
     assert EventType.SESSION_CREATED in types
@@ -323,6 +386,9 @@ def test_register_websocket_bridge_handlers_subscribes_all_event_types() -> None
     assert EventType.AGENT_ERROR in types
     assert EventType.RATE_LIMIT_HIT in types
     assert EventType.RATE_LIMIT_LIFTED in types
+    # Usage events forwarded to /ws/system.
+    assert EventType.USAGE_UPDATE in types
+    assert EventType.USAGE_SNAPSHOT in types
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_usage_events.py
+++ b/tests/unit/services/test_usage_events.py
@@ -1,0 +1,241 @@
+"""Unit tests for roboco.services.usage_events.
+
+Covers the _UsageThrottle class and the publish_usage_update /
+publish_usage_snapshot helpers.  No real Redis or event bus is needed —
+we use AsyncMock to assert that bus.publish is called with the right
+payload and type.
+
+The throttle suppression test is the acceptance-criterion gate:
+  "Server-side throttle prevents more than 1 USAGE_UPDATE publish per
+   agent per 5-second window."
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from roboco.services.usage_events import (
+    _UsageThrottle,
+    publish_usage_snapshot,
+    publish_usage_update,
+)
+
+# ---------------------------------------------------------------------------
+# _UsageThrottle
+# ---------------------------------------------------------------------------
+
+
+def test_throttle_allows_first_publish() -> None:
+    """A fresh agent has no prior timestamp — first publish is always allowed."""
+    th = _UsageThrottle(window=5.0)
+    assert th.should_publish("be-dev-1") is True
+
+
+def test_throttle_suppresses_second_publish_within_window() -> None:
+    """Second call within the 5-second window returns False (suppressed)."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 100.0
+        assert th.should_publish("be-dev-1") is True  # first → allowed
+
+        mock_time.monotonic.return_value = 104.9  # 4.9 s later — still inside window
+        assert th.should_publish("be-dev-1") is False  # suppressed
+
+
+def test_throttle_allows_publish_after_window_expires() -> None:
+    """After the full window elapses, the next publish is allowed again."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 100.0
+        assert th.should_publish("be-dev-1") is True  # first
+
+        mock_time.monotonic.return_value = 105.0  # exactly 5 s later
+        assert th.should_publish("be-dev-1") is True  # window elapsed → allowed
+
+
+def test_throttle_tracks_agents_independently() -> None:
+    """Different agents have independent throttle windows."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 100.0
+
+        assert th.should_publish("be-dev-1") is True
+        # be-dev-2 has never published, so it is always allowed.
+        assert th.should_publish("be-dev-2") is True
+
+        mock_time.monotonic.return_value = 101.0
+        # be-dev-1 is suppressed; be-dev-2 is also now suppressed.
+        assert th.should_publish("be-dev-1") is False
+        assert th.should_publish("be-dev-2") is False
+
+
+def test_throttle_records_timestamp_on_allow() -> None:
+    """should_publish records the current time when it returns True."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 200.0
+        th.should_publish("be-dev-1")
+        assert th._last["be-dev-1"] == 200.0  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# publish_usage_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_update_calls_bus_publish() -> None:
+    """First call in a window publishes the event and returns True."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events._throttle", th):
+        result = await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id="task-abc",
+            input_tokens=100,
+            output_tokens=50,
+            model="claude-sonnet-4-6",
+        )
+
+    assert result is True
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.type.value == "usage.update"
+    assert event.data["agent_id"] == "be-dev-1"
+    assert event.data["task_id"] == "task-abc"
+    assert event.data["input_tokens"] == 100  # noqa: PLR2004
+    assert event.data["output_tokens"] == 50  # noqa: PLR2004
+    assert event.data["model"] == "claude-sonnet-4-6"
+    assert "timestamp" in event.data
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_update_throttle_suppresses_second_call() -> None:
+    """Second publish within the throttle window is suppressed (returns False)."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    th = _UsageThrottle(window=5.0)
+
+    with (
+        patch("roboco.services.usage_events._throttle", th),
+        patch("roboco.services.usage_events.time") as mock_time,
+    ):
+        mock_time.monotonic.return_value = 100.0
+        first = await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id=None,
+            input_tokens=10,
+            output_tokens=5,
+            model="sonnet",
+        )
+
+        mock_time.monotonic.return_value = 102.0  # 2 s later — still suppressed
+        second = await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id=None,
+            input_tokens=20,
+            output_tokens=10,
+            model="sonnet",
+        )
+
+    assert first is True
+    assert second is False
+    # bus.publish should only have been called once.
+    assert bus.publish.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_update_custom_timestamp() -> None:
+    """Custom timestamp is passed through to the event data."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    ts = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+
+    # Use a fresh throttle so the first publish goes through.
+    th = _UsageThrottle(window=5.0)
+    with patch("roboco.services.usage_events._throttle", th):
+        await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id=None,
+            input_tokens=0,
+            output_tokens=0,
+            model="sonnet",
+            timestamp=ts,
+        )
+
+    event = bus.publish.await_args.args[0]
+    assert event.data["timestamp"] == ts.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# publish_usage_snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_snapshot_always_publishes() -> None:
+    """publish_usage_snapshot has no throttle — always publishes."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+
+    await publish_usage_snapshot(
+        bus=bus,
+        period="60s",
+        totals={"input_tokens": 500, "output_tokens": 200},
+        cost_estimate=0.0025,
+        by_agent=[
+            {
+                "agent_id": "be-dev-1",
+                "input_tokens": 300,
+                "output_tokens": 100,
+                "model": "sonnet",
+                "cost_estimate": 0.0015,
+            },
+            {
+                "agent_id": "be-dev-2",
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "model": "sonnet",
+                "cost_estimate": 0.0010,
+            },
+        ],
+    )
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.type.value == "usage.snapshot"
+    assert event.data["period"] == "60s"
+    assert event.data["totals"]["input_tokens"] == 500  # noqa: PLR2004
+    assert event.data["cost_estimate"] == 0.0025  # noqa: PLR2004
+    assert len(event.data["by_agent"]) == 2  # noqa: PLR2004
+    assert "timestamp" in event.data
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_snapshot_twice_both_published() -> None:
+    """No throttle on snapshot: two rapid calls both publish."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+
+    for _ in range(2):
+        await publish_usage_snapshot(
+            bus=bus,
+            period="60s",
+            totals={"input_tokens": 0, "output_tokens": 0},
+            cost_estimate=0.0,
+            by_agent=[],
+        )
+
+    assert bus.publish.await_count == 2  # noqa: PLR2004


### PR DESCRIPTION
Add real-time usage event infrastructure to the backend so usage metrics are pushed over the /ws/system operator WebSocket stream. Goal: when token usage occurs, USAGE_UPDATE and USAGE_SNAPSHOT events flow through the StreamEventBus and websocket_bridge to connected /ws/system clients — following the same pattern the rate-limit banner already uses for RATE_LIMIT_HIT/RATE_LIMIT_LIFTED events. Constraints: (1) Reuse the existing /ws/system endpoint and websocket_bridge event-forwarding pattern — no new WebSocket endpoint. (2) Events must be throttled server-side to prevent flooding (max 1 update per 5s per agent). (3) The event payload contract (shared with the frontend cell) is: USAGE_UPDATE = {type, agent_id, task_id, input_tokens, output_tokens, model, timestamp}; USAGE_SNAPSHOT = {type, period, totals, cost_estimate, by_agent}. If the /ws/system backend route doesn't yet exist on master, establish it following the existing websocket.py connection patterns.