### PR TITLE
[cf808060] Fix self-contradictory migration 028 test (CEO RW2-1)

### DIFF
--- a/tests/integration/test_migration_028_seed_self_hosted.py
+++ b/tests/integration/test_migration_028_seed_self_hosted.py
@@ -23,14 +23,39 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.asyncio
-async def test_migration_028_upgrade_local_row_inserted(
+async def test_migration_028_upgrade_insert_contract(
     db_session: AsyncSession,
 ) -> None:
-    """After upgrade to head, the LOCAL provider row is present in provider_configs.
+    """The upgrade INSERT SQL seeds the correct LOCAL provider row and is idempotent.
 
-    The upgrade() in migration 028 does an INSERT ... ON CONFLICT DO NOTHING,
-    so this row must exist after running `alembic upgrade head`.
+    Executes the INSERT ... ON CONFLICT DO NOTHING SQL from migration 028's
+    upgrade() directly in the test session, verifying:
+      - name='Self-Hosted (Ollama)', type='local', enabled=False on the row.
+      - Running the same INSERT a second time leaves exactly one row (idempotency).
     """
+    _insert_sql = text(
+        """
+        INSERT INTO provider_configs
+            (id, name, type, base_url, auth_token_encrypted, enabled, created_at)
+        VALUES
+            (
+                gen_random_uuid(),
+                'Self-Hosted (Ollama)',
+                'local',
+                NULL,
+                NULL,
+                false,
+                now()
+            )
+        ON CONFLICT (name) DO NOTHING
+        """
+    )
+
+    # --- First run: the row should be inserted.
+    await db_session.execute(_insert_sql)
+    await db_session.flush()
+
+    # Verify the field contract on the newly-inserted row.
     result = await db_session.execute(
         text(
             "SELECT name, type, enabled "
@@ -39,14 +64,23 @@ async def test_migration_028_upgrade_local_row_inserted(
         )
     )
     rows = list(result)
-    assert len(rows) == 1, (
-        "Expected exactly one 'Self-Hosted (Ollama)' row; "
-        f"found {len(rows)}. Run `alembic upgrade head` to seed it."
-    )
+    assert len(rows) == 1
     name, ptype, enabled = rows[0]
     assert name == "Self-Hosted (Ollama)"
     assert ptype == "local"
     assert enabled is False  # starts disabled; user configures via PUT /self-hosted
+
+    # --- Second run: ON CONFLICT DO NOTHING must not create a duplicate.
+    await db_session.execute(_insert_sql)
+    await db_session.flush()
+
+    result = await db_session.execute(
+        text("SELECT id FROM provider_configs WHERE name = 'Self-Hosted (Ollama)'")
+    )
+    assert len(list(result)) == 1, (
+        "Expected exactly one 'Self-Hosted (Ollama)' row after two INSERT "
+        "executions; ON CONFLICT DO NOTHING must prevent duplicates."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
CEO rejected PR #128 with a BLOCKER: test_migration_028_upgrade_local_row_inserted in tests/integration/test_migration_028_seed_self_hosted.py always fails because the integration test harness uses Base.metadata.create_all (not alembic migrations), so the seed INSERT from migration 028 never runs. The test asserts a 'Self-Hosted (Ollama)' row exists, but under this harness it never will. Full suite: 1 failed, 7956 passed — this is the only red test.

CEO's recommended fix (simplest, correct): remove test_migration_028_upgrade_local_row_inserted entirely. A real alembic upgrade-head round-trip is the only thing that would legitimately verify the seed, and conftest documents that a real upgrade is currently blocked by pre-existing 001 enum-casing / 008 column drift — so it's out of scope. Alternatively, replace it with a self-seeding contract test that inserts its own LOCAL ProviderConfigTable row and asserts the column contract (type == 'local', enabled is False, base_url is None), mirroring the route-test fixture pattern in tests/integration/test_provider_routes.py:43.

IMPORTANT: The second test in the same file — the downgrade FK-ordering test — is correct and self-contained. Leave it alone. Do NOT skip/xfail the failing test — fix or remove it. Acceptance: make quality (full test suite) exits 0 locally.