### PR TITLE
[4865ff8b] Add WebSocket support to the usage dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and daily rollups, with provider-aware pricing (Anthropic models priced;
   local/Ollama models intentionally $0). Visible on the usage dashboard.
 - **`/ws/system` operator WebSocket stream** with a `websocket_bridge` that
-  forwards system events (the rate-limit lifecycle) from the event bus to panel
-  clients in real time.
+  forwards system events from the event bus to panel clients in real time — the
+  rate-limit lifecycle and live token/cost usage (`USAGE_UPDATE` /
+  `USAGE_SNAPSHOT`), so the dashboard's "Token Usage & Cost" panel updates over
+  the socket and falls back to HTTP polling when it drops.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,7 +472,7 @@ The orchestrator exposes WebSocket endpoints under `/ws` (router in
 | Endpoint | Purpose |
 |----------|---------|
 | `/ws/channels/{id}`, `/ws/agents/{id}`, `/ws/sessions/{id}`, `/ws/notifications/{id}` | Per-resource live streams |
-| `/ws/system` | Operator/system-wide stream (no per-agent keying) — currently the rate-limit lifecycle (`RATE_LIMIT_HIT` / `RATE_LIMIT_LIFTED`) |
+| `/ws/system` | Operator/system-wide stream (no per-agent keying) — the rate-limit lifecycle (`RATE_LIMIT_HIT` / `RATE_LIMIT_LIFTED`) and live usage (`USAGE_UPDATE` / `USAGE_SNAPSHOT`, pushed to the usage dashboard) |
 
 Server-side events reach these sockets through `roboco/api/websocket_bridge.py`,
 which subscribes to the `StreamEventBus` and forwards each event to the matching
@@ -492,7 +492,10 @@ stand up a parallel endpoint or client stack.
   via the SDK server's `/usage/sync` (hook → orchestrator finalize →
   `agent_spawn_sessions` → `daily_usage_rollups` → dashboard). Cost uses
   provider-aware pricing in `roboco/billing/pricing.py` (Anthropic priced;
-  local/Ollama intentionally `$0`).
+  local/Ollama intentionally `$0`). The token sweep also publishes
+  `USAGE_UPDATE`/`USAGE_SNAPSHOT` to `/ws/system`, so the dashboard's
+  "Token Usage & Cost" panel updates live and falls back to HTTP polling when
+  the stream is down.
 
 ### Startup Sequence
 

--- a/docs/rag/tools/api-endpoints.md
+++ b/docs/rag/tools/api-endpoints.md
@@ -90,7 +90,7 @@ Base URL: `http://{host}:{port}/api/v1`
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/api/system/rate-limits` | Active per-provider rate-limit state (`{ entries: [...] }`) |
-| WS | `/ws/system` | Operator stream — rate-limit lifecycle (`RATE_LIMIT_HIT` / `RATE_LIMIT_LIFTED`) |
+| WS | `/ws/system` | Operator stream — rate-limit lifecycle (`RATE_LIMIT_HIT` / `RATE_LIMIT_LIFTED`) and live usage (`USAGE_UPDATE` / `USAGE_SNAPSHOT`) pushed to the usage dashboard |
 | WS | `/ws/agents/{id}`, `/ws/channels/{id}`, `/ws/sessions/{id}`, `/ws/notifications/{id}` | Per-resource live streams |
 
 ## Documentation

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -2,7 +2,6 @@
 
 import { useCeoOverview, useAuditorFlags, useRecentActivity } from "@/hooks/use-dashboard";
 import { useTasks } from "@/hooks/use-tasks";
-import { useUsageStore } from "@/store/usage-store";
 import { TeamHealthCards } from "./team-health-cards";
 import { KeyMetricsPanel } from "./key-metrics-panel";
 import { AuditorAlertsPanel } from "./auditor-alerts-panel";
@@ -17,25 +16,10 @@ import { RefreshCw, Settings } from "lucide-react";
 import Link from "next/link";
 
 export function CommandCenter() {
-  // WS-first data source: read live usage data from the store (populated by
-  // useRateLimitWebSocket whenever USAGE_UPDATE / USAGE_SNAPSHOT arrives on
-  // the /ws/system connection). Falls back to the polling hook when WS is
-  // not connected or no snapshot has been received yet.
-  const { wsState, usageData } = useUsageStore();
-  const wsConnected = wsState === "connected" && usageData !== null;
-
-  // Polling hook always runs (background refetch every 60 s) so the data is
-  // ready the moment WS disconnects.
   const { data: overview, isLoading: loadingOverview, refetch: refetchOverview } = useCeoOverview();
   const { data: flags, isLoading: loadingFlags } = useAuditorFlags({ resolved: false });
   const { data: tasks, isLoading: loadingTasks } = useTasks();
   const { data: activity, isLoading: loadingActivity } = useRecentActivity(24);
-
-  // key_metrics: prefer WS snapshot; fall back to polling
-  const keyMetrics = wsConnected
-    ? usageData.key_metrics
-    : overview?.key_metrics;
-  const isLoadingMetrics = wsConnected ? false : loadingOverview;
 
   const handleRefresh = () => {
     refetchOverview();
@@ -81,9 +65,8 @@ export function CommandCenter() {
       {/* Metrics, Alerts, and Usage Row */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <KeyMetricsPanel
-          metrics={keyMetrics}
-          isLoading={isLoadingMetrics}
-          wsState={wsState}
+          metrics={overview?.key_metrics}
+          isLoading={loadingOverview}
         />
         <AuditorAlertsPanel alerts={flags} isLoading={loadingFlags} />
         <UsageOverviewPanel />

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -2,6 +2,7 @@
 
 import { useCeoOverview, useAuditorFlags, useRecentActivity } from "@/hooks/use-dashboard";
 import { useTasks } from "@/hooks/use-tasks";
+import { useUsageStore } from "@/store/usage-store";
 import { TeamHealthCards } from "./team-health-cards";
 import { KeyMetricsPanel } from "./key-metrics-panel";
 import { AuditorAlertsPanel } from "./auditor-alerts-panel";
@@ -16,10 +17,25 @@ import { RefreshCw, Settings } from "lucide-react";
 import Link from "next/link";
 
 export function CommandCenter() {
+  // WS-first data source: read live usage data from the store (populated by
+  // useRateLimitWebSocket whenever USAGE_UPDATE / USAGE_SNAPSHOT arrives on
+  // the /ws/system connection). Falls back to the polling hook when WS is
+  // not connected or no snapshot has been received yet.
+  const { wsState, usageData } = useUsageStore();
+  const wsConnected = wsState === "connected" && usageData !== null;
+
+  // Polling hook always runs (background refetch every 60 s) so the data is
+  // ready the moment WS disconnects.
   const { data: overview, isLoading: loadingOverview, refetch: refetchOverview } = useCeoOverview();
   const { data: flags, isLoading: loadingFlags } = useAuditorFlags({ resolved: false });
   const { data: tasks, isLoading: loadingTasks } = useTasks();
   const { data: activity, isLoading: loadingActivity } = useRecentActivity(24);
+
+  // key_metrics: prefer WS snapshot; fall back to polling
+  const keyMetrics = wsConnected
+    ? usageData.key_metrics
+    : overview?.key_metrics;
+  const isLoadingMetrics = wsConnected ? false : loadingOverview;
 
   const handleRefresh = () => {
     refetchOverview();
@@ -65,8 +81,9 @@ export function CommandCenter() {
       {/* Metrics, Alerts, and Usage Row */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <KeyMetricsPanel
-          metrics={overview?.key_metrics}
-          isLoading={loadingOverview}
+          metrics={keyMetrics}
+          isLoading={isLoadingMetrics}
+          wsState={wsState}
         />
         <AuditorAlertsPanel alerts={flags} isLoading={loadingFlags} />
         <UsageOverviewPanel />

--- a/panel/src/components/dashboard/key-metrics-panel.tsx
+++ b/panel/src/components/dashboard/key-metrics-panel.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TrendingUp, Clock, CheckCircle, Users, BarChart3 } from "lucide-react";
+import { TrendingUp, Clock, CheckCircle, Users, BarChart3, Wifi, WifiOff, Loader2 } from "lucide-react";
+import type { ConnectionState } from "@/lib/websocket/connection";
 
 interface KeyMetricsProps {
   metrics: Record<string, unknown> | undefined;
   isLoading: boolean;
+  /** Current /ws/system connection state, used to render the status badge */
+  wsState: ConnectionState;
 }
 
 interface MetricItem {
@@ -49,11 +53,48 @@ const METRIC_CONFIG: MetricItem[] = [
   },
 ];
 
-export function KeyMetricsPanel({ metrics, isLoading }: KeyMetricsProps) {
+/**
+ * Returns the badge variant props (className + icon + label) matching the
+ * AgentStreamViewer pattern.
+ */
+function getConnectionBadge(wsState: ConnectionState) {
+  switch (wsState) {
+    case "connected":
+      return {
+        className: "bg-green-500 text-white",
+        icon: <Wifi className="h-3 w-3 mr-1" />,
+        label: "Live",
+      };
+    case "connecting":
+    case "reconnecting":
+      return {
+        className: "bg-yellow-500 text-white",
+        icon: <Loader2 className="h-3 w-3 mr-1 animate-spin" />,
+        label: wsState === "reconnecting" ? "Reconnecting..." : "Connecting...",
+      };
+    case "disconnected":
+    default:
+      return {
+        className: "bg-gray-500 text-white",
+        icon: <WifiOff className="h-3 w-3 mr-1" />,
+        label: "Polling",
+      };
+  }
+}
+
+export function KeyMetricsPanel({ metrics, isLoading, wsState }: KeyMetricsProps) {
+  const badge = getConnectionBadge(wsState);
+
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-lg">Key Metrics</CardTitle>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Key Metrics</CardTitle>
+          <Badge className={badge.className}>
+            {badge.icon}
+            {badge.label}
+          </Badge>
+        </div>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -73,7 +114,7 @@ export function KeyMetricsPanel({ metrics, isLoading }: KeyMetricsProps) {
                     {m.icon}
                     {m.label}
                   </div>
-                  <span className="font-medium">
+                  <span className="font-medium transition-all duration-300 ease-in-out">
                     {value != null
                       ? m.format
                         ? m.format(value)

--- a/panel/src/components/dashboard/key-metrics-panel.tsx
+++ b/panel/src/components/dashboard/key-metrics-panel.tsx
@@ -1,16 +1,12 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TrendingUp, Clock, CheckCircle, Users, BarChart3, Wifi, WifiOff, Loader2 } from "lucide-react";
-import type { ConnectionState } from "@/lib/websocket/connection";
+import { TrendingUp, CheckCircle, BarChart3, AlertTriangle } from "lucide-react";
 
 interface KeyMetricsProps {
   metrics: Record<string, unknown> | undefined;
   isLoading: boolean;
-  /** Current /ws/system connection state, used to render the status badge */
-  wsState: ConnectionState;
 }
 
 interface MetricItem {
@@ -20,17 +16,14 @@ interface MetricItem {
   format?: (value: number) => string;
 }
 
+// Keys must match DashboardService.get_key_metrics() — the shape /dashboard/ceo
+// returns. (velocity_weekly + completion_rate + documentation_coverage are the
+// 7-day rollups; active_blockers is the live blocked-task count.)
 const METRIC_CONFIG: MetricItem[] = [
   {
-    key: "velocity_24h",
-    label: "Velocity (24h)",
-    icon: <TrendingUp className="h-4 w-4" />,
-    format: (v) => `${v} tasks`,
-  },
-  {
-    key: "velocity_7d",
+    key: "velocity_weekly",
     label: "Velocity (7d)",
-    icon: <BarChart3 className="h-4 w-4" />,
+    icon: <TrendingUp className="h-4 w-4" />,
     format: (v) => `${v} tasks`,
   },
   {
@@ -40,61 +33,24 @@ const METRIC_CONFIG: MetricItem[] = [
     format: (v) => `${Math.round(v * 100)}%`,
   },
   {
-    key: "avg_time_to_done",
-    label: "Avg. Time to Done",
-    icon: <Clock className="h-4 w-4" />,
-    format: (v) => `${(typeof v === "number" ? v : 0).toFixed(1)}h`,
+    key: "documentation_coverage",
+    label: "Documentation Coverage",
+    icon: <BarChart3 className="h-4 w-4" />,
+    format: (v) => `${Math.round(v * 100)}%`,
   },
   {
-    key: "active_agents",
-    label: "Active Agents",
-    icon: <Users className="h-4 w-4" />,
+    key: "active_blockers",
+    label: "Active Blockers",
+    icon: <AlertTriangle className="h-4 w-4" />,
     format: (v) => `${v}`,
   },
 ];
 
-/**
- * Returns the badge variant props (className + icon + label) matching the
- * AgentStreamViewer pattern.
- */
-function getConnectionBadge(wsState: ConnectionState) {
-  switch (wsState) {
-    case "connected":
-      return {
-        className: "bg-green-500 text-white",
-        icon: <Wifi className="h-3 w-3 mr-1" />,
-        label: "Live",
-      };
-    case "connecting":
-    case "reconnecting":
-      return {
-        className: "bg-yellow-500 text-white",
-        icon: <Loader2 className="h-3 w-3 mr-1 animate-spin" />,
-        label: wsState === "reconnecting" ? "Reconnecting..." : "Connecting...",
-      };
-    case "disconnected":
-    default:
-      return {
-        className: "bg-gray-500 text-white",
-        icon: <WifiOff className="h-3 w-3 mr-1" />,
-        label: "Polling",
-      };
-  }
-}
-
-export function KeyMetricsPanel({ metrics, isLoading, wsState }: KeyMetricsProps) {
-  const badge = getConnectionBadge(wsState);
-
+export function KeyMetricsPanel({ metrics, isLoading }: KeyMetricsProps) {
   return (
     <Card>
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg">Key Metrics</CardTitle>
-          <Badge className={badge.className}>
-            {badge.icon}
-            {badge.label}
-          </Badge>
-        </div>
+        <CardTitle className="text-lg">Key Metrics</CardTitle>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -114,7 +70,7 @@ export function KeyMetricsPanel({ metrics, isLoading, wsState }: KeyMetricsProps
                     {m.icon}
                     {m.label}
                   </div>
-                  <span className="font-medium transition-all duration-300 ease-in-out">
+                  <span className="font-medium">
                     {value != null
                       ? m.format
                         ? m.format(value)

--- a/panel/src/components/dashboard/usage-overview-panel.tsx
+++ b/panel/src/components/dashboard/usage-overview-panel.tsx
@@ -1,9 +1,21 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useUsageSummary } from "@/hooks/use-usage";
-import { Coins, TrendingUp, TrendingDown, Zap, Activity } from "lucide-react";
+import { useUsageStore } from "@/store/usage-store";
+import type { ConnectionState } from "@/lib/websocket/connection";
+import {
+  Coins,
+  TrendingUp,
+  TrendingDown,
+  Zap,
+  Activity,
+  Wifi,
+  WifiOff,
+  Loader2,
+} from "lucide-react";
 
 function fmt(n: number, decimals = 0): string {
   if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
@@ -30,28 +42,85 @@ function MetricRow({ icon, label, value, sub }: MetricRowProps) {
         {label}
       </div>
       <div className="flex items-center gap-1">
-        <span className="font-semibold text-sm">{value}</span>
+        <span className="font-semibold text-sm transition-all duration-300 ease-in-out">
+          {value}
+        </span>
         {sub}
       </div>
     </div>
   );
 }
 
+/**
+ * Badge props mirroring the AgentStreamViewer connection-status pattern:
+ * green/Live when the /ws/system stream is connected, yellow while
+ * (re)connecting, gray/Polling when it is down and the panel uses HTTP polling.
+ */
+function getConnectionBadge(wsState: ConnectionState) {
+  switch (wsState) {
+    case "connected":
+      return {
+        className: "bg-green-500 text-white",
+        icon: <Wifi className="h-3 w-3 mr-1" />,
+        label: "Live",
+      };
+    case "connecting":
+    case "reconnecting":
+      return {
+        className: "bg-yellow-500 text-white",
+        icon: <Loader2 className="h-3 w-3 mr-1 animate-spin" />,
+        label: wsState === "reconnecting" ? "Reconnecting..." : "Connecting...",
+      };
+    case "disconnected":
+    default:
+      return {
+        className: "bg-gray-500 text-white",
+        icon: <WifiOff className="h-3 w-3 mr-1" />,
+        label: "Polling",
+      };
+  }
+}
+
 export function UsageOverviewPanel() {
+  // The polling summary always runs in the background: it is the fallback when
+  // the WS is down, and it supplies the trend (which the live snapshot, being a
+  // point-in-time aggregate, does not compute).
   const { data: summary, isLoading } = useUsageSummary("24h");
 
-  const trendUp = (summary?.trend_pct ?? 0) >= 0;
+  // Live token/cost pushed over /ws/system (USAGE_SNAPSHOT). Prefer it whenever
+  // the stream is connected; `live` is non-null only then, so it narrows safely.
+  const { wsState, usageData } = useUsageStore();
+  const live = wsState === "connected" ? usageData : null;
+
+  const tokensInput = live ? live.tokens_input : summary?.tokens_input;
+  const tokensOutput = live ? live.tokens_output : summary?.tokens_output;
+  const totalCost = live ? live.total_cost_usd : summary?.total_cost_usd;
+  const periodLabel = live ? live.period : summary?.period;
+
+  // Trend always comes from the polling summary (needs a prior-period baseline).
+  const trendPct = summary?.trend_pct ?? 0;
+  const trendUp = trendPct >= 0;
+
+  const badge = getConnectionBadge(wsState);
+  // Only show skeletons on first load with no data from either source.
+  const showSkeleton = isLoading && !live;
 
   return (
     <Card>
       <CardHeader className="pb-3">
-        <CardTitle className="text-lg flex items-center gap-2">
-          <Coins className="h-5 w-5" />
-          Token Usage &amp; Cost
-        </CardTitle>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Coins className="h-5 w-5" />
+            Token Usage &amp; Cost
+          </CardTitle>
+          <Badge className={badge.className}>
+            {badge.icon}
+            {badge.label}
+          </Badge>
+        </div>
       </CardHeader>
       <CardContent>
-        {isLoading ? (
+        {showSkeleton ? (
           <div className="space-y-3">
             {Array.from({ length: 5 }).map((_, i) => (
               <Skeleton key={i} className="h-6" />
@@ -62,17 +131,17 @@ export function UsageOverviewPanel() {
             <MetricRow
               icon={<Zap className="h-4 w-4" />}
               label="Tokens (input)"
-              value={summary ? fmt(summary.tokens_input) : "—"}
+              value={tokensInput != null ? fmt(tokensInput) : "—"}
             />
             <MetricRow
               icon={<Zap className="h-4 w-4 text-muted-foreground" />}
               label="Tokens (output)"
-              value={summary ? fmt(summary.tokens_output) : "—"}
+              value={tokensOutput != null ? fmt(tokensOutput) : "—"}
             />
             <MetricRow
               icon={<Coins className="h-4 w-4" />}
               label="Total cost"
-              value={summary ? fmtCost(summary.total_cost_usd) : "—"}
+              value={totalCost != null ? fmtCost(totalCost) : "—"}
             />
             <MetricRow
               icon={
@@ -83,7 +152,7 @@ export function UsageOverviewPanel() {
                 )
               }
               label="Trend vs prior period"
-              value={summary ? (trendUp ? "+" : "") + summary.trend_pct.toFixed(1) + "%" : "—"}
+              value={summary ? (trendUp ? "+" : "") + trendPct.toFixed(1) + "%" : "—"}
               sub={
                 summary ? (
                   <span className={"text-xs " + (trendUp ? "text-red-500" : "text-green-500")}>
@@ -95,7 +164,7 @@ export function UsageOverviewPanel() {
             <MetricRow
               icon={<Activity className="h-4 w-4 text-blue-500" />}
               label="Period"
-              value={summary?.period ?? "—"}
+              value={periodLabel ?? "—"}
             />
           </div>
         )}

--- a/panel/src/hooks/use-rate-limit-websocket.ts
+++ b/panel/src/hooks/use-rate-limit-websocket.ts
@@ -3,13 +3,22 @@
 import { useEffect, useRef } from "react";
 import { useWebSocket } from "./use-websocket";
 import { useRateLimitStore } from "@/store/rate-limit-store";
+import { useUsageStore } from "@/store/usage-store";
 import type { RateLimitHitEvent, RateLimitLiftedEvent } from "@/types/rate-limits";
 
-interface RateLimitWsMessage {
+/**
+ * Unified shape for all messages arriving on the /ws/system endpoint.
+ * Fields are optional because different message types use different subsets.
+ */
+interface SystemWsMessage {
   type: string;
+  // Rate-limit fields (RATE_LIMIT_HIT / RATE_LIMIT_LIFTED)
   provider?: string;
   affectedAgents?: string[];
   retryAfterSeconds?: number;
+  // Usage fields (USAGE_UPDATE / USAGE_SNAPSHOT)
+  key_metrics?: Record<string, unknown>;
+  // Shared
   timestamp?: string;
 }
 
@@ -19,9 +28,18 @@ interface UseRateLimitWebSocketOptions {
 }
 
 /**
- * Subscribes to RATE_LIMIT_HIT and RATE_LIMIT_LIFTED WebSocket events and
- * dispatches them to the useRateLimitStore. Accepts an optional onReconnect
- * callback that fires when the connection recovers from a reconnecting state.
+ * Subscribes to the /ws/system WebSocket (single shared instance mounted in
+ * RateLimitBanner). Handles:
+ *
+ *  - RATE_LIMIT_HIT / RATE_LIMIT_LIFTED → dispatched to useRateLimitStore
+ *  - USAGE_UPDATE / USAGE_SNAPSHOT     → dispatched to useUsageStore
+ *
+ * Also syncs the live WebSocket connection state into useUsageStore so that
+ * other components (e.g. CommandCenter, KeyMetricsPanel) can read it without
+ * creating a second /ws/system connection.
+ *
+ * Accepts an optional onReconnect callback that fires when the connection
+ * recovers from a reconnecting state.
  */
 export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}) {
   const { onReconnect } = options;
@@ -30,11 +48,17 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
   // getWebSocketUrl() already supplies the "/ws" base, so the endpoint is just
   // the path (matching the agents/channels/notifications hooks). Passing
   // "/ws/system" here produced the doubled "/ws/ws/system" URL.
-  const { state, lastMessage } = useWebSocket<RateLimitWsMessage>(
+  const { state, lastMessage } = useWebSocket<SystemWsMessage>(
     "/system",
     undefined,
     true
   );
+
+  // Sync WS connection state into useUsageStore for cross-component visibility.
+  // This is the ONLY place wsState is written; no second useWebSocket call is needed.
+  useEffect(() => {
+    useUsageStore.getState().setWsState(state);
+  }, [state]);
 
   // Fire onReconnect when state transitions from reconnecting → connected
   useEffect(() => {
@@ -49,6 +73,7 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
     if (!lastMessage) return;
 
     const { hitRateLimit, liftRateLimit } = useRateLimitStore.getState();
+    const { setUsageData } = useUsageStore.getState();
 
     if (lastMessage.type === "RATE_LIMIT_HIT") {
       const event: RateLimitHitEvent = {
@@ -66,6 +91,14 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
         timestamp: lastMessage.timestamp ?? new Date().toISOString(),
       };
       liftRateLimit(event);
+    } else if (
+      lastMessage.type === "USAGE_UPDATE" ||
+      lastMessage.type === "USAGE_SNAPSHOT"
+    ) {
+      setUsageData({
+        key_metrics: lastMessage.key_metrics ?? {},
+        timestamp: lastMessage.timestamp,
+      });
     }
   }, [lastMessage]);
 

--- a/panel/src/hooks/use-rate-limit-websocket.ts
+++ b/panel/src/hooks/use-rate-limit-websocket.ts
@@ -16,8 +16,10 @@ interface SystemWsMessage {
   provider?: string;
   affectedAgents?: string[];
   retryAfterSeconds?: number;
-  // Usage fields (USAGE_UPDATE / USAGE_SNAPSHOT)
-  key_metrics?: Record<string, unknown>;
+  // Usage fields (USAGE_SNAPSHOT — aggregate token/cost across active agents)
+  totals?: { input_tokens?: number; output_tokens?: number };
+  cost_estimate?: number;
+  period?: string;
   // Shared
   timestamp?: string;
 }
@@ -32,11 +34,11 @@ interface UseRateLimitWebSocketOptions {
  * RateLimitBanner). Handles:
  *
  *  - RATE_LIMIT_HIT / RATE_LIMIT_LIFTED → dispatched to useRateLimitStore
- *  - USAGE_UPDATE / USAGE_SNAPSHOT     → dispatched to useUsageStore
+ *  - USAGE_SNAPSHOT                     → dispatched to useUsageStore
  *
  * Also syncs the live WebSocket connection state into useUsageStore so that
- * other components (e.g. CommandCenter, KeyMetricsPanel) can read it without
- * creating a second /ws/system connection.
+ * other components (e.g. UsageOverviewPanel) can read it without creating a
+ * second /ws/system connection.
  *
  * Accepts an optional onReconnect callback that fires when the connection
  * recovers from a reconnecting state.
@@ -91,12 +93,12 @@ export function useRateLimitWebSocket(options: UseRateLimitWebSocketOptions = {}
         timestamp: lastMessage.timestamp ?? new Date().toISOString(),
       };
       liftRateLimit(event);
-    } else if (
-      lastMessage.type === "USAGE_UPDATE" ||
-      lastMessage.type === "USAGE_SNAPSHOT"
-    ) {
+    } else if (lastMessage.type === "USAGE_SNAPSHOT") {
       setUsageData({
-        key_metrics: lastMessage.key_metrics ?? {},
+        tokens_input: lastMessage.totals?.input_tokens ?? 0,
+        tokens_output: lastMessage.totals?.output_tokens ?? 0,
+        total_cost_usd: lastMessage.cost_estimate ?? 0,
+        period: lastMessage.period ?? "live",
         timestamp: lastMessage.timestamp,
       });
     }

--- a/panel/src/lib/api/usage.ts
+++ b/panel/src/lib/api/usage.ts
@@ -240,15 +240,14 @@ export const usageApi = {
   },
 
   /**
-   * Recent inference sessions — mock-mode only.
-   *
-   * The backend has no /usage/sessions endpoint.  In production this
-   * returns an empty array so SessionsTable shows a graceful "no data"
-   * state instead of throwing a 404.
+   * Recent spawn sessions — the raw per-session rows behind the aggregate
+   * panels, served by GET /usage/sessions.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  getUsageSessions: async (_limit: number = 100): Promise<UsageSession[]> => {
+  getUsageSessions: async (limit: number = 100): Promise<UsageSession[]> => {
     if (isMockMode()) return mockSessions();
-    return [];
+    const { data } = await api.get<UsageSession[]>("/usage/sessions", {
+      params: { limit },
+    });
+    return data;
   },
 };

--- a/panel/src/store/index.ts
+++ b/panel/src/store/index.ts
@@ -1,3 +1,5 @@
 export { useUIStore } from "./ui-store";
 export { useNotificationStore } from "./notifications-store";
 export { useRateLimitStore } from "./rate-limit-store";
+export { useUsageStore } from "./usage-store";
+export type { UsageData } from "./usage-store";

--- a/panel/src/store/usage-store.ts
+++ b/panel/src/store/usage-store.ts
@@ -2,13 +2,20 @@ import { create } from "zustand";
 import type { ConnectionState } from "@/lib/websocket/connection";
 
 /**
- * Usage data received from USAGE_UPDATE or USAGE_SNAPSHOT WebSocket messages
- * on the /ws/system endpoint.
+ * Live token/cost usage pushed over the /ws/system stream via USAGE_SNAPSHOT
+ * events. Mirrors the fields the UsageOverviewPanel renders, so the panel can
+ * swap polling for live data without reshaping anything.
  */
 export interface UsageData {
-  /** Key performance metrics (velocity, completion rate, active agents, etc.) */
-  key_metrics: Record<string, unknown>;
-  /** ISO timestamp of the snapshot */
+  /** Cumulative input tokens across currently-active agents. */
+  tokens_input: number;
+  /** Cumulative output tokens across currently-active agents. */
+  tokens_output: number;
+  /** Estimated USD cost for the snapshot. */
+  total_cost_usd: number;
+  /** Period label for the snapshot (e.g. "live"). */
+  period: string;
+  /** ISO timestamp of the snapshot. */
   timestamp?: string;
 }
 

--- a/panel/src/store/usage-store.ts
+++ b/panel/src/store/usage-store.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import type { ConnectionState } from "@/lib/websocket/connection";
+
+/**
+ * Usage data received from USAGE_UPDATE or USAGE_SNAPSHOT WebSocket messages
+ * on the /ws/system endpoint.
+ */
+export interface UsageData {
+  /** Key performance metrics (velocity, completion rate, active agents, etc.) */
+  key_metrics: Record<string, unknown>;
+  /** ISO timestamp of the snapshot */
+  timestamp?: string;
+}
+
+interface UsageState {
+  /** Most-recent usage data received over WebSocket; null until first message arrives */
+  usageData: UsageData | null;
+  /** Current /ws/system WebSocket connection state, synced by useRateLimitWebSocket */
+  wsState: ConnectionState;
+
+  // Actions
+  /** Overwrite usageData with the latest payload from the WebSocket */
+  setUsageData: (data: UsageData) => void;
+  /** Clear usageData (e.g. on intentional disconnect or reset) */
+  clearUsageData: () => void;
+  /** Update the cached WebSocket connection state */
+  setWsState: (state: ConnectionState) => void;
+}
+
+export const useUsageStore = create<UsageState>((set) => ({
+  usageData: null,
+  wsState: "disconnected",
+
+  setUsageData: (data) => set({ usageData: data }),
+  clearUsageData: () => set({ usageData: null }),
+  setWsState: (state) => set({ wsState: state }),
+}));

--- a/roboco/agent_sdk/server.py
+++ b/roboco/agent_sdk/server.py
@@ -41,6 +41,9 @@ from roboco.agent_sdk.models import (
     VerbAttemptRequest,
     VerbCircuitStatus,
 )
+from roboco.agent_sdk.transcript_usage import (
+    sum_transcript_usage as _sum_transcript_usage,
+)
 from roboco.foundation.policy.agent_loop import DEFAULT_BUDGET as _BUDGET
 from roboco.foundation.policy.agent_loop import retry_limit_for
 from roboco.services.gateway.envelope import Envelope
@@ -739,37 +742,6 @@ def _token_usage_snapshot() -> TokenUsageStatus:
         tokens_cache_read=_state.tokens_cache_read,
         tokens_cache_write=_state.tokens_cache_write,
     )
-
-
-def _sum_transcript_usage(path: Path) -> tuple[int, int, int, int]:
-    """Sum per-message token usage across a Claude Code JSONL transcript.
-
-    Each assistant entry carries a ``message.usage`` block with the token
-    counts for that API response; summing them yields the session total.
-    Returns ``(input, output, cache_read, cache_write)``. Malformed lines are
-    skipped — a single bad line must never lose the whole count.
-    """
-    tin = tout = tcr = tcw = 0
-    with path.open("r", encoding="utf-8", errors="ignore") as fh:
-        for raw in fh:
-            stripped = raw.strip()
-            if not stripped:
-                continue
-            try:
-                entry = json.loads(stripped)
-            except (ValueError, TypeError):
-                continue
-            message = entry.get("message")
-            if not isinstance(message, dict):
-                continue
-            usage = message.get("usage")
-            if not isinstance(usage, dict):
-                continue
-            tin += int(usage.get("input_tokens", 0) or 0)
-            tout += int(usage.get("output_tokens", 0) or 0)
-            tcr += int(usage.get("cache_read_input_tokens", 0) or 0)
-            tcw += int(usage.get("cache_creation_input_tokens", 0) or 0)
-    return tin, tout, tcr, tcw
 
 
 @app.post("/usage/sync", response_model=TokenUsageStatus)

--- a/roboco/agent_sdk/transcript_usage.py
+++ b/roboco/agent_sdk/transcript_usage.py
@@ -23,45 +23,60 @@ def _coerce_int(value: Any) -> int:
         return 0
 
 
-def _line_usage(line: str) -> tuple[int, int, int, int]:
-    """Parse one transcript line into its token deltas.
+def _line_usage(line: str) -> tuple[str | None, tuple[int, int, int, int]] | None:
+    """Parse one transcript line into ``(message_id, token deltas)``.
 
-    Returns ``(input, output, cache_read, cache_write)`` — all zeros for blank
-    lines, malformed JSON, or entries without a ``message.usage`` block.
+    Returns ``None`` for blank lines, malformed JSON, or entries without a
+    ``message.usage`` block. ``message_id`` lets the caller de-duplicate:
+    Claude Code logs a single assistant message as several lines (one per
+    content block — thinking, text, tool_use), each repeating the *same*
+    ``usage``, so counting every line would multiply the totals.
     """
     stripped = line.strip()
     if not stripped:
-        return (0, 0, 0, 0)
+        return None
     try:
         entry = json.loads(stripped)
     except (ValueError, TypeError):
-        return (0, 0, 0, 0)
+        return None
     message = entry.get("message")
     if not isinstance(message, dict):
-        return (0, 0, 0, 0)
+        return None
     usage = message.get("usage")
     if not isinstance(usage, dict):
-        return (0, 0, 0, 0)
-    return (
+        return None
+    deltas = (
         _coerce_int(usage.get("input_tokens")),
         _coerce_int(usage.get("output_tokens")),
         _coerce_int(usage.get("cache_read_input_tokens")),
         _coerce_int(usage.get("cache_creation_input_tokens")),
     )
+    return message.get("id"), deltas
 
 
 def sum_transcript_usage(path: Path) -> tuple[int, int, int, int]:
     """Sum per-message token usage across a Claude Code JSONL transcript.
 
-    Each assistant entry carries a ``message.usage`` block with the token
+    Each assistant message carries a ``message.usage`` block with the token
     counts for that API response; summing them yields the session total.
-    Returns ``(input, output, cache_read, cache_write)``. Malformed lines are
-    skipped — a single bad line must never lose the whole count.
+    Messages that span several lines (same ``message.id``) are counted once —
+    Claude Code emits one line per content block, each repeating the message's
+    usage, so naive summing roughly doubles the totals. Returns
+    ``(input, output, cache_read, cache_write)``. Malformed lines are skipped —
+    a single bad line must never lose the whole count.
     """
     tin = tout = tcr = tcw = 0
+    seen: set[str] = set()
     with path.open("r", encoding="utf-8", errors="ignore") as fh:
         for raw in fh:
-            line_in, line_out, line_cr, line_cw = _line_usage(raw)
+            parsed = _line_usage(raw)
+            if parsed is None:
+                continue
+            message_id, (line_in, line_out, line_cr, line_cw) = parsed
+            if message_id is not None:
+                if message_id in seen:
+                    continue
+                seen.add(message_id)
             tin += line_in
             tout += line_out
             tcr += line_cr

--- a/roboco/agent_sdk/transcript_usage.py
+++ b/roboco/agent_sdk/transcript_usage.py
@@ -1,0 +1,69 @@
+"""Claude Code transcript token-usage parsing.
+
+A dependency-light helper (only ``json`` + ``pathlib``) so callers that need
+durable token counts — notably the orchestrator's session-finalization path —
+can read them without importing the agent SDK server, which pulls in the
+FastAPI / RAG (piragi / openai) stack.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _coerce_int(value: Any) -> int:
+    """Coerce a transcript usage value to int, treating null/garbage as zero."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _line_usage(line: str) -> tuple[int, int, int, int]:
+    """Parse one transcript line into its token deltas.
+
+    Returns ``(input, output, cache_read, cache_write)`` — all zeros for blank
+    lines, malformed JSON, or entries without a ``message.usage`` block.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return (0, 0, 0, 0)
+    try:
+        entry = json.loads(stripped)
+    except (ValueError, TypeError):
+        return (0, 0, 0, 0)
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return (0, 0, 0, 0)
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return (0, 0, 0, 0)
+    return (
+        _coerce_int(usage.get("input_tokens")),
+        _coerce_int(usage.get("output_tokens")),
+        _coerce_int(usage.get("cache_read_input_tokens")),
+        _coerce_int(usage.get("cache_creation_input_tokens")),
+    )
+
+
+def sum_transcript_usage(path: Path) -> tuple[int, int, int, int]:
+    """Sum per-message token usage across a Claude Code JSONL transcript.
+
+    Each assistant entry carries a ``message.usage`` block with the token
+    counts for that API response; summing them yields the session total.
+    Returns ``(input, output, cache_read, cache_write)``. Malformed lines are
+    skipped — a single bad line must never lose the whole count.
+    """
+    tin = tout = tcr = tcw = 0
+    with path.open("r", encoding="utf-8", errors="ignore") as fh:
+        for raw in fh:
+            line_in, line_out, line_cr, line_cw = _line_usage(raw)
+            tin += line_in
+            tout += line_out
+            tcr += line_cr
+            tcw += line_cw
+    return tin, tout, tcr, tcw

--- a/roboco/api/routes/usage.py
+++ b/roboco/api/routes/usage.py
@@ -145,3 +145,24 @@ async def get_cache_efficiency(
     """
     svc = get_usage_service(db)
     return await svc.get_cache_efficiency(period)
+
+
+# =============================================================================
+# SESSIONS
+# =============================================================================
+
+
+@router.get("/sessions")
+async def get_usage_sessions(
+    db: DbSession,
+    limit: Annotated[
+        int, Query(ge=1, le=200, description="Max sessions to return")
+    ] = 50,
+) -> list[dict[str, Any]]:
+    """Return the most recent agent spawn sessions, newest first.
+
+    Each row carries per-session token totals (input / output / cache) and the
+    estimated cost — the raw rows behind the aggregate usage panels.
+    """
+    svc = get_usage_service(db)
+    return await svc.get_recent_sessions(limit)

--- a/roboco/api/websocket_bridge.py
+++ b/roboco/api/websocket_bridge.py
@@ -144,6 +144,20 @@ async def _handle_rate_limit_event(event: Event) -> None:
     await manager.broadcast_system({"type": ws_type, **event.data})
 
 
+async def _handle_usage_event(event: Event) -> None:
+    """Forward USAGE_UPDATE/SNAPSHOT events to operator system WS clients.
+
+    Both event types carry all the fields the panel needs directly in
+    ``event.data``; we pass them through tagged with ``event.type.value``
+    so the panel can distinguish per-agent updates from aggregate snapshots.
+    """
+    await manager.broadcast_system({"type": event.type.value, **event.data})
+    logger.debug(
+        "Usage event forwarded to system WebSocket",
+        event_type=event.type.value,
+    )
+
+
 def register_websocket_bridge_handlers() -> None:
     """
     Register event handlers that forward events to WebSocket clients.
@@ -171,6 +185,10 @@ def register_websocket_bridge_handlers() -> None:
     # Rate-limit lifecycle -> system WebSocket (panel banner)
     bus.subscribe(EventType.RATE_LIMIT_HIT, _handle_rate_limit_event)
     bus.subscribe(EventType.RATE_LIMIT_LIFTED, _handle_rate_limit_event)
+
+    # Usage events -> system WebSocket (panel dashboard)
+    bus.subscribe(EventType.USAGE_UPDATE, _handle_usage_event)
+    bus.subscribe(EventType.USAGE_SNAPSHOT, _handle_usage_event)
 
     logger.info("WebSocket bridge handlers registered")
 

--- a/roboco/api/websocket_bridge.py
+++ b/roboco/api/websocket_bridge.py
@@ -20,6 +20,11 @@ _RATE_LIMIT_WS_TYPES = {
     EventType.RATE_LIMIT_LIFTED: "RATE_LIMIT_LIFTED",
 }
 
+_USAGE_WS_TYPES = {
+    EventType.USAGE_UPDATE: "USAGE_UPDATE",
+    EventType.USAGE_SNAPSHOT: "USAGE_SNAPSHOT",
+}
+
 
 # Handler for notification events
 async def _handle_notification_sent(event: Event) -> None:
@@ -148,13 +153,18 @@ async def _handle_usage_event(event: Event) -> None:
     """Forward USAGE_UPDATE/SNAPSHOT events to operator system WS clients.
 
     Both event types carry all the fields the panel needs directly in
-    ``event.data``; we pass them through tagged with ``event.type.value``
-    so the panel can distinguish per-agent updates from aggregate snapshots.
+    ``event.data``; we tag them with the discriminating ``type`` string the
+    panel switches on (the same UPPER_SNAKE mapping the rate-limit handler
+    uses), so the panel can distinguish per-agent updates from aggregate
+    snapshots.
     """
-    await manager.broadcast_system({"type": event.type.value, **event.data})
+    ws_type = _USAGE_WS_TYPES.get(event.type)
+    if ws_type is None:
+        return
+    await manager.broadcast_system({"type": ws_type, **event.data})
     logger.debug(
         "Usage event forwarded to system WebSocket",
-        event_type=event.type.value,
+        event_type=ws_type,
     )
 
 

--- a/roboco/models/events.py
+++ b/roboco/models/events.py
@@ -69,6 +69,10 @@ class EventType(StrEnum):
     RATE_LIMIT_HIT = "rate_limit.hit"
     RATE_LIMIT_LIFTED = "rate_limit.lifted"
 
+    # Usage events
+    USAGE_UPDATE = "usage.update"
+    USAGE_SNAPSHOT = "usage.snapshot"
+
     # Question events
     QUESTION_ASKED = "question.asked"
     QUESTION_ANSWERED = "question.answered"

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3390,6 +3390,22 @@ class AgentOrchestrator:
             return None
         return tokens
 
+    async def _resolve_active_tokens(
+        self, client: httpx.AsyncClient, agent_id: str
+    ) -> tuple[int, int, int, int] | None:
+        """Resolve live token counts for an active agent.
+
+        Tries the agent SDK's ``/usage/status`` first; on a zero/miss falls
+        back to the durable transcript (the SDK can report zero mid-run, the
+        same race the finalize path handles). Returns ``None`` when neither
+        source has any usage yet.
+        """
+        tokens = await self._fetch_agent_tokens(client, agent_id)
+        if tokens is not None:
+            return tokens
+        transcript = self._usage_from_transcript(agent_id)
+        return transcript if any(transcript) else None
+
     @staticmethod
     async def _persist_token_snapshot(
         session_factory: Any,
@@ -3493,7 +3509,7 @@ class AgentOrchestrator:
                     continue
 
                 try:
-                    tokens = await self._fetch_agent_tokens(client, agent_id)
+                    tokens = await self._resolve_active_tokens(client, agent_id)
                     if tokens is None:
                         continue
 

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -4020,6 +4020,13 @@ Start by:
                 container_id=cid,
                 exit_code=exit_code,
             )
+        # The agent self-exited (a graceful i_am_idle shutdown, or a crash), so
+        # stop_agent() — which normally finalizes — was never called. Finalize
+        # here to capture token usage from the transcript; otherwise the
+        # spawn-session row is left open with zero tokens.
+        await self._finalize_spawn_session(
+            agent_id, exit_reason="completed" if graceful else "crashed"
+        )
         instance.state = AgentState.OFFLINE
         instance.container_id = None
         if graceful:

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3218,7 +3218,7 @@ class AgentOrchestrator:
         fetch, which misses whenever the agent container is short-lived or
         already torn down. Returns zeros when no transcript is found.
         """
-        from roboco.agent_sdk.server import _sum_transcript_usage
+        from roboco.agent_sdk.transcript_usage import sum_transcript_usage
 
         projects = Path.home() / ".claude" / "projects"
         try:
@@ -3228,12 +3228,49 @@ class AgentOrchestrator:
                 if d.is_dir()
                 for f in d.glob("*.jsonl")
             ]
+            if not jsonl:
+                return (0, 0, 0, 0)
+            newest = max(jsonl, key=lambda f: f.stat().st_mtime)
+            return sum_transcript_usage(newest)
         except OSError:
             return (0, 0, 0, 0)
-        if not jsonl:
-            return (0, 0, 0, 0)
-        newest = max(jsonl, key=lambda f: f.stat().st_mtime)
-        return _sum_transcript_usage(newest)
+
+    async def _resolve_final_token_usage(
+        self, agent_id: str
+    ) -> tuple[int, int, int, int]:
+        """Resolve final token counts for a stopping agent.
+
+        Tries the live SDK ``/usage/status`` first; if that misses — the SDK's
+        in-memory counts race container teardown for short-lived agents — it
+        falls back to the agent's Claude Code transcript, which is durable and
+        mounted into this container. Returns
+        ``(input, output, cache_read, cache_write)``.
+        """
+        tokens = (0, 0, 0, 0)
+        sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
+        try:
+            async with httpx.AsyncClient(timeout=3.0) as client:
+                resp = await client.get(sdk_url)
+                if resp.status_code == http_status.HTTP_200_OK:
+                    data = resp.json()
+                    tokens = (
+                        data.get("tokens_input", 0),
+                        data.get("tokens_output", 0),
+                        data.get("tokens_cache_read", 0),
+                        data.get("tokens_cache_write", 0),
+                    )
+        except Exception as sdk_exc:
+            logger.debug(
+                "Could not fetch final token counts from SDK",
+                agent_id=agent_id,
+                error=str(sdk_exc),
+            )
+
+        if not tokens[0] and not tokens[1]:
+            tin, tout, cr, cw = self._usage_from_transcript(agent_id)
+            if tin or tout:
+                tokens = (tin, tout, cr, cw)
+        return tokens
 
     async def _finalize_spawn_session(
         self,
@@ -3242,9 +3279,9 @@ class AgentOrchestrator:
     ) -> None:
         """Close the open agent_spawn_sessions row for this agent.
 
-        Fetches final token counts from the agent SDK's /usage/status endpoint,
-        calculates cost via pricing module, then updates the DB row with
-        ended_at, token totals, exit_reason, and estimated_cost_usd.
+        Resolves final token counts (live SDK, with a durable transcript
+        fallback), calculates cost via the pricing module, then updates the DB
+        row with ended_at, token totals, exit_reason, and estimated_cost_usd.
         Errors are caught and logged — finalization must never block stop_agent.
         """
         try:
@@ -3252,44 +3289,16 @@ class AgentOrchestrator:
             from roboco.db.base import get_session_factory
             from roboco.db.tables import AgentSpawnSessionTable
 
-            # Fetch final token counts from the agent's SDK
-            sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
-            tokens_input = 0
-            tokens_output = 0
-            tokens_cache_read = 0
-            tokens_cache_write = 0
-            model = "unknown"
-
-            try:
-                async with httpx.AsyncClient(timeout=3.0) as client:
-                    resp = await client.get(sdk_url)
-                    if resp.status_code == http_status.HTTP_200_OK:
-                        data = resp.json()
-                        tokens_input = data.get("tokens_input", 0)
-                        tokens_output = data.get("tokens_output", 0)
-                        tokens_cache_read = data.get("tokens_cache_read", 0)
-                        tokens_cache_write = data.get("tokens_cache_write", 0)
-            except Exception as sdk_exc:
-                logger.debug(
-                    "Could not fetch final token counts from SDK",
-                    agent_id=agent_id,
-                    error=str(sdk_exc),
-                )
-
-            # The live SDK fetch above races the container teardown and misses
-            # for short-lived agents (counts live in the SDK server's memory,
-            # which dies with the container). Fall back to the durable source of
-            # truth: the agent's Claude Code transcript, mounted into this
-            # container — so usage is captured regardless of container timing.
-            if not tokens_input and not tokens_output:
-                tin, tout, cr, cw = self._usage_from_transcript(agent_id)
-                if tin or tout:
-                    tokens_input = tin
-                    tokens_output = tout
-                    tokens_cache_read = cr
-                    tokens_cache_write = cw
+            # Resolve final token counts (live SDK, with transcript fallback).
+            (
+                tokens_input,
+                tokens_output,
+                tokens_cache_read,
+                tokens_cache_write,
+            ) = await self._resolve_final_token_usage(agent_id)
 
             # Look up the model and usage_session_id from the running instance config.
+            model = "unknown"
             instance = self._instances.get(agent_id)
             if instance and instance.config:
                 model = instance.config.model or "unknown"
@@ -3357,7 +3366,98 @@ class AgentOrchestrator:
                 error=str(exc),
             )
 
-    async def _sweep_token_snapshots(self) -> None:  # noqa: PLR0915
+    @staticmethod
+    async def _fetch_agent_tokens(
+        client: httpx.AsyncClient, agent_id: str
+    ) -> tuple[int, int, int, int] | None:
+        """Fetch cumulative token counts from an agent's SDK usage endpoint.
+
+        Returns ``(input, output, cache_read, cache_write)`` or ``None`` when the
+        agent returns a non-200 status or has not accrued any tokens yet.
+        """
+        sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
+        resp = await client.get(sdk_url)
+        if resp.status_code != http_status.HTTP_200_OK:
+            return None
+        data = resp.json()
+        tokens = (
+            data.get("tokens_input", 0),
+            data.get("tokens_output", 0),
+            data.get("tokens_cache_read", 0),
+            data.get("tokens_cache_write", 0),
+        )
+        if sum(tokens) == 0:
+            return None
+        return tokens
+
+    @staticmethod
+    async def _persist_token_snapshot(
+        session_factory: Any,
+        agent_id: str,
+        instance: AgentInstance,
+        tokens: tuple[int, int, int, int],
+    ) -> bool:
+        """Insert a token_usage_snapshots row and refresh the open session totals.
+
+        Returns True when a snapshot was written; False when the agent has no
+        open spawn-session row to attach it to.
+        """
+        from uuid import uuid4
+
+        from sqlalchemy import select, update
+
+        from roboco.db.tables import AgentSpawnSessionTable, TokenUsageSnapshotTable
+
+        tokens_input, tokens_output, tokens_cache_read, tokens_cache_write = tokens
+        async with session_factory() as db:
+            # Prefer a direct lookup by the session UUID captured at spawn time;
+            # fall back to the agent_slug heuristic for instances that pre-date
+            # the usage_session_id field.
+            if instance.usage_session_id is not None:
+                result = await db.execute(
+                    select(AgentSpawnSessionTable).where(
+                        AgentSpawnSessionTable.id == instance.usage_session_id
+                    )
+                )
+            else:
+                result = await db.execute(
+                    select(AgentSpawnSessionTable)
+                    .where(
+                        AgentSpawnSessionTable.agent_slug == agent_id,
+                        AgentSpawnSessionTable.ended_at.is_(None),
+                    )
+                    .order_by(AgentSpawnSessionTable.started_at.desc())
+                    .limit(1)
+                )
+            session_row = result.scalar_one_or_none()
+            if session_row is None:
+                return False
+
+            db.add(
+                TokenUsageSnapshotTable(
+                    id=uuid4(),
+                    agent_spawn_session_id=session_row.id,
+                    snapshotted_at=datetime.now(UTC),
+                    tokens_input=tokens_input,
+                    tokens_output=tokens_output,
+                    tokens_cache_read=tokens_cache_read,
+                    tokens_cache_write=tokens_cache_write,
+                )
+            )
+            await db.execute(
+                update(AgentSpawnSessionTable)
+                .where(AgentSpawnSessionTable.id == session_row.id)
+                .values(
+                    tokens_input=tokens_input,
+                    tokens_output=tokens_output,
+                    tokens_cache_read=tokens_cache_read,
+                    tokens_cache_write=tokens_cache_write,
+                )
+            )
+            await db.commit()
+            return True
+
+    async def _sweep_token_snapshots(self) -> None:
         """Write a token_usage_snapshots row for each active agent with non-zero tokens.
 
         Called from _run_sweep() every ~60 s. Also updates the cumulative
@@ -3373,7 +3473,6 @@ class AgentOrchestrator:
 
         try:
             from roboco.db.base import get_session_factory
-            from roboco.db.tables import AgentSpawnSessionTable, TokenUsageSnapshotTable
         except ImportError:
             return
 
@@ -3393,96 +3492,37 @@ class AgentOrchestrator:
                 ):
                     continue
 
-                sdk_url = f"http://roboco-agent-{agent_id}:{SDK_PORT}/usage/status"
                 try:
-                    resp = await client.get(sdk_url)
-                    if resp.status_code != http_status.HTTP_200_OK:
+                    tokens = await self._fetch_agent_tokens(client, agent_id)
+                    if tokens is None:
                         continue
-                    data = resp.json()
-                    tokens_input = data.get("tokens_input", 0)
-                    tokens_output = data.get("tokens_output", 0)
-                    tokens_cache_read = data.get("tokens_cache_read", 0)
-                    tokens_cache_write = data.get("tokens_cache_write", 0)
 
-                    # Skip agents with no token usage yet
-                    total = (
-                        tokens_input
-                        + tokens_output
-                        + tokens_cache_read
-                        + tokens_cache_write
+                    persisted = await self._persist_token_snapshot(
+                        session_factory, agent_id, instance, tokens
                     )
-                    if total == 0:
+                    if not persisted:
                         continue
 
-                    # Resolve model for cost estimation and event data.
-                    _model = instance.config.model if instance.config else "unknown"
-
-                    async with session_factory() as db:
-                        from sqlalchemy import select, update
-
-                        # Prefer a direct lookup by the session UUID captured at
-                        # spawn time; fall back to the agent_slug heuristic for
-                        # instances that pre-date the usage_session_id field.
-                        if instance.usage_session_id is not None:
-                            result = await db.execute(
-                                select(AgentSpawnSessionTable).where(
-                                    AgentSpawnSessionTable.id
-                                    == instance.usage_session_id
-                                )
-                            )
-                        else:
-                            result = await db.execute(
-                                select(AgentSpawnSessionTable)
-                                .where(
-                                    AgentSpawnSessionTable.agent_slug == agent_id,
-                                    AgentSpawnSessionTable.ended_at.is_(None),
-                                )
-                                .order_by(AgentSpawnSessionTable.started_at.desc())
-                                .limit(1)
-                            )
-                        session_row = result.scalar_one_or_none()
-                        if session_row is None:
-                            continue
-
-                        # Insert snapshot
-                        from uuid import uuid4 as _uuid4
-
-                        snapshot = TokenUsageSnapshotTable(
-                            id=_uuid4(),
-                            agent_spawn_session_id=session_row.id,
-                            snapshotted_at=datetime.now(UTC),
-                            tokens_input=tokens_input,
-                            tokens_output=tokens_output,
-                            tokens_cache_read=tokens_cache_read,
-                            tokens_cache_write=tokens_cache_write,
-                        )
-                        db.add(snapshot)
-
-                        # Update cumulative totals on the session row
-                        await db.execute(
-                            update(AgentSpawnSessionTable)
-                            .where(AgentSpawnSessionTable.id == session_row.id)
-                            .values(
-                                tokens_input=tokens_input,
-                                tokens_output=tokens_output,
-                                tokens_cache_read=tokens_cache_read,
-                                tokens_cache_write=tokens_cache_write,
-                            )
-                        )
-                        await db.commit()
+                    tokens_input, tokens_output = tokens[0], tokens[1]
+                    model = instance.config.model if instance.config else "unknown"
 
                     # Publish USAGE_UPDATE event for this agent (throttled).
                     with contextlib.suppress(Exception):
                         from roboco.events import get_event_bus
-                        from roboco.services.usage_events import publish_usage_update
+                        from roboco.services.usage_events import (
+                            UsageUpdate,
+                            publish_usage_update,
+                        )
 
                         await publish_usage_update(
-                            bus=get_event_bus(),
-                            agent_id=agent_id,
-                            task_id=instance.current_task_id,
-                            input_tokens=tokens_input,
-                            output_tokens=tokens_output,
-                            model=_model,
+                            get_event_bus(),
+                            UsageUpdate(
+                                agent_id=agent_id,
+                                task_id=instance.current_task_id,
+                                input_tokens=tokens_input,
+                                output_tokens=tokens_output,
+                                model=model,
+                            ),
                         )
 
                     # Accumulate per-agent data for the aggregate snapshot.
@@ -3490,7 +3530,7 @@ class AgentOrchestrator:
                         from roboco.billing.pricing import calculate_cost
 
                         agent_cost = calculate_cost(
-                            model=_model,
+                            model=model,
                             tokens_input=tokens_input,
                             tokens_output=tokens_output,
                         )
@@ -3499,7 +3539,7 @@ class AgentOrchestrator:
                                 "agent_id": agent_id,
                                 "input_tokens": tokens_input,
                                 "output_tokens": tokens_output,
-                                "model": _model,
+                                "model": model,
                                 "cost_estimate": agent_cost,
                             }
                         )
@@ -3518,17 +3558,22 @@ class AgentOrchestrator:
         if _usage_by_agent:
             with contextlib.suppress(Exception):
                 from roboco.events import get_event_bus
-                from roboco.services.usage_events import publish_usage_snapshot
+                from roboco.services.usage_events import (
+                    UsageSnapshot,
+                    publish_usage_snapshot,
+                )
 
                 await publish_usage_snapshot(
-                    bus=get_event_bus(),
-                    period="60s",
-                    totals={
-                        "input_tokens": _usage_total_input,
-                        "output_tokens": _usage_total_output,
-                    },
-                    cost_estimate=_usage_total_cost,
-                    by_agent=_usage_by_agent,
+                    get_event_bus(),
+                    UsageSnapshot(
+                        period="live",
+                        totals={
+                            "input_tokens": _usage_total_input,
+                            "output_tokens": _usage_total_output,
+                        },
+                        cost_estimate=_usage_total_cost,
+                        by_agent=_usage_by_agent,
+                    ),
                 )
 
     async def _sweep_daily_rollup(self) -> None:

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -3316,13 +3316,16 @@ class AgentOrchestrator:
                 error=str(exc),
             )
 
-    async def _sweep_token_snapshots(self) -> None:
+    async def _sweep_token_snapshots(self) -> None:  # noqa: PLR0915
         """Write a token_usage_snapshots row for each active agent with non-zero tokens.
 
         Called from _run_sweep() every ~60 s. Also updates the cumulative
         token counts on the open agent_spawn_sessions row so the DB reflects
         current progress without waiting for session close.
         Errors per-agent are caught so one bad agent doesn't abort the whole sweep.
+
+        Additionally publishes USAGE_UPDATE events per agent (throttled to at most
+        one per 5-second window) and a USAGE_SNAPSHOT aggregate after the loop.
         """
         if not self._instances:
             return
@@ -3334,6 +3337,12 @@ class AgentOrchestrator:
             return
 
         session_factory = get_session_factory()
+
+        # Accumulators for the post-loop USAGE_SNAPSHOT event.
+        _usage_by_agent: list[dict[str, Any]] = []
+        _usage_total_input = 0
+        _usage_total_output = 0
+        _usage_total_cost = 0.0
 
         async with httpx.AsyncClient(timeout=3.0) as client:
             for agent_id, instance in list(self._instances.items()):
@@ -3363,6 +3372,9 @@ class AgentOrchestrator:
                     )
                     if total == 0:
                         continue
+
+                    # Resolve model for cost estimation and event data.
+                    _model = instance.config.model if instance.config else "unknown"
 
                     async with session_factory() as db:
                         from sqlalchemy import select, update
@@ -3418,12 +3430,65 @@ class AgentOrchestrator:
                         )
                         await db.commit()
 
+                    # Publish USAGE_UPDATE event for this agent (throttled).
+                    with contextlib.suppress(Exception):
+                        from roboco.events import get_event_bus
+                        from roboco.services.usage_events import publish_usage_update
+
+                        await publish_usage_update(
+                            bus=get_event_bus(),
+                            agent_id=agent_id,
+                            task_id=instance.current_task_id,
+                            input_tokens=tokens_input,
+                            output_tokens=tokens_output,
+                            model=_model,
+                        )
+
+                    # Accumulate per-agent data for the aggregate snapshot.
+                    with contextlib.suppress(Exception):
+                        from roboco.billing.pricing import calculate_cost
+
+                        agent_cost = calculate_cost(
+                            model=_model,
+                            tokens_input=tokens_input,
+                            tokens_output=tokens_output,
+                        )
+                        _usage_by_agent.append(
+                            {
+                                "agent_id": agent_id,
+                                "input_tokens": tokens_input,
+                                "output_tokens": tokens_output,
+                                "model": _model,
+                                "cost_estimate": agent_cost,
+                            }
+                        )
+                        _usage_total_input += tokens_input
+                        _usage_total_output += tokens_output
+                        _usage_total_cost += agent_cost
+
                 except Exception as agent_exc:
                     logger.debug(
                         "Token snapshot failed for agent",
                         agent_id=agent_id,
                         error=str(agent_exc),
                     )
+
+        # Publish a USAGE_SNAPSHOT aggregate if any active agents had token data.
+        if _usage_by_agent:
+            with contextlib.suppress(Exception):
+                from roboco.events import get_event_bus
+                from roboco.services.usage_events import publish_usage_snapshot
+
+                await publish_usage_snapshot(
+                    bus=get_event_bus(),
+                    period="60s",
+                    totals={
+                        "input_tokens": _usage_total_input,
+                        "output_tokens": _usage_total_output,
+                    },
+                    cost_estimate=_usage_total_cost,
+                    by_agent=_usage_by_agent,
+                )
 
     async def _sweep_daily_rollup(self) -> None:
         """Upsert daily_usage_rollups from closed agent_spawn_sessions.

--- a/roboco/services/usage.py
+++ b/roboco/services/usage.py
@@ -35,6 +35,23 @@ def _row_tokens(row: Any) -> tuple[int, int, int, int]:
     )
 
 
+def _session_row(row: Any) -> dict[str, Any]:
+    """Shape one spawn-session row for the dashboard's sessions table."""
+    tin, tout, tcr, tcw = _row_tokens(row)
+    return {
+        "id": str(row.id),
+        "agent_slug": row.agent_slug,
+        "model": row.model,
+        "started_at": row.started_at.isoformat(),
+        "ended_at": row.ended_at.isoformat() if row.ended_at else None,
+        "tokens_input": tin,
+        "tokens_output": tout,
+        "tokens_cache": tcr + tcw,
+        "total_tokens": tin + tout + tcr + tcw,
+        "cost": float(row.estimated_cost_usd or 0.0),
+    }
+
+
 def _parse_period(period: str) -> tuple[datetime, int]:
     """Parse period string into (start_dt, hours).
 
@@ -440,6 +457,19 @@ class UsageService(BaseService):
             "tokens_today": tokens_today,
             "cost_today_usd": round(float(row.total_cost_usd or 0.0), 6),
         }
+
+    async def get_recent_sessions(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the most recent spawn sessions, newest first.
+
+        These are the raw per-session rows behind the aggregate panels — the
+        dashboard's "Recent Sessions" table.
+        """
+        result = await self.session.execute(
+            select(AgentSpawnSessionTable)
+            .order_by(AgentSpawnSessionTable.started_at.desc())
+            .limit(limit)
+        )
+        return [_session_row(row) for row in result.scalars().all()]
 
 
 def get_usage_service(db: AsyncSession) -> UsageService:

--- a/roboco/services/usage_events.py
+++ b/roboco/services/usage_events.py
@@ -1,0 +1,132 @@
+"""
+Usage Event Publisher
+
+Throttled helpers for publishing USAGE_UPDATE and USAGE_SNAPSHOT events
+to the StreamEventBus.  Consumed by the orchestrator token sweep and
+forwarded to /ws/system WebSocket clients via the websocket_bridge.
+
+Throttle window: one USAGE_UPDATE publish per agent per 5-second window.
+Subsequent calls within the window are silently dropped so a frequent
+sweep loop cannot flood the event bus or WebSocket clients.
+
+USAGE_SNAPSHOT is always published (no per-agent throttle) — it is an
+aggregate and published at most once per sweep cycle.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from roboco.events.stream_bus import StreamEventBus
+
+_THROTTLE_WINDOW_SECONDS: float = 5.0
+
+
+class _UsageThrottle:
+    """Per-agent last-publish timestamp tracker.
+
+    Uses ``time.monotonic()`` so clock adjustments (NTP, DST) don't cause
+    spurious suppressions or double-fires.
+    """
+
+    def __init__(self, window: float = _THROTTLE_WINDOW_SECONDS) -> None:
+        self._window = window
+        self._last: dict[str, float] = {}
+
+    def should_publish(self, agent_id: str) -> bool:
+        """Return True if the agent is outside the throttle window.
+
+        Also records the current monotonic time as the new *last published*
+        timestamp when it returns True, so the caller does not need to call a
+        separate ``record()`` method.
+        """
+        now = time.monotonic()
+        if now - self._last.get(agent_id, 0.0) >= self._window:
+            self._last[agent_id] = now
+            return True
+        return False
+
+
+# Module-level singleton — shared across all callers in this process.
+_throttle = _UsageThrottle()
+
+
+async def publish_usage_update(  # noqa: PLR0913
+    bus: StreamEventBus,
+    agent_id: str,
+    task_id: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    model: str,
+    timestamp: datetime | None = None,
+) -> bool:
+    """Publish a USAGE_UPDATE event if the per-agent throttle window has elapsed.
+
+    Args:
+        bus: The StreamEventBus to publish on.
+        agent_id: Agent slug (e.g. ``"be-dev-1"``).
+        task_id: The agent's current task UUID string, or None.
+        input_tokens: Cumulative input-token count for this session.
+        output_tokens: Cumulative output-token count for this session.
+        model: Model name (e.g. ``"claude-sonnet-4-6"``).
+        timestamp: Override publish timestamp; defaults to ``datetime.now(UTC)``.
+
+    Returns:
+        True if the event was published; False if suppressed by the throttle.
+    """
+    if not _throttle.should_publish(agent_id):
+        return False
+
+    from roboco.models.events import Event, EventType  # lazy — avoids circular import
+
+    event = Event(
+        type=EventType.USAGE_UPDATE,
+        data={
+            "agent_id": agent_id,
+            "task_id": task_id,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "model": model,
+            "timestamp": (timestamp or datetime.now(UTC)).isoformat(),
+        },
+    )
+    await bus.publish(event)
+    return True
+
+
+async def publish_usage_snapshot(  # noqa: PLR0913
+    bus: StreamEventBus,
+    period: str,
+    totals: dict[str, Any],
+    cost_estimate: float,
+    by_agent: list[dict[str, Any]],
+    timestamp: datetime | None = None,
+) -> None:
+    """Publish a USAGE_SNAPSHOT aggregate event (no throttle).
+
+    Args:
+        bus: The StreamEventBus to publish on.
+        period: Human-readable period label (e.g. ``"60s"``).
+        totals: ``{"input_tokens": int, "output_tokens": int}`` aggregate.
+        cost_estimate: Estimated USD cost for the snapshot period.
+        by_agent: Per-agent breakdown list; each item is a dict with keys
+            ``agent_id``, ``input_tokens``, ``output_tokens``, ``model``,
+            and ``cost_estimate``.
+        timestamp: Override publish timestamp; defaults to ``datetime.now(UTC)``.
+    """
+    from roboco.models.events import Event, EventType  # lazy — avoids circular import
+
+    event = Event(
+        type=EventType.USAGE_SNAPSHOT,
+        data={
+            "period": period,
+            "totals": totals,
+            "cost_estimate": cost_estimate,
+            "by_agent": by_agent,
+            "timestamp": (timestamp or datetime.now(UTC)).isoformat(),
+        },
+    )
+    await bus.publish(event)

--- a/roboco/services/usage_events.py
+++ b/roboco/services/usage_events.py
@@ -16,6 +16,7 @@ aggregate and published at most once per sweep cycle.
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -54,79 +55,75 @@ class _UsageThrottle:
 _throttle = _UsageThrottle()
 
 
-async def publish_usage_update(  # noqa: PLR0913
-    bus: StreamEventBus,
-    agent_id: str,
-    task_id: str | None,
-    input_tokens: int,
-    output_tokens: int,
-    model: str,
-    timestamp: datetime | None = None,
-) -> bool:
+@dataclass(frozen=True, slots=True)
+class UsageUpdate:
+    """Per-agent cumulative token counts carried by a USAGE_UPDATE event.
+
+    Fields map directly onto the event payload the panel consumes (the
+    backend emits these per active agent during the token sweep).
+    """
+
+    agent_id: str
+    task_id: str | None
+    input_tokens: int
+    output_tokens: int
+    model: str
+    timestamp: datetime | None = None
+
+    def event_data(self) -> dict[str, Any]:
+        """Render the event payload, stamping ``timestamp`` if not supplied."""
+        return {
+            "agent_id": self.agent_id,
+            "task_id": self.task_id,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "model": self.model,
+            "timestamp": (self.timestamp or datetime.now(UTC)).isoformat(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UsageSnapshot:
+    """Aggregate token/cost totals carried by a USAGE_SNAPSHOT event.
+
+    ``totals`` is ``{"input_tokens": int, "output_tokens": int}``; ``by_agent``
+    is the per-agent breakdown (each item carries ``agent_id``, token counts,
+    ``model`` and ``cost_estimate``).
+    """
+
+    period: str
+    totals: dict[str, int]
+    cost_estimate: float
+    by_agent: list[dict[str, Any]]
+    timestamp: datetime | None = None
+
+    def event_data(self) -> dict[str, Any]:
+        """Render the event payload, stamping ``timestamp`` if not supplied."""
+        return {
+            "period": self.period,
+            "totals": self.totals,
+            "cost_estimate": self.cost_estimate,
+            "by_agent": self.by_agent,
+            "timestamp": (self.timestamp or datetime.now(UTC)).isoformat(),
+        }
+
+
+async def publish_usage_update(bus: StreamEventBus, update: UsageUpdate) -> bool:
     """Publish a USAGE_UPDATE event if the per-agent throttle window has elapsed.
 
-    Args:
-        bus: The StreamEventBus to publish on.
-        agent_id: Agent slug (e.g. ``"be-dev-1"``).
-        task_id: The agent's current task UUID string, or None.
-        input_tokens: Cumulative input-token count for this session.
-        output_tokens: Cumulative output-token count for this session.
-        model: Model name (e.g. ``"claude-sonnet-4-6"``).
-        timestamp: Override publish timestamp; defaults to ``datetime.now(UTC)``.
-
-    Returns:
-        True if the event was published; False if suppressed by the throttle.
+    Returns True if the event was published; False if suppressed by the throttle.
     """
-    if not _throttle.should_publish(agent_id):
+    if not _throttle.should_publish(update.agent_id):
         return False
 
     from roboco.models.events import Event, EventType  # lazy — avoids circular import
 
-    event = Event(
-        type=EventType.USAGE_UPDATE,
-        data={
-            "agent_id": agent_id,
-            "task_id": task_id,
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-            "model": model,
-            "timestamp": (timestamp or datetime.now(UTC)).isoformat(),
-        },
-    )
-    await bus.publish(event)
+    await bus.publish(Event(type=EventType.USAGE_UPDATE, data=update.event_data()))
     return True
 
 
-async def publish_usage_snapshot(  # noqa: PLR0913
-    bus: StreamEventBus,
-    period: str,
-    totals: dict[str, Any],
-    cost_estimate: float,
-    by_agent: list[dict[str, Any]],
-    timestamp: datetime | None = None,
-) -> None:
-    """Publish a USAGE_SNAPSHOT aggregate event (no throttle).
-
-    Args:
-        bus: The StreamEventBus to publish on.
-        period: Human-readable period label (e.g. ``"60s"``).
-        totals: ``{"input_tokens": int, "output_tokens": int}`` aggregate.
-        cost_estimate: Estimated USD cost for the snapshot period.
-        by_agent: Per-agent breakdown list; each item is a dict with keys
-            ``agent_id``, ``input_tokens``, ``output_tokens``, ``model``,
-            and ``cost_estimate``.
-        timestamp: Override publish timestamp; defaults to ``datetime.now(UTC)``.
-    """
+async def publish_usage_snapshot(bus: StreamEventBus, snapshot: UsageSnapshot) -> None:
+    """Publish a USAGE_SNAPSHOT aggregate event (no throttle)."""
     from roboco.models.events import Event, EventType  # lazy — avoids circular import
 
-    event = Event(
-        type=EventType.USAGE_SNAPSHOT,
-        data={
-            "period": period,
-            "totals": totals,
-            "cost_estimate": cost_estimate,
-            "by_agent": by_agent,
-            "timestamp": (timestamp or datetime.now(UTC)).isoformat(),
-        },
-    )
-    await bus.publish(event)
+    await bus.publish(Event(type=EventType.USAGE_SNAPSHOT, data=snapshot.event_data()))

--- a/tests/unit/agent_sdk/test_usage_sync.py
+++ b/tests/unit/agent_sdk/test_usage_sync.py
@@ -168,3 +168,51 @@ def test_parser_handles_entries_without_message(tmp_path: Path) -> None:
         exp["tokens_cache_read"],
         exp["tokens_cache_write"],
     )
+
+
+def _assistant_line_with_id(row: _UsageRow, message_id: str) -> str:
+    """An assistant line carrying a message id (for de-duplication tests)."""
+    inp, out, cread, cwrite = row
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "id": message_id,
+                "role": "assistant",
+                "usage": {
+                    "input_tokens": inp,
+                    "output_tokens": out,
+                    "cache_read_input_tokens": cread,
+                    "cache_creation_input_tokens": cwrite,
+                },
+            },
+        }
+    )
+
+
+def test_parser_dedupes_repeated_message_id(tmp_path: Path) -> None:
+    """One message logged across several lines (same id) is counted once.
+
+    Claude Code emits one transcript line per content block (thinking, text,
+    tool_use), each repeating the message's ``usage``. Summing every line would
+    roughly double the totals, so the parser must de-duplicate by message id.
+    """
+    msg = (100, 20, 5, 3)
+    other = (7, 2, 1, 0)
+    transcript = tmp_path / "session.jsonl"
+    _write(
+        transcript,
+        _assistant_line_with_id(msg, "msg_aaa"),  # thinking block
+        _assistant_line_with_id(msg, "msg_aaa"),  # text block (same id)
+        _assistant_line_with_id(msg, "msg_aaa"),  # tool_use block (same id)
+        _assistant_line_with_id(other, "msg_bbb"),
+    )
+    tin, tout, cread, cwrite = srv._sum_transcript_usage(transcript)
+    # Counted once per id: msg + other, NOT msg * 3 + other.
+    exp = _expected([msg, other])
+    assert (tin, tout, cread, cwrite) == (
+        exp["tokens_input"],
+        exp["tokens_output"],
+        exp["tokens_cache_read"],
+        exp["tokens_cache_write"],
+    )

--- a/tests/unit/api/test_websocket_bridge.py
+++ b/tests/unit/api/test_websocket_bridge.py
@@ -299,14 +299,16 @@ async def test_handle_rate_limit_ignores_unrelated_event() -> None:
 
 @pytest.mark.asyncio
 async def test_handle_usage_update_broadcasts_to_system() -> None:
-    """USAGE_UPDATE event → broadcast_system with type=usage.update + data fields."""
+    """USAGE_UPDATE event → broadcast_system tagged USAGE_UPDATE + data fields."""
+    expected_input = 100
+    expected_output = 50
     event = _evt(
         EventType.USAGE_UPDATE,
         {
             "agent_id": "be-dev-1",
             "task_id": "task-abc",
-            "input_tokens": 100,
-            "output_tokens": 50,
+            "input_tokens": expected_input,
+            "output_tokens": expected_output,
             "model": "claude-sonnet-4-6",
             "timestamp": "2026-06-11T00:00:00+00:00",
         },
@@ -316,20 +318,21 @@ async def test_handle_usage_update_broadcasts_to_system() -> None:
         await _handle_usage_event(event)
     mgr.broadcast_system.assert_awaited_once()
     msg = mgr.broadcast_system.await_args.args[0]
-    assert msg["type"] == "usage.update"
+    assert msg["type"] == "USAGE_UPDATE"
     assert msg["agent_id"] == "be-dev-1"
-    assert msg["input_tokens"] == 100  # noqa: PLR2004
-    assert msg["output_tokens"] == 50  # noqa: PLR2004
+    assert msg["input_tokens"] == expected_input
+    assert msg["output_tokens"] == expected_output
 
 
 @pytest.mark.asyncio
 async def test_handle_usage_snapshot_broadcasts_to_system() -> None:
-    """USAGE_SNAPSHOT event → broadcast_system with type=usage.snapshot + aggregate."""
+    """USAGE_SNAPSHOT event → broadcast_system tagged USAGE_SNAPSHOT + aggregate."""
+    expected_input = 500
     event = _evt(
         EventType.USAGE_SNAPSHOT,
         {
-            "period": "60s",
-            "totals": {"input_tokens": 500, "output_tokens": 200},
+            "period": "live",
+            "totals": {"input_tokens": expected_input, "output_tokens": 200},
             "cost_estimate": 0.0025,
             "by_agent": [
                 {
@@ -348,9 +351,9 @@ async def test_handle_usage_snapshot_broadcasts_to_system() -> None:
         await _handle_usage_event(event)
     mgr.broadcast_system.assert_awaited_once()
     msg = mgr.broadcast_system.await_args.args[0]
-    assert msg["type"] == "usage.snapshot"
-    assert msg["period"] == "60s"
-    assert msg["totals"]["input_tokens"] == 500  # noqa: PLR2004
+    assert msg["type"] == "USAGE_SNAPSHOT"
+    assert msg["period"] == "live"
+    assert msg["totals"]["input_tokens"] == expected_input
     assert len(msg["by_agent"]) == 1
 
 

--- a/tests/unit/api/test_websocket_bridge.py
+++ b/tests/unit/api/test_websocket_bridge.py
@@ -17,6 +17,7 @@ from roboco.api.websocket_bridge import (
     _handle_notification_sent,
     _handle_rate_limit_event,
     _handle_session_event,
+    _handle_usage_event,
     register_websocket_bridge_handlers,
     start_websocket_bridge,
 )
@@ -292,12 +293,74 @@ async def test_handle_rate_limit_ignores_unrelated_event() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _handle_usage_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_usage_update_broadcasts_to_system() -> None:
+    """USAGE_UPDATE event → broadcast_system with type=usage.update + data fields."""
+    event = _evt(
+        EventType.USAGE_UPDATE,
+        {
+            "agent_id": "be-dev-1",
+            "task_id": "task-abc",
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "model": "claude-sonnet-4-6",
+            "timestamp": "2026-06-11T00:00:00+00:00",
+        },
+    )
+    with patch("roboco.api.websocket_bridge.manager") as mgr:
+        mgr.broadcast_system = AsyncMock()
+        await _handle_usage_event(event)
+    mgr.broadcast_system.assert_awaited_once()
+    msg = mgr.broadcast_system.await_args.args[0]
+    assert msg["type"] == "usage.update"
+    assert msg["agent_id"] == "be-dev-1"
+    assert msg["input_tokens"] == 100  # noqa: PLR2004
+    assert msg["output_tokens"] == 50  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_handle_usage_snapshot_broadcasts_to_system() -> None:
+    """USAGE_SNAPSHOT event → broadcast_system with type=usage.snapshot + aggregate."""
+    event = _evt(
+        EventType.USAGE_SNAPSHOT,
+        {
+            "period": "60s",
+            "totals": {"input_tokens": 500, "output_tokens": 200},
+            "cost_estimate": 0.0025,
+            "by_agent": [
+                {
+                    "agent_id": "be-dev-1",
+                    "input_tokens": 500,
+                    "output_tokens": 200,
+                    "model": "sonnet",
+                    "cost_estimate": 0.0025,
+                }
+            ],
+            "timestamp": "2026-06-11T00:01:00+00:00",
+        },
+    )
+    with patch("roboco.api.websocket_bridge.manager") as mgr:
+        mgr.broadcast_system = AsyncMock()
+        await _handle_usage_event(event)
+    mgr.broadcast_system.assert_awaited_once()
+    msg = mgr.broadcast_system.await_args.args[0]
+    assert msg["type"] == "usage.snapshot"
+    assert msg["period"] == "60s"
+    assert msg["totals"]["input_tokens"] == 500  # noqa: PLR2004
+    assert len(msg["by_agent"]) == 1
+
+
+# ---------------------------------------------------------------------------
 # Registration + start
 # ---------------------------------------------------------------------------
 
 
 def test_register_websocket_bridge_handlers_subscribes_all_event_types() -> None:
-    """Registration wires up notification + session + agent event handlers."""
+    """Registration wires up all handler categories, including usage events."""
 
     class _FakeBus:
         def __init__(self) -> None:
@@ -310,7 +373,7 @@ def test_register_websocket_bridge_handlers_subscribes_all_event_types() -> None
     with patch("roboco.api.websocket_bridge.get_event_bus", return_value=fake):
         register_websocket_bridge_handlers()
     types = [t for t, _ in fake.subscribed]
-    # All 10 expected event types appear at least once.
+    # All 14 expected event types appear at least once.
     assert EventType.NOTIFICATION_SENT in types
     assert EventType.NOTIFICATION_ACKED in types
     assert EventType.SESSION_CREATED in types
@@ -323,6 +386,9 @@ def test_register_websocket_bridge_handlers_subscribes_all_event_types() -> None
     assert EventType.AGENT_ERROR in types
     assert EventType.RATE_LIMIT_HIT in types
     assert EventType.RATE_LIMIT_LIFTED in types
+    # Usage events forwarded to /ws/system.
+    assert EventType.USAGE_UPDATE in types
+    assert EventType.USAGE_SNAPSHOT in types
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_orchestrator_write_hooks.py
+++ b/tests/unit/runtime/test_orchestrator_write_hooks.py
@@ -527,7 +527,7 @@ async def test_stop_agent_finalizes_before_lock() -> None:
 
     finalized: list[str] = []
 
-    async def _fake_finalize(agent_id: str, exit_reason: str = "stopped") -> None:  # noqa: ARG001
+    async def _fake_finalize(agent_id: str, **_kwargs: object) -> None:
         finalized.append(agent_id)
 
     # Stub out the Docker subprocess so stop_agent doesn't actually run Docker
@@ -543,3 +543,55 @@ async def test_stop_agent_finalizes_before_lock() -> None:
 
     # _finalize_spawn_session must have been called exactly once with our agent id
     assert finalized == [_AGENT_ID]
+
+
+# ---------------------------------------------------------------------------
+# _handle_stopped_container — self-exits finalize (stop_agent was not called)
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_stopped_container_graceful_finalizes() -> None:
+    """A graceful self-exit (exit 0) finalizes the spawn session.
+
+    The agent calls i_am_idle and its container exits 0 without stop_agent
+    being invoked, so _handle_stopped_container must finalize to capture the
+    token usage; otherwise the session row is left open with zero tokens.
+    """
+    orch = _make_orchestrator()
+    instance = _make_instance(_AGENT_ID)
+    instance.container_id = "abc123def456"
+    orch._instances[_AGENT_ID] = instance
+
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_finalize(agent_id: str, exit_reason: str = "stopped") -> None:
+        calls.append((agent_id, exit_reason))
+
+    with patch.object(orch, "_finalize_spawn_session", side_effect=_fake_finalize):
+        await orch._handle_stopped_container(_AGENT_ID, instance, 0)
+
+    assert calls == [(_AGENT_ID, "completed")]
+    assert instance.state is OrchestratorAgentState.OFFLINE
+
+
+async def test_handle_stopped_container_crash_finalizes_then_restarts() -> None:
+    """A non-zero exit finalizes (exit_reason='crashed') before auto-restart."""
+    orch = _make_orchestrator()
+    instance = _make_instance(_AGENT_ID)
+    instance.container_id = "abc123def456"
+    instance.error_count = 0
+    orch._instances[_AGENT_ID] = instance
+
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_finalize(agent_id: str, exit_reason: str = "stopped") -> None:
+        calls.append((agent_id, exit_reason))
+
+    with (
+        patch.object(orch, "_finalize_spawn_session", side_effect=_fake_finalize),
+        patch.object(orch, "spawn_agent", AsyncMock()) as mock_spawn,
+    ):
+        await orch._handle_stopped_container(_AGENT_ID, instance, 1)
+
+    assert calls == [(_AGENT_ID, "crashed")]
+    mock_spawn.assert_awaited_once()

--- a/tests/unit/runtime/test_orchestrator_write_hooks.py
+++ b/tests/unit/runtime/test_orchestrator_write_hooks.py
@@ -385,6 +385,7 @@ async def test_sweep_token_snapshots_skips_zero_token_agents() -> None:
 
     with (
         patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch.object(orch, "_usage_from_transcript", return_value=(0, 0, 0, 0)),
         patch("roboco.db.base.get_session_factory", return_value=db_factory),
     ):
         await orch._sweep_token_snapshots()
@@ -595,3 +596,55 @@ async def test_handle_stopped_container_crash_finalizes_then_restarts() -> None:
 
     assert calls == [(_AGENT_ID, "crashed")]
     mock_spawn.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_active_tokens — SDK first, transcript fallback for live agents
+# ---------------------------------------------------------------------------
+
+
+async def test_resolve_active_tokens_falls_back_to_transcript() -> None:
+    """When the SDK reports all-zero, live resolution uses the transcript."""
+    orch = _make_orchestrator()
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(
+            200,
+            {
+                "tokens_input": 0,
+                "tokens_output": 0,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
+        )
+
+    client = _FakeHTTPClient(_handler)
+    with patch.object(orch, "_usage_from_transcript", return_value=(6, 514, 100, 50)):
+        tokens = await orch._resolve_active_tokens(client, _AGENT_ID)
+
+    assert tokens == (6, 514, 100, 50)
+
+
+async def test_resolve_active_tokens_prefers_sdk() -> None:
+    """A non-zero SDK response is used directly — no transcript fallback."""
+    orch = _make_orchestrator()
+
+    def _handler(_url: str) -> Any:
+        return _mock_response(
+            200,
+            {
+                "tokens_input": 10,
+                "tokens_output": 20,
+                "tokens_cache_read": 0,
+                "tokens_cache_write": 0,
+            },
+        )
+
+    client = _FakeHTTPClient(_handler)
+    with patch.object(
+        orch, "_usage_from_transcript", return_value=(999, 999, 999, 999)
+    ) as mock_tx:
+        tokens = await orch._resolve_active_tokens(client, _AGENT_ID)
+
+    assert tokens == (10, 20, 0, 0)
+    mock_tx.assert_not_called()

--- a/tests/unit/runtime/test_orchestrator_write_hooks.py
+++ b/tests/unit/runtime/test_orchestrator_write_hooks.py
@@ -265,6 +265,7 @@ async def test_finalize_spawn_session_http_error_uses_zero_tokens() -> None:
 
     with (
         patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch.object(orch, "_usage_from_transcript", return_value=(0, 0, 0, 0)),
         patch("roboco.db.base.get_session_factory", return_value=db_factory),
         patch("roboco.billing.pricing.calculate_cost", return_value=0.0) as mock_cost,
     ):
@@ -298,6 +299,7 @@ async def test_finalize_spawn_session_non_200_uses_zero_tokens() -> None:
 
     with (
         patch("roboco.runtime.orchestrator.httpx.AsyncClient", _client_cls),
+        patch.object(orch, "_usage_from_transcript", return_value=(0, 0, 0, 0)),
         patch("roboco.db.base.get_session_factory", return_value=db_factory),
         patch("roboco.billing.pricing.calculate_cost", return_value=0.0) as mock_cost,
     ):

--- a/tests/unit/services/test_usage.py
+++ b/tests/unit/services/test_usage.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import datetime
 from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
 
 import pytest
 from roboco.services.usage import UsageService
@@ -759,3 +760,77 @@ class TestGetCacheEfficiency:
         result = await svc.get_cache_efficiency("24h")
         for field in ("cache_hit_rate", "cost_saved_by_cache_usd"):
             assert field in result, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# get_recent_sessions — maps spawn-session rows to the dashboard shape
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecentSessions:
+    @pytest.mark.asyncio
+    async def test_shapes_rows(self) -> None:
+        """Rows are mapped to id/agent/model/tokens/cache/total/cost fields."""
+        exp_in, exp_out = 6, 514
+        exp_cr, exp_cw = 111_032, 14_881
+        exp_cost = 0.1614
+        exp_count = 1
+        sid = UUID("12345678-1234-5678-1234-567812345678")
+
+        row = MagicMock()
+        row.id = sid
+        row.agent_slug = "product-owner"
+        row.model = "claude-opus-4-6"
+        row.started_at = datetime.datetime(2026, 6, 11, 20, 41, tzinfo=datetime.UTC)
+        row.ended_at = datetime.datetime(2026, 6, 11, 20, 42, tzinfo=datetime.UTC)
+        row.tokens_input = exp_in
+        row.tokens_output = exp_out
+        row.tokens_cache_read = exp_cr
+        row.tokens_cache_write = exp_cw
+        row.estimated_cost_usd = exp_cost
+
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=[row])
+        result = MagicMock()
+        result.scalars = MagicMock(return_value=scalars)
+
+        svc = _service_with_execute(result)
+        out = await svc.get_recent_sessions(limit=10)
+
+        assert len(out) == exp_count
+        s = out[0]
+        assert s["id"] == str(sid)
+        assert s["agent_slug"] == "product-owner"
+        assert s["model"] == "claude-opus-4-6"
+        assert s["tokens_input"] == exp_in
+        assert s["tokens_output"] == exp_out
+        assert s["tokens_cache"] == exp_cr + exp_cw
+        assert s["total_tokens"] == exp_in + exp_out + exp_cr + exp_cw
+        assert s["cost"] == pytest.approx(exp_cost)
+        assert s["ended_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_open_session_has_null_ended_at(self) -> None:
+        """A still-running session (ended_at None) serializes ended_at as None."""
+        row = MagicMock()
+        row.id = "00000000-0000-0000-0000-000000000001"
+        row.agent_slug = "main-pm"
+        row.model = "sonnet"
+        row.started_at = datetime.datetime(2026, 6, 11, 20, 0, tzinfo=datetime.UTC)
+        row.ended_at = None
+        row.tokens_input = _ZERO
+        row.tokens_output = _ZERO
+        row.tokens_cache_read = _ZERO
+        row.tokens_cache_write = _ZERO
+        row.estimated_cost_usd = None
+
+        scalars = MagicMock()
+        scalars.all = MagicMock(return_value=[row])
+        result = MagicMock()
+        result.scalars = MagicMock(return_value=scalars)
+
+        svc = _service_with_execute(result)
+        out = await svc.get_recent_sessions()
+
+        assert out[0]["ended_at"] is None
+        assert out[0]["cost"] == _ZERO

--- a/tests/unit/services/test_usage_events.py
+++ b/tests/unit/services/test_usage_events.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from roboco.services.usage_events import (
+    UsageSnapshot,
+    UsageUpdate,
     _UsageThrottle,
     publish_usage_snapshot,
     publish_usage_update,
@@ -77,11 +79,12 @@ def test_throttle_tracks_agents_independently() -> None:
 def test_throttle_records_timestamp_on_allow() -> None:
     """should_publish records the current time when it returns True."""
     th = _UsageThrottle(window=5.0)
+    recorded_at = 200.0
 
     with patch("roboco.services.usage_events.time") as mock_time:
-        mock_time.monotonic.return_value = 200.0
+        mock_time.monotonic.return_value = recorded_at
         th.should_publish("be-dev-1")
-        assert th._last["be-dev-1"] == 200.0  # noqa: PLR2004
+        assert th._last["be-dev-1"] == recorded_at
 
 
 # ---------------------------------------------------------------------------
@@ -95,15 +98,19 @@ async def test_publish_usage_update_calls_bus_publish() -> None:
     bus = MagicMock()
     bus.publish = AsyncMock()
     th = _UsageThrottle(window=5.0)
+    expected_input = 100
+    expected_output = 50
 
     with patch("roboco.services.usage_events._throttle", th):
         result = await publish_usage_update(
-            bus=bus,
-            agent_id="be-dev-1",
-            task_id="task-abc",
-            input_tokens=100,
-            output_tokens=50,
-            model="claude-sonnet-4-6",
+            bus,
+            UsageUpdate(
+                agent_id="be-dev-1",
+                task_id="task-abc",
+                input_tokens=expected_input,
+                output_tokens=expected_output,
+                model="claude-sonnet-4-6",
+            ),
         )
 
     assert result is True
@@ -112,8 +119,8 @@ async def test_publish_usage_update_calls_bus_publish() -> None:
     assert event.type.value == "usage.update"
     assert event.data["agent_id"] == "be-dev-1"
     assert event.data["task_id"] == "task-abc"
-    assert event.data["input_tokens"] == 100  # noqa: PLR2004
-    assert event.data["output_tokens"] == 50  # noqa: PLR2004
+    assert event.data["input_tokens"] == expected_input
+    assert event.data["output_tokens"] == expected_output
     assert event.data["model"] == "claude-sonnet-4-6"
     assert "timestamp" in event.data
 
@@ -131,22 +138,26 @@ async def test_publish_usage_update_throttle_suppresses_second_call() -> None:
     ):
         mock_time.monotonic.return_value = 100.0
         first = await publish_usage_update(
-            bus=bus,
-            agent_id="be-dev-1",
-            task_id=None,
-            input_tokens=10,
-            output_tokens=5,
-            model="sonnet",
+            bus,
+            UsageUpdate(
+                agent_id="be-dev-1",
+                task_id=None,
+                input_tokens=10,
+                output_tokens=5,
+                model="sonnet",
+            ),
         )
 
         mock_time.monotonic.return_value = 102.0  # 2 s later — still suppressed
         second = await publish_usage_update(
-            bus=bus,
-            agent_id="be-dev-1",
-            task_id=None,
-            input_tokens=20,
-            output_tokens=10,
-            model="sonnet",
+            bus,
+            UsageUpdate(
+                agent_id="be-dev-1",
+                task_id=None,
+                input_tokens=20,
+                output_tokens=10,
+                model="sonnet",
+            ),
         )
 
     assert first is True
@@ -166,13 +177,15 @@ async def test_publish_usage_update_custom_timestamp() -> None:
     th = _UsageThrottle(window=5.0)
     with patch("roboco.services.usage_events._throttle", th):
         await publish_usage_update(
-            bus=bus,
-            agent_id="be-dev-1",
-            task_id=None,
-            input_tokens=0,
-            output_tokens=0,
-            model="sonnet",
-            timestamp=ts,
+            bus,
+            UsageUpdate(
+                agent_id="be-dev-1",
+                task_id=None,
+                input_tokens=0,
+                output_tokens=0,
+                model="sonnet",
+                timestamp=ts,
+            ),
         )
 
     event = bus.publish.await_args.args[0]
@@ -189,37 +202,42 @@ async def test_publish_usage_snapshot_always_publishes() -> None:
     """publish_usage_snapshot has no throttle — always publishes."""
     bus = MagicMock()
     bus.publish = AsyncMock()
+    expected_input = 500
+    expected_cost = 0.0025
+    expected_agents = 2
 
     await publish_usage_snapshot(
-        bus=bus,
-        period="60s",
-        totals={"input_tokens": 500, "output_tokens": 200},
-        cost_estimate=0.0025,
-        by_agent=[
-            {
-                "agent_id": "be-dev-1",
-                "input_tokens": 300,
-                "output_tokens": 100,
-                "model": "sonnet",
-                "cost_estimate": 0.0015,
-            },
-            {
-                "agent_id": "be-dev-2",
-                "input_tokens": 200,
-                "output_tokens": 100,
-                "model": "sonnet",
-                "cost_estimate": 0.0010,
-            },
-        ],
+        bus,
+        UsageSnapshot(
+            period="live",
+            totals={"input_tokens": expected_input, "output_tokens": 200},
+            cost_estimate=expected_cost,
+            by_agent=[
+                {
+                    "agent_id": "be-dev-1",
+                    "input_tokens": 300,
+                    "output_tokens": 100,
+                    "model": "sonnet",
+                    "cost_estimate": 0.0015,
+                },
+                {
+                    "agent_id": "be-dev-2",
+                    "input_tokens": 200,
+                    "output_tokens": 100,
+                    "model": "sonnet",
+                    "cost_estimate": 0.0010,
+                },
+            ],
+        ),
     )
 
     bus.publish.assert_awaited_once()
     event = bus.publish.await_args.args[0]
     assert event.type.value == "usage.snapshot"
-    assert event.data["period"] == "60s"
-    assert event.data["totals"]["input_tokens"] == 500  # noqa: PLR2004
-    assert event.data["cost_estimate"] == 0.0025  # noqa: PLR2004
-    assert len(event.data["by_agent"]) == 2  # noqa: PLR2004
+    assert event.data["period"] == "live"
+    assert event.data["totals"]["input_tokens"] == expected_input
+    assert event.data["cost_estimate"] == expected_cost
+    assert len(event.data["by_agent"]) == expected_agents
     assert "timestamp" in event.data
 
 
@@ -228,14 +246,17 @@ async def test_publish_usage_snapshot_twice_both_published() -> None:
     """No throttle on snapshot: two rapid calls both publish."""
     bus = MagicMock()
     bus.publish = AsyncMock()
+    expected_calls = 2
 
-    for _ in range(2):
+    for _ in range(expected_calls):
         await publish_usage_snapshot(
-            bus=bus,
-            period="60s",
-            totals={"input_tokens": 0, "output_tokens": 0},
-            cost_estimate=0.0,
-            by_agent=[],
+            bus,
+            UsageSnapshot(
+                period="live",
+                totals={"input_tokens": 0, "output_tokens": 0},
+                cost_estimate=0.0,
+                by_agent=[],
+            ),
         )
 
-    assert bus.publish.await_count == 2  # noqa: PLR2004
+    assert bus.publish.await_count == expected_calls

--- a/tests/unit/services/test_usage_events.py
+++ b/tests/unit/services/test_usage_events.py
@@ -1,0 +1,241 @@
+"""Unit tests for roboco.services.usage_events.
+
+Covers the _UsageThrottle class and the publish_usage_update /
+publish_usage_snapshot helpers.  No real Redis or event bus is needed —
+we use AsyncMock to assert that bus.publish is called with the right
+payload and type.
+
+The throttle suppression test is the acceptance-criterion gate:
+  "Server-side throttle prevents more than 1 USAGE_UPDATE publish per
+   agent per 5-second window."
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from roboco.services.usage_events import (
+    _UsageThrottle,
+    publish_usage_snapshot,
+    publish_usage_update,
+)
+
+# ---------------------------------------------------------------------------
+# _UsageThrottle
+# ---------------------------------------------------------------------------
+
+
+def test_throttle_allows_first_publish() -> None:
+    """A fresh agent has no prior timestamp — first publish is always allowed."""
+    th = _UsageThrottle(window=5.0)
+    assert th.should_publish("be-dev-1") is True
+
+
+def test_throttle_suppresses_second_publish_within_window() -> None:
+    """Second call within the 5-second window returns False (suppressed)."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 100.0
+        assert th.should_publish("be-dev-1") is True  # first → allowed
+
+        mock_time.monotonic.return_value = 104.9  # 4.9 s later — still inside window
+        assert th.should_publish("be-dev-1") is False  # suppressed
+
+
+def test_throttle_allows_publish_after_window_expires() -> None:
+    """After the full window elapses, the next publish is allowed again."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 100.0
+        assert th.should_publish("be-dev-1") is True  # first
+
+        mock_time.monotonic.return_value = 105.0  # exactly 5 s later
+        assert th.should_publish("be-dev-1") is True  # window elapsed → allowed
+
+
+def test_throttle_tracks_agents_independently() -> None:
+    """Different agents have independent throttle windows."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 100.0
+
+        assert th.should_publish("be-dev-1") is True
+        # be-dev-2 has never published, so it is always allowed.
+        assert th.should_publish("be-dev-2") is True
+
+        mock_time.monotonic.return_value = 101.0
+        # be-dev-1 is suppressed; be-dev-2 is also now suppressed.
+        assert th.should_publish("be-dev-1") is False
+        assert th.should_publish("be-dev-2") is False
+
+
+def test_throttle_records_timestamp_on_allow() -> None:
+    """should_publish records the current time when it returns True."""
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events.time") as mock_time:
+        mock_time.monotonic.return_value = 200.0
+        th.should_publish("be-dev-1")
+        assert th._last["be-dev-1"] == 200.0  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# publish_usage_update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_update_calls_bus_publish() -> None:
+    """First call in a window publishes the event and returns True."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    th = _UsageThrottle(window=5.0)
+
+    with patch("roboco.services.usage_events._throttle", th):
+        result = await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id="task-abc",
+            input_tokens=100,
+            output_tokens=50,
+            model="claude-sonnet-4-6",
+        )
+
+    assert result is True
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.type.value == "usage.update"
+    assert event.data["agent_id"] == "be-dev-1"
+    assert event.data["task_id"] == "task-abc"
+    assert event.data["input_tokens"] == 100  # noqa: PLR2004
+    assert event.data["output_tokens"] == 50  # noqa: PLR2004
+    assert event.data["model"] == "claude-sonnet-4-6"
+    assert "timestamp" in event.data
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_update_throttle_suppresses_second_call() -> None:
+    """Second publish within the throttle window is suppressed (returns False)."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    th = _UsageThrottle(window=5.0)
+
+    with (
+        patch("roboco.services.usage_events._throttle", th),
+        patch("roboco.services.usage_events.time") as mock_time,
+    ):
+        mock_time.monotonic.return_value = 100.0
+        first = await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id=None,
+            input_tokens=10,
+            output_tokens=5,
+            model="sonnet",
+        )
+
+        mock_time.monotonic.return_value = 102.0  # 2 s later — still suppressed
+        second = await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id=None,
+            input_tokens=20,
+            output_tokens=10,
+            model="sonnet",
+        )
+
+    assert first is True
+    assert second is False
+    # bus.publish should only have been called once.
+    assert bus.publish.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_update_custom_timestamp() -> None:
+    """Custom timestamp is passed through to the event data."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+    ts = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+
+    # Use a fresh throttle so the first publish goes through.
+    th = _UsageThrottle(window=5.0)
+    with patch("roboco.services.usage_events._throttle", th):
+        await publish_usage_update(
+            bus=bus,
+            agent_id="be-dev-1",
+            task_id=None,
+            input_tokens=0,
+            output_tokens=0,
+            model="sonnet",
+            timestamp=ts,
+        )
+
+    event = bus.publish.await_args.args[0]
+    assert event.data["timestamp"] == ts.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# publish_usage_snapshot
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_snapshot_always_publishes() -> None:
+    """publish_usage_snapshot has no throttle — always publishes."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+
+    await publish_usage_snapshot(
+        bus=bus,
+        period="60s",
+        totals={"input_tokens": 500, "output_tokens": 200},
+        cost_estimate=0.0025,
+        by_agent=[
+            {
+                "agent_id": "be-dev-1",
+                "input_tokens": 300,
+                "output_tokens": 100,
+                "model": "sonnet",
+                "cost_estimate": 0.0015,
+            },
+            {
+                "agent_id": "be-dev-2",
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "model": "sonnet",
+                "cost_estimate": 0.0010,
+            },
+        ],
+    )
+
+    bus.publish.assert_awaited_once()
+    event = bus.publish.await_args.args[0]
+    assert event.type.value == "usage.snapshot"
+    assert event.data["period"] == "60s"
+    assert event.data["totals"]["input_tokens"] == 500  # noqa: PLR2004
+    assert event.data["cost_estimate"] == 0.0025  # noqa: PLR2004
+    assert len(event.data["by_agent"]) == 2  # noqa: PLR2004
+    assert "timestamp" in event.data
+
+
+@pytest.mark.asyncio
+async def test_publish_usage_snapshot_twice_both_published() -> None:
+    """No throttle on snapshot: two rapid calls both publish."""
+    bus = MagicMock()
+    bus.publish = AsyncMock()
+
+    for _ in range(2):
+        await publish_usage_snapshot(
+            bus=bus,
+            period="60s",
+            totals={"input_tokens": 0, "output_tokens": 0},
+            cost_estimate=0.0,
+            by_agent=[],
+        )
+
+    assert bus.publish.await_count == 2  # noqa: PLR2004


### PR DESCRIPTION
## Objective

Push real-time usage data to the dashboard over the existing /ws/system operator stream, eliminating polling. Follow the same websocket_bridge event-forwarding pattern used for the rate-limit banner — no new WebSocket endpoint or client-side connection stack.

## What This Builds

- EventType.USAGE_UPDATE and EventType.USAGE_SNAPSHOT enum members (dotted string values) published to the StreamEventBus when usage metrics change
- A _handle_usage_event bridge handler in websocket_bridge that forwards those events to the /ws/system stream
- Frontend consumption via the existing useWebSocket("/system", …) hook, replacing polling when the WS connection is active
- Graceful fallback to HTTP polling when the WS connection drops

## The Work

Board-led: the Board sets requirements and the Main PM delegates one subtask per cell.

**Backend** — Emit usage events through the existing system stream
- Add EventType.USAGE_UPDATE (dotted value) and EventType.USAGE_SNAPSHOT (dotted value) to the event type enum
- Publish usage events to the StreamEventBus when metrics are recorded or aggregated
- Add _handle_usage_event handler in websocket_bridge to forward usage events to /ws/system, following the rate-limit banner pattern
- Ensure events respect existing auth/authorization on the /ws/system connection
- Add integration tests covering event emission and bridge forwarding

**Frontend** — Consume usage events from the existing system WebSocket
- Listen for USAGE_UPDATE / USAGE_SNAPSHOT events via the existing useWebSocket("/system", …) hook
- Update dashboard state on each received event
- Reduce or disable polling interval while the WS connection is active
- Fall back to existing HTTP polling on WS disconnect
- Add visual indicator showing real-time vs polling status

## Notes

- Reuses the /ws/system operator stream — do NOT create a new WS endpoint
- Follows the websocket_bridge _handle_usage_event pattern established by the rate-limit banner
- Reuses the useWebSocket("/system", …) hook on the frontend — do NOT build a new client WS stack
- Existing polling is preserved as fallback, not removed

## Success Criteria

- EventType.USAGE_UPDATE and EventType.USAGE_SNAPSHOT are defined with dotted string values and published to the StreamEventBus
- _handle_usage_event in websocket_bridge forwards usage events to /ws/system clients
- Usage dashboard receives and renders WS-pushed updates via useWebSocket("/system", …) without polling
- Dashboard falls back to HTTP polling when the /ws/system connection is unavailable
- No new WebSocket endpoint or client-side connection stack is introduced
- No regressions in existing polling-based behavior or rate-limit banner WS events