### PR TITLE
[7cd6ae6e] Fix SelfHostedConfig.base_url type: string | null in providers.ts

### DIFF
--- a/panel/src/lib/api/providers.ts
+++ b/panel/src/lib/api/providers.ts
@@ -44,7 +44,7 @@ export interface ApplyModePayload {
 
 /** Configuration stored server-side for the self-hosted provider. */
 export interface SelfHostedConfig {
-  base_url: string;
+  base_url: string | null;
   has_token: boolean;
   enabled: boolean;
 }


### PR DESCRIPTION
The `SelfHostedConfig` interface in `panel/src/lib/api/providers.ts` declares `base_url: string`, but the backend API contract returns `base_url` as `string | null` (null when no URL has been configured yet). This type mismatch causes the Next.js TypeScript build to fail.

**What to do:**

1. Open `panel/src/lib/api/providers.ts` and change line 47 from:
   ```ts
   base_url: string;
   ```
   to:
   ```ts
   base_url: string | null;
   ```

2. Audit every file that reads `SelfHostedConfig.base_url` to ensure it compiles cleanly with the new `string | null` type. The known consumers are:
   - `panel/src/components/settings/self-hosted-section.tsx` — already uses `config?.base_url` (optional chaining) and `config.base_url ?? "http://localhost:11434"` (nullish coalescing), so these lines are already null-safe.
   - `panel/src/components/settings/ai-routing-card.tsx` — imports `SelfHostedConfig` type but does not read `base_url` directly; check that no TypeScript errors surface there.
   - `panel/src/hooks/use-providers.ts` — hooks only return the typed response; confirm no new errors.
   - Run `grep -r "base_url" panel/src/` to catch any additional usages.

3. Fix any consumer that TypeScript flags (add `?? ""` or a type guard if needed).

4. Run `npm run build` from the `panel/` directory to verify the full Next.js build completes with zero errors. Also run `npx tsc --noEmit` if `npm run build` doesn't surface type-only errors.

5. Do NOT touch any other interfaces, components, or files beyond what is strictly required to make this compile cleanly.