### PR TITLE
[19168003] Backend: Self-hosted LLM provider API, routing, and discovery

### DIFF
--- a/alembic/versions/028_seed_self_hosted_provider.py
+++ b/alembic/versions/028_seed_self_hosted_provider.py
@@ -1,0 +1,58 @@
+"""Idempotently seed the Self-Hosted (Ollama) LOCAL provider row.
+
+Revision ID: 028_seed_self_hosted_provider
+Revises: 027_system_settings
+Create Date: 2026-06-12
+
+The `provider_configs` table already has `type='local'` in the
+`modelprovider` enum (seeded in 004_provider_routing). This migration
+seeds the corresponding row so the Settings UI can configure a
+self-hosted Ollama server without requiring an additional API call.
+
+The row starts disabled with no base_url — the user configures those
+via PUT /api/providers/self-hosted. ON CONFLICT DO NOTHING makes this
+migration safe to re-run on a DB that already has the row (e.g. from
+a prior manual insert or a future fresh-schema bootstrap).
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "028_seed_self_hosted_provider"
+down_revision = "027_system_settings"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO provider_configs
+                (id, name, type, base_url, auth_token_encrypted, enabled, created_at)
+            VALUES
+                (
+                    gen_random_uuid(),
+                    'Self-Hosted (Ollama)',
+                    'local',
+                    NULL,
+                    NULL,
+                    false,
+                    now()
+                )
+            ON CONFLICT (name) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "DELETE FROM provider_configs "
+            "WHERE name = 'Self-Hosted (Ollama)'"
+        )
+    )

--- a/roboco/api/routes/provider.py
+++ b/roboco/api/routes/provider.py
@@ -1,10 +1,12 @@
 """
 Provider Routes
 
-Thin HTTP plumbing for the Settings UI's AI-routing panel. Four endpoints
-cover the whole UX: fetch the catalog, get / set the Ollama key, fetch the
-current mode + assignments, apply a mode change. No provider CRUD — the
-two providers (Anthropic + Ollama Cloud) are pre-seeded by migration 004.
+Thin HTTP plumbing for the Settings UI's AI-routing panel. Endpoints
+cover the whole UX: fetch the catalog, get / set the Ollama key,
+configure / test / discover the self-hosted server, fetch the current
+mode + assignments, apply a mode change. No provider CRUD — the
+providers (Anthropic, Ollama Cloud, Self-Hosted) are pre-seeded by
+migrations 004 and 027.
 """
 
 from fastapi import APIRouter, HTTPException, status
@@ -15,14 +17,18 @@ from roboco.api.schemas.provider import (
     CatalogEntryResponse,
     ModeResponse,
     OllamaKeyStatus,
+    SelfHostedConfigRequest,
+    SelfHostedConfigResponse,
+    SelfHostedTestResponse,
     SetOllamaKeyRequest,
     assignment_to_response,
 )
 from roboco.models.base import ModelProvider
 from roboco.models.llm_catalog import MODEL_CATALOG
 from roboco.services.base import NotFoundError
-from roboco.services.llm import get_model_routing_service
-from roboco.services.provider import get_provider_service
+from roboco.services.llm import get_model_routing_service, probe_ollama_tags
+from roboco.services.provider import ProviderUpdate, get_provider_service
+from roboco.utils.converters import require_uuid
 
 router = APIRouter()
 
@@ -104,6 +110,136 @@ async def set_ollama_key(
         has_key=bool(provider.auth_token_encrypted),
         enabled=provider.enabled,
     )
+
+
+# =============================================================================
+# SELF-HOSTED (LOCAL) OLLAMA SERVER
+# =============================================================================
+
+
+@router.put("/self-hosted", response_model=SelfHostedConfigResponse)
+async def set_self_hosted_config(
+    data: SelfHostedConfigRequest,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> SelfHostedConfigResponse:
+    """Save the base URL (and optionally an auth token) for the LOCAL provider.
+
+    The LOCAL provider row must be seeded (migration 027). The token, when
+    provided and non-empty, is Fernet-encrypted before storing. An empty
+    string for `auth_token` clears the stored token. The provider is
+    automatically enabled when a valid base_url is saved.
+    """
+    require_pm_or_above(agent.role, "configure the self-hosted provider")
+    provider_svc = get_provider_service(db)
+    providers = await provider_svc.list_providers(include_disabled=True)
+    local = next(
+        (p for p in providers if p.type == ModelProvider.LOCAL),
+        None,
+    )
+    if local is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Self-Hosted provider not seeded. "
+                "Run alembic upgrade head (migration 027)."
+            ),
+        )
+
+    # Determine token update intent:
+    # None → leave unchanged, "" → clear, non-empty str → re-encrypt.
+    clear_token = data.auth_token is not None and data.auth_token == ""
+    new_token = data.auth_token if (data.auth_token and data.auth_token != "") else None
+
+    await provider_svc.update_provider(
+        require_uuid(local.id),
+        ProviderUpdate(
+            base_url=data.base_url,
+            auth_token=new_token,
+            clear_auth_token=clear_token,
+            enabled=True,
+        ),
+    )
+    await db.commit()
+
+    # Re-fetch after commit to get the persisted state.
+    updated = await provider_svc.list_providers(include_disabled=True)
+    local_updated = next(p for p in updated if p.type == ModelProvider.LOCAL)
+    return SelfHostedConfigResponse(
+        base_url=local_updated.base_url,
+        has_token=bool(local_updated.auth_token_encrypted),
+        enabled=local_updated.enabled,
+    )
+
+
+@router.post("/self-hosted/test", response_model=SelfHostedTestResponse)
+async def test_self_hosted_connection(
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> SelfHostedTestResponse:
+    """Probe the configured self-hosted Ollama server.
+
+    Returns ``{ok: true, model_count: N}`` when the server is reachable
+    and returns a valid model list from ``{base_url}/api/tags``.
+    Returns ``{ok: false, error: '<message>'}`` on any failure — never
+    raises a 500, so the Settings UI can display a friendly error.
+    """
+    require_pm_or_above(agent.role, "test the self-hosted connection")
+    provider_svc = get_provider_service(db)
+    providers = await provider_svc.list_providers(include_disabled=True)
+    local = next(
+        (p for p in providers if p.type == ModelProvider.LOCAL),
+        None,
+    )
+    if local is None or not local.base_url:
+        return SelfHostedTestResponse(
+            ok=False,
+            error=(
+                "Self-hosted server is not configured."
+                " Set base_url first via PUT /self-hosted."
+            ),
+        )
+
+    models, error = await probe_ollama_tags(local.base_url)
+    if error is not None:
+        return SelfHostedTestResponse(ok=False, error=error)
+    return SelfHostedTestResponse(ok=True, model_count=len(models))
+
+
+@router.get("/self-hosted/models", response_model=list[str])
+async def get_self_hosted_models(
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> list[str]:
+    """Return the list of model names available on the self-hosted Ollama server.
+
+    Queries ``{base_url}/api/tags`` and extracts the ``name`` field from
+    each model entry. Raises 503 if the server is unreachable, 404 if
+    the LOCAL provider is not configured.
+    """
+    require_pm_or_above(agent.role, "list self-hosted models")
+    provider_svc = get_provider_service(db)
+    providers = await provider_svc.list_providers(include_disabled=True)
+    local = next(
+        (p for p in providers if p.type == ModelProvider.LOCAL),
+        None,
+    )
+    if local is None or not local.base_url:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Self-hosted provider is not configured. "
+                "Set base_url via PUT /self-hosted first."
+            ),
+        )
+
+    models, error = await probe_ollama_tags(local.base_url)
+    if error is not None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Self-hosted server unreachable: {error}",
+        )
+    return models
 
 
 # =============================================================================

--- a/roboco/api/schemas/provider.py
+++ b/roboco/api/schemas/provider.py
@@ -4,8 +4,9 @@ Providers API Schemas
 Minimal surface that backs the Settings UI:
  - fetch the preset catalog of selectable models
  - set / clear / check the single Ollama Cloud API key
+ - configure / test / discover the self-hosted (LOCAL) Ollama server
  - read current routing assignments (so the UI renders Mix mode)
- - apply a routing mode (anthropic | ollama | mix)
+ - apply a routing mode (anthropic | ollama | mix | self_hosted)
 """
 
 from __future__ import annotations
@@ -58,6 +59,53 @@ class SetOllamaKeyRequest(BaseModel):
 
 
 # =============================================================================
+# SELF-HOSTED (LOCAL) OLLAMA SERVER
+# =============================================================================
+
+
+class SelfHostedConfigRequest(BaseModel):
+    """Save the base URL (and optionally an auth token) for the self-hosted server.
+
+    `base_url` is the root URL of the Ollama instance, e.g.
+    ``http://192.168.1.50:11434``. The Settings UI sends this on every
+    save; the service stores it on the LOCAL provider row.
+
+    `auth_token`, when present and non-empty, is Fernet-encrypted before
+    storing. Pass ``None`` or omit to leave any existing token unchanged.
+    Pass an empty string to clear the stored token.
+    """
+
+    base_url: str = Field(..., description="Root URL of the self-hosted Ollama server")
+    auth_token: str | None = Field(
+        default=None,
+        description=(
+            "Optional bearer token for the Ollama server; omit to leave unchanged"
+        ),
+    )
+
+
+class SelfHostedConfigResponse(BaseModel):
+    """Current configuration state of the LOCAL provider row."""
+
+    base_url: str | None
+    has_token: bool
+    enabled: bool
+
+
+class SelfHostedTestResponse(BaseModel):
+    """Result of a connectivity probe to the self-hosted server.
+
+    The endpoint always returns HTTP 200; reachability is indicated by
+    the `ok` field so the UI can display a human-readable error without
+    triggering its generic error handler.
+    """
+
+    ok: bool
+    model_count: int | None = None
+    error: str | None = None
+
+
+# =============================================================================
 # MODEL ASSIGNMENTS (read-only for the UI)
 # =============================================================================
 
@@ -99,10 +147,13 @@ class ApplyModeRequest(BaseModel):
       `default_model` (if omitted, the service picks a sensible default).
     - mode="mix": clear existing per-agent pins; upsert the `per_agent`
       map verbatim. Role + GLOBAL rows are left untouched so the user can
-      layer with an existing partial setup.
+      layer with an existing partial setup. Self-hosted model names in
+      `per_agent` are routed to the LOCAL provider automatically.
+    - mode="self_hosted": clear every assignment; enable LOCAL provider;
+      set GLOBAL default to `default_model` (a self-hosted model name).
     """
 
-    mode: Literal["anthropic", "ollama", "mix"]
+    mode: Literal["anthropic", "ollama", "mix", "self_hosted"]
     default_model: str | None = None
     per_agent: dict[str, str] | None = None
 
@@ -110,5 +161,5 @@ class ApplyModeRequest(BaseModel):
 class ModeResponse(BaseModel):
     """Server-side view of the current mode + a snapshot of active rules."""
 
-    mode: Literal["anthropic", "ollama", "mix"]
+    mode: Literal["anthropic", "ollama", "mix", "self_hosted"]
     assignments: list[AssignmentResponse]

--- a/roboco/services/llm.py
+++ b/roboco/services/llm.py
@@ -10,6 +10,17 @@ If none apply, falls back to the legacy `ROLE_MODEL_MAP` + implicit
 Anthropic provider so deployments with zero rows behave exactly as
 before. Decryption failures are contained: the service logs the error
 and downgrades to the legacy path rather than failing the spawn.
+
+Self-hosted (LOCAL) provider support:
+- derive_mode() returns 'self_hosted' when there is exactly one
+  GLOBAL assignment pointing to a LOCAL provider.
+- apply_mode('self_hosted', ...) enables the LOCAL provider and
+  sets a GLOBAL assignment to the given model name.
+- upsert_assignment() accepts model names not in the MODEL_CATALOG
+  when the target provider is LOCAL (self-hosted models are dynamic;
+  they bypass catalog validation).
+- resolve_for_agent() checks reachability of the LOCAL base_url
+  and falls back to Anthropic if the server is unreachable.
 """
 
 from __future__ import annotations
@@ -17,6 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
+import httpx
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 
@@ -37,6 +49,40 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Module-level HTTP helper — decoupled from the service so tests can patch it.
+# ---------------------------------------------------------------------------
+
+_OLLAMA_TAGS_TIMEOUT = 5.0  # seconds
+
+
+async def probe_ollama_tags(base_url: str) -> tuple[list[str], str | None]:
+    """Fetch the model list from a running Ollama server.
+
+    Hits ``{base_url}/api/tags`` and returns ``(model_names, None)`` on
+    success or ``([], error_message)`` on any failure. Never raises.
+
+    Returns:
+        A tuple of (list_of_model_name_strings, error_string_or_None).
+    """
+    url = base_url.rstrip("/") + "/api/tags"
+    try:
+        async with httpx.AsyncClient(timeout=_OLLAMA_TAGS_TIMEOUT) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+            models: list[str] = [m["name"] for m in data.get("models", [])]
+            return models, None
+    except httpx.TimeoutException:
+        return [], f"Connection to {base_url} timed out after {_OLLAMA_TAGS_TIMEOUT}s"
+    except httpx.ConnectError:
+        return [], f"Could not connect to {base_url} — server may be offline"
+    except httpx.HTTPStatusError as exc:
+        return [], f"Server at {base_url} returned HTTP {exc.response.status_code}"
+    except Exception as exc:
+        return [], f"Unexpected error probing {base_url}: {exc}"
 
 
 @dataclass(frozen=True)
@@ -71,9 +117,10 @@ class ModelRoutingService(BaseService):
     async def resolve_for_agent(self, agent_slug: str) -> AgentRoute:
         """Resolve routing for `agent_slug` using the precedence ladder.
 
-        Never raises for a normal agent — decrypt failures and missing
-        agents both downgrade to the legacy Anthropic path, because a
-        stalled spawn is worse than a routing miss.
+        Never raises for a normal agent — decrypt failures, unreachable
+        self-hosted servers, and missing agents all downgrade to the
+        legacy Anthropic path, because a stalled spawn is worse than a
+        routing miss.
         """
         role = get_agent_role(agent_slug) or ""
 
@@ -93,14 +140,40 @@ class ModelRoutingService(BaseService):
             )
 
         if resolved is not None and resolved.provider.enabled:
-            try:
-                return await self._route_from_assignment(resolved)
-            except EncryptionError:
-                self.log.error(
-                    "Provider token decrypt failed; falling back to legacy path",
-                    provider_id=str(resolved.provider.id),
-                    agent_slug=agent_slug,
-                )
+            # For LOCAL (self-hosted) providers, probe reachability first.
+            # If the server is down, fall through to the Anthropic path so
+            # agents can still spawn — better a wrong provider than no spawn.
+            if resolved.provider.type == ModelProvider.LOCAL:
+                base_url = resolved.provider.base_url or ""
+                if base_url:
+                    _, error = await probe_ollama_tags(base_url)
+                    if error is not None:
+                        self.log.warning(
+                            "Self-hosted server unreachable; falling back to Anthropic",
+                            base_url=base_url,
+                            error=error,
+                            agent_slug=agent_slug,
+                        )
+                        # fall through to legacy path below
+                    else:
+                        try:
+                            return await self._route_from_assignment(resolved)
+                        except EncryptionError:
+                            self.log.error(
+                                "Provider token decrypt failed; falling back",
+                                provider_id=str(resolved.provider.id),
+                                agent_slug=agent_slug,
+                            )
+                # base_url empty → treat as unconfigured; fall through
+            else:
+                try:
+                    return await self._route_from_assignment(resolved)
+                except EncryptionError:
+                    self.log.error(
+                        "Provider token decrypt failed; falling back to legacy path",
+                        provider_id=str(resolved.provider.id),
+                        agent_slug=agent_slug,
+                    )
 
         # 4) legacy fallback: role-default short name through MODEL_MAP.
         short = ROLE_MODEL_MAP.get(role, "sonnet")
@@ -141,21 +214,41 @@ class ModelRoutingService(BaseService):
         scope: AssignmentScope,
         scope_value: str | None,
         model_name: str,
+        provider_type_override: ModelProvider | None = None,
     ) -> ModelAssignmentTable:
         """Insert-or-update (by unique (scope, scope_value)).
 
-        Provider is derived from `MODEL_CATALOG` — the UI never picks a
-        provider separately, so the service looks up the pre-seeded
+        Provider is normally derived from `MODEL_CATALOG` — the UI never
+        picks a provider separately, so the service looks up the pre-seeded
         provider row for the catalog entry's type.
+
+        When `provider_type_override` is supplied (used internally by
+        `apply_mode('self_hosted', ...)` and mix mode for LOCAL models),
+        the catalog look-up is skipped and the named provider type is used
+        directly. This allows self-hosted model names (which are not in the
+        static catalog) to be assigned to the LOCAL provider.
         """
         self._validate_scope(scope, scope_value)
-        entry = MODEL_CATALOG_BY_NAME.get(model_name)
-        if entry is None:
-            raise ValueError(
-                f"Unknown model '{model_name}'. Use one from "
-                "GET /api/providers/catalog."
-            )
-        provider = await self._get_seeded_provider(entry.provider_type)
+
+        if provider_type_override is not None:
+            provider = await self._get_seeded_provider(provider_type_override)
+            provider_type_for_log = provider_type_override
+        else:
+            entry = MODEL_CATALOG_BY_NAME.get(model_name)
+            if entry is None:
+                # Try to route to LOCAL if a LOCAL provider is seeded — this
+                # allows self-hosted model names in mix mode without an error.
+                local_provider = await self._find_local_provider()
+                if local_provider is None:
+                    raise ValueError(
+                        f"Unknown model '{model_name}'. Use one from "
+                        "GET /api/providers/catalog."
+                    )
+                provider = local_provider
+                provider_type_for_log = ModelProvider.LOCAL
+            else:
+                provider = await self._get_seeded_provider(entry.provider_type)
+                provider_type_for_log = entry.provider_type
 
         row = await self.get_assignment(scope=scope, scope_value=scope_value)
         if row is None:
@@ -175,7 +268,7 @@ class ModelRoutingService(BaseService):
             "Assignment upserted",
             scope=scope.value,
             scope_value=scope_value,
-            provider_type=entry.provider_type.value,
+            provider_type=provider_type_for_log.value,
             model_name=model_name,
         )
         return row
@@ -184,9 +277,10 @@ class ModelRoutingService(BaseService):
         """Return the current "mode" label for the Settings UI.
 
         Decision tree matches what `apply_mode` writes:
-          - no assignments at all      → "anthropic"
-          - only a global row, Ollama  → "ollama"
-          - anything else              → "mix"
+          - no assignments at all           → "anthropic"
+          - only a global row, Ollama Cloud → "ollama"
+          - only a global row, LOCAL        → "self_hosted"
+          - anything else                   → "mix"
         """
         assignments = await self.list_assignments()
         if not assignments:
@@ -194,11 +288,11 @@ class ModelRoutingService(BaseService):
         only_global = (
             len(assignments) == 1 and assignments[0].scope == AssignmentScope.GLOBAL
         )
-        is_ollama = (
-            only_global and assignments[0].provider.type == ModelProvider.OLLAMA_CLOUD
-        )
-        if is_ollama:
-            return "ollama"
+        if only_global:
+            if assignments[0].provider.type == ModelProvider.OLLAMA_CLOUD:
+                return "ollama"
+            if assignments[0].provider.type == ModelProvider.LOCAL:
+                return "self_hosted"
         return "mix"
 
     async def set_ollama_api_key(self, api_key: str) -> ProviderConfigTable:
@@ -268,14 +362,18 @@ class ModelRoutingService(BaseService):
         """Apply a routing "mode" in a single transactional call.
 
         Modes:
-          - "anthropic": wipe all assignments so every spawn falls through
+          - "anthropic":   wipe all assignments so every spawn falls through
             to the legacy ROLE_MODEL_MAP + mounted ~/.claude path.
-          - "ollama":    wipe role/agent overrides, set GLOBAL to the given
+          - "ollama":      wipe role/agent overrides, set GLOBAL to the given
             Ollama model (default: Kimi K2.6). CEO-type pins can be layered
             back manually if the user wants them.
-          - "mix":       apply per-agent map verbatim. Any agent not in the
+          - "self_hosted": wipe all assignments, enable the LOCAL provider,
+            and set the GLOBAL default to `default_model` (a self-hosted
+            model name — not validated against the static catalog).
+          - "mix":         apply per-agent map verbatim. Any agent not in the
             map falls through to the GLOBAL default — which is whatever it
-            was (preserves prior state).
+            was (preserves prior state). Self-hosted model names (not in the
+            catalog) are automatically routed to the LOCAL provider.
         """
         if mode == "anthropic":
             await self.session.execute(sa_delete(ModelAssignmentTable))
@@ -297,6 +395,39 @@ class ModelRoutingService(BaseService):
             )
             return
 
+        if mode == "self_hosted":
+            if not default_model:
+                raise ValueError(
+                    "self_hosted mode requires a default_model (self-hosted model name)"
+                )
+            # Wipe all existing assignments and enable the LOCAL provider.
+            await self.session.execute(sa_delete(ModelAssignmentTable))
+            await self.session.flush()
+            # Enable the LOCAL provider row so resolve_for_agent() will use it.
+            local = await self._find_local_provider()
+            if local is None:
+                raise NotFoundError(
+                    resource_type="Provider",
+                    resource_id=f"type={ModelProvider.LOCAL.value}",
+                )
+            provider_svc = ProviderService(self.session)
+            await provider_svc.update_provider(
+                require_uuid(local.id),
+                ProviderUpdate(enabled=True),
+            )
+            # Insert the GLOBAL assignment pointing to LOCAL.
+            await self.upsert_assignment(
+                scope=AssignmentScope.GLOBAL,
+                scope_value=None,
+                model_name=default_model,
+                provider_type_override=ModelProvider.LOCAL,
+            )
+            self.log.info(
+                "Mode applied: self_hosted",
+                default_model=default_model,
+            )
+            return
+
         if mode == "mix":
             if not per_agent:
                 raise ValueError("mix mode requires a per_agent map")
@@ -311,6 +442,7 @@ class ModelRoutingService(BaseService):
             for agent_slug, model_name in per_agent.items():
                 if not model_name:
                     continue
+                # upsert_assignment will route to LOCAL for non-catalog names.
                 await self.upsert_assignment(
                     scope=AssignmentScope.AGENT_SLUG,
                     scope_value=agent_slug,
@@ -319,7 +451,10 @@ class ModelRoutingService(BaseService):
             self.log.info("Mode applied: mix", agents=len(per_agent))
             return
 
-        raise ValueError(f"Unknown mode '{mode}'. Use 'anthropic', 'ollama', or 'mix'.")
+        raise ValueError(
+            f"Unknown mode '{mode}'."
+            " Use 'anthropic', 'ollama', 'self_hosted', or 'mix'."
+        )
 
     # =========================================================================
     # INTERNAL
@@ -333,6 +468,15 @@ class ModelRoutingService(BaseService):
             return None
         # Relationship is lazy="joined" in the ORM so `.provider` is loaded.
         return _ResolvedAssignment(provider=row.provider, model_name=row.model_name)
+
+    async def _find_local_provider(self) -> ProviderConfigTable | None:
+        """Return the LOCAL provider row, or None if not seeded."""
+        result = await self.session.execute(
+            select(ProviderConfigTable).where(
+                ProviderConfigTable.type == ModelProvider.LOCAL
+            )
+        )
+        return result.scalar_one_or_none()
 
     async def _route_from_assignment(self, resolved: _ResolvedAssignment) -> AgentRoute:
         provider = resolved.provider

--- a/tests/integration/test_llm_routing.py
+++ b/tests/integration/test_llm_routing.py
@@ -347,3 +347,195 @@ async def test_resolve_for_agent_falls_back_on_decrypt_error(
         route = await svc.resolve_for_agent("be-dev-1")
     # Falls back to legacy ANTHROPIC route.
     assert route.provider_type == ModelProvider.ANTHROPIC
+
+
+# ---------------------------------------------------------------------------
+# Self-hosted (LOCAL) provider
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def llm_setup_with_local(
+    db_session: AsyncSession,
+) -> AsyncIterator[dict]:
+    """Seed Anthropic, Ollama Cloud, and LOCAL provider rows."""
+    anthropic = ProviderConfigTable(
+        name="anthropic-test-local",
+        type=ModelProvider.ANTHROPIC,
+        enabled=True,
+    )
+    ollama = ProviderConfigTable(
+        name="ollama-test-local",
+        type=ModelProvider.OLLAMA_CLOUD,
+        enabled=True,
+        base_url="https://ollama.example.com",
+    )
+    local = ProviderConfigTable(
+        name="self-hosted-test",
+        type=ModelProvider.LOCAL,
+        enabled=True,
+        base_url="http://localhost:11434",
+    )
+    db_session.add_all([anthropic, ollama, local])
+    await db_session.flush()
+    yield {"svc": ModelRoutingService(db_session), "local": local}
+
+
+@pytest.mark.asyncio
+async def test_derive_mode_self_hosted_when_only_local_global(
+    llm_setup_with_local: dict,
+) -> None:
+    """Single GLOBAL assignment pointing to LOCAL → 'self_hosted' mode."""
+    svc = llm_setup_with_local["svc"]
+    await svc.upsert_assignment(
+        scope=AssignmentScope.GLOBAL,
+        scope_value=None,
+        model_name="llama3.1:8b",
+        provider_type_override=ModelProvider.LOCAL,
+    )
+    assert await svc.derive_mode() == "self_hosted"
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_self_hosted_sets_global_local(
+    llm_setup_with_local: dict,
+) -> None:
+    """apply_mode('self_hosted') clears assignments, enables LOCAL, inserts GLOBAL."""
+    svc = llm_setup_with_local["svc"]
+    await svc.apply_mode(mode="self_hosted", default_model="llama3.1:8b")
+    assignments = await svc.list_assignments()
+    assert len(assignments) == 1
+    assert assignments[0].scope == AssignmentScope.GLOBAL
+    assert assignments[0].provider.type == ModelProvider.LOCAL
+    assert assignments[0].model_name == "llama3.1:8b"
+    # Verify derive_mode reflects the new state.
+    assert await svc.derive_mode() == "self_hosted"
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_self_hosted_requires_default_model(
+    llm_setup_with_local: dict,
+) -> None:
+    """apply_mode('self_hosted') without default_model raises ValueError."""
+    svc = llm_setup_with_local["svc"]
+    with pytest.raises(ValueError, match="requires a default_model"):
+        await svc.apply_mode(mode="self_hosted")
+
+
+@pytest.mark.asyncio
+async def test_apply_mode_self_hosted_clears_prior_assignments(
+    llm_setup_with_local: dict,
+) -> None:
+    """apply_mode('self_hosted') clears ALL prior assignments."""
+    svc = llm_setup_with_local["svc"]
+    anthropic_model = _first_model_for_type(ModelProvider.ANTHROPIC)
+    await svc.upsert_assignment(
+        scope=AssignmentScope.AGENT_SLUG,
+        scope_value="be-dev-1",
+        model_name=anthropic_model,
+    )
+    await svc.upsert_assignment(
+        scope=AssignmentScope.GLOBAL,
+        scope_value=None,
+        model_name=anthropic_model,
+    )
+    assert len(await svc.list_assignments()) == 2  # noqa: PLR2004
+    await svc.apply_mode(mode="self_hosted", default_model="gemma2:9b")
+    assignments = await svc.list_assignments()
+    assert len(assignments) == 1  # Only the new GLOBAL row.
+    assert assignments[0].provider.type == ModelProvider.LOCAL
+
+
+@pytest.mark.asyncio
+async def test_upsert_assignment_routes_unknown_model_to_local(
+    llm_setup_with_local: dict,
+) -> None:
+    """Non-catalog model names are silently routed to LOCAL if seeded."""
+    svc = llm_setup_with_local["svc"]
+    row = await svc.upsert_assignment(
+        scope=AssignmentScope.AGENT_SLUG,
+        scope_value="be-dev-1",
+        model_name="my-custom-model:latest",
+    )
+    assert row.provider.type == ModelProvider.LOCAL
+    assert row.model_name == "my-custom-model:latest"
+
+
+@pytest.mark.asyncio
+async def test_mix_mode_with_self_hosted_models(
+    llm_setup_with_local: dict,
+) -> None:
+    """mix mode accepts self-hosted model names without raising ValueError."""
+    svc = llm_setup_with_local["svc"]
+    anthropic_model = _first_model_for_type(ModelProvider.ANTHROPIC)
+    await svc.apply_mode(
+        mode="mix",
+        per_agent={
+            "be-dev-1": anthropic_model,  # catalog model
+            "be-dev-2": "self-hosted-model:7b",  # non-catalog → routed to LOCAL
+        },
+    )
+    rows = await svc.list_assignments()
+    by_slug = {r.scope_value: r for r in rows if r.scope == AssignmentScope.AGENT_SLUG}
+    assert by_slug["be-dev-1"].provider.type == ModelProvider.ANTHROPIC
+    assert by_slug["be-dev-2"].provider.type == ModelProvider.LOCAL
+    assert by_slug["be-dev-2"].model_name == "self-hosted-model:7b"
+
+
+@pytest.mark.asyncio
+async def test_resolve_for_agent_self_hosted_returns_base_url(
+    llm_setup_with_local: dict,
+) -> None:
+    """When LOCAL assignment is reachable, route has base_url from provider."""
+    svc = llm_setup_with_local["svc"]
+    await svc.upsert_assignment(
+        scope=AssignmentScope.GLOBAL,
+        scope_value=None,
+        model_name="llama3.1:8b",
+        provider_type_override=ModelProvider.LOCAL,
+    )
+    with patch(
+        "roboco.services.llm.probe_ollama_tags",
+        new_callable=AsyncMock,
+        return_value=(["llama3.1:8b"], None),
+    ):
+        route = await svc.resolve_for_agent("be-dev-1")
+    assert route.provider_type == ModelProvider.LOCAL
+    assert route.base_url == "http://localhost:11434"
+    assert route.base_url is not None
+
+
+@pytest.mark.asyncio
+async def test_resolve_for_agent_falls_back_when_self_hosted_unreachable(
+    llm_setup_with_local: dict,
+) -> None:
+    """When LOCAL provider is unreachable, falls back to Anthropic default."""
+    svc = llm_setup_with_local["svc"]
+    await svc.upsert_assignment(
+        scope=AssignmentScope.GLOBAL,
+        scope_value=None,
+        model_name="llama3.1:8b",
+        provider_type_override=ModelProvider.LOCAL,
+    )
+    with patch(
+        "roboco.services.llm.probe_ollama_tags",
+        new_callable=AsyncMock,
+        return_value=([], "Could not connect to http://localhost:11434"),
+    ):
+        route = await svc.resolve_for_agent("be-dev-1")
+    assert route.provider_type == ModelProvider.ANTHROPIC
+    assert route.base_url is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_assignment_unknown_model_without_local_raises(
+    llm_setup: dict,
+) -> None:
+    """Without LOCAL provider seeded, non-catalog models raise ValueError."""
+    svc = llm_setup["svc"]
+    with pytest.raises(ValueError, match="Unknown model"):
+        await svc.upsert_assignment(
+            scope=AssignmentScope.AGENT_SLUG,
+            scope_value="be-dev-1",
+            model_name="ghost-model:latest",
+        )

--- a/tests/integration/test_provider_routes.py
+++ b/tests/integration/test_provider_routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from http import HTTPStatus
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -260,3 +261,250 @@ async def test_apply_mode_ollama_without_provider_returns_404(
         )
     app.dependency_overrides.clear()
     assert response.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.OK)
+
+
+# =============================================================================
+# Self-hosted endpoints
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def app_client_with_local(
+    db_session: AsyncSession,
+) -> AsyncIterator[AsyncClient]:
+    """App client pre-seeded with Anthropic, Ollama Cloud, and LOCAL providers."""
+    app = _make_app(db_session)
+    suffix = uuid4().hex[:8]
+    db_session.add(
+        ProviderConfigTable(
+            name=f"anthropic-local-{suffix}",
+            type=ModelProvider.ANTHROPIC,
+            enabled=True,
+        )
+    )
+    db_session.add(
+        ProviderConfigTable(
+            name=f"ollama-local-{suffix}",
+            type=ModelProvider.OLLAMA_CLOUD,
+            enabled=False,
+            base_url="https://ollama.example.com",
+        )
+    )
+    db_session.add(
+        ProviderConfigTable(
+            name=f"self-hosted-local-{suffix}",
+            type=ModelProvider.LOCAL,
+            enabled=False,
+        )
+    )
+    await db_session.flush()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_put_self_hosted_saves_base_url(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """PUT /self-hosted saves base_url and enables the LOCAL provider."""
+    response = await app_client_with_local.put(
+        "/api/providers/self-hosted",
+        json={"base_url": "http://192.168.1.10:11434"},
+        headers=_HDR_PM,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["base_url"] == "http://192.168.1.10:11434"
+    assert body["enabled"] is True
+    assert body["has_token"] is False
+
+
+@pytest.mark.asyncio
+async def test_put_self_hosted_with_token_stores_encrypted(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """PUT /self-hosted with auth_token stores Fernet-encrypted token."""
+    response = await app_client_with_local.put(
+        "/api/providers/self-hosted",
+        json={
+            "base_url": "http://192.168.1.10:11434",
+            "auth_token": "secret-ollama-key",
+        },
+        headers=_HDR_PM,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["has_token"] is True
+
+
+@pytest.mark.asyncio
+async def test_put_self_hosted_not_seeded_returns_404(
+    db_session: AsyncSession,
+) -> None:
+    """PUT /self-hosted when LOCAL provider not seeded returns 404."""
+    await db_session.execute(
+        delete(ProviderConfigTable).where(
+            ProviderConfigTable.type == ModelProvider.LOCAL
+        )
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/providers/self-hosted",
+            json={"base_url": "http://localhost:11434"},
+            headers=_HDR_PM,
+        )
+    app.dependency_overrides.clear()
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_put_self_hosted_developer_forbidden(
+    db_session: AsyncSession,
+) -> None:
+    """PUT /self-hosted is forbidden for developer role."""
+    app = _make_app(db_session, role=AgentRole.DEVELOPER, team=Team.BACKEND)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.put(
+            "/api/providers/self-hosted",
+            json={"base_url": "http://localhost:11434"},
+            headers={"X-Agent-ID": str(uuid4()), "X-Agent-Role": "developer"},
+        )
+    app.dependency_overrides.clear()
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_post_test_self_hosted_when_reachable(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """POST /self-hosted/test returns {ok: true, model_count: N} when reachable."""
+    # First configure the base_url.
+    await app_client_with_local.put(
+        "/api/providers/self-hosted",
+        json={"base_url": "http://192.168.1.10:11434"},
+        headers=_HDR_PM,
+    )
+    with patch(
+        "roboco.api.routes.provider.probe_ollama_tags",
+        new_callable=AsyncMock,
+        return_value=(["llama3.1:8b", "gemma2:9b"], None),
+    ):
+        response = await app_client_with_local.post(
+            "/api/providers/self-hosted/test",
+            headers=_HDR_PM,
+        )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["ok"] is True
+    assert body["model_count"] == 2  # noqa: PLR2004
+    assert body["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_post_test_self_hosted_when_unreachable(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """POST /self-hosted/test returns {ok: false, error: '...'} when unreachable."""
+    await app_client_with_local.put(
+        "/api/providers/self-hosted",
+        json={"base_url": "http://192.168.1.10:11434"},
+        headers=_HDR_PM,
+    )
+    with patch(
+        "roboco.api.routes.provider.probe_ollama_tags",
+        new_callable=AsyncMock,
+        return_value=([], "Could not connect to http://192.168.1.10:11434"),
+    ):
+        response = await app_client_with_local.post(
+            "/api/providers/self-hosted/test",
+            headers=_HDR_PM,
+        )
+    # Must be 200 with ok=false, NOT 500.
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"] is not None
+    assert body["model_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_post_test_self_hosted_not_configured(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """POST /self-hosted/test when no base_url returns {ok: false} without 500."""
+    # LOCAL provider seeded but no base_url configured.
+    response = await app_client_with_local.post(
+        "/api/providers/self-hosted/test",
+        headers=_HDR_PM,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_self_hosted_models_returns_list(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """GET /self-hosted/models returns model name strings from Ollama /api/tags."""
+    await app_client_with_local.put(
+        "/api/providers/self-hosted",
+        json={"base_url": "http://192.168.1.10:11434"},
+        headers=_HDR_PM,
+    )
+    with patch(
+        "roboco.api.routes.provider.probe_ollama_tags",
+        new_callable=AsyncMock,
+        return_value=(["llama3.1:8b", "gemma2:9b", "qwen2.5:14b"], None),
+    ):
+        response = await app_client_with_local.get(
+            "/api/providers/self-hosted/models",
+            headers=_HDR_PM,
+        )
+    assert response.status_code == HTTPStatus.OK
+    models = response.json()
+    assert isinstance(models, list)
+    assert "llama3.1:8b" in models
+    assert len(models) == 3  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_get_self_hosted_models_not_configured_returns_404(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """GET /self-hosted/models when no base_url configured returns 404."""
+    response = await app_client_with_local.get(
+        "/api/providers/self-hosted/models",
+        headers=_HDR_PM,
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_get_self_hosted_models_unreachable_returns_503(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """GET /self-hosted/models when server unreachable returns 503."""
+    await app_client_with_local.put(
+        "/api/providers/self-hosted",
+        json={"base_url": "http://192.168.1.10:11434"},
+        headers=_HDR_PM,
+    )
+    with patch(
+        "roboco.api.routes.provider.probe_ollama_tags",
+        new_callable=AsyncMock,
+        return_value=([], "Could not connect"),
+    ):
+        response = await app_client_with_local.get(
+            "/api/providers/self-hosted/models",
+            headers=_HDR_PM,
+        )
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE


### PR DESCRIPTION
Build the backend API layer for self-hosted LLM provider support (Ollama-compatible servers). The existing architecture is ready: ModelProvider.LOCAL is already seeded in migration 004, ProviderConfigTable has base_url + auth_token_encrypted columns, and the orchestrator spawn path injects ANTHROPIC_BASE_URL when base_url is non-null.

Goal: Enable the platform to connect to, discover models from, and route agents through a user-specified self-hosted Ollama server — as a first-class provider alongside Anthropic and Ollama Cloud.

Key backend deliverables:
- Discovery endpoint that proxies the self-hosted server's /api/tags to return available models
- Test-connection endpoint that validates the self-hosted URL and reports success with model count or a specific error
- Routing mode extensions: derive_mode() needs a 4th branch ('only global row pointing to LOCAL provider' → return 'self_hosted'); apply_mode('self_hosted') mirrors the 'ollama' path but uses LOCAL provider
- Dynamic catalog merge: upsert_assignment currently does MODEL_CATALOG_BY_NAME lookup which fails for dynamic models — needs a bypass for LOCAL provider that resolves ephemeral models directly
- Fernet-encrypted storage for the optional auth token, same pattern as the Ollama Cloud key
- Graceful fallback to Anthropic defaults when the self-hosted server is unreachable at spawn time — agents must not fail to spawn

Scope constraints: Ollama-only (no vLLM/TGI/llama.cpp). Do not modify ROBOCO_OLLAMA_BASE_URL (that's for RAG/embeddings). Dynamic models are ephemeral — NOT persisted in MODEL_CATALOG, fetched on demand.