### PR TITLE
[1c7bb453] Fix SelfHostedConfig.base_url type to match backend contract (CEO RW2-2)

### DIFF
--- a/panel/src/lib/api/providers.ts
+++ b/panel/src/lib/api/providers.ts
@@ -44,7 +44,7 @@ export interface ApplyModePayload {
 
 /** Configuration stored server-side for the self-hosted provider. */
 export interface SelfHostedConfig {
-  base_url: string;
+  base_url: string | null;
   has_token: boolean;
   enabled: boolean;
 }


### PR DESCRIPTION
CEO flagged a MINOR contract inaccuracy: in panel/src/lib/api/providers.ts, the SelfHostedConfig interface types base_url as string, but the backend SelfHostedConfigResponse.base_url is str | None (null until the operator configures a URL). The FE type claims a value that can be null at runtime is always a string.

Fix: change base_url: string to base_url: string | null in the SelfHostedConfig interface. Then confirm all consumers still compile — they already use optional chaining (?.) and nullish coalescing (??), so no logic change is expected. The Next.js build must pass after the change.

No runtime break exists today, but the inaccurate type could mask a real null-handling bug later. This is a ~1-line type fix plus build verification.