### PR TITLE
fix(git): retarget PR base to default when the resolved base is missing on origin

### DIFF
--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -1402,6 +1402,29 @@ class GitService(BaseService):
         target_branch = await self._resolve_pr_target_branch(
             request, task, default_branch
         )
+        # The PR base must exist on the remote, or GitHub rejects creation with
+        # 422 "base field invalid". An ancestor task's branch can be absent on
+        # origin (parent claimed but never pushed — e.g. a PM paused before any
+        # commit), which strands every child at PR time. Mirror the
+        # branch-cutting fallback (see create_branch): if the resolved base is
+        # missing on origin, retarget the PR to the default branch rather than
+        # hard-failing.
+        if target_branch != default_branch:
+            ls = await self._run_git(
+                workspace,
+                ["ls-remote", "--heads", "origin", target_branch],
+                check=False,
+                token=git_token,
+            )
+            if not ls.stdout.strip():
+                self.log.warning(
+                    "PR base branch not on remote; retargeting PR to the "
+                    "default branch",
+                    base_branch=target_branch,
+                    default_branch=default_branch,
+                    task_id=str(request.task_id),
+                )
+                target_branch = default_branch
         pr_title, pr_body = await self._generate_pr_title_body(
             request, task, source_branch, target_branch, request.task_id
         )

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -1383,6 +1383,42 @@ class GitService(BaseService):
                 {"owner": owner, "repo": repo, "head": payload.get("head")},
             ) from e
 
+    async def _pr_base_on_remote(
+        self,
+        workspace: Path,
+        target_branch: str,
+        default_branch: str,
+        git_token: str,
+        task_id: UUID,
+    ) -> str:
+        """Return a PR base branch that actually exists on origin.
+
+        The PR base must exist on the remote, or GitHub rejects creation with
+        422 "base field invalid". An ancestor task's branch can be absent on
+        origin (parent claimed but never pushed — e.g. a PM paused before any
+        commit), which strands every child at PR time. Mirror the branch-cutting
+        fallback (see ``create_branch``): if the resolved base is missing on
+        origin, retarget to the default branch rather than hard-failing. The
+        default branch is assumed present, so it is returned unchecked.
+        """
+        if target_branch == default_branch:
+            return target_branch
+        ls = await self._run_git(
+            workspace,
+            ["ls-remote", "--heads", "origin", target_branch],
+            check=False,
+            token=git_token,
+        )
+        if ls.stdout.strip():
+            return target_branch
+        self.log.warning(
+            "PR base branch not on remote; retargeting PR to the default branch",
+            base_branch=target_branch,
+            default_branch=default_branch,
+            task_id=str(task_id),
+        )
+        return default_branch
+
     async def create_pull_request(
         self, workspace: Path, request: GitCreatePRRequest
     ) -> tuple[int, str, str, str, str]:
@@ -1402,29 +1438,9 @@ class GitService(BaseService):
         target_branch = await self._resolve_pr_target_branch(
             request, task, default_branch
         )
-        # The PR base must exist on the remote, or GitHub rejects creation with
-        # 422 "base field invalid". An ancestor task's branch can be absent on
-        # origin (parent claimed but never pushed — e.g. a PM paused before any
-        # commit), which strands every child at PR time. Mirror the
-        # branch-cutting fallback (see create_branch): if the resolved base is
-        # missing on origin, retarget the PR to the default branch rather than
-        # hard-failing.
-        if target_branch != default_branch:
-            ls = await self._run_git(
-                workspace,
-                ["ls-remote", "--heads", "origin", target_branch],
-                check=False,
-                token=git_token,
-            )
-            if not ls.stdout.strip():
-                self.log.warning(
-                    "PR base branch not on remote; retargeting PR to the "
-                    "default branch",
-                    base_branch=target_branch,
-                    default_branch=default_branch,
-                    task_id=str(request.task_id),
-                )
-                target_branch = default_branch
+        target_branch = await self._pr_base_on_remote(
+            workspace, target_branch, default_branch, git_token, request.task_id
+        )
         pr_title, pr_body = await self._generate_pr_title_body(
             request, task, source_branch, target_branch, request.task_id
         )

--- a/tests/unit/services/test_git_pr_base_fallback.py
+++ b/tests/unit/services/test_git_pr_base_fallback.py
@@ -1,0 +1,67 @@
+"""GitService PR base falls back to the default branch when the resolved base
+is missing on origin (PR #121).
+
+An ancestor task's branch can be absent on origin (parent claimed but never
+pushed — e.g. a PM paused before any commit), which makes GitHub reject PR
+creation with 422 "base field invalid" and strands every child at PR time.
+``_pr_base_on_remote`` retargets the PR to the default branch instead of
+hard-failing, mirroring the branch-cutting fallback in ``create_branch``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from roboco.services.git import GitService
+
+
+def _git_service() -> GitService:
+    svc = GitService.__new__(GitService)
+    svc.log = MagicMock()  # type: ignore[attr-defined]
+    return svc
+
+
+def _result(stdout: str) -> Any:
+    return type("R", (), {"returncode": 0, "stdout": stdout})()
+
+
+@pytest.mark.asyncio
+async def test_pr_base_kept_when_present_on_remote() -> None:
+    """ls-remote finds the base on origin → keep it (the normal case)."""
+    svc = _git_service()
+    svc._run_git = AsyncMock(  # type: ignore[method-assign]
+        return_value=_result("abc123\trefs/heads/feature/backend/root--parent\n")
+    )
+    base = await svc._pr_base_on_remote(
+        Path("/tmp/ws"), "feature/backend/root--parent", "main", "tok", uuid4()
+    )
+    assert base == "feature/backend/root--parent"
+
+
+@pytest.mark.asyncio
+async def test_pr_base_retargets_to_default_when_absent_on_remote() -> None:
+    """ls-remote returns nothing (parent branch never pushed) → retarget the
+    PR to the default branch rather than letting GitHub 422."""
+    svc = _git_service()
+    svc._run_git = AsyncMock(return_value=_result(""))  # type: ignore[method-assign]
+    base = await svc._pr_base_on_remote(
+        Path("/tmp/ws"), "feature/backend/root--orphan", "main", "tok", uuid4()
+    )
+    assert base == "main"
+    svc.log.warning.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pr_base_skips_remote_check_when_target_is_default() -> None:
+    """When the base already IS the default branch, no ls-remote is run — the
+    default branch is assumed present."""
+    svc = _git_service()
+    run = AsyncMock()
+    svc._run_git = run  # type: ignore[method-assign]
+    base = await svc._pr_base_on_remote(Path("/tmp/ws"), "main", "main", "tok", uuid4())
+    assert base == "main"
+    run.assert_not_awaited()


### PR DESCRIPTION
## Problem

`create_pull_request` resolves the PR base from the parent task's branch. When
that branch was never pushed to origin — an ancestor task claimed but paused
before its first commit — GitHub rejects PR creation with **422 "base field
invalid"**, and every child task strands at the `open_pr` step. Retrying never
helps, and the error reads like a branch-naming issue when it is really a
**missing base branch** on the remote.

Observed in the wild: a backend task looped through dev → cell PM → main PM →
pool five times, blocked solely on this 422, because its parent subtask's branch
(`feature/backend/<root>--<parent>`) didn't exist on origin.

## Fix

The **branch-cutting** path already handles this — `create_branch` `ls-remote`s
the base and falls back to the default branch if it's absent (with a warning).
The **PR-creation** path didn't. This mirrors that guard in
`create_pull_request`: `ls-remote` the resolved base and, if it's missing on
origin, retarget the PR to the project default branch instead of raising.

No behavior change when the base exists. Verified by reproducing the 422 against
a repo whose base branch was absent, then confirming the PR opens against the
default branch once the guard retargets it. `ruff` + `mypy` clean.