### PR TITLE
fix(git): fall back to a permitted merge method when the repo refuses one

### DIFF
--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -1719,6 +1719,45 @@ class GitService(BaseService):
                 {"owner": owner, "repo": repo, "pr": pr_number},
             ) from e
 
+    async def _first_allowed_merge_method(
+        self,
+        owner: str,
+        repo: str,
+        git_token: str,
+        *,
+        exclude: str | None = None,
+    ) -> str | None:
+        """Return a merge method the repo permits, preferring squash > merge >
+        rebase and skipping ``exclude``; ``None`` if the lookup fails.
+
+        Used to recover when a merge is refused with 405 because the repo has
+        that merge method disabled in its settings.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=_default_git_timeout()) as client:
+                resp = await client.get(
+                    f"https://api.github.com/repos/{owner}/{repo}",
+                    headers={
+                        "Authorization": f"Bearer {git_token}",
+                        "Accept": "application/vnd.github+json",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                )
+            if not resp.is_success:
+                return None
+            data = resp.json()
+        except httpx.HTTPError:
+            return None
+        allowed = {
+            "squash": data.get("allow_squash_merge", True),
+            "merge": data.get("allow_merge_commit", True),
+            "rebase": data.get("allow_rebase_merge", True),
+        }
+        for method in ("squash", "merge", "rebase"):
+            if method != exclude and allowed.get(method):
+                return method
+        return None
+
     async def _sync_target_branch(
         self, workspace: Path, target_branch: str, git_token: str
     ) -> str:
@@ -1817,6 +1856,27 @@ class GitService(BaseService):
         resp = await self._call_merge_api(
             owner, repo, pr_number, git_token, merge_method
         )
+        # A 405 means the repo disallows this merge method (e.g. "Squash merges
+        # are not allowed on this repository" when that button is turned off).
+        # Fall back to a method the repo actually permits and retry once, so a
+        # repo's merge-button settings can't permanently wedge the PM at task
+        # completion with an open, mergeable PR.
+        if resp.status_code == httpx.codes.METHOD_NOT_ALLOWED:
+            fallback = await self._first_allowed_merge_method(
+                owner, repo, git_token, exclude=merge_method
+            )
+            if fallback and fallback != merge_method:
+                self.log.info(
+                    "Merge method refused by repo; retrying with a permitted one",
+                    requested=merge_method,
+                    fallback=fallback,
+                    owner=owner,
+                    repo=repo,
+                    pr=pr_number,
+                )
+                resp = await self._call_merge_api(
+                    owner, repo, pr_number, git_token, fallback
+                )
         if not resp.is_success:
             raise GitError(
                 f"GitHub API refused PR merge ({resp.status_code}): {resp.text[:200]}",

--- a/tests/unit/services/test_git_merge_method_fallback.py
+++ b/tests/unit/services/test_git_merge_method_fallback.py
@@ -1,0 +1,197 @@
+"""GitService falls back to a permitted merge method when the repo refuses the
+requested one with 405 (PR #120).
+
+A repo can disable a merge button (e.g. "Squash merges are not allowed on this
+repository"), which 405s the merge and would permanently wedge the PM at task
+completion with an open, mergeable PR. ``merge_pull_request`` retries once with
+a method the repo actually permits, resolved by ``_first_allowed_merge_method``.
+httpx is fully mocked — no real network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from roboco.exceptions import GitError
+from roboco.services.git import GitService
+
+_PR = 42
+_METHOD_NOT_ALLOWED = 405
+
+
+def _service() -> GitService:
+    session = MagicMock()
+    session.execute = AsyncMock()
+    session.commit = AsyncMock()
+    svc = GitService(session)
+    object.__setattr__(svc, "log", MagicMock())
+    return svc
+
+
+def _bind(svc: GitService, name: str, value: object) -> None:
+    object.__setattr__(svc, name, value)
+
+
+def _resp(
+    status_code: int, json_payload: dict | None = None, text: str = ""
+) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status_code
+    r.is_success = 200 <= status_code < 300  # noqa: PLR2004
+    r.json.return_value = json_payload or {}
+    r.text = text
+    return r
+
+
+def _get_client(get_resp: MagicMock) -> MagicMock:
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=get_resp)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _first_allowed_merge_method — resolve a method the repo permits.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_allowed_prefers_squash() -> None:
+    """All three permitted → squash is preferred."""
+    svc = _service()
+    client = _get_client(
+        _resp(
+            200,
+            {
+                "allow_squash_merge": True,
+                "allow_merge_commit": True,
+                "allow_rebase_merge": True,
+            },
+        )
+    )
+    with patch("roboco.services.git.httpx.AsyncClient", return_value=client):
+        assert await svc._first_allowed_merge_method("acme", "repo", "tok") == "squash"
+
+
+@pytest.mark.asyncio
+async def test_first_allowed_skips_excluded_and_disabled() -> None:
+    """exclude=squash and squash disabled → next permitted is merge."""
+    svc = _service()
+    client = _get_client(
+        _resp(
+            200,
+            {
+                "allow_squash_merge": False,
+                "allow_merge_commit": True,
+                "allow_rebase_merge": True,
+            },
+        )
+    )
+    with patch("roboco.services.git.httpx.AsyncClient", return_value=client):
+        m = await svc._first_allowed_merge_method(
+            "acme", "repo", "tok", exclude="squash"
+        )
+    assert m == "merge"
+
+
+@pytest.mark.asyncio
+async def test_first_allowed_returns_only_remaining_method() -> None:
+    """Only rebase enabled (squash excluded, merge disabled) → rebase."""
+    svc = _service()
+    client = _get_client(
+        _resp(
+            200,
+            {
+                "allow_squash_merge": False,
+                "allow_merge_commit": False,
+                "allow_rebase_merge": True,
+            },
+        )
+    )
+    with patch("roboco.services.git.httpx.AsyncClient", return_value=client):
+        m = await svc._first_allowed_merge_method(
+            "acme", "repo", "tok", exclude="squash"
+        )
+    assert m == "rebase"
+
+
+@pytest.mark.asyncio
+async def test_first_allowed_none_on_api_failure() -> None:
+    """Repo lookup fails → None (caller leaves the original refusal to surface)."""
+    svc = _service()
+    client = _get_client(_resp(404, text="Not Found"))
+    with patch("roboco.services.git.httpx.AsyncClient", return_value=client):
+        assert await svc._first_allowed_merge_method("acme", "repo", "tok") is None
+
+
+# ---------------------------------------------------------------------------
+# merge_pull_request — 405 fallback + retry.
+# ---------------------------------------------------------------------------
+
+
+def _wire_merge(svc: GitService) -> None:
+    _bind(svc, "_get_project_token_or_raise", AsyncMock(return_value="tok"))
+    _bind(svc, "_parse_github_remote", MagicMock(return_value=("acme", "repo")))
+    _bind(svc, "_delete_pr_branch_best_effort", AsyncMock())
+    _bind(svc, "_project_default_branch", AsyncMock(return_value="main"))
+    _bind(svc, "_sync_target_branch", AsyncMock(return_value="abc123"))
+
+
+@pytest.mark.asyncio
+async def test_merge_retries_with_fallback_on_405() -> None:
+    """405 on the requested method → retry once with a permitted method."""
+    svc = _service()
+    _wire_merge(svc)
+    call_merge = AsyncMock(
+        side_effect=[
+            _resp(_METHOD_NOT_ALLOWED, text="Squash merges are not allowed"),
+            _resp(200),
+        ]
+    )
+    _bind(svc, "_call_merge_api", call_merge)
+    _bind(svc, "_first_allowed_merge_method", AsyncMock(return_value="merge"))
+
+    target, commit = await svc.merge_pull_request(
+        Path("/tmp/ws"), _PR, "squash", "roboco"
+    )
+
+    assert (target, commit) == ("main", "abc123")
+    assert call_merge.await_count == 2  # noqa: PLR2004 -- initial + fallback retry
+    # The retry used the permitted fallback method (5th positional arg).
+    assert call_merge.await_args_list[1].args[4] == "merge"
+
+
+@pytest.mark.asyncio
+async def test_merge_no_retry_when_first_method_succeeds() -> None:
+    """Requested method accepted → no repo lookup, no second merge call."""
+    svc = _service()
+    _wire_merge(svc)
+    call_merge = AsyncMock(return_value=_resp(200))
+    _bind(svc, "_call_merge_api", call_merge)
+    first_allowed = AsyncMock(return_value="merge")
+    _bind(svc, "_first_allowed_merge_method", first_allowed)
+
+    target, _ = await svc.merge_pull_request(Path("/tmp/ws"), _PR, "squash", "roboco")
+
+    assert target == "main"
+    call_merge.assert_awaited_once()
+    first_allowed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_merge_raises_when_no_permitted_fallback() -> None:
+    """405 and no permitted fallback → the refusal still surfaces as GitError."""
+    svc = _service()
+    _wire_merge(svc)
+    _bind(
+        svc,
+        "_call_merge_api",
+        AsyncMock(return_value=_resp(_METHOD_NOT_ALLOWED, text="not allowed")),
+    )
+    _bind(svc, "_first_allowed_merge_method", AsyncMock(return_value=None))
+
+    with pytest.raises(GitError, match="refused PR merge"):
+        await svc.merge_pull_request(Path("/tmp/ws"), _PR, "squash", "roboco")


### PR DESCRIPTION
## Problem

The PM merge step (`merge_pull_request`) defaults to a **squash** merge. If the
target repo has squash merges **disabled** in its settings, GitHub rejects the
merge:

```
GitHub API refused PR merge (405): {"message":"Squash merges are not allowed on this repository."}
```

`complete()` then fails and the task is left **stranded** — code built, QA
passed, docs written, PR open and mergeable — but never merged, and nothing is
surfaced to the human. The whole cell goes idle on a task that's one API call
from done. A repo's merge-button configuration shouldn't be able to permanently
wedge task completion.

## Fix

Make the central merge call resilient. On a `405`, query the repo's actually-
permitted merge methods (`allow_squash_merge` / `allow_merge_commit` /
`allow_rebase_merge`) and retry once with a permitted one, preferring
`squash > merge > rebase`. All merge paths funnel through this one method, so
every caller benefits regardless of the method it requests.

- `merge_pull_request`: on 405, look up an allowed method and retry once.
- `_first_allowed_merge_method`: new helper; returns a permitted method (or
  `None` if the lookup fails, in which case the original 405 is raised as before).

No behavior change when the requested method is allowed.

## Verification

Reproduced against a repo with `allow_squash_merge: false` (only merge commits):
the original code failed with the 405 above; with this change the merge falls
back to a merge commit and succeeds. `ruff check` / `ruff format --check` clean.