### PR TITLE
[a87ca4e2] Frontend: Wire merge hook, add copy buttons, fix subtask query, backoff, status dropdown, dialog reset

### DIFF
--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState } from "react";
 import { useTask, useTaskLifecycle } from "@/hooks/use-tasks";
 import { useProject } from "@/hooks/use-projects";
-import { useCreateBranch, useCreatePR } from "@/hooks/use-git";
+import { useCreateBranch, useCreatePR, useMergePR } from "@/hooks/use-git";
 import { Team, TaskStatus } from "@/types";
 import { TaskHeader, TaskMetadata, TaskTabs } from "@/components/tasks/task-detail";
 import { ApproveAndStartButton } from "@/components/tasks/approve-and-start-button";
@@ -35,6 +35,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   const lifecycle = useTaskLifecycle();
   const createBranch = useCreateBranch();
   const createPR = useCreatePR();
+  const mergePR = useMergePR();
 
   // Dialog states
   const [escalateDialogOpen, setEscalateDialogOpen] = useState(false);
@@ -136,6 +137,23 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
           }
           setPrDialogOpen(true);
           return; // Don't refetch yet, dialog will handle it
+        case "merge-pr":
+          if (!project) {
+            toast.error("Project not found - cannot merge PR");
+            return;
+          }
+          if (!task.pr_number) {
+            toast.error("No PR number found on this task");
+            return;
+          }
+          await mergePR.mutateAsync({
+            project_slug: project.slug,
+            pr_number: task.pr_number,
+            task_id: task.id,
+            agent_id: "ceo", // CEO is merging the PR from the panel
+          });
+          toast.success(`PR #${task.pr_number} merged successfully`);
+          break;
         default:
           console.warn("Unknown action:", action);
       }

--- a/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
+++ b/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
@@ -324,8 +324,14 @@ export function CreateBranchDialog({
     onConfirm(branchType);
   };
 
+  // Reset branchType to 'feature' when dialog is dismissed without confirming
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) setBranchType("feature");
+    onOpenChange(newOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create Branch</DialogTitle>
@@ -393,10 +399,14 @@ export function CreatePRDialog({
     }
   };
 
-  // Reset title when dialog opens with new default
+  // On open: seed title from defaultTitle. On close without confirming: reset both fields to empty.
   const handleOpenChange = (newOpen: boolean) => {
-    if (newOpen && defaultTitle) {
-      setTitle(defaultTitle);
+    if (newOpen) {
+      if (defaultTitle) setTitle(defaultTitle);
+    } else {
+      // Reset both fields when dismissed without confirming
+      setTitle("");
+      setBody("");
     }
     onOpenChange(newOpen);
   };

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Task, TaskStatus, Team } from "@/types";
-import { useDeleteTask, useUpdateTask } from "@/hooks/use-tasks";
+import { useDeleteTask, useUpdateTask, useTaskValidTransitions } from "@/hooks/use-tasks";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -40,6 +40,7 @@ import {
   AlertTriangle,
   Trash2,
   GitBranch,
+  GitMerge,
   GitPullRequest,
   FileCheck,
   Send,
@@ -112,6 +113,10 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
   const router = useRouter();
   const deleteTask = useDeleteTask();
   const updateTask = useUpdateTask();
+  // Fetch valid next statuses from GET /tasks/{id}/valid-transitions; falls back
+  // to the hardcoded validNextStatuses map if the endpoint errors or returns 404.
+  const { data: validTransitionsData } = useTaskValidTransitions(task.id);
+  const nextStatuses: TaskStatus[] = validTransitionsData ?? validNextStatuses[task.status];
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   // Inline editing states
@@ -287,6 +292,11 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
       actions.push({ label: "Cancel Task", action: "cancel", icon: <XCircle className="h-4 w-4 mr-2" /> });
     }
 
+    // Merge PR is available whenever task.pr_number is set and the task is not in a terminal state
+    if (task.pr_number && task.status !== TaskStatus.COMPLETED && task.status !== TaskStatus.CANCELLED) {
+      actions.push({ label: "Merge PR", action: "merge-pr", icon: <GitMerge className="h-4 w-4 mr-2" /> });
+    }
+
     return actions;
   };
 
@@ -337,7 +347,9 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
                     {statusLabels[task.status]}
                   </span>
                 </SelectItem>
-                {validNextStatuses[task.status].map((status) => (
+                {/* nextStatuses sourced from useTaskValidTransitions (GET /tasks/{id}/valid-transitions)
+                    with graceful fallback to the hardcoded validNextStatuses map */}
+                {nextStatuses.map((status) => (
                   <SelectItem key={status} value={status}>
                     <span className={`px-2 py-0.5 rounded ${statusColors[status]}`}>
                       {statusLabels[status]}

--- a/panel/src/hooks/use-tasks.ts
+++ b/panel/src/hooks/use-tasks.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { tasksApi, type TaskFilters } from "@/lib/api/tasks";
 import {
   Team,
+  TaskStatus,
   type Task,
   type TaskCreate,
   type ProgressRequest,
@@ -66,8 +67,24 @@ export function useBoardReview(taskId: string, enabled = true) {
 export function useSubtasks(parentTaskId: string) {
   return useQuery({
     queryKey: taskKeys.subtasks(parentTaskId),
+    // Calls tasksApi.getSubtasks which hits GET /tasks/{id}/subtasks
     queryFn: () => tasksApi.getSubtasks(parentTaskId),
     enabled: !!parentTaskId,
+  });
+}
+
+/**
+ * Fetches valid next statuses for a task from GET /tasks/{id}/valid-transitions.
+ * Returns undefined while loading; on error (including 404) gracefully returns
+ * undefined so callers can fall back to a hardcoded map.
+ */
+export function useTaskValidTransitions(taskId: string) {
+  return useQuery<TaskStatus[]>({
+    queryKey: ["tasks", "valid-transitions", taskId] as const,
+    queryFn: () => tasksApi.getValidTransitions(taskId),
+    enabled: !!taskId,
+    staleTime: 30000, // 30 seconds
+    retry: false, // don't retry on 404 or other errors — caller falls back to hardcoded map
   });
 }
 

--- a/panel/src/lib/api/tasks.ts
+++ b/panel/src/lib/api/tasks.ts
@@ -399,7 +399,14 @@ export const tasksApi = {
     if (isMockMode()) {
       return mockTasks.filter((t) => t.parent_task_id === taskId);
     }
+    // Hits GET /tasks/{id}/subtasks
     const { data } = await api.get<Task[]>("/tasks/" + taskId + "/subtasks");
+    return data;
+  },
+
+  // Returns the valid next statuses for a task from GET /tasks/{id}/valid-transitions
+  getValidTransitions: async (taskId: string): Promise<TaskStatus[]> => {
+    const { data } = await api.get<TaskStatus[]>("/tasks/" + taskId + "/valid-transitions");
     return data;
   },
 


### PR DESCRIPTION
Fix six frontend issues in the panel. Goal: approve buttons trigger PR merge, all messages have copy buttons, subtask fetching uses the dedicated endpoint, 429 retries use backoff, status dropdown shows only valid transitions, and dialogs reset state on dismiss.

Frontend-verified gaps (from PO code review):
1. useMergePR hook (use-git.ts:212) exists but no component imports it — approve buttons go straight to lifecycle.complete without merging.
2. CopyButton component exists but is only applied to fenced code blocks in chat-messages.tsx — not on individual message bubbles. Communications components (message-item.tsx, session detail) don't import CopyButton at all.
3. useSubtasks (use-tasks.ts:46-56) calls useTasks() (all tasks) and filters client-side. The dedicated tasksApi.getSubtasks() endpoint (lib/api/tasks.ts:378) exists but is never called.
4. 429 retry in client.ts:93 retries immediately — safeRetryAfter is calculated but never used as a delay.
5. Status dropdown in task-actions.tsx shows hard-coded options without validating against lifecycle valid-next-transitions.
6. Dialog text state doesn't reset when dismissed without confirming.

Cell PM: split across both your devs for parallel delivery. Items 1-2 (approve wiring + copy buttons) are UI component work for one dev. Items 3-6 (query, retry, dropdown, dialog) are data/logic fixes for the other dev.