### PR TITLE
[aca47ae8] Fix task update schema, slug resolution, null guard, and approve error handling

### DIFF
--- a/roboco/api/routes/tasks.py
+++ b/roboco/api/routes/tasks.py
@@ -41,7 +41,7 @@ from roboco.api.schemas.tasks import (
     task_to_response,
     transform_update_data,
 )
-from roboco.exceptions import TaskLifecycleError
+from roboco.exceptions import GitError, TaskLifecycleError
 from roboco.foundation.policy import task_completeness as tc
 from roboco.models.base import AgentRole, TaskStatus, Team
 from roboco.models.task import TaskCreate
@@ -522,6 +522,36 @@ async def update_task(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not authorized to update this task",
         )
+
+    # Resolve assigned_to slug → UUID before transforming. The schema accepts
+    # either a UUID string or an agent slug (e.g. "be-dev-1"). The transform
+    # helper parse_uuid_or_none returns None on non-UUID strings, so we must
+    # resolve slugs here before delegating to the transform step.
+    # Explicitly-sent null (unassign) is handled correctly by transform itself.
+    if "assigned_to" in data.model_fields_set and data.assigned_to is not None:
+        try:
+            UUID(data.assigned_to)  # already a valid UUID — no action needed
+        except ValueError:
+            # It's a slug — look up the agent
+            from roboco.services.repositories.query_helpers import get_agent_by_slug
+
+            agent_row = await get_agent_by_slug(db, data.assigned_to)
+            if agent_row is None:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail={
+                        "error": {
+                            "code": "ASSIGNEE_NOT_FOUND",
+                            "message": (
+                                f"No agent with slug or UUID '{data.assigned_to}'"
+                            ),
+                            "hint": "Use an agent slug (e.g. 'be-dev-1') or UUID",
+                        }
+                    },
+                ) from None
+            # Replace the slug with the resolved UUID string so transform
+            # can parse it as a proper UUID.
+            data = data.model_copy(update={"assigned_to": str(agent_row.id)})
 
     # Transform input data for database storage
     updates = transform_update_data(data)
@@ -1354,6 +1384,144 @@ async def ceo_approve_task(
 
     await db.commit()
     return task_to_response(task)
+
+
+@router.get("/{task_id}/ceo-approve", response_model=TaskResponse)
+async def ceo_approve_eligibility_check(
+    task_id: UUID,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> TaskResponse:
+    """Pre-flight check: can this task be CEO-approved?
+
+    Returns the task if it is eligible (has a PR attached).
+    Returns HTTP 400 with 'NO_PR' if the task has no pull request.
+    Useful for panel gates and automated pre-checks before POSTing to
+    ceo-approve or approve-and-merge.
+    """
+    if agent.role != AgentRole.CEO:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only CEO can check CEO-approval eligibility",
+        )
+
+    service = get_task_service(db)
+    task = await service.get(task_id)
+    if not task:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
+
+    if task.pr_number is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "NO_PR: Task has no pull request attached. A PR must be "
+                "opened and approved by QA before CEO approval. Use the "
+                "developer's open_pr flow to create the PR."
+            ),
+        )
+
+    return task_to_response(task)
+
+
+@router.post("/{task_id}/approve-and-merge", response_model=TaskResponse)
+async def approve_and_merge_task(
+    task_id: UUID,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> TaskResponse:
+    """CEO merge + complete in one step.
+
+    Merges the task's PR, updates the work session, and marks the task
+    completed. Only CEO can perform this action. The PR must already exist
+    on the task (pr_number set). Merge failures are returned as structured
+    HTTP errors rather than unhandled exceptions.
+    """
+    if agent.role != AgentRole.CEO:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only CEO can approve-and-merge tasks",
+        )
+
+    service = get_task_service(db)
+    task = await service.get(task_id)
+    if not task:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
+
+    if task.pr_number is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "NO_PR: Cannot approve-and-merge — task has no PR. "
+                "The developer must open a PR (open_pr gateway verb or "
+                "POST /api/git/create-pr) before CEO can merge."
+            ),
+        )
+
+    # Resolve the project slug from the task's project_id so the git
+    # service can locate the workspace and call the GitHub API.
+    if task.project_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "NO_PROJECT: Task has no project_id; cannot resolve "
+                "workspace for merge. Set project_id on the task first."
+            ),
+        )
+
+    from roboco.api.schemas.git import GitMergePRRequest
+    from roboco.services.git import get_git_service
+    from roboco.services.project import get_project_service
+
+    project_service = get_project_service(db)
+    project = await project_service.get(UUID(str(task.project_id)))
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"NO_PROJECT: Project {task.project_id} not found; "
+                "cannot resolve workspace for merge."
+            ),
+        )
+
+    git_service = get_git_service(db)
+    try:
+        await git_service.merge_pr_for_task(
+            agent.agent_id,
+            agent.role,
+            GitMergePRRequest(
+                project_slug=project.slug,
+                pr_number=task.pr_number,
+                task_id=task_id,
+                merge_method="squash",
+                agent_id=str(agent.agent_id),
+            ),
+        )
+    except (ServiceError, GitError) as e:
+        msg = getattr(e, "message", str(e))
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Merge failed: {msg}",
+        ) from e
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Merge failed (unexpected error): {e}",
+        ) from e
+
+    # merge_pr_for_task commits the session internally; re-fetch the
+    # updated task to return the merged state.
+    updated_task = await service.get(task_id)
+    if not updated_task:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Task disappeared after merge",
+        )
+
+    return task_to_response(updated_task)
 
 
 @router.post("/{task_id}/approve-and-start", response_model=TaskResponse)

--- a/roboco/api/schemas/tasks.py
+++ b/roboco/api/schemas/tasks.py
@@ -193,6 +193,11 @@ class TaskUpdate(BaseModel):
     target_date: datetime | None = None
     estimated_complexity: Complexity | None = None
 
+    # Classification
+    nature: TaskNature | None = None
+    task_type: TaskType | None = None
+    project_id: str | None = None  # UUID string
+
     # Ownership & assignment
     team: Team | None = None
     assigned_to: str | None = None  # UUID string or null to unassign
@@ -761,7 +766,7 @@ def _parse_uuid_list(id_strings: list[str] | None) -> list[UUID]:
     return [UUID(id_str) for id_str in id_strings if id_str]
 
 
-_SINGLE_UUID_FIELDS = ("assigned_to", "parent_task_id")
+_SINGLE_UUID_FIELDS = ("assigned_to", "parent_task_id", "project_id")
 _UUID_LIST_FIELDS = ("dependency_ids", "blocker_ids")
 
 

--- a/tests/integration/test_tasks_routes.py
+++ b/tests/integration/test_tasks_routes.py
@@ -22,7 +22,7 @@ from roboco.api.routes.tasks import (
     router as tasks_router,
 )
 from roboco.db.tables import AgentTable, ProjectTable, TaskTable
-from roboco.exceptions import TaskLifecycleError
+from roboco.exceptions import GitError, TaskLifecycleError
 from roboco.models import AgentRole, AgentStatus, Team
 from roboco.models.base import (
     TaskNature,
@@ -36,6 +36,7 @@ from roboco.services.base import (
     UnauthorizedError,
     ValidationError,
 )
+from roboco.services.base import ServiceError as SvcError
 from roboco.services.notification_delivery import EscalationError
 from roboco.services.permissions import PermissionService
 
@@ -2925,3 +2926,366 @@ async def test_get_sessions_for_task_not_found(task_client: dict) -> None:
         f"/api/tasks/{uuid4()}/sessions", headers=_HDR
     )
     assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# TaskUpdate schema: nature / task_type / project_id (AC: schema fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_nature_persists(task_client: dict) -> None:
+    """PATCH with nature=non_technical persists; GET returns updated value."""
+    task = _seed_task(task_client, nature=TaskNature.TECHNICAL)
+    await task_client["db"].flush()
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"nature": "non_technical"},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["nature"] == "non_technical"
+
+
+@pytest.mark.asyncio
+async def test_patch_task_type_persists(task_client: dict) -> None:
+    """PATCH with task_type=research persists; GET returns updated value."""
+    task = _seed_task(task_client, task_type=TaskType.CODE)
+    await task_client["db"].flush()
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"task_type": "research"},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["task_type"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_patch_project_id_persists(task_client: dict) -> None:
+    """PATCH with project_id=<valid-uuid> persists; GET returns updated value."""
+    task = _seed_task(task_client)
+    # Create a second project to switch to
+    second_project = ProjectTable(
+        id=uuid4(),
+        name="Proj2",
+        slug=f"proj2-{uuid4().hex[:6]}",
+        git_url="https://example.com/proj2.git",
+        assigned_cell=Team.BACKEND,
+        created_by=task_client["agent"].id,
+    )
+    task_client["db"].add(second_project)
+    await task_client["db"].flush()
+
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"project_id": str(second_project.id)},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["project_id"] == str(second_project.id)
+
+
+@pytest.mark.asyncio
+async def test_patch_title_only_changes_title(task_client: dict) -> None:
+    """PATCH with only title does not mutate nature/task_type/status/team."""
+    task = _seed_task(
+        task_client,
+        title="original title",
+        nature=TaskNature.TECHNICAL,
+        task_type=TaskType.CODE,
+        team=Team.BACKEND,
+    )
+    await task_client["db"].flush()
+
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"title": "updated title"},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["title"] == "updated title"
+    # Other fields unchanged
+    assert body["nature"] == "technical"
+    assert body["task_type"] == "code"
+    assert body["team"] == "backend"
+
+
+# ---------------------------------------------------------------------------
+# assigned_to: slug resolution and null guard (AC: slug-resolution fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_assigned_to_slug_resolves_to_uuid(task_client: dict) -> None:
+    """PATCH assigned_to with agent slug resolves to agent UUID."""
+    dev = await _seed_agent(task_client)
+    task = _seed_task(task_client)
+    await task_client["db"].flush()
+
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"assigned_to": dev.slug},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["assigned_to"] == str(dev.id)
+
+
+@pytest.mark.asyncio
+async def test_patch_assigned_to_null_unassigns(task_client: dict) -> None:
+    """PATCH assigned_to: null sets assigned_to to null (unassign)."""
+    dev = await _seed_agent(task_client)
+    task = _seed_task(task_client, assigned_to=dev.id)
+    await task_client["db"].flush()
+
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"assigned_to": None},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["assigned_to"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_assigned_to_unknown_slug_returns_422(task_client: dict) -> None:
+    """PATCH assigned_to with unknown slug returns 422 ASSIGNEE_NOT_FOUND."""
+    task = _seed_task(task_client)
+    await task_client["db"].flush()
+
+    response = await task_client["client"].patch(
+        f"/api/tasks/{task.id}",
+        json={"assigned_to": "totally-nonexistent-slug"},
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict)
+    assert detail["error"]["code"] == "ASSIGNEE_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# GET /tasks/{id}/ceo-approve — eligibility check (AC: ceo-approve fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ceo_approve_get_no_pr_returns_400(ceo_client: dict) -> None:
+    """GET /ceo-approve with no pr_number on the task → 400 NO_PR."""
+    task = _seed_task_ceo(ceo_client, pr_number=None)
+    await ceo_client["db"].flush()
+    response = await ceo_client["client"].get(
+        f"/api/tasks/{task.id}/ceo-approve",
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "NO_PR" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_ceo_approve_get_with_pr_returns_200(ceo_client: dict) -> None:
+    """GET /ceo-approve with pr_number set → 200 with task."""
+    task = _seed_task_ceo(ceo_client, pr_number=42)
+    await ceo_client["db"].flush()
+    response = await ceo_client["client"].get(
+        f"/api/tasks/{task.id}/ceo-approve",
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    _expected_pr = 42
+    assert body["pr_number"] == _expected_pr
+
+
+@pytest.mark.asyncio
+async def test_ceo_approve_get_not_ceo_returns_403(task_client: dict) -> None:
+    """GET /ceo-approve by non-CEO → 403 Forbidden."""
+    response = await task_client["client"].get(
+        f"/api/tasks/{uuid4()}/ceo-approve",
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_ceo_approve_get_task_not_found(ceo_client: dict) -> None:
+    """GET /ceo-approve for unknown task → 404."""
+    response = await ceo_client["client"].get(
+        f"/api/tasks/{uuid4()}/ceo-approve",
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# POST /tasks/{id}/approve-and-merge (AC: approve-and-merge fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approve_and_merge_no_pr_returns_400(ceo_client: dict) -> None:
+    """POST /approve-and-merge with no pr_number → 400 NO_PR."""
+    task = _seed_task_ceo(ceo_client, pr_number=None)
+    await ceo_client["db"].flush()
+    response = await ceo_client["client"].post(
+        f"/api/tasks/{task.id}/approve-and-merge",
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "NO_PR" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_approve_and_merge_not_ceo_returns_403(task_client: dict) -> None:
+    """POST /approve-and-merge by non-CEO → 403 Forbidden."""
+    response = await task_client["client"].post(
+        f"/api/tasks/{uuid4()}/approve-and-merge",
+        headers=_HDR,
+    )
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_approve_and_merge_task_not_found(ceo_client: dict) -> None:
+    """POST /approve-and-merge for unknown task → 404."""
+    with patch("roboco.api.routes.tasks.get_task_service") as mock_factory:
+        instance = AsyncMock()
+        instance.get = AsyncMock(return_value=None)
+        mock_factory.return_value = instance
+        response = await ceo_client["client"].post(
+            f"/api/tasks/{uuid4()}/approve-and-merge",
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_approve_and_merge_success(ceo_client: dict) -> None:
+    """POST /approve-and-merge with PR + fully mocked services → 200 task."""
+    task = _seed_task_ceo(ceo_client, pr_number=99)
+    await ceo_client["db"].flush()
+
+    # The handler does lazy imports of get_project_service and get_git_service.
+    # Patch them at their source modules so the lazy import picks up the mock.
+    with (
+        patch("roboco.api.routes.tasks.get_task_service") as mock_task_factory,
+        patch("roboco.services.project.get_project_service") as mock_proj_factory,
+        patch("roboco.services.git.get_git_service") as mock_git_factory,
+    ):
+        task_instance = AsyncMock()
+        # service.get is called twice: once for the initial check, once to re-fetch.
+        task_instance.get = AsyncMock(side_effect=[task, task])
+        mock_task_factory.return_value = task_instance
+
+        proj_instance = AsyncMock()
+        proj_instance.get = AsyncMock(return_value=ceo_client["project"])
+        mock_proj_factory.return_value = proj_instance
+
+        git_instance = AsyncMock()
+        git_instance.merge_pr_for_task = AsyncMock(return_value=("main", "abc1234"))
+        mock_git_factory.return_value = git_instance
+
+        response = await ceo_client["client"].post(
+            f"/api/tasks/{task.id}/approve-and-merge",
+            headers=_HDR,
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    _expected_pr = 99
+    assert body["pr_number"] == _expected_pr
+
+
+@pytest.mark.asyncio
+async def test_approve_and_merge_merge_failure_returns_structured_error(
+    ceo_client: dict,
+) -> None:
+    """POST /approve-and-merge where git merge fails → 400 with descriptive message.
+
+    The error must NOT be an unhandled exception (500 with traceback); it must
+    be a structured HTTP error (400 or 500) with a human-readable message.
+    """
+    task = _seed_task_ceo(ceo_client, pr_number=55)
+    await ceo_client["db"].flush()
+
+    with (
+        patch("roboco.api.routes.tasks.get_task_service") as mock_task_factory,
+        patch("roboco.services.project.get_project_service") as mock_proj_factory,
+        patch("roboco.services.git.get_git_service") as mock_git_factory,
+    ):
+        task_instance = AsyncMock()
+        task_instance.get = AsyncMock(return_value=task)
+        mock_task_factory.return_value = task_instance
+
+        proj_instance = AsyncMock()
+        proj_instance.get = AsyncMock(return_value=ceo_client["project"])
+        mock_proj_factory.return_value = proj_instance
+
+        git_instance = AsyncMock()
+        git_instance.merge_pr_for_task = AsyncMock(
+            side_effect=SvcError("GitHub refused the merge: 409 Conflict")
+        )
+        mock_git_factory.return_value = git_instance
+
+        response = await ceo_client["client"].post(
+            f"/api/tasks/{task.id}/approve-and-merge",
+            headers=_HDR,
+        )
+
+    # Must be a structured error, not an unhandled 500
+    _ok_statuses = (HTTPStatus.BAD_REQUEST, HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert response.status_code in _ok_statuses
+    body = response.json()
+    # The detail must be a string (not a raw traceback or empty)
+    assert isinstance(body.get("detail"), str)
+    assert len(body["detail"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_approve_and_merge_git_error_returns_structured_error(
+    ceo_client: dict,
+) -> None:
+    """POST /approve-and-merge: GitError → 400 with descriptive message."""
+    task = _seed_task_ceo(ceo_client, pr_number=66)
+    await ceo_client["db"].flush()
+
+    with (
+        patch("roboco.api.routes.tasks.get_task_service") as mock_task_factory,
+        patch("roboco.services.project.get_project_service") as mock_proj_factory,
+        patch("roboco.services.git.get_git_service") as mock_git_factory,
+    ):
+        task_instance = AsyncMock()
+        task_instance.get = AsyncMock(return_value=task)
+        mock_task_factory.return_value = task_instance
+
+        proj_instance = AsyncMock()
+        proj_instance.get = AsyncMock(return_value=ceo_client["project"])
+        mock_proj_factory.return_value = proj_instance
+
+        git_instance = AsyncMock()
+        git_instance.merge_pr_for_task = AsyncMock(
+            side_effect=GitError(
+                "GitHub API refused PR merge (422): branch protected",
+                {"pr": 66},
+            )
+        )
+        mock_git_factory.return_value = git_instance
+
+        response = await ceo_client["client"].post(
+            f"/api/tasks/{task.id}/approve-and-merge",
+            headers=_HDR,
+        )
+
+    # Must be a structured error — NOT an unhandled traceback
+    _ok_statuses = (HTTPStatus.BAD_REQUEST, HTTPStatus.INTERNAL_SERVER_ERROR)
+    assert response.status_code in _ok_statuses
+    body = response.json()
+    assert isinstance(body.get("detail"), str)
+    assert len(body["detail"]) > 0


### PR DESCRIPTION
Fix four backend bug clusters in the task update and approve workflows. All changes are in roboco/api/schemas/tasks.py, roboco/api/routes/tasks.py, and roboco/services/task.py.

**Bug 1 — Missing fields in TaskUpdate schema (AC #1, #4):**
Add `nature: TaskNature | None = None`, `task_type: TaskType | None = None`, and `project_id: str | None = None` to the `TaskUpdate` Pydantic model. Also add `project_id` to `_SINGLE_UUID_FIELDS` in `transform_update_data` so it is parsed as UUID|None like `assigned_to` and `parent_task_id` already are.

**Bug 2 — No slug resolution for `assigned_to` in PATCH route (AC #2):**
In the `update_task` route handler, after calling `transform_update_data(data)`, check whether `updates.get('assigned_to')` is a string that looks like a slug (UUID parse raises ValueError). If so, call `get_agent_by_slug(db, slug)` exactly as the `create_task` route does, returning 422 with ASSIGNEE_NOT_FOUND if the slug doesn't exist.

**Bug 3 — `value is not None` null guard blocks explicit null on nullable fields (AC #3, #4):**
In `TaskService.update()` (roboco/services/task.py), replace:
```python
if hasattr(task, key) and value is not None:
    setattr(task, key, value)
```
with logic that also allows setting nullable fields to None:
```python
NULLABLE_TASK_FIELDS = {'assigned_to', 'parent_task_id', 'project_id', 'target_date', 'plan', 'dev_notes', 'qa_notes', 'auditor_notes', 'quick_context'}
if hasattr(task, key) and (value is not None or key in NULLABLE_TASK_FIELDS):
    setattr(task, key, value)
```

**Bug 4 — Approve & Merge and Approve & Complete error handling (AC #5, #6, #7):**
(a) In the `ceo_approve_task` route, add a guard before calling `service.ceo_approve`: if `task.pr_number is None`, raise HTTP 400 with message `"NO_PR: This task has no open PR. Use Approve & Merge to merge the PR and complete the task in one step."`.
(b) Add a new route `POST /tasks/{task_id}/approve-and-merge` that: (1) verifies caller has CEO or PM role, (2) returns 404 if task not found, (3) returns 400 with `NO_PR` message if `task.pr_number is None`, (4) calls `git_service.merge_pr_for_task(agent_id, agent_role, GitMergePRRequest(task_id=task_id, pr_number=task.pr_number, project_slug=..., merge_method='merge'))` which already calls `_auto_complete_on_merge`, (5) returns the updated task. Wrap in try/except to surface merge failures as 400 with the underlying error message.

Write or update tests for each fix. All tests must pass under `uv run pytest`.