### PR TITLE
[f66d6d4d] Fix self-hosted API S1-S4/L1-L5: routes, schemas, services, migration 028, and tests

### DIFF
--- a/alembic/versions/028_seed_self_hosted_provider.py
+++ b/alembic/versions/028_seed_self_hosted_provider.py
@@ -50,6 +50,16 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Delete any model_assignments that point to the LOCAL provider row first
+    # to avoid a FK RESTRICT violation on provider_configs.id.
+    op.execute(
+        sa.text(
+            "DELETE FROM model_assignments "
+            "WHERE provider_config_id IN ("
+            "    SELECT id FROM provider_configs WHERE name = 'Self-Hosted (Ollama)'"
+            ")"
+        )
+    )
     op.execute(
         sa.text(
             "DELETE FROM provider_configs "

--- a/roboco/api/routes/provider.py
+++ b/roboco/api/routes/provider.py
@@ -6,7 +6,7 @@ cover the whole UX: fetch the catalog, get / set the Ollama key,
 configure / test / discover the self-hosted server, fetch the current
 mode + assignments, apply a mode change. No provider CRUD — the
 providers (Anthropic, Ollama Cloud, Self-Hosted) are pre-seeded by
-migrations 004 and 027.
+migrations 004 and 028.
 """
 
 from fastapi import APIRouter, HTTPException, status
@@ -19,6 +19,7 @@ from roboco.api.schemas.provider import (
     OllamaKeyStatus,
     SelfHostedConfigRequest,
     SelfHostedConfigResponse,
+    SelfHostedModelEntry,
     SelfHostedTestResponse,
     SetOllamaKeyRequest,
     assignment_to_response,
@@ -117,6 +118,39 @@ async def set_ollama_key(
 # =============================================================================
 
 
+@router.get("/self-hosted", response_model=SelfHostedConfigResponse)
+async def get_self_hosted_config(
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> SelfHostedConfigResponse:
+    """Return the current configuration of the LOCAL (self-hosted) provider.
+
+    The LOCAL provider row must be seeded (migration 028). Returns
+    ``{base_url, has_token, enabled}`` so the Settings UI can display
+    the current state without exposing the encrypted token.
+    """
+    require_pm_or_above(agent.role, "view the self-hosted provider config")
+    provider_svc = get_provider_service(db)
+    providers = await provider_svc.list_providers(include_disabled=True)
+    local = next(
+        (p for p in providers if p.type == ModelProvider.LOCAL),
+        None,
+    )
+    if local is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Self-Hosted provider not seeded. "
+                "Run alembic upgrade head (migration 028)."
+            ),
+        )
+    return SelfHostedConfigResponse(
+        base_url=local.base_url,
+        has_token=bool(local.auth_token_encrypted),
+        enabled=local.enabled,
+    )
+
+
 @router.put("/self-hosted", response_model=SelfHostedConfigResponse)
 async def set_self_hosted_config(
     data: SelfHostedConfigRequest,
@@ -125,10 +159,10 @@ async def set_self_hosted_config(
 ) -> SelfHostedConfigResponse:
     """Save the base URL (and optionally an auth token) for the LOCAL provider.
 
-    The LOCAL provider row must be seeded (migration 027). The token, when
+    The LOCAL provider row must be seeded (migration 028). The token, when
     provided and non-empty, is Fernet-encrypted before storing. An empty
     string for `auth_token` clears the stored token. The provider is
-    automatically enabled when a valid base_url is saved.
+    automatically enabled only when a non-empty base_url is provided.
     """
     require_pm_or_above(agent.role, "configure the self-hosted provider")
     provider_svc = get_provider_service(db)
@@ -142,7 +176,7 @@ async def set_self_hosted_config(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=(
                 "Self-Hosted provider not seeded. "
-                "Run alembic upgrade head (migration 027)."
+                "Run alembic upgrade head (migration 028)."
             ),
         )
 
@@ -157,7 +191,8 @@ async def set_self_hosted_config(
             base_url=data.base_url,
             auth_token=new_token,
             clear_auth_token=clear_token,
-            enabled=True,
+            # Only enable the provider when a non-empty base_url is provided.
+            enabled=bool(data.base_url),
         ),
     )
     await db.commit()
@@ -206,15 +241,15 @@ async def test_self_hosted_connection(
     return SelfHostedTestResponse(ok=True, model_count=len(models))
 
 
-@router.get("/self-hosted/models", response_model=list[str])
+@router.get("/self-hosted/models", response_model=list[SelfHostedModelEntry])
 async def get_self_hosted_models(
     db: DbSession,
     agent: CurrentAgentContext,
-) -> list[str]:
-    """Return the list of model names available on the self-hosted Ollama server.
+) -> list[SelfHostedModelEntry]:
+    """Return the list of models available on the self-hosted Ollama server.
 
-    Queries ``{base_url}/api/tags`` and extracts the ``name`` field from
-    each model entry. Raises 503 if the server is unreachable, 404 if
+    Queries ``{base_url}/api/tags`` and returns ``[{model_name, display_name}]``
+    for each model entry. Raises 503 if the server is unreachable, 404 if
     the LOCAL provider is not configured.
     """
     require_pm_or_above(agent.role, "list self-hosted models")
@@ -233,13 +268,15 @@ async def get_self_hosted_models(
             ),
         )
 
-    models, error = await probe_ollama_tags(local.base_url)
+    model_names, error = await probe_ollama_tags(local.base_url)
     if error is not None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=f"Self-hosted server unreachable: {error}",
         )
-    return models
+    return [
+        SelfHostedModelEntry(model_name=name, display_name=name) for name in model_names
+    ]
 
 
 # =============================================================================
@@ -258,7 +295,7 @@ async def get_current_mode(
     mode = await routing.derive_mode()
     assignments = await routing.list_assignments()
     return ModeResponse(
-        mode=mode,  # type: ignore[arg-type]
+        mode=mode,
         assignments=[assignment_to_response(a) for a in assignments],
     )
 
@@ -293,6 +330,6 @@ async def apply_mode(
     mode = await routing.derive_mode()
     assignments = await routing.list_assignments()
     return ModeResponse(
-        mode=mode,  # type: ignore[arg-type]
+        mode=mode,
         assignments=[assignment_to_response(a) for a in assignments],
     )

--- a/roboco/api/schemas/provider.py
+++ b/roboco/api/schemas/provider.py
@@ -105,6 +105,19 @@ class SelfHostedTestResponse(BaseModel):
     error: str | None = None
 
 
+class SelfHostedModelEntry(BaseModel):
+    """One model available on the self-hosted Ollama server.
+
+    `model_name` is the raw Ollama tag identifier (e.g. ``llama3.1:8b``).
+    `display_name` is a human-readable label for the Settings UI dropdown;
+    for self-hosted models it mirrors `model_name` since Ollama's ``/api/tags``
+    does not return a separate display label.
+    """
+
+    model_name: str
+    display_name: str
+
+
 # =============================================================================
 # MODEL ASSIGNMENTS (read-only for the UI)
 # =============================================================================

--- a/roboco/models/base.py
+++ b/roboco/models/base.py
@@ -191,7 +191,10 @@ class ModelProvider(StrEnum):
     `ANTHROPIC` is the built-in default — routed via the mounted `~/.claude/`
     credentials inside each agent container. `OLLAMA_CLOUD` routes via
     `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` env injection at spawn.
-    OPENAI / LOCAL are historical placeholders (unused today).
+    `LOCAL` is the self-hosted Ollama provider: the operator configures its
+    base URL via PUT /api/providers/self-hosted (seeded by migration 028).
+    Agents assigned to LOCAL are routed to that server at spawn time.
+    `OPENAI` is reserved for future use.
     """
 
     ANTHROPIC = "anthropic"

--- a/roboco/services/llm.py
+++ b/roboco/services/llm.py
@@ -26,9 +26,10 @@ Self-hosted (LOCAL) provider support:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 import httpx
+import structlog
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
 
@@ -56,6 +57,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 _OLLAMA_TAGS_TIMEOUT = 5.0  # seconds
+_log = structlog.get_logger(__name__)
 
 
 async def probe_ollama_tags(base_url: str) -> tuple[list[str], str | None]:
@@ -82,7 +84,12 @@ async def probe_ollama_tags(base_url: str) -> tuple[list[str], str | None]:
     except httpx.HTTPStatusError as exc:
         return [], f"Server at {base_url} returned HTTP {exc.response.status_code}"
     except Exception as exc:
-        return [], f"Unexpected error probing {base_url}: {exc}"
+        _log.error(
+            "Unexpected error probing Ollama server",
+            base_url=base_url,
+            error=str(exc),
+        )
+        return [], "An unexpected error occurred while probing the self-hosted server."
 
 
 @dataclass(frozen=True)
@@ -250,6 +257,14 @@ class ModelRoutingService(BaseService):
                 provider = await self._get_seeded_provider(entry.provider_type)
                 provider_type_for_log = entry.provider_type
 
+        # Whenever an assignment resolves to LOCAL, ensure the LOCAL provider
+        # row is enabled so resolve_for_agent() will actually use it.
+        if provider_type_for_log == ModelProvider.LOCAL:
+            provider_svc = ProviderService(self.session)
+            await provider_svc.update_provider(
+                require_uuid(provider.id), ProviderUpdate(enabled=True)
+            )
+
         row = await self.get_assignment(scope=scope, scope_value=scope_value)
         if row is None:
             row = ModelAssignmentTable(
@@ -273,7 +288,7 @@ class ModelRoutingService(BaseService):
         )
         return row
 
-    async def derive_mode(self) -> str:
+    async def derive_mode(self) -> Literal["anthropic", "ollama", "mix", "self_hosted"]:
         """Return the current "mode" label for the Settings UI.
 
         Decision tree matches what `apply_mode` writes:

--- a/tests/integration/test_llm_routing.py
+++ b/tests/integration/test_llm_routing.py
@@ -539,3 +539,54 @@ async def test_upsert_assignment_unknown_model_without_local_raises(
             scope_value="be-dev-1",
             model_name="ghost-model:latest",
         )
+
+
+@pytest.mark.asyncio
+async def test_upsert_assignment_enables_local_when_disabled(
+    db_session: AsyncSession,
+) -> None:
+    """upsert_assignment transitions LOCAL provider from enabled=False to enabled=True.
+
+    AC4: proves that mix-mode assignment of a non-catalog model name resolves
+    to provider_type LOCAL and LOCAL.enabled is True afterward — even when the
+    LOCAL provider starts with enabled=False (the seeded state from migration 028
+    before the operator configures a base_url via PUT /providers/self-hosted).
+    """
+    # Arrange: Anthropic provider (required by ModelRoutingService internals)
+    # and LOCAL provider starting with enabled=False.
+    anthropic = ProviderConfigTable(
+        name="anthropic-ac4-test",
+        type=ModelProvider.ANTHROPIC,
+        enabled=True,
+    )
+    local = ProviderConfigTable(
+        name="self-hosted-ac4-test",
+        type=ModelProvider.LOCAL,
+        enabled=False,  # Starts DISABLED — this is the state to be transitioned.
+        base_url="http://localhost:11434",
+    )
+    db_session.add_all([anthropic, local])
+    await db_session.flush()
+
+    # Pre-condition: LOCAL is disabled before the call.
+    assert local.enabled is False
+
+    # Act: upsert a non-catalog model name → resolves to LOCAL →
+    # calls ProviderService.update_provider(enabled=True) on the LOCAL row.
+    svc = ModelRoutingService(db_session)
+    row = await svc.upsert_assignment(
+        scope=AssignmentScope.AGENT_SLUG,
+        scope_value="test-agent-ac4",
+        model_name="non-catalog-model:7b",
+    )
+
+    # Refresh local from DB so the in-memory object reflects the DB write.
+    await db_session.refresh(local)
+
+    # Assert: assignment resolved to LOCAL and LOCAL provider is now enabled.
+    assert row.provider.type == ModelProvider.LOCAL
+    assert row.model_name == "non-catalog-model:7b"
+    assert local.enabled is True, (
+        "upsert_assignment must call update_provider(enabled=True) on LOCAL "
+        "whenever it routes a non-catalog model to the LOCAL provider"
+    )

--- a/tests/integration/test_migration_028_seed_self_hosted.py
+++ b/tests/integration/test_migration_028_seed_self_hosted.py
@@ -1,0 +1,134 @@
+"""Migration 028 tests — seed_self_hosted_provider.
+
+Verifies the post-upgrade state and exercises the downgrade SQL ordering
+to prove the FK-safe delete sequence works.
+
+NOT a real alembic round-trip — the suite builds the test DB via
+Base.metadata.create_all (see conftest). Migration 028's upgrade()/downgrade()
+bodies are reviewed here; the tests guard the resulting DB-level contract.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from roboco.db.tables import ModelAssignmentTable, ProviderConfigTable
+from roboco.models.base import AssignmentScope, ModelProvider
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_migration_028_upgrade_local_row_inserted(
+    db_session: AsyncSession,
+) -> None:
+    """After upgrade to head, the LOCAL provider row is present in provider_configs.
+
+    The upgrade() in migration 028 does an INSERT ... ON CONFLICT DO NOTHING,
+    so this row must exist after running `alembic upgrade head`.
+    """
+    result = await db_session.execute(
+        text(
+            "SELECT name, type, enabled "
+            "FROM provider_configs "
+            "WHERE name = 'Self-Hosted (Ollama)'"
+        )
+    )
+    rows = list(result)
+    assert len(rows) == 1, (
+        "Expected exactly one 'Self-Hosted (Ollama)' row; "
+        f"found {len(rows)}. Run `alembic upgrade head` to seed it."
+    )
+    name, ptype, enabled = rows[0]
+    assert name == "Self-Hosted (Ollama)"
+    assert ptype == "local"
+    assert enabled is False  # starts disabled; user configures via PUT /self-hosted
+
+
+@pytest.mark.asyncio
+async def test_migration_028_downgrade_deletes_assignments_before_config(
+    db_session: AsyncSession,
+) -> None:
+    """Downgrade SQL deletes model_assignments before provider_configs.
+
+    Simulates the downgrade() logic from migration 028:
+      1. DELETE FROM model_assignments WHERE provider_config_id IN (SELECT id ...)
+      2. DELETE FROM provider_configs WHERE name = 'Self-Hosted (Ollama)'
+
+    A FK RESTRICT constraint on model_assignments.provider_config_id means that
+    executing step 2 before step 1 would raise an IntegrityError. This test
+    proves that doing them in the correct order succeeds without violation.
+    """
+    # --- Arrange: insert a fresh LOCAL provider row and a referencing assignment.
+    suffix = uuid4().hex[:8]
+    local = ProviderConfigTable(
+        name=f"Self-Hosted (Ollama)-test-{suffix}",
+        type=ModelProvider.LOCAL,
+        enabled=False,
+    )
+    db_session.add(local)
+    await db_session.flush()
+
+    assignment = ModelAssignmentTable(
+        scope=AssignmentScope.AGENT_SLUG,
+        scope_value=f"test-agent-{suffix}",
+        provider_config_id=local.id,
+        model_name="llama3.1:8b",
+    )
+    db_session.add(assignment)
+    await db_session.flush()
+
+    # Verify both rows exist before we run the downgrade SQL.
+    result = await db_session.execute(
+        text("SELECT id FROM provider_configs WHERE name = :name").bindparams(
+            name=local.name
+        )
+    )
+    assert result.scalar_one_or_none() is not None
+
+    result = await db_session.execute(
+        text("SELECT id FROM model_assignments WHERE scope_value = :sv").bindparams(
+            sv=assignment.scope_value
+        )
+    )
+    assert result.scalar_one_or_none() is not None
+
+    # --- Act: execute downgrade SQL in the correct FK-safe order.
+    # Step 1: delete referencing model_assignments first.
+    await db_session.execute(
+        text(
+            "DELETE FROM model_assignments "
+            "WHERE provider_config_id IN ("
+            "    SELECT id FROM provider_configs WHERE name = :name"
+            ")"
+        ).bindparams(name=local.name)
+    )
+    # Step 2: now safe to delete the provider row.
+    await db_session.execute(
+        text("DELETE FROM provider_configs WHERE name = :name").bindparams(
+            name=local.name
+        )
+    )
+
+    # --- Assert: both rows are gone, no IntegrityError was raised.
+    result = await db_session.execute(
+        text("SELECT id FROM provider_configs WHERE name = :name").bindparams(
+            name=local.name
+        )
+    )
+    assert result.scalar_one_or_none() is None, (
+        "provider_configs row should be deleted by downgrade"
+    )
+
+    result = await db_session.execute(
+        text("SELECT id FROM model_assignments WHERE scope_value = :sv").bindparams(
+            sv=assignment.scope_value
+        )
+    )
+    assert result.scalar_one_or_none() is None, (
+        "model_assignments row should be deleted before provider_configs"
+    )

--- a/tests/integration/test_provider_routes.py
+++ b/tests/integration/test_provider_routes.py
@@ -260,7 +260,7 @@ async def test_apply_mode_ollama_without_provider_returns_404(
             "/api/providers", json={"mode": "ollama"}, headers=_HDR_PM
         )
     app.dependency_overrides.clear()
-    assert response.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.OK)
+    assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 # =============================================================================
@@ -402,6 +402,11 @@ async def test_post_test_self_hosted_when_reachable(
         )
     assert response.status_code == HTTPStatus.OK
     body = response.json()
+    # Contract: field names and types for the test response schema.
+    assert "ok" in body
+    assert "model_count" in body
+    assert "error" in body
+    assert isinstance(body["ok"], bool)
     assert body["ok"] is True
     assert body["model_count"] == 2  # noqa: PLR2004
     assert body["error"] is None
@@ -451,10 +456,52 @@ async def test_post_test_self_hosted_not_configured(
 
 
 @pytest.mark.asyncio
+async def test_get_self_hosted_config_returns_200(
+    app_client_with_local: AsyncClient,
+) -> None:
+    """GET /self-hosted returns {base_url, has_token, enabled} when LOCAL is seeded."""
+    response = await app_client_with_local.get(
+        "/api/providers/self-hosted",
+        headers=_HDR_PM,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    # Contract: field names and types must match the schema.
+    assert "base_url" in body
+    assert "has_token" in body
+    assert "enabled" in body
+    assert isinstance(body["has_token"], bool)
+    assert isinstance(body["enabled"], bool)
+
+
+@pytest.mark.asyncio
+async def test_get_self_hosted_config_not_seeded_returns_404(
+    db_session: AsyncSession,
+) -> None:
+    """GET /self-hosted when LOCAL provider not seeded returns 404."""
+    await db_session.execute(
+        delete(ProviderConfigTable).where(
+            ProviderConfigTable.type == ModelProvider.LOCAL
+        )
+    )
+    await db_session.flush()
+
+    app = _make_app(db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            "/api/providers/self-hosted",
+            headers=_HDR_PM,
+        )
+    app.dependency_overrides.clear()
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
 async def test_get_self_hosted_models_returns_list(
     app_client_with_local: AsyncClient,
 ) -> None:
-    """GET /self-hosted/models returns model name strings from Ollama /api/tags."""
+    """GET /self-hosted/models returns [{model_name, display_name}] objects."""
     await app_client_with_local.put(
         "/api/providers/self-hosted",
         json={"base_url": "http://192.168.1.10:11434"},
@@ -472,8 +519,17 @@ async def test_get_self_hosted_models_returns_list(
     assert response.status_code == HTTPStatus.OK
     models = response.json()
     assert isinstance(models, list)
-    assert "llama3.1:8b" in models
     assert len(models) == 3  # noqa: PLR2004
+    # Contract: each entry must be an object with model_name and display_name.
+    first = models[0]
+    assert isinstance(first, dict)
+    assert "model_name" in first
+    assert "display_name" in first
+    assert isinstance(first["model_name"], str)
+    assert isinstance(first["display_name"], str)
+    # Verify specific entry present.
+    names = [m["model_name"] for m in models]
+    assert "llama3.1:8b" in names
 
 
 @pytest.mark.asyncio

--- a/tests/unit/llm/test_probe_ollama_tags.py
+++ b/tests/unit/llm/test_probe_ollama_tags.py
@@ -1,0 +1,131 @@
+"""Unit tests for roboco.services.llm.probe_ollama_tags.
+
+Covers all five branches of the function:
+  1. Successful JSON parse → returns model names list
+  2. httpx.TimeoutException → returns ([], timeout message)
+  3. httpx.ConnectError → returns ([], connect-error message)
+  4. httpx.HTTPStatusError → returns ([], http-status message)
+  5. Generic Exception → logs server-side and returns ([], generic error string)
+
+All tests mock `httpx.AsyncClient` so they require no network or DB.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from roboco.services.llm import probe_ollama_tags
+
+_BASE_URL = "http://localhost:11434"
+
+
+@pytest.mark.asyncio
+async def test_probe_ollama_tags_success() -> None:
+    """Successful /api/tags response returns list of model name strings."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "models": [
+            {"name": "llama3.1:8b"},
+            {"name": "gemma2:9b"},
+            {"name": "qwen2.5:14b"},
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("roboco.services.llm.httpx.AsyncClient", return_value=mock_client):
+        models, error = await probe_ollama_tags(_BASE_URL)
+
+    assert error is None
+    assert models == ["llama3.1:8b", "gemma2:9b", "qwen2.5:14b"]
+
+
+@pytest.mark.asyncio
+async def test_probe_ollama_tags_timeout() -> None:
+    """httpx.TimeoutException returns ([], message) mentioning the timeout."""
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("roboco.services.llm.httpx.AsyncClient", return_value=mock_client):
+        models, error = await probe_ollama_tags(_BASE_URL)
+
+    assert models == []
+    assert error is not None
+    assert "timed out" in error.lower() or "timeout" in error.lower()
+
+
+@pytest.mark.asyncio
+async def test_probe_ollama_tags_connect_error() -> None:
+    """httpx.ConnectError returns ([], message) mentioning connection failure."""
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("roboco.services.llm.httpx.AsyncClient", return_value=mock_client):
+        models, error = await probe_ollama_tags(_BASE_URL)
+
+    assert models == []
+    assert error is not None
+    assert "connect" in error.lower() or "offline" in error.lower()
+
+
+@pytest.mark.asyncio
+async def test_probe_ollama_tags_http_status_error() -> None:
+    """httpx.HTTPStatusError returns ([], message) containing the HTTP status code."""
+    mock_response = MagicMock()
+    mock_response.status_code = 503
+
+    http_err = httpx.HTTPStatusError(
+        "service unavailable",
+        request=MagicMock(),
+        response=mock_response,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=http_err)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("roboco.services.llm.httpx.AsyncClient", return_value=mock_client):
+        models, error = await probe_ollama_tags(_BASE_URL)
+
+    assert models == []
+    assert error is not None
+    assert "503" in error
+
+
+@pytest.mark.asyncio
+async def test_probe_ollama_tags_generic_exception_logs_and_returns_generic() -> None:
+    """Generic Exception logs the error server-side and returns a generic string.
+
+    The raw exception message must NOT appear in the returned error string
+    (to avoid leaking internal server details in HTTP responses).
+    """
+    secret_detail = "internal secret detail that must not leak"
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=RuntimeError(secret_detail))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("roboco.services.llm.httpx.AsyncClient", return_value=mock_client),
+        patch("roboco.services.llm._log") as mock_log,
+    ):
+        models, error = await probe_ollama_tags(_BASE_URL)
+
+    assert models == []
+    assert error is not None
+    # The returned error string must NOT contain the raw exception text.
+    assert secret_detail not in error
+    # The logger must have been called to record the exception server-side.
+    mock_log.error.assert_called_once()


### PR DESCRIPTION
Implement all 13 fixes for the self-hosted provider API surface. All changes are in the same file cluster: `roboco/api/routes/provider.py`, `roboco/api/schemas/provider.py`, `roboco/services/llm.py`, `roboco/models/base.py`, `alembic/versions/028_seed_self_hosted_provider.py`, `tests/integration/test_provider_routes.py`, `tests/integration/test_llm_routing.py`, and a new `tests/unit/services/test_probe_ollama_tags.py` (or similar).

**S1 — Add GET /providers/self-hosted route**: Add a `@router.get("/self-hosted", response_model=SelfHostedConfigResponse)` handler in `provider.py` that fetches the LOCAL provider row (same pattern as PUT /self-hosted) and returns `{base_url, has_token, enabled}`. Returns 404 if LOCAL not seeded.

**S2 — Enrich GET /self-hosted/models response**: Add a new Pydantic schema `SelfHostedModelEntry(model_name: str, display_name: str)` to `schemas/provider.py`. Change `GET /self-hosted/models` route `response_model` from `list[str]` to `list[SelfHostedModelEntry]`. In the route body, map each string from `probe_ollama_tags` to `SelfHostedModelEntry(model_name=name, display_name=name)` (display_name equals model_name for now — Ollama returns raw names like "llama3.1:8b").

**S3 — Fix probe_ollama_tags generic Exception branch**: In `services/llm.py`, the `except Exception as exc:` branch currently returns `f"Unexpected error probing {base_url}: {exc}"`. Change it to: log the exception server-side (use `structlog.get_logger(__name__).error(...)` or the module-level logger if one exists), then return a hardcoded generic message like `"An unexpected error occurred while probing the self-hosted server"` — no raw exception text in the HTTP response.

**S4 — Fix set_self_hosted_config enabled logic**: In `routes/provider.py`, the PUT /self-hosted handler currently always passes `enabled=True` in `ProviderUpdate`. Fix it to only pass `enabled=True` when `data.base_url` is non-empty. When `data.base_url` is empty string, do NOT set enabled=True (either pass enabled=False or omit the enabled field to leave it unchanged — choose False to be explicit).

**L1 — Remove # type: ignore[arg-type] from provider.py**: Currently `derive_mode()` returns `str` and `ModeResponse(mode=mode, ...)` requires `Literal["anthropic","ollama","mix","self_hosted"]`. Fix `derive_mode` return type in `services/llm.py` to `Literal["anthropic", "ollama", "mix", "self_hosted"]` (import `Literal` from `typing`). Then remove the `# type: ignore[arg-type]` comments from both `get_current_mode` and `apply_mode` route handlers.

**L2 — Fix migration number references**: In `routes/provider.py` docstrings and error strings, change all occurrences of `migration 027` or `(migration 027)` to `028`. Also check `services/llm.py` module docstring and any other inline comments — change all `004 and 027` references to `004 and 028`.

**L3 — Fix migration 028 downgrade()**: In `alembic/versions/028_seed_self_hosted_provider.py`, the `downgrade()` function must delete `model_assignments` rows that reference the LOCAL provider BEFORE deleting the `provider_configs` row. Use a subquery: `DELETE FROM model_assignments WHERE provider_config_id IN (SELECT id FROM provider_configs WHERE name = 'Self-Hosted (Ollama)')` then `DELETE FROM provider_configs WHERE name = 'Self-Hosted (Ollama)'`.

**L4 — upsert_assignment enables LOCAL provider on assignment**: In `services/llm.py`, in `upsert_assignment()`, after the provider is resolved to LOCAL (either via `provider_type_override=ModelProvider.LOCAL` or via the `_find_local_provider()` fallback for unknown model names), call `ProviderService(self.session).update_provider(require_uuid(provider.id), ProviderUpdate(enabled=True))` to ensure the LOCAL provider is enabled. This makes mix-mode self-hosted assignments automatically enable the LOCAL provider.

**L5 — Fix ModelProvider.LOCAL docstring**: In `roboco/models/base.py`, the `ModelProvider` class docstring says "OPENAI / LOCAL are historical placeholders (unused today)". Update it to reflect that LOCAL is now the self-hosted Ollama provider, actively used via migration 028 and the /self-hosted API surface. Example: "LOCAL routes to a self-hosted Ollama server; configured via PUT /api/providers/self-hosted."

**Tests to add/fix**:
- `test_probe_ollama_tags_*`: Add a new test file (e.g., `tests/unit/services/test_probe_ollama_tags.py`) with `@pytest.mark.asyncio` tests covering: (a) successful JSON parse returns (list_of_names, None), (b) `httpx.TimeoutException` returns ([], timeout_msg), (c) `httpx.ConnectError` returns ([], connect_msg), (d) `httpx.HTTPStatusError` returns ([], http_status_msg), (e) generic `Exception` returns ([], generic_msg) — verify the generic message does NOT contain raw exception text.
- Contract tests: In `test_provider_routes.py`, add tests for all `/providers/self-hosted*` endpoints asserting exact field names and types: GET /self-hosted returns `{"base_url": ..., "has_token": bool, "enabled": bool}`; GET /self-hosted/models returns a list of objects each with `"model_name": str` and `"display_name": str`; POST /self-hosted/test returns `{"ok": bool, ...}`.
- Migration 028 test: Add `tests/integration/test_migration_028_seed_self_hosted.py` with upgrade and downgrade tests (follow the pattern in `test_migration_013_drop_role.py` etc.). Test that upgrade inserts the LOCAL provider row and downgrade removes it (and any model_assignments first).
- Fix disjunctive assertion: In `test_provider_routes.py`, `test_apply_mode_ollama_without_provider_returns_404` uses `assert response.status_code in (HTTPStatus.NOT_FOUND, HTTPStatus.OK)`. Remove the disjunction — inspect the actual behavior (it should be 404 when the Ollama provider is deleted) and assert exactly `HTTPStatus.NOT_FOUND`.

After all changes: run `uv run ruff format . && uv run ruff check . && uv run mypy roboco/ && uv run pytest` — all must pass.