### PR TITLE
[a88a2ab9] Implement all 6 frontend fixes: copy buttons, subtask query, 429 backoff, status dropdown, dialog reset, and wire merge hook

### DIFF
--- a/panel/src/app/(dashboard)/communications/[sessionId]/page.tsx
+++ b/panel/src/app/(dashboard)/communications/[sessionId]/page.tsx
@@ -21,6 +21,7 @@ import {
   Hash,
   RefreshCw,
 } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
 import { formatDistanceToNow, format } from "date-fns";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -238,7 +239,7 @@ function SessionDetailContent() {
                 {messages.map((message) => (
                   <div
                     key={message.id}
-                    className="flex gap-3 p-3 rounded-lg border bg-card hover:bg-muted/30 transition-colors"
+                    className="group relative flex gap-3 p-3 rounded-lg border bg-card hover:bg-muted/30 transition-colors"
                   >
                     <div className="h-9 w-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 border">
                       <span className="text-[10px] font-bold tracking-tight">
@@ -259,6 +260,11 @@ function SessionDetailContent() {
                         <Markdown>{message.content}</Markdown>
                       </div>
                     </div>
+                    {/* Copy button — visible on hover */}
+                    <CopyButton
+                      value={message.content}
+                      className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100"
+                    />
                   </div>
                 ))}
               </div>

--- a/panel/src/components/agents/resolve-wait-dialog.tsx
+++ b/panel/src/components/agents/resolve-wait-dialog.tsx
@@ -41,8 +41,13 @@ export function ResolveWaitDialog({ agentId }: ResolveWaitDialogProps) {
     }
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setResolution("");
+    setOpen(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button>
           <Send className="h-4 w-4 mr-2" />

--- a/panel/src/components/communications/message-item.tsx
+++ b/panel/src/components/communications/message-item.tsx
@@ -4,6 +4,7 @@ import { Message } from "@/types";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Markdown } from "@/components/ui/markdown";
+import { CopyButton } from "@/components/ui/copy-button";
 import { MessageTypeBadge } from "./message-type-badge";
 import { Clock, Link2 } from "lucide-react";
 import Link from "next/link";
@@ -23,7 +24,7 @@ function formatTime(timestamp: string): string {
 
 export function MessageItem({ message }: MessageItemProps) {
   return (
-    <div className="flex gap-3 py-3 hover:bg-muted/30 px-2 rounded-lg">
+    <div className="group relative flex gap-3 py-3 hover:bg-muted/30 px-2 rounded-lg">
       <Avatar className="h-8 w-8 shrink-0">
         <AvatarFallback className="bg-primary/10 text-primary text-xs">
           {getAgentInitials(message.agent_id)}
@@ -61,6 +62,11 @@ export function MessageItem({ message }: MessageItemProps) {
           </Link>
         )}
       </div>
+      {/* Copy button — visible on hover */}
+      <CopyButton
+        value={message.content}
+        className="absolute right-2 top-3 opacity-0 transition-opacity group-hover:opacity-100"
+      />
     </div>
   );
 }

--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -19,6 +19,7 @@ import {
   GitCommit,
   Upload,
   GitPullRequest,
+  GitMerge,
   RefreshCw,
   ArrowUp,
 } from "lucide-react";
@@ -31,9 +32,11 @@ interface GitActionsPanelProps {
   onCommit: (message: string) => void;
   onPush: (force?: boolean) => void;
   onCreatePR: (title: string, body: string) => void;
+  onMergePR: (prNumber: number) => void;
   isCommitting: boolean;
   isPushing: boolean;
   isCreatingPR: boolean;
+  isMerging: boolean;
 }
 
 export function GitActionsPanel({
@@ -44,21 +47,52 @@ export function GitActionsPanel({
   onCommit,
   onPush,
   onCreatePR,
+  onMergePR,
   isCommitting,
   isPushing,
   isCreatingPR,
+  isMerging,
 }: GitActionsPanelProps) {
   void _agentId; // Reserved for future use
   const [showCommitDialog, setShowCommitDialog] = useState(false);
   const [showPRDialog, setShowPRDialog] = useState(false);
+  const [showMergeDialog, setShowMergeDialog] = useState(false);
   const [commitMessage, setCommitMessage] = useState("");
   const [prTitle, setPrTitle] = useState("");
   const [prBody, setPrBody] = useState("");
+  const [mergePrNumber, setMergePrNumber] = useState("");
 
   const hasStagedChanges = (status?.staged_files.length ?? 0) > 0;
   const hasUnpushedCommits = (status?.ahead ?? 0) > 0;
   const canPush = hasUnpushedCommits;
   const canCreatePR = hasUnpushedCommits || status?.current_branch !== "main";
+
+  const handleCommitDialogOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setCommitMessage("");
+    setShowCommitDialog(newOpen);
+  };
+
+  const handlePRDialogOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setPrTitle("");
+      setPrBody("");
+    }
+    setShowPRDialog(newOpen);
+  };
+
+  const handleMergeDialogOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setMergePrNumber("");
+    setShowMergeDialog(newOpen);
+  };
+
+  const handleMergePR = () => {
+    const prNum = parseInt(mergePrNumber, 10);
+    if (!isNaN(prNum) && prNum > 0) {
+      onMergePR(prNum);
+      setShowMergeDialog(false);
+      setMergePrNumber("");
+    }
+  };
 
   const handleCommit = () => {
     if (commitMessage.trim()) {
@@ -84,7 +118,7 @@ export function GitActionsPanel({
       </CardHeader>
       <CardContent className="space-y-3">
         {/* Commit Action */}
-        <Dialog open={showCommitDialog} onOpenChange={setShowCommitDialog}>
+        <Dialog open={showCommitDialog} onOpenChange={handleCommitDialogOpenChange}>
           <DialogTrigger asChild>
             <Button
               className="w-full justify-start"
@@ -168,7 +202,7 @@ export function GitActionsPanel({
         </Button>
 
         {/* Create PR Action */}
-        <Dialog open={showPRDialog} onOpenChange={setShowPRDialog}>
+        <Dialog open={showPRDialog} onOpenChange={handlePRDialogOpenChange}>
           <DialogTrigger asChild>
             <Button
               className="w-full justify-start"
@@ -217,6 +251,52 @@ export function GitActionsPanel({
               >
                 {isCreatingPR && <RefreshCw className="h-4 w-4 mr-2 animate-spin" />}
                 Create PR
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Merge PR Action */}
+        <Dialog open={showMergeDialog} onOpenChange={handleMergeDialogOpenChange}>
+          <DialogTrigger asChild>
+            <Button
+              className="w-full justify-start"
+              variant="outline"
+            >
+              {isMerging ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <GitMerge className="h-4 w-4 mr-2" />
+              )}
+              Merge PR
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle>Merge Pull Request</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">PR Number</label>
+                <Input
+                  type="number"
+                  placeholder="e.g. 42"
+                  value={mergePrNumber}
+                  onChange={(e) => setMergePrNumber(e.target.value)}
+                  min={1}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setShowMergeDialog(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleMergePR}
+                disabled={!mergePrNumber.trim() || isNaN(parseInt(mergePrNumber, 10)) || isMerging}
+              >
+                {isMerging && <RefreshCw className="h-4 w-4 mr-2 animate-spin" />}
+                Merge
               </Button>
             </DialogFooter>
           </DialogContent>

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -49,7 +49,7 @@ function GitBrowserContent() {
   const { data: unstagedDiff, isLoading: loadingUnstagedDiff } = useGitDiff(projectSlug, false, undefined, !!projectSlug);
 
   // Git operations
-  const { commit, push, createBranch, checkout, createPR } = useGitOperations();
+  const { commit, push, createBranch, checkout, createPR, mergePR } = useGitOperations();
 
   // Update URL params
   const updateParams = useCallback(
@@ -160,6 +160,20 @@ function GitBrowserContent() {
     }
   };
 
+  const handleMergePR = async (prNumber: number) => {
+    try {
+      const result = await mergePR.mutateAsync({
+        project_slug: projectSlug,
+        pr_number: prNumber,
+        task_id: taskId || "manual",
+        agent_id: "ceo",
+      });
+      toast.success(`Merged PR #${result.pr_number} → ${result.target_branch}`);
+    } catch {
+      toast.error("Failed to merge PR");
+    }
+  };
+
   // Check offline
   const isOffline = projectsError && (
     projectsError.message?.includes("Network Error") ||
@@ -243,9 +257,11 @@ function GitBrowserContent() {
               onCommit={handleCommit}
               onPush={handlePush}
               onCreatePR={handleCreatePR}
+              onMergePR={handleMergePR}
               isCommitting={commit.isPending}
               isPushing={push.isPending}
               isCreatingPR={createPR.isPending}
+              isMerging={mergePR.isPending}
             />
           </div>
 

--- a/panel/src/components/prompter/chat-messages.tsx
+++ b/panel/src/components/prompter/chat-messages.tsx
@@ -91,8 +91,12 @@ export function ChatMessages({
         if (msg.role === "user") {
           return (
             <div key={msg.id} className="flex justify-end">
-              <div className="max-w-[70%] rounded-2xl rounded-tr-sm bg-primary px-4 py-3 text-sm text-primary-foreground">
+              <div className="group relative max-w-[70%] rounded-2xl rounded-tr-sm bg-primary px-4 py-3 text-sm text-primary-foreground">
                 <MarkdownBody content={msg.content} />
+                <CopyButton
+                  value={msg.content}
+                  className="absolute right-1.5 top-1.5 bg-primary-foreground/10 text-primary-foreground opacity-0 transition-opacity group-hover:opacity-100"
+                />
               </div>
             </div>
           );
@@ -101,9 +105,13 @@ export function ChatMessages({
         if (msg.role === "error") {
           return (
             <div key={msg.id} className="flex justify-start">
-              <div className="flex max-w-[70%] items-start gap-2 rounded-2xl rounded-tl-sm border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              <div className="group relative flex max-w-[70%] items-start gap-2 rounded-2xl rounded-tl-sm border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                 <span>{msg.content}</span>
+                <CopyButton
+                  value={msg.content}
+                  className="absolute right-1.5 top-1.5 bg-background/80 opacity-0 transition-opacity group-hover:opacity-100"
+                />
               </div>
             </div>
           );
@@ -115,11 +123,15 @@ export function ChatMessages({
             <div className="flex justify-start">
               <div
                 className={cn(
-                  "max-w-[70%] rounded-2xl rounded-tl-sm bg-muted px-4 py-3 text-sm text-foreground",
+                  "group relative max-w-[70%] rounded-2xl rounded-tl-sm bg-muted px-4 py-3 text-sm text-foreground",
                   msg.draft && "max-w-[85%]"
                 )}
               >
                 <MarkdownBody content={msg.content} />
+                <CopyButton
+                  value={msg.content}
+                  className="absolute right-1.5 top-1.5 bg-background/80 opacity-0 transition-opacity group-hover:opacity-100"
+                />
               </div>
             </div>
 

--- a/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
+++ b/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
@@ -44,8 +44,13 @@ export function EscalateToCeoDialog({
     }
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setReason("");
+    onOpenChange(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Escalate to CEO</DialogTitle>
@@ -101,8 +106,13 @@ export function CeoRejectDialog({
     }
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setNotes("");
+    onOpenChange(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Request Changes</DialogTitle>
@@ -167,8 +177,13 @@ export function CeoApproveDialog({
     }
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setNotes("");
+    onOpenChange(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Approve &amp; Merge</DialogTitle>
@@ -244,8 +259,13 @@ export function RequiredNotesDialog({
     }
   };
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setText("");
+    onOpenChange(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -50,6 +50,24 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { TaskTypeBadge } from "../task-type-badge";
 
+// Valid next statuses per current status (for the status dropdown)
+const validNextStatuses: Record<TaskStatus, TaskStatus[]> = {
+  [TaskStatus.BACKLOG]: [TaskStatus.PENDING],
+  [TaskStatus.PENDING]: [TaskStatus.CLAIMED, TaskStatus.CANCELLED],
+  [TaskStatus.CLAIMED]: [TaskStatus.IN_PROGRESS, TaskStatus.PENDING, TaskStatus.CANCELLED],
+  [TaskStatus.IN_PROGRESS]: [TaskStatus.BLOCKED, TaskStatus.PAUSED, TaskStatus.VERIFYING, TaskStatus.CANCELLED],
+  [TaskStatus.BLOCKED]: [TaskStatus.IN_PROGRESS],
+  [TaskStatus.PAUSED]: [TaskStatus.IN_PROGRESS],
+  [TaskStatus.VERIFYING]: [TaskStatus.AWAITING_QA, TaskStatus.CANCELLED],
+  [TaskStatus.NEEDS_REVISION]: [TaskStatus.CLAIMED],
+  [TaskStatus.AWAITING_QA]: [TaskStatus.AWAITING_DOCUMENTATION, TaskStatus.NEEDS_REVISION],
+  [TaskStatus.AWAITING_DOCUMENTATION]: [TaskStatus.AWAITING_PM_REVIEW],
+  [TaskStatus.AWAITING_PM_REVIEW]: [TaskStatus.COMPLETED, TaskStatus.AWAITING_CEO_APPROVAL, TaskStatus.NEEDS_REVISION],
+  [TaskStatus.AWAITING_CEO_APPROVAL]: [TaskStatus.COMPLETED, TaskStatus.NEEDS_REVISION, TaskStatus.CANCELLED],
+  [TaskStatus.COMPLETED]: [],
+  [TaskStatus.CANCELLED]: [TaskStatus.PENDING],
+};
+
 // Status badge colors
 const statusColors: Record<TaskStatus, string> = {
   [TaskStatus.BACKLOG]: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
@@ -307,13 +325,19 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
               </h1>
             )}
 
-            {/* Status Dropdown */}
+            {/* Status Dropdown — only current status + valid next statuses */}
             <Select value={task.status} onValueChange={(v) => handleStatusChange(v as TaskStatus)}>
               <SelectTrigger className={`w-auto h-7 text-xs font-medium border-0 ${statusColors[task.status]}`}>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {Object.values(TaskStatus).map((status) => (
+                {/* Always render the current status first so the trigger value is always present */}
+                <SelectItem key={task.status} value={task.status}>
+                  <span className={`px-2 py-0.5 rounded ${statusColors[task.status]}`}>
+                    {statusLabels[task.status]}
+                  </span>
+                </SelectItem>
+                {validNextStatuses[task.status].map((status) => (
                   <SelectItem key={status} value={status}>
                     <span className={`px-2 py-0.5 rounded ${statusColors[status]}`}>
                       {statusLabels[status]}

--- a/panel/src/hooks/use-tasks.ts
+++ b/panel/src/hooks/use-tasks.ts
@@ -43,15 +43,10 @@ export function useTask(taskId: string) {
 }
 
 export function useSubtasks(parentTaskId: string) {
-  const { data: allTasks = [] } = useTasks();
-
   return useQuery({
     queryKey: taskKeys.subtasks(parentTaskId),
-    queryFn: async (): Promise<Task[]> => {
-      // Filter tasks where parent_task_id matches
-      return allTasks.filter((task) => task.parent_task_id === parentTaskId);
-    },
-    enabled: !!parentTaskId && allTasks.length > 0,
+    queryFn: () => tasksApi.getSubtasks(parentTaskId),
+    enabled: !!parentTaskId,
   });
 }
 

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -84,13 +84,16 @@ api.interceptors.response.use(
       };
       useRateLimitStore.getState().hitRateLimit(hitEvent);
 
-      // Track retry count; retry the request until exhausted, then toast
+      // Track retry count; retry the request (after backoff delay) until exhausted, then toast
       const retryCount = (error.config?._retryCount ?? 0) + 1;
       if (error.config) {
         error.config._retryCount = retryCount;
         if (retryCount < RATE_LIMIT_MAX_RETRIES) {
-          // Retry the request — interceptor re-runs on each subsequent 429
-          return api(error.config);
+          // Wait retryAfterSeconds before retrying — interceptor re-runs on each subsequent 429
+          const delayMs = safeRetryAfter * 1000;
+          return new Promise<void>((resolve) => setTimeout(resolve, delayMs)).then(
+            () => api(error.config!)
+          );
         }
       }
       // Retries exhausted — notify the user via Sonner toast


### PR DESCRIPTION
Implement six interconnected bug fixes and one hook wire-up in the panel frontend (panel/src/). All changes are in TypeScript/React files; no backend changes needed.

## Fix 1 — Copy buttons on prompter chat messages (chat-messages.tsx)

Currently only fenced code blocks inside messages have a CopyButton. The acceptance criterion requires a copy button visible on hover for EACH message bubble (user, assistant, error roles). Wrap each message bubble `div` with `group` class and add a `<CopyButton value={msg.content} className="opacity-0 group-hover:opacity-100 ..." />` in the top-right corner of each bubble. Use the existing `CopyButton` component from `@/components/ui/copy-button`. The error message copies `msg.content` (the plain text, not the AlertTriangle icon).

## Fix 2 — Copy buttons on communications messages

Two locations:
a) `message-item.tsx`: Add `group` class to the outer `div` and a `<CopyButton value={message.content} />` that shows on hover beside the message content.
b) Session detail page (`/communications/[sessionId]/page.tsx`): The inline message rows (lines ~239-263) render messages without CopyButton. Add `group` to each row div and a `<CopyButton value={message.content} />` that shows on hover.

## Fix 3 — Fix useSubtasks to call dedicated endpoint (use-tasks.ts)

Current implementation (lines 45-56) calls `useTasks()` (which fetches ALL tasks) and filters client-side. Replace with a direct call to `tasksApi.getSubtasks(parentTaskId)` which hits `GET /tasks/{id}/subtasks`. The API function already exists in `lib/api/tasks.ts` line 378. Remove the dependency on `useTasks()` entirely:

```typescript
export function useSubtasks(parentTaskId: string) {
  return useQuery({
    queryKey: taskKeys.subtasks(parentTaskId),
    queryFn: () => tasksApi.getSubtasks(parentTaskId),
    enabled: !!parentTaskId,
  });
}
```

## Fix 4 — 429 retry with backoff delay (lib/api/client.ts)

Current code (lines 88-95) retries immediately with `return api(error.config)`. Add the calculated delay before retrying:

```typescript
if (retryCount < RATE_LIMIT_MAX_RETRIES) {
  return new Promise((resolve) =>
    setTimeout(() => resolve(api(error.config!)), safeRetryAfter * 1000)
  );
}
```

This makes the interceptor wait `retryAfterSeconds` seconds before firing the retry request, which is what the backend is asking for.

## Fix 5 — Status dropdown shows only valid transitions (task-header.tsx)

The `<Select>` on lines 311-325 renders every `TaskStatus` value. Replace the `Object.values(TaskStatus).map(...)` iteration with a filtered list. Build a `getValidStatusTargets(status: TaskStatus): TaskStatus[]` helper that returns the current status (always shown as selected) plus the statuses reachable from the current state, based on the existing `getAvailableActions()` logic and the known lifecycle graph:

```
pending     → claimed
claimed     → in_progress
in_progress → blocked, paused, verifying
blocked     → in_progress
paused      → in_progress
verifying   → awaiting_qa
awaiting_qa → awaiting_documentation (pass), needs_revision (fail)
needs_revision → claimed (reclaim)
awaiting_documentation → awaiting_pm_review
awaiting_pm_review → awaiting_ceo_approval, completed, needs_revision
awaiting_ceo_approval → completed, needs_revision
completed   → (terminal, show only completed)
cancelled   → pending (reopen)
backlog     → pending (activate), cancelled
```

Only the current status + its valid next statuses appear in the dropdown. Non-reachable statuses are omitted.

## Fix 6 — Dialog text state resets on dismiss without confirming

Multiple dialogs hold text state (reason, notes, text) that persists after the user clicks Cancel or the backdrop. Fix each one by resetting the state in the `onOpenChange` handler when `open` becomes `false` without a confirm action:

Files and dialogs to fix:
- `task-action-dialogs.tsx`:
  - `EscalateToCeoDialog`: reset `reason` when `onOpenChange(false)` is called via Cancel or backdrop
  - `CeoRejectDialog`: reset `notes`
  - `RequiredNotesDialog`: reset `text`
  - `CeoApproveDialog`: reset `notes`
- `components/agents/resolve-wait-dialog.tsx`: reset `resolution` on close without confirm
- `components/git/git-actions-panel.tsx`: reset `commitMessage` when commit dialog closes, reset `prTitle`/`prBody` when PR dialog closes

Pattern: intercept `onOpenChange` (or the dialog's own `open` setter) to reset state when `newOpen === false`:
```typescript
const handleOpenChange = (newOpen: boolean) => {
  if (!newOpen) setReason("");
  onOpenChange(newOpen);
};
```

## Fix 7 — Wire useMergePR to the Git browser (git-browser.tsx, git-actions-panel.tsx)

The `useMergePR` hook is implemented in `use-git.ts` but never destructured from `useGitOperations()` in `git-browser.tsx`. Add it:

In `git-browser.tsx`:
1. Destructure `mergePR` from `useGitOperations()`
2. Add `handleMergePR` async function that calls `mergePR.mutateAsync({ project_slug: projectSlug, task_id: taskId || 'manual', pr_number: <from status or user input>, merge_method: 'merge', agent_id: 'ceo' })`
3. Pass `onMergePR`, `isMergingPR` props to `GitActionsPanel`

In `git-actions-panel.tsx`:
1. Add `onMergePR?: (prNumber: number) => void` and `isMergingPR?: boolean` props
2. Add a "Merge PR" button (disabled when no PR exists in status or when isMergingPR)

Refer to `GitMergePRRequest` type in `types/git.ts` for the exact request shape.