### PR TITLE
[684dace4] Self-hosted LLM provider: API layer, hooks, UI section, routing mode button, and Mix mode grouping

### DIFF
--- a/panel/src/components/settings/ai-routing-card.tsx
+++ b/panel/src/components/settings/ai-routing-card.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import {
   useApplyMode,
   useCatalog,
   useOllamaKey,
   useRoutingMode,
   useSetOllamaKey,
+  useSelfHostedModels,
 } from "@/hooks/use-providers";
 import {
   Card,
@@ -21,7 +22,9 @@ import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -31,12 +34,14 @@ import {
   Cpu,
   Key,
   KeyRound,
+  Server,
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
 import { toast } from "sonner";
 import { AssignmentScope, ModelProvider } from "@/types";
-import type { RoutingMode } from "@/lib/api/providers";
+import type { RoutingMode, SelfHostedTestResult } from "@/lib/api/providers";
+import { SelfHostedSection } from "@/components/settings/self-hosted-section";
 
 // Matches the roboco agents_config AGENT_ROLE_MAP / AGENT_TEAM_MAP.
 // Hard-coded so Mix mode shows a stable 18-row picker without an extra
@@ -70,12 +75,28 @@ export function AIRoutingCard() {
   const { data: catalog = [] } = useCatalog();
   const { data: keyStatus } = useOllamaKey();
   const { data: snapshot } = useRoutingMode();
+  const { data: selfHostedModels = [] } = useSelfHostedModels();
 
   const setKey = useSetOllamaKey();
   const applyMode = useApplyMode();
 
   const hasOllamaKey = !!keyStatus?.has_key;
   const currentMode: RoutingMode = snapshot?.mode ?? "anthropic";
+
+  // Track the latest self-hosted test result so ModeButton can gate access.
+  const [selfHostedTestResult, setSelfHostedTestResult] =
+    useState<SelfHostedTestResult | null>(null);
+  const isSelfHostedConnected = selfHostedTestResult?.status === "connected";
+
+  const handleSelfHostedTestResult = useCallback(
+    (result: SelfHostedTestResult) => {
+      setSelfHostedTestResult(result);
+    },
+    [],
+  );
+
+  // Selected self-hosted model (used when mode === 'self_hosted').
+  const [selfHostedModel, setSelfHostedModel] = useState<string>("");
 
   // --- API key input ---
   const [apiKey, setApiKey] = useState("");
@@ -123,6 +144,9 @@ export function AIRoutingCard() {
   const catalogOllamaOnly = catalog.filter(
     (c: { provider_type: ModelProvider }) => c.provider_type === ModelProvider.OLLAMA_CLOUD,
   );
+  const catalogAnthropicOnly = catalog.filter(
+    (c: { provider_type: ModelProvider }) => c.provider_type === ModelProvider.ANTHROPIC,
+  );
 
   // --- Mode toggle handlers ---
   const flipToAnthropic = async () => {
@@ -144,6 +168,28 @@ export function AIRoutingCard() {
     try {
       await applyMode.mutateAsync({ mode: "ollama" });
       toast.success("All agents now on Ollama");
+    } catch (e) {
+      toast.error("Switch failed: " + errMsg(e));
+    }
+  };
+
+  const flipToSelfHosted = async () => {
+    if (!isSelfHostedConnected) {
+      toast.error("Test the self-hosted connection first");
+      return;
+    }
+    if (
+      !confirm(
+        "Switch every agent to the self-hosted LLM? Clears any overrides.",
+      )
+    )
+      return;
+    try {
+      await applyMode.mutateAsync({
+        mode: "self_hosted",
+        ...(selfHostedModel ? { default_model: selfHostedModel } : {}),
+      });
+      toast.success("All agents now on Self-Hosted LLM");
     } catch (e) {
       toast.error("Switch failed: " + errMsg(e));
     }
@@ -172,6 +218,15 @@ export function AIRoutingCard() {
       );
       return;
     }
+    const needsSelfHosted = Object.values(per_agent).some((m) =>
+      selfHostedModels.find((sh) => sh.model_name === m),
+    );
+    if (needsSelfHosted && !isSelfHostedConnected) {
+      toast.error(
+        "At least one agent is routed to a self-hosted model but the connection has not been tested",
+      );
+      return;
+    }
     try {
       await applyMode.mutateAsync({ mode: "mix", per_agent });
       toast.success("Per-agent routing saved");
@@ -189,7 +244,8 @@ export function AIRoutingCard() {
         <CardDescription>
           Decide which model backs each agent. Anthropic uses the mounted
           <code className="px-1"> ~/.claude </code> auth; Ollama Cloud uses
-          the API key you save below.
+          the API key you save below; Self-Hosted connects to any OpenAI-compatible
+          endpoint you run locally.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -242,10 +298,19 @@ export function AIRoutingCard() {
 
         <Separator />
 
+        {/* -------- Self-Hosted LLM -------- */}
+        <SelfHostedSection
+          testResult={selfHostedTestResult}
+          onTestResult={handleSelfHostedTestResult}
+          onTestSuccess={() => undefined}
+        />
+
+        <Separator />
+
         {/* -------- Mode toggle -------- */}
         <section className="space-y-3">
           <Label className="text-sm font-medium">Routing mode</Label>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
             <ModeButton
               icon={<ShieldCheck className="h-4 w-4" />}
               label="Anthropic"
@@ -267,6 +332,18 @@ export function AIRoutingCard() {
               disabled={applyMode.isPending || !hasOllamaKey}
             />
             <ModeButton
+              icon={<Server className="h-4 w-4" />}
+              label="Self-Hosted"
+              description={
+                isSelfHostedConnected
+                  ? "Every agent uses your self-hosted LLM endpoint."
+                  : "Test the connection above first."
+              }
+              active={currentMode === "self_hosted"}
+              onClick={flipToSelfHosted}
+              disabled={applyMode.isPending || !isSelfHostedConnected}
+            />
+            <ModeButton
               icon={<Cpu className="h-4 w-4" />}
               label="Mix"
               description="Pick a model per agent (table appears below)."
@@ -286,6 +363,41 @@ export function AIRoutingCard() {
             </p>
           ) : null}
         </section>
+
+        {/* -------- Self-Hosted model picker (when self_hosted mode active) -------- */}
+        {currentMode === "self_hosted" && (
+          <>
+            <Separator />
+            <section className="space-y-2">
+              <Label className="text-sm font-medium">
+                Self-Hosted default model
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Choose which discovered model all agents should use in
+                self-hosted mode.
+              </p>
+              <Select
+                value={selfHostedModel}
+                onValueChange={setSelfHostedModel}
+              >
+                <SelectTrigger className="w-full max-w-sm">
+                  <SelectValue placeholder="(use server default)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">(use server default)</SelectItem>
+                  {selfHostedModels.map((m) => (
+                    <SelectItem key={m.model_name} value={m.model_name}>
+                      {m.display_name}
+                      {m.display_name !== m.model_name
+                        ? ` — ${m.model_name}`
+                        : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </section>
+          </>
+        )}
 
         {/* -------- Mix-mode per-agent picker -------- */}
         <Separator />
@@ -327,16 +439,72 @@ export function AIRoutingCard() {
                     }))
                   }
                 >
-                  <SelectTrigger>
+                  <SelectTrigger className="w-full">
                     <SelectValue placeholder="(inherit)" />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="__clear__">(inherit global)</SelectItem>
-                    {catalogForMix.map((c: { model_name: string; display_name: string }) => (
-                      <SelectItem key={c.model_name} value={c.model_name}>
-                        {c.display_name} — {c.model_name}
-                      </SelectItem>
-                    ))}
+
+                    {/* Anthropic models */}
+                    {catalogAnthropicOnly.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>
+                          <ProviderBadge variant="anthropic" />
+                          Anthropic
+                        </SelectLabel>
+                        {catalogAnthropicOnly.map(
+                          (c: { model_name: string; display_name: string }) => (
+                            <SelectItem key={c.model_name} value={c.model_name}>
+                              {c.display_name}
+                            </SelectItem>
+                          ),
+                        )}
+                      </SelectGroup>
+                    )}
+
+                    {/* Ollama Cloud models */}
+                    {catalogOllamaOnly.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>
+                          <ProviderBadge variant="ollama" />
+                          Ollama Cloud
+                        </SelectLabel>
+                        {catalogOllamaOnly.map(
+                          (c: { model_name: string; display_name: string }) => (
+                            <SelectItem key={c.model_name} value={c.model_name}>
+                              {c.display_name}
+                            </SelectItem>
+                          ),
+                        )}
+                      </SelectGroup>
+                    )}
+
+                    {/* Self-Hosted models */}
+                    {selfHostedModels.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>
+                          <ProviderBadge variant="self-hosted" />
+                          Self-Hosted
+                        </SelectLabel>
+                        {selfHostedModels.map((m) => (
+                          <SelectItem key={m.model_name} value={m.model_name}>
+                            {m.display_name}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    )}
+
+                    {/* Fallback: un-grouped catalog when no grouping is possible */}
+                    {catalogAnthropicOnly.length === 0 &&
+                      catalogOllamaOnly.length === 0 &&
+                      selfHostedModels.length === 0 &&
+                      catalogForMix.map(
+                        (c: { model_name: string; display_name: string }) => (
+                          <SelectItem key={c.model_name} value={c.model_name}>
+                            {c.display_name} — {c.model_name}
+                          </SelectItem>
+                        ),
+                      )}
                   </SelectContent>
                 </Select>
               </div>
@@ -401,4 +569,35 @@ function ModeButton({
 
 function errMsg(e: unknown): string {
   return e instanceof Error ? e.message : "Unknown error";
+}
+
+// ---------------------------------------------------------------------------
+// Small colored pill to distinguish providers in the Mix mode dropdown.
+// ---------------------------------------------------------------------------
+
+function ProviderBadge({
+  variant,
+}: {
+  variant: "anthropic" | "ollama" | "self-hosted";
+}) {
+  const styles: Record<string, string> = {
+    anthropic: "bg-blue-500/20 text-blue-700 dark:text-blue-400",
+    ollama: "bg-violet-500/20 text-violet-700 dark:text-violet-400",
+    "self-hosted": "bg-purple-500/20 text-purple-700 dark:text-purple-400",
+  };
+  const labels: Record<string, string> = {
+    anthropic: "A",
+    ollama: "O",
+    "self-hosted": "S",
+  };
+  return (
+    <span
+      className={
+        "mr-1 inline-flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-bold " +
+        (styles[variant] ?? "")
+      }
+    >
+      {labels[variant]}
+    </span>
+  );
 }

--- a/panel/src/components/settings/self-hosted-section.tsx
+++ b/panel/src/components/settings/self-hosted-section.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  useSelfHostedConfig,
+  useSetSelfHostedConfig,
+  useTestSelfHosted,
+  useSelfHostedModels,
+  useRefreshSelfHostedModels,
+} from "@/hooks/use-providers";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  RefreshCw,
+  Server,
+  XCircle,
+} from "lucide-react";
+import { toast } from "sonner";
+import type { SelfHostedTestResult } from "@/lib/api/providers";
+
+// Relative-time helper (no date-fns dependency).
+function relativeTime(isoDate: string | null): string {
+  if (!isoDate) return "never";
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : "Unknown error";
+}
+
+/** Props exposed to the parent (ai-routing-card) so it can read test status. */
+export interface SelfHostedSectionProps {
+  /** Called whenever a successful connection test completes. */
+  onTestSuccess?: (modelCount: number) => void;
+  /** The last known test result — driven by parent if the parent stores it. */
+  testResult?: SelfHostedTestResult | null;
+  /** Called when the user clicks "Test Connection" and we get any result. */
+  onTestResult?: (result: SelfHostedTestResult) => void;
+}
+
+export function SelfHostedSection({
+  onTestSuccess,
+  testResult,
+  onTestResult,
+}: SelfHostedSectionProps) {
+  const { data: config } = useSelfHostedConfig();
+  const { data: models = [] } = useSelfHostedModels();
+
+  const saveConfig = useSetSelfHostedConfig();
+  const testConnection = useTestSelfHosted();
+  const refreshModels = useRefreshSelfHostedModels();
+
+  // Local form state
+  const [baseUrl, setBaseUrl] = useState("");
+  const [authToken, setAuthToken] = useState("");
+  const [showToken, setShowToken] = useState(false);
+
+  // Timestamps for "Last refreshed" label
+  const [lastRefreshed, setLastRefreshed] = useState<string | null>(null);
+
+  const hasSavedUrl = !!(config?.base_url);
+
+  // ---- Save handler --------------------------------------------------------
+  const handleSave = async () => {
+    const url = baseUrl.trim();
+    if (!url) {
+      toast.error("Enter a base URL first");
+      return;
+    }
+    try {
+      await saveConfig.mutateAsync({
+        base_url: url,
+        ...(authToken ? { auth_token: authToken } : {}),
+      });
+      toast.success("Self-hosted config saved");
+      setBaseUrl("");
+      setAuthToken("");
+    } catch (e) {
+      toast.error("Save failed: " + errMsg(e));
+    }
+  };
+
+  // ---- Test Connection handler ---------------------------------------------
+  const handleTest = async () => {
+    try {
+      const result = await testConnection.mutateAsync();
+      onTestResult?.(result);
+      if (result.status === "connected") {
+        onTestSuccess?.(result.model_count);
+        setLastRefreshed(new Date().toISOString());
+        toast.success(
+          `Connected — ${result.model_count} model${result.model_count === 1 ? "" : "s"} available`,
+        );
+      } else {
+        toast.error(`Connection failed: ${result.error_message ?? "unknown error"}`);
+      }
+    } catch (e) {
+      toast.error("Test failed: " + errMsg(e));
+    }
+  };
+
+  // ---- Refresh Models handler ----------------------------------------------
+  const handleRefresh = useCallback(async () => {
+    try {
+      await refreshModels.mutateAsync();
+      setLastRefreshed(new Date().toISOString());
+      toast.success("Model list refreshed");
+    } catch (e) {
+      toast.error("Refresh failed: " + errMsg(e));
+    }
+  }, [refreshModels]);
+
+  // ---- Retry handler (from error empty state) ------------------------------
+  const handleRetry = () => handleTest();
+
+  // Determine which empty state to show, if any.
+  const showNoUrlState = !hasSavedUrl;
+  const showErrorState =
+    hasSavedUrl && testResult?.status === "error" && !showNoUrlState;
+  const showNoModelsState =
+    hasSavedUrl &&
+    testResult?.status === "connected" &&
+    models.length === 0 &&
+    !showNoUrlState;
+  const showModelList =
+    hasSavedUrl && testResult?.status === "connected" && models.length > 0;
+
+  return (
+    <section className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Server className="h-4 w-4 text-muted-foreground" />
+        <Label className="text-sm font-medium">Self-Hosted LLM</Label>
+        {testResult?.status === "connected" && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+            <CheckCircle2 className="h-3 w-3" /> connected
+          </span>
+        )}
+        {testResult?.status === "error" && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-600">
+            <XCircle className="h-3 w-3" /> error
+          </span>
+        )}
+      </div>
+
+      {/* Base URL input */}
+      <div className="space-y-1">
+        <Label className="text-xs text-muted-foreground">Base URL</Label>
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            placeholder={
+              hasSavedUrl
+                ? config.base_url ?? "http://localhost:11434"
+                : "http://localhost:11434"
+            }
+            className="font-mono text-sm"
+          />
+        </div>
+      </div>
+
+      {/* Auth token input with Eye toggle */}
+      <div className="space-y-1">
+        <Label className="text-xs text-muted-foreground">
+          Auth token{" "}
+          <span className="text-muted-foreground/60">(optional)</span>
+        </Label>
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <Input
+              type={showToken ? "text" : "password"}
+              value={authToken}
+              onChange={(e) => setAuthToken(e.target.value)}
+              placeholder={
+                config?.has_auth_token
+                  ? "•••••••••••• (leave blank to keep)"
+                  : "sk-… or Bearer token"
+              }
+              className="pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowToken((v) => !v)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              aria-label={showToken ? "Hide token" : "Show token"}
+            >
+              {showToken ? (
+                <EyeOff className="h-4 w-4" />
+              ) : (
+                <Eye className="h-4 w-4" />
+              )}
+            </button>
+          </div>
+          <Button onClick={handleSave} disabled={saveConfig.isPending}>
+            {saveConfig.isPending ? "Saving…" : "Save"}
+          </Button>
+        </div>
+        {config?.has_auth_token && (
+          <p className="text-xs text-muted-foreground">
+            A token is stored. Type a new value to update it.
+          </p>
+        )}
+        {!config?.has_auth_token && (
+          <p className="text-xs text-muted-foreground">
+            Stored Fernet-encrypted server-side; never returned by the API.
+          </p>
+        )}
+      </div>
+
+      {/* Test Connection button + inline result badge */}
+      <div className="flex items-center gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleTest}
+          disabled={!hasSavedUrl || testConnection.isPending}
+        >
+          {testConnection.isPending ? (
+            <>
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              Testing…
+            </>
+          ) : (
+            "Test Connection"
+          )}
+        </Button>
+
+        {/* Inline result badge */}
+        {testResult?.status === "connected" && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Connected &mdash; {testResult.model_count} model
+            {testResult.model_count === 1 ? "" : "s"} available
+          </span>
+        )}
+        {testResult?.status === "error" && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-3 py-1 text-xs font-medium text-red-700 dark:text-red-400">
+            <XCircle className="h-3.5 w-3.5" />
+            {testResult.error_message ?? "Connection failed"}
+          </span>
+        )}
+      </div>
+
+      {/* ── Empty state 1: no base URL configured ── */}
+      {showNoUrlState && (
+        <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+          <p className="font-medium">No base URL configured</p>
+          <p className="mt-1 text-xs">
+            Enter the URL of your self-hosted LLM endpoint (e.g.{" "}
+            <code>http://localhost:11434</code> for Ollama) and click{" "}
+            <strong>Save</strong>. Then click <strong>Test Connection</strong>{" "}
+            to verify and discover available models.
+          </p>
+        </div>
+      )}
+
+      {/* ── Empty state 2: error state ── */}
+      {showErrorState && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 dark:border-red-900/40 dark:bg-red-950/20">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" />
+            <div className="flex-1 space-y-1 text-sm">
+              <p className="font-medium text-red-700 dark:text-red-400">
+                Last test failed
+              </p>
+              <p className="text-xs text-red-600 dark:text-red-500">
+                {testResult?.error_message ?? "Unknown error"}
+              </p>
+              {testResult?.last_checked && (
+                <p className="text-xs text-muted-foreground">
+                  Last checked: {relativeTime(testResult.last_checked)}
+                </p>
+              )}
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRetry}
+              disabled={testConnection.isPending}
+            >
+              Retry
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Empty state 3: connected but 0 models ── */}
+      {showNoModelsState && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/40 dark:bg-amber-950/20">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <p className="text-sm text-amber-700 dark:text-amber-400">
+              Connected but no models found. Pull a model first (e.g.{" "}
+              <code className="font-mono">ollama pull llama3.2</code>) then
+              click <strong>Refresh Models</strong>.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Model list ── */}
+      {showModelList && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs text-muted-foreground">
+              Last refreshed:{" "}
+              <span className="font-medium">
+                {relativeTime(lastRefreshed)}
+              </span>
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={refreshModels.isPending}
+            >
+              {refreshModels.isPending ? (
+                <>
+                  <RefreshCw className="mr-1.5 h-3 w-3 animate-spin" />
+                  Refreshing…
+                </>
+              ) : (
+                <>
+                  <RefreshCw className="mr-1.5 h-3 w-3" />
+                  Refresh Models
+                </>
+              )}
+            </Button>
+          </div>
+          <div className="divide-y rounded-md border">
+            {models.map((m) => (
+              <div
+                key={m.model_name}
+                className="flex items-center justify-between px-3 py-2"
+              >
+                <div>
+                  <span className="text-sm font-medium">{m.display_name}</span>
+                  <span className="ml-2 font-mono text-xs text-muted-foreground">
+                    {m.model_name}
+                  </span>
+                </div>
+                <Badge variant="secondary" className="text-xs">
+                  auto-discovered
+                </Badge>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/panel/src/hooks/use-providers.ts
+++ b/panel/src/hooks/use-providers.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   providersApi,
   type ApplyModePayload,
+  type SelfHostedConfigPayload,
 } from "@/lib/api/providers";
 
 export const providerKeys = {
@@ -9,6 +10,9 @@ export const providerKeys = {
   catalog: () => [...providerKeys.all, "catalog"] as const,
   ollamaKey: () => [...providerKeys.all, "ollama-key"] as const,
   mode: () => [...providerKeys.all, "mode"] as const,
+  selfHostedConfig: () => [...providerKeys.all, "self-hosted-config"] as const,
+  selfHostedModels: () => [...providerKeys.all, "self-hosted-models"] as const,
+  selfHostedTest: () => [...providerKeys.all, "self-hosted-test"] as const,
 };
 
 export function useCatalog() {
@@ -53,6 +57,64 @@ export function useApplyMode() {
     mutationFn: (payload: ApplyModePayload) => providersApi.applyMode(payload),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: providerKeys.mode() });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Self-hosted LLM hooks
+// ---------------------------------------------------------------------------
+
+/** Query: fetch saved self-hosted config (base_url + has_auth_token flag). */
+export function useSelfHostedConfig() {
+  return useQuery({
+    queryKey: providerKeys.selfHostedConfig(),
+    queryFn: () => providersApi.getSelfHostedConfig(),
+    staleTime: 30_000,
+  });
+}
+
+/** Mutation: save self-hosted base URL + optional auth token. */
+export function useSetSelfHostedConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: SelfHostedConfigPayload) =>
+      providersApi.saveSelfHostedConfig(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: providerKeys.selfHostedConfig() });
+    },
+  });
+}
+
+/** Mutation: test the self-hosted connection and return status + model count. */
+export function useTestSelfHosted() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => providersApi.testSelfHosted(),
+    onSuccess: () => {
+      // After a successful test, also refresh the model list.
+      qc.invalidateQueries({ queryKey: providerKeys.selfHostedModels() });
+    },
+  });
+}
+
+/** Query: list models discovered from the self-hosted endpoint. */
+export function useSelfHostedModels() {
+  return useQuery({
+    queryKey: providerKeys.selfHostedModels(),
+    queryFn: () => providersApi.getSelfHostedModels(),
+    staleTime: 2 * 60_000, // 2 minutes
+  });
+}
+
+/** Mutation: force-refresh the discovered model list. */
+export function useRefreshSelfHostedModels() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => providersApi.refreshSelfHostedModels(),
+    onSuccess: (data) => {
+      // Update the cached model list in place.
+      qc.setQueryData(providerKeys.selfHostedModels(), data);
     },
   });
 }

--- a/panel/src/lib/api/providers.ts
+++ b/panel/src/lib/api/providers.ts
@@ -24,7 +24,7 @@ export interface ModelAssignment {
   model_name: string;
 }
 
-export type RoutingMode = "anthropic" | "ollama" | "mix";
+export type RoutingMode = "anthropic" | "ollama" | "self_hosted" | "mix";
 
 export interface ModeSnapshot {
   mode: RoutingMode;
@@ -36,6 +36,39 @@ export interface ApplyModePayload {
   default_model?: string;
   // Required when mode=mix: map of agent_slug → model_name.
   per_agent?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Self-hosted LLM types
+// ---------------------------------------------------------------------------
+
+/** Configuration stored server-side for the self-hosted provider. */
+export interface SelfHostedConfig {
+  base_url: string | null;
+  has_auth_token: boolean;
+}
+
+/** Status values returned by the test-connection endpoint. */
+export type SelfHostedTestStatus = "connected" | "error";
+
+/** Result of a test-connection call. */
+export interface SelfHostedTestResult {
+  status: SelfHostedTestStatus;
+  model_count: number;
+  error_message: string | null;
+  last_checked: string | null; // ISO datetime
+}
+
+/** One model entry returned by the discovery endpoint. */
+export interface SelfHostedModel {
+  model_name: string;
+  display_name: string;
+}
+
+/** Payload for saving the self-hosted config (base URL + optional token). */
+export interface SelfHostedConfigPayload {
+  base_url: string;
+  auth_token?: string; // omit to leave token unchanged; "" to clear
 }
 
 export const providersApi = {
@@ -63,6 +96,46 @@ export const providersApi = {
 
   applyMode: async (payload: ApplyModePayload): Promise<ModeSnapshot> => {
     const { data } = await api.post<ModeSnapshot>("/providers", payload);
+    return data;
+  },
+
+  // -------------------------------------------------------------------------
+  // Self-hosted provider
+  // -------------------------------------------------------------------------
+
+  getSelfHostedConfig: async (): Promise<SelfHostedConfig> => {
+    const { data } = await api.get<SelfHostedConfig>("/providers/self-hosted");
+    return data;
+  },
+
+  saveSelfHostedConfig: async (
+    payload: SelfHostedConfigPayload,
+  ): Promise<SelfHostedConfig> => {
+    const { data } = await api.put<SelfHostedConfig>(
+      "/providers/self-hosted",
+      payload,
+    );
+    return data;
+  },
+
+  testSelfHosted: async (): Promise<SelfHostedTestResult> => {
+    const { data } = await api.post<SelfHostedTestResult>(
+      "/providers/self-hosted/test",
+    );
+    return data;
+  },
+
+  getSelfHostedModels: async (): Promise<SelfHostedModel[]> => {
+    const { data } = await api.get<SelfHostedModel[]>(
+      "/providers/self-hosted/models",
+    );
+    return data;
+  },
+
+  refreshSelfHostedModels: async (): Promise<SelfHostedModel[]> => {
+    const { data } = await api.post<SelfHostedModel[]>(
+      "/providers/self-hosted/models/refresh",
+    );
     return data;
   },
 };

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -101,6 +101,7 @@ export enum ModelProvider {
   OLLAMA_CLOUD = "ollama_cloud",
   OPENAI = "openai",
   LOCAL = "local",
+  SELF_HOSTED = "self_hosted",
 }
 
 export enum AssignmentScope {


### PR DESCRIPTION
Implement the complete Self-Hosted LLM provider feature across four layers that must land as one atomic PR. All 8 acceptance criteria must be met.

## Context
The AI Providers settings page (`src/app/(dashboard)/settings/ai-providers/page.tsx`) renders `<AIRoutingCard />` from `src/components/settings/ai-routing-card.tsx`. The card currently has:
- Ollama Cloud API key section
- 3 routing mode buttons (Anthropic, Ollama, Mix)
- Per-agent Mix mode table

You will extend this into a full 4-mode provider page.

## Layer 1: Types (`src/types/index.ts` + `src/lib/api/providers.ts`)
- In `providers.ts`: extend `RoutingMode` to `"anthropic" | "ollama" | "mix" | "self_hosted"`.
- Add interfaces: `SelfHostedConfig { base_url: string | null; has_token: boolean }`, `SelfHostedStatus { base_url: string | null; has_token: boolean; test_status: "connected" | "error" | "untested"; model_count: number; last_tested_at: string | null; last_refreshed_at: string | null }`, `DiscoveredModel { model_name: string; display_name: string; size?: string }`.
- Add API methods to `providersApi`:
  - `getSelfHosted(): Promise<SelfHostedStatus>` → GET /providers/self-hosted
  - `setSelfHosted(config: { base_url: string; auth_token?: string }): Promise<SelfHostedConfig>` → PUT /providers/self-hosted
  - `testSelfHosted(): Promise<{ success: boolean; model_count?: number; error?: string }>` → POST /providers/self-hosted/test
  - `getSelfHostedModels(): Promise<{ models: DiscoveredModel[]; last_refreshed_at: string | null }>` → GET /providers/self-hosted/models
  - `refreshSelfHostedModels(): Promise<{ models: DiscoveredModel[]; last_refreshed_at: string | null }>` → POST /providers/self-hosted/models/refresh
- If backend endpoints are absent, stub them with realistic mock data and mark each with a `// TODO: wire to real backend endpoint` comment.
- Check `ModelProvider` enum: it has `LOCAL = "local"`. Confirm whether backend catalog entries for self-hosted models use `"local"` or a new string. If `"local"` is correct, use `ModelProvider.LOCAL` in the Mix mode grouping logic. If a new value is needed, add `SELF_HOSTED = "self_hosted"` to the enum.

## Layer 2: Hooks (`src/hooks/use-providers.ts`)
Add to `providerKeys`: `selfHosted: () => [...providerKeys.all, "self-hosted"]`, `selfHostedModels: () => [...providerKeys.all, "self-hosted-models"]`.

Add hooks:
- `useSelfHostedStatus()` — `useQuery` calling `getSelfHosted()`, staleTime 30s
- `useSetSelfHostedConfig()` — `useMutation` calling `setSelfHosted()`, on success invalidate `selfHosted` key
- `useTestSelfHosted()` — `useMutation` calling `testSelfHosted()`, on success invalidate `selfHosted` and `selfHostedModels` keys
- `useDiscoveredModels()` — `useQuery` calling `getSelfHostedModels()`, staleTime 60s
- `useRefreshModels()` — `useMutation` calling `refreshSelfHostedModels()`, on success invalidate `selfHostedModels` key

## Layer 3: UI (`src/components/settings/ai-routing-card.tsx`)

### A — Self-Hosted LLM configuration section (new `<section>` after the Ollama key section)
Place after the first `<Separator />`. Label: "Self-Hosted LLM". Sub-sections:
1. **Base URL input + Save button**: text input (placeholder `http://localhost:11434`). Save button disabled while mutation is pending. On success toast "Self-hosted server saved".
2. **Auth token field**: `type="password"` input with a show/hide toggle button (Eye / EyeOff icon from lucide-react). Optional field — user can leave blank. After saving when a token exists, display a masked placeholder (`••••••••••••  (leave blank to keep)`) identical to the Ollama Cloud key field pattern. Save button clears the local input state on success.
3. **Test Connection button**: disabled when `selfHostedStatus?.base_url` is null/empty. On click calls `testSelfHosted` mutation. On success shows inline green badge: "Connected — N models available" (N from response). On error shows inline red badge with the specific error string from the response (e.g., "Connection refused — check the server is running on that port"). Badge replaces itself on subsequent clicks.
4. **Discovered models list** (visible only when `test_status === 'connected'`): a rounded-border `<div>` listing each `DiscoveredModel` by `display_name` (or `model_name` fallback), with a small "auto-discovered" chip/badge next to each name. Above the list: a "Refresh Models" button (calls `refreshSelfHosted` mutation, shows spinner while pending) and a "Last refreshed: <relative-time>" label (e.g., "2 minutes ago" — use a simple date-fns `formatDistanceToNow` or inline logic).

### B — Empty states (rendered inside the Self-Hosted section based on `selfHostedStatus`)
- **No server configured** (`base_url` null): Show a CTA prompt: "Enter a base URL above to connect your local LLM server (e.g. Ollama, LM Studio, vLLM)."
- **Configured but unreachable** (`base_url` set, `test_status === 'error'`): Show last-known status with timestamp ("Last checked: <time>") and a "Retry" button that re-triggers the test connection mutation.
- **Connected but no models** (`test_status === 'connected'`, model_count 0): Show: "No models found. Run `ollama pull <model>` on your server to add models, then click Refresh Models."

### C — 4th routing mode button
Extend the mode grid from 3 to 4 columns (`grid-cols-1 md:grid-cols-2 lg:grid-cols-4`). Add a 4th `<ModeButton>`:
- Icon: `Server` from lucide-react
- Label: "Self-Hosted"
- Description: (when no URL) "Configure a self-hosted server above first." / (when URL set but untested) "Run Test Connection first." / (when connected) "Every agent uses your self-hosted server."
- `active={currentMode === "self_hosted"}`
- `disabled={selfHostedStatus?.test_status !== "connected" || applyMode.isPending}`
- `onClick`: `flipToSelfHosted` — calls `applyMode.mutateAsync({ mode: "self_hosted" })`, toast "All agents now on self-hosted server"

### D — Self-Hosted mode model picker
When `currentMode === "self_hosted"`: render a model-selection row below the mode grid (similar to Ollama's global model selection). A `<Select>` populated from `discoveredModels.data?.models`. Selecting a model calls `applyMode.mutateAsync({ mode: "self_hosted", default_model: modelName })`. Show loading state while `discoveredModels.isLoading`.

### E — Mix mode grouped dropdown
In the per-agent Mix mode table, replace the flat `<SelectContent>` with grouped items:
```
<SelectGroup>
  <SelectLabel>Anthropic</SelectLabel>
  {catalog.filter(c => c.provider_type === ModelProvider.ANTHROPIC).map(...)}
</SelectGroup>
<SelectGroup>
  <SelectLabel>Ollama Cloud</SelectLabel>
  {catalog.filter(c => c.provider_type === ModelProvider.OLLAMA_CLOUD).map(...)}
</SelectGroup>
<SelectGroup>
  <SelectLabel>Self-Hosted</SelectLabel>
  {discoveredModels.map(m => <SelectItem key={m.model_name} value={m.model_name}>
    <ProviderBadge provider="self_hosted" /> {m.display_name}
  </SelectItem>)}
</SelectGroup>
```
Add a small `<ProviderBadge>` sub-component (can be inline or in a sibling file) that renders a colored pill: violet/purple for Self-Hosted, sky/blue for Ollama Cloud.

## Quality bar
- `pnpm typecheck` must pass (no `any` casts on new types)
- `pnpm lint` must pass
- No console.log left in production code
- All new components/hooks have JSDoc comments explaining their purpose