### PR TITLE
[aca7dfb9] Wire merge hook, fix status dropdown, fix dialog reset, verify remaining frontend fixes

### DIFF
--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState } from "react";
 import { useTask, useTaskLifecycle } from "@/hooks/use-tasks";
 import { useProject } from "@/hooks/use-projects";
-import { useCreateBranch, useCreatePR } from "@/hooks/use-git";
+import { useCreateBranch, useCreatePR, useMergePR } from "@/hooks/use-git";
 import { Team, TaskStatus } from "@/types";
 import { TaskHeader, TaskMetadata, TaskTabs } from "@/components/tasks/task-detail";
 import { ApproveAndStartButton } from "@/components/tasks/approve-and-start-button";
@@ -35,6 +35,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   const lifecycle = useTaskLifecycle();
   const createBranch = useCreateBranch();
   const createPR = useCreatePR();
+  const mergePR = useMergePR();
 
   // Dialog states
   const [escalateDialogOpen, setEscalateDialogOpen] = useState(false);
@@ -136,6 +137,23 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
           }
           setPrDialogOpen(true);
           return; // Don't refetch yet, dialog will handle it
+        case "merge-pr":
+          if (!project) {
+            toast.error("Project not found - cannot merge PR");
+            return;
+          }
+          if (!task.pr_number) {
+            toast.error("No PR number found on this task");
+            return;
+          }
+          await mergePR.mutateAsync({
+            project_slug: project.slug,
+            pr_number: task.pr_number,
+            task_id: task.id,
+            agent_id: "ceo", // CEO is merging the PR from the panel
+          });
+          toast.success(`PR #${task.pr_number} merged successfully`);
+          break;
         default:
           console.warn("Unknown action:", action);
       }

--- a/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
+++ b/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
@@ -324,8 +324,14 @@ export function CreateBranchDialog({
     onConfirm(branchType);
   };
 
+  // Reset branchType to 'feature' when dialog is dismissed without confirming
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setBranchType("feature");
+    onOpenChange(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create Branch</DialogTitle>
@@ -393,10 +399,14 @@ export function CreatePRDialog({
     }
   };
 
-  // Reset title when dialog opens with new default
+  // On open: seed title from defaultTitle. On close without confirming: reset both fields to empty.
   const handleOpenChange = (newOpen: boolean) => {
-    if (newOpen && defaultTitle) {
-      setTitle(defaultTitle);
+    if (newOpen) {
+      if (defaultTitle) setTitle(defaultTitle);
+    } else {
+      // Reset both fields when dismissed without confirming
+      setTitle("");
+      setBody("");
     }
     onOpenChange(newOpen);
   };

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Task, TaskStatus, Team } from "@/types";
-import { useDeleteTask, useUpdateTask } from "@/hooks/use-tasks";
+import { useDeleteTask, useUpdateTask, useTaskValidTransitions } from "@/hooks/use-tasks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -40,6 +40,7 @@ import {
   AlertTriangle,
   Trash2,
   GitBranch,
+  GitMerge,
   GitPullRequest,
   FileCheck,
   Send,
@@ -112,6 +113,10 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
   const router = useRouter();
   const deleteTask = useDeleteTask();
   const updateTask = useUpdateTask();
+  // Fetch valid next statuses from GET /tasks/{id}/valid-transitions; falls back
+  // to the hardcoded validNextStatuses map if the endpoint errors or returns 404.
+  const { data: validTransitionsData } = useTaskValidTransitions(task.id);
+  const nextStatuses: TaskStatus[] = validTransitionsData ?? validNextStatuses[task.status];
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   // Inline editing states
@@ -287,6 +292,11 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
       actions.push({ label: "Cancel Task", action: "cancel", icon: <XCircle className="h-4 w-4 mr-2" /> });
     }
 
+    // Merge PR is available whenever task.pr_number is set and the task is not in a terminal state
+    if (task.pr_number && task.status !== TaskStatus.COMPLETED && task.status !== TaskStatus.CANCELLED) {
+      actions.push({ label: "Merge PR", action: "merge-pr", icon: <GitMerge className="h-4 w-4 mr-2" /> });
+    }
+
     return actions;
   };
 
@@ -337,7 +347,9 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
                     {statusLabels[task.status]}
                   </span>
                 </SelectItem>
-                {validNextStatuses[task.status].map((status) => (
+                {/* nextStatuses sourced from useTaskValidTransitions (GET /tasks/{id}/valid-transitions)
+                    with graceful fallback to the hardcoded validNextStatuses map */}
+                {nextStatuses.map((status) => (
                   <SelectItem key={status} value={status}>
                     <span className={`px-2 py-0.5 rounded ${statusColors[status]}`}>
                       {statusLabels[status]}

--- a/panel/src/hooks/use-tasks.ts
+++ b/panel/src/hooks/use-tasks.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { tasksApi, type TaskFilters } from "@/lib/api/tasks";
 import {
   Team,
+  TaskStatus,
   type Task,
   type TaskCreate,
   type ProgressRequest,
@@ -66,8 +67,24 @@ export function useBoardReview(taskId: string, enabled = true) {
 export function useSubtasks(parentTaskId: string) {
   return useQuery({
     queryKey: taskKeys.subtasks(parentTaskId),
+    // Calls tasksApi.getSubtasks which hits GET /tasks/{id}/subtasks
     queryFn: () => tasksApi.getSubtasks(parentTaskId),
     enabled: !!parentTaskId,
+  });
+}
+
+/**
+ * Fetches valid next statuses for a task from GET /tasks/{id}/valid-transitions.
+ * Returns undefined while loading; on error (including 404) gracefully returns
+ * undefined so callers can fall back to a hardcoded map.
+ */
+export function useTaskValidTransitions(taskId: string) {
+  return useQuery<TaskStatus[]>({
+    queryKey: ["tasks", "valid-transitions", taskId] as const,
+    queryFn: () => tasksApi.getValidTransitions(taskId),
+    enabled: !!taskId,
+    staleTime: 30000, // 30 seconds
+    retry: false, // don't retry on 404 or other errors — caller falls back to hardcoded map
   });
 }
 

--- a/panel/src/lib/api/tasks.ts
+++ b/panel/src/lib/api/tasks.ts
@@ -399,7 +399,14 @@ export const tasksApi = {
     if (isMockMode()) {
       return mockTasks.filter((t) => t.parent_task_id === taskId);
     }
+    // Hits GET /tasks/{id}/subtasks
     const { data } = await api.get<Task[]>("/tasks/" + taskId + "/subtasks");
+    return data;
+  },
+
+  // Returns the valid next statuses for a task from GET /tasks/{id}/valid-transitions
+  getValidTransitions: async (taskId: string): Promise<TaskStatus[]> => {
+    const { data } = await api.get<TaskStatus[]>("/tasks/" + taskId + "/valid-transitions");
     return data;
   },
 


### PR DESCRIPTION
Implement and verify all 6 acceptance criteria for the parent task. After a full codebase audit, three fixes are already present (copy buttons, useSubtasks endpoint, 429 backoff) but need commit evidence; three require new code. Concretely:

(A) WIRE MERGE HOOK — src/app/(dashboard)/tasks/[taskId]/page.tsx currently imports useCreateBranch and useCreatePR from use-git but does NOT import useMergePR. Add: import useMergePR, instantiate it alongside createPR, add a 'merge-pr' case in handleAction that calls mergePR.mutateAsync({ project_slug: project.slug, pr_number: task.pr_number, task_id: task.id, agent_id: 'ceo' }), and surface a 'Merge PR' action in getAvailableActions in task-header.tsx (gated on task.pr_number != null). You may also need to add a merge-pr action in the dropdown actions map in task-header.tsx.

(B) STATUS DROPDOWN FROM BACKEND — src/components/tasks/task-detail/task-header.tsx uses a hardcoded validNextStatuses map. Add a function tasksApi.getValidTransitions(taskId: string): Promise<TaskStatus[]> in src/lib/api/tasks.ts calling GET /tasks/{taskId}/valid-transitions. Add a hook useTaskValidTransitions(taskId: string) in src/hooks/use-tasks.ts using React Query. Update task-header.tsx to call this hook and use the returned array instead of validNextStatuses[task.status]. Gracefully fall back to the hardcoded map if the endpoint returns 404 or errors (the hardcoded map is correct and serves as fallback).

(C) DIALOG RESET — In src/components/tasks/task-detail/task-action-dialogs.tsx: (i) CreatePRDialog.handleOpenChange currently only sets title on open but does NOT clear body or title on close — fix it to reset both title (to '') and body (to '') when !newOpen; (ii) CreateBranchDialog passes onOpenChange directly to Dialog without resetting state — wrap it in a handleOpenChange function that resets branchType to 'feature' when !newOpen.

(D) VERIFY COPY BUTTONS — Confirm src/components/prompter/chat-messages.tsx has CopyButton on all three message roles (user: already present at line ~98; assistant: at line ~132; error: at line ~110). Confirm src/components/communications/message-item.tsx has CopyButton (already present at line ~66). If any are missing, add them. Add a brief comment for audit trail.

(E) VERIFY SUBTASKS ENDPOINT — Confirm useSubtasks in src/hooks/use-tasks.ts calls tasksApi.getSubtasks(parentTaskId) which calls GET /tasks/{taskId}/subtasks. Add a code comment confirming this uses the dedicated endpoint, not the all-tasks list.

(F) VERIFY 429 BACKOFF — Confirm src/lib/api/client.ts 429 handler uses retryAfterSeconds (parsed from Retry-After header) in the setTimeout delay (delayMs = safeRetryAfter * 1000). Add a brief comment for clarity if not already clear.