### PR TITLE
[042462df] Align self-hosted types, hooks, and UI components to backend contract

### DIFF
--- a/panel/src/components/settings/ai-routing-card.tsx
+++ b/panel/src/components/settings/ai-routing-card.tsx
@@ -86,7 +86,7 @@ export function AIRoutingCard() {
   // Track the latest self-hosted test result so ModeButton can gate access.
   const [selfHostedTestResult, setSelfHostedTestResult] =
     useState<SelfHostedTestResult | null>(null);
-  const isSelfHostedConnected = selfHostedTestResult?.status === "connected";
+  const isSelfHostedConnected = selfHostedTestResult?.ok === true;
 
   const handleSelfHostedTestResult = useCallback(
     (result: SelfHostedTestResult) => {
@@ -377,14 +377,16 @@ export function AIRoutingCard() {
                 self-hosted mode.
               </p>
               <Select
-                value={selfHostedModel}
-                onValueChange={setSelfHostedModel}
+                value={selfHostedModel || "__clear__"}
+                onValueChange={(v: string) =>
+                  setSelfHostedModel(v === "__clear__" ? "" : v)
+                }
               >
                 <SelectTrigger className="w-full max-w-sm">
                   <SelectValue placeholder="(use server default)" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">(use server default)</SelectItem>
+                  <SelectItem value="__clear__">(use server default)</SelectItem>
                   {selfHostedModels.map((m) => (
                     <SelectItem key={m.model_name} value={m.model_name}>
                       {m.display_name}

--- a/panel/src/components/settings/self-hosted-section.tsx
+++ b/panel/src/components/settings/self-hosted-section.tsx
@@ -98,14 +98,15 @@ export function SelfHostedSection({
     try {
       const result = await testConnection.mutateAsync();
       onTestResult?.(result);
-      if (result.status === "connected") {
-        onTestSuccess?.(result.model_count);
+      if (result.ok) {
+        onTestSuccess?.(result.model_count ?? 0);
         setLastRefreshed(new Date().toISOString());
+        const count = result.model_count ?? 0;
         toast.success(
-          `Connected — ${result.model_count} model${result.model_count === 1 ? "" : "s"} available`,
+          `Connected — ${count} model${count === 1 ? "" : "s"} available`,
         );
       } else {
-        toast.error(`Connection failed: ${result.error_message ?? "unknown error"}`);
+        toast.error(`Connection failed: ${result.error ?? "unknown error"}`);
       }
     } catch (e) {
       toast.error("Test failed: " + errMsg(e));
@@ -129,14 +130,14 @@ export function SelfHostedSection({
   // Determine which empty state to show, if any.
   const showNoUrlState = !hasSavedUrl;
   const showErrorState =
-    hasSavedUrl && testResult?.status === "error" && !showNoUrlState;
+    hasSavedUrl && testResult?.ok === false && !showNoUrlState;
   const showNoModelsState =
     hasSavedUrl &&
-    testResult?.status === "connected" &&
+    testResult?.ok === true &&
     models.length === 0 &&
     !showNoUrlState;
   const showModelList =
-    hasSavedUrl && testResult?.status === "connected" && models.length > 0;
+    hasSavedUrl && testResult?.ok === true && models.length > 0;
 
   return (
     <section className="space-y-4">
@@ -144,12 +145,12 @@ export function SelfHostedSection({
       <div className="flex items-center gap-2">
         <Server className="h-4 w-4 text-muted-foreground" />
         <Label className="text-sm font-medium">Self-Hosted LLM</Label>
-        {testResult?.status === "connected" && (
+        {testResult?.ok === true && (
           <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
             <CheckCircle2 className="h-3 w-3" /> connected
           </span>
         )}
-        {testResult?.status === "error" && (
+        {testResult?.ok === false && (
           <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-600">
             <XCircle className="h-3 w-3" /> error
           </span>
@@ -187,7 +188,7 @@ export function SelfHostedSection({
               value={authToken}
               onChange={(e) => setAuthToken(e.target.value)}
               placeholder={
-                config?.has_auth_token
+                config?.has_token
                   ? "•••••••••••• (leave blank to keep)"
                   : "sk-… or Bearer token"
               }
@@ -210,12 +211,12 @@ export function SelfHostedSection({
             {saveConfig.isPending ? "Saving…" : "Save"}
           </Button>
         </div>
-        {config?.has_auth_token && (
+        {config?.has_token && (
           <p className="text-xs text-muted-foreground">
             A token is stored. Type a new value to update it.
           </p>
         )}
-        {!config?.has_auth_token && (
+        {!config?.has_token && (
           <p className="text-xs text-muted-foreground">
             Stored Fernet-encrypted server-side; never returned by the API.
           </p>
@@ -241,17 +242,17 @@ export function SelfHostedSection({
         </Button>
 
         {/* Inline result badge */}
-        {testResult?.status === "connected" && (
+        {testResult?.ok === true && (
           <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
             <CheckCircle2 className="h-3.5 w-3.5" />
-            Connected &mdash; {testResult.model_count} model
-            {testResult.model_count === 1 ? "" : "s"} available
+            Connected &mdash; {testResult.model_count ?? 0} model
+            {(testResult.model_count ?? 0) === 1 ? "" : "s"} available
           </span>
         )}
-        {testResult?.status === "error" && (
+        {testResult?.ok === false && (
           <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-3 py-1 text-xs font-medium text-red-700 dark:text-red-400">
             <XCircle className="h-3.5 w-3.5" />
-            {testResult.error_message ?? "Connection failed"}
+            {testResult.error ?? "Connection failed"}
           </span>
         )}
       </div>
@@ -279,13 +280,8 @@ export function SelfHostedSection({
                 Last test failed
               </p>
               <p className="text-xs text-red-600 dark:text-red-500">
-                {testResult?.error_message ?? "Unknown error"}
+                {testResult?.error ?? "Unknown error"}
               </p>
-              {testResult?.last_checked && (
-                <p className="text-xs text-muted-foreground">
-                  Last checked: {relativeTime(testResult.last_checked)}
-                </p>
-              )}
             </div>
             <Button
               variant="outline"

--- a/panel/src/hooks/use-providers.ts
+++ b/panel/src/hooks/use-providers.ts
@@ -65,7 +65,7 @@ export function useApplyMode() {
 // Self-hosted LLM hooks
 // ---------------------------------------------------------------------------
 
-/** Query: fetch saved self-hosted config (base_url + has_auth_token flag). */
+/** Query: fetch saved self-hosted config (base_url + has_token flag). */
 export function useSelfHostedConfig() {
   return useQuery({
     queryKey: providerKeys.selfHostedConfig(),
@@ -107,14 +107,12 @@ export function useSelfHostedModels() {
   });
 }
 
-/** Mutation: force-refresh the discovered model list. */
+/** Mutation: invalidate the cached model list so it is re-fetched from GET /self-hosted/models. */
 export function useRefreshSelfHostedModels() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: () => providersApi.refreshSelfHostedModels(),
-    onSuccess: (data) => {
-      // Update the cached model list in place.
-      qc.setQueryData(providerKeys.selfHostedModels(), data);
+    mutationFn: async () => {
+      await qc.invalidateQueries({ queryKey: providerKeys.selfHostedModels() });
     },
   });
 }

--- a/panel/src/lib/api/providers.ts
+++ b/panel/src/lib/api/providers.ts
@@ -44,19 +44,16 @@ export interface ApplyModePayload {
 
 /** Configuration stored server-side for the self-hosted provider. */
 export interface SelfHostedConfig {
-  base_url: string | null;
-  has_auth_token: boolean;
+  base_url: string;
+  has_token: boolean;
+  enabled: boolean;
 }
-
-/** Status values returned by the test-connection endpoint. */
-export type SelfHostedTestStatus = "connected" | "error";
 
 /** Result of a test-connection call. */
 export interface SelfHostedTestResult {
-  status: SelfHostedTestStatus;
-  model_count: number;
-  error_message: string | null;
-  last_checked: string | null; // ISO datetime
+  ok: boolean;
+  model_count: number | null;
+  error: string | null;
 }
 
 /** One model entry returned by the discovery endpoint. */
@@ -128,13 +125,6 @@ export const providersApi = {
   getSelfHostedModels: async (): Promise<SelfHostedModel[]> => {
     const { data } = await api.get<SelfHostedModel[]>(
       "/providers/self-hosted/models",
-    );
-    return data;
-  },
-
-  refreshSelfHostedModels: async (): Promise<SelfHostedModel[]> => {
-    const { data } = await api.post<SelfHostedModel[]>(
-      "/providers/self-hosted/models/refresh",
     );
     return data;
   },

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -101,7 +101,6 @@ export enum ModelProvider {
   OLLAMA_CLOUD = "ollama_cloud",
   OPENAI = "openai",
   LOCAL = "local",
-  SELF_HOSTED = "self_hosted",
 }
 
 export enum AssignmentScope {


### PR DESCRIPTION
The backend updated its self-hosted LLM provider contract. Five frontend files need coordinated fixes to match it.

**Files to change and exactly what to do:**

1. `src/lib/api/providers.ts`
   - `SelfHostedConfig`: rename `has_auth_token: boolean` → `has_token: boolean`, add `enabled: boolean`, change `base_url: string | null` → `base_url: string`
   - `SelfHostedTestResult`: remove the `status: SelfHostedTestStatus` field and the `SelfHostedTestStatus` type entirely, replace with `ok: boolean`; rename `error_message: string | null` → `error: string | null`; change `model_count: number` → `model_count: number | null`; remove `last_checked: string | null`
   - Remove the `refreshSelfHostedModels` API function (calls the now-defunct POST /providers/self-hosted/models/refresh endpoint)

2. `src/hooks/use-providers.ts`
   - Rewrite `useRefreshSelfHostedModels`: instead of calling the removed `providersApi.refreshSelfHostedModels()` mutation, make it simply invalidate the `providerKeys.selfHostedModels()` query so React Query refetches the GET endpoint. Remove the `mutationFn` and replace with a regular function that calls `qc.invalidateQueries({ queryKey: providerKeys.selfHostedModels() })` and returns a Promise. Update the comment.

3. `src/components/settings/self-hosted-section.tsx`
   - In `handleTest`: change `if (result.status === "connected")` → `if (result.ok === true)`, change `result.error_message` → `result.error`, handle `result.model_count` being potentially null (use `result.model_count ?? 0`)
   - Change all `config?.has_auth_token` → `config?.has_token` (3 occurrences: placeholder text, conditional hint paragraph)
   - Change all `testResult?.status === "connected"` → `testResult?.ok === true` (all occurrences in display logic and header badges)
   - Change all `testResult?.status === "error"` → `testResult?.ok === false && testResult != null` (in error state display)  
   - Change `testResult.error_message` → `testResult.error` (inline badge)
   - Change `testResult?.error_message` → `testResult?.error` (error state block)
   - Remove the `testResult?.last_checked` block (the field no longer exists) and the `relativeTime` helper function if it's only used for `last_checked`
   - Remove the `SelfHostedTestStatus` import if it exists

4. `src/components/settings/ai-routing-card.tsx`
   - Change `const isSelfHostedConnected = selfHostedTestResult?.status === "connected"` → `const isSelfHostedConnected = selfHostedTestResult?.ok === true`
   - In the self-hosted default-model picker Select, change `<SelectItem value="">` → `<SelectItem value="__clear__">` for the "(use server default)" option
   - In the same Select's `onValueChange`, if the value is `"__clear__"` set `selfHostedModel` to `""` (i.e., add `setSelfHostedModel(v === "__clear__" ? "" : v)`)

5. `src/types/index.ts`
   - In the `ModelProvider` enum, remove `SELF_HOSTED = "self_hosted"` entirely
   - Search for any other references to `ModelProvider.SELF_HOSTED` in the src/ directory and replace with `ModelProvider.LOCAL`

After all changes, run `pnpm typecheck` and `pnpm lint` to verify no TypeScript errors remain. The `relativeTime` function can be removed from self-hosted-section.tsx if it is exclusively used for the `last_checked` field (which is being removed).