### PR TITLE
fix(prompts): compose the prompter role layer for the intake agent

### DIFF
--- a/roboco/agents/factories/_base.py
+++ b/roboco/agents/factories/_base.py
@@ -61,6 +61,10 @@ _ROLE_LAYER_MAP: dict[str, str] = {
     "product_owner": "board.md",
     "head_marketing": "board.md",
     "auditor": "board.md",
+    # Intake interviewer — the live-session role prompt that wires up the
+    # propose_draft mission. Without this the prompter only sees the
+    # gateway verbs layer (i_am_idle) and refuses to draft.
+    "prompter": "prompter.md",
 }
 
 _TEAM_LAYER_MAP: dict[str, str] = {


### PR DESCRIPTION
## Problem

The intake (prompter) agent refuses to do its job. In the live intake chat it
produces empty turns and never drafts a task — it tells the human things like
"my only available verb is `i_am_idle`… I don't have the authority to create
tasks." `propose_draft` is never called, so no draft card is ever produced.

## Root cause

`prompter` is missing from `_ROLE_LAYER_MAP` in
`roboco/agents/factories/_base.py`. Because of that, `compose_prompt` silently
skips `agents/prompts/roles/prompter.md` — the interviewer prompt that defines
the intake mission and the `propose_draft` tool. The agent is left with only:

- the autogenerated verbs layer (`lifecycle-prompter.md`), whose sole verb is
  `i_am_idle`, and
- `base.md` ("stepping outside your role is failure… you escalate or idle").

So the agent reads its prompt literally and concludes it has nothing to do. The
`propose_draft` MCP tool is wired into the SDK options the whole time
(`build_intake_options` in `roboco/agent_sdk/intake_driver.py`); the agent is
simply never told it exists.

## Fix

Add `prompter` to `_ROLE_LAYER_MAP` so its role layer is composed in, exactly
like every other role. One-line change.

## Verification

Rebuilt the orchestrator, restarted, and started a fresh intake session against
a real project. The generated system prompt now includes the interviewer role,
and behaviour flips from refusal to a working interviewer:

| | before | after |
|---|---|---|
| response chunks | 3 (empty) | 95 (real content) |
| tool calls in a turn | 0 | 16 (Read/Grep/Task — reading the repo) |
| behaviour | "I only have `i_am_idle`, no authority" | reads the codebase, interviews, then calls `propose_draft` |