### PR TITLE
[5e24c2df] Wire Approve & Merge button to POST /tasks/{id}/approve-and-merge with structured error handling

### DIFF
--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
+import axios from "axios";
 import { useTask, useTaskLifecycle } from "@/hooks/use-tasks";
 import { useProject } from "@/hooks/use-projects";
 import { useCreateBranch, useCreatePR, useMergePR } from "@/hooks/use-git";
@@ -9,6 +10,7 @@ import { TaskHeader, TaskMetadata, TaskTabs } from "@/components/tasks/task-deta
 import { ApproveAndStartButton } from "@/components/tasks/approve-and-start-button";
 import {
   EscalateToCeoDialog,
+  ApproveAndMergeDialog,
   CeoApproveDialog,
   CeoRejectDialog,
   CreateBranchDialog,
@@ -39,6 +41,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   // Dialog states
   const [escalateDialogOpen, setEscalateDialogOpen] = useState(false);
+  const [approveAndMergeDialogOpen, setApproveAndMergeDialogOpen] = useState(false);
   const [approveDialogOpen, setApproveDialogOpen] = useState(false);
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
   const [branchDialogOpen, setBranchDialogOpen] = useState(false);
@@ -110,6 +113,9 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         case "submit-pm-review":
           setSubmitPmReviewDialogOpen(true);
           return; // Don't refetch yet — dialog collects the required note
+        case "approve-and-merge":
+          setApproveAndMergeDialogOpen(true);
+          return; // Don't refetch yet — dialog handles confirmation
         case "ceo-approve":
           setApproveDialogOpen(true);
           return; // Don't refetch yet — dialog collects the required note
@@ -187,6 +193,30 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
       refetch();
     } catch (err) {
       toast.error("Failed to request changes");
+      console.error(err);
+    }
+  };
+
+  const handleApproveAndMerge = async () => {
+    if (!task) return;
+    try {
+      await lifecycle.approveAndMerge.mutateAsync(task.id);
+      toast.success("Task approved and PR merged");
+      setApproveAndMergeDialogOpen(false);
+      refetch();
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const detail = (err.response?.data as { detail?: string } | undefined)?.detail ?? "";
+        if (typeof detail === "string" && detail.startsWith("NO_PR")) {
+          toast.error("No PR found for this task. Create a pull request before merging.");
+        } else if (typeof detail === "string" && detail.startsWith("Merge failed")) {
+          toast.error("Merge failed: " + (detail.slice("Merge failed".length).replace(/^[: ]+/, "") || "the merge could not be completed"));
+        } else {
+          toast.error("Failed to approve and merge task");
+        }
+      } else {
+        toast.error("Failed to approve and merge task");
+      }
       console.error(err);
     }
   };
@@ -422,6 +452,13 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         onOpenChange={setEscalateDialogOpen}
         onConfirm={handleEscalateToCeo}
         isPending={lifecycle.escalateToCeo.isPending}
+      />
+
+      <ApproveAndMergeDialog
+        open={approveAndMergeDialogOpen}
+        onOpenChange={setApproveAndMergeDialogOpen}
+        onConfirm={handleApproveAndMerge}
+        isPending={lifecycle.approveAndMerge.isPending}
       />
 
       <CeoApproveDialog

--- a/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
+++ b/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
@@ -149,6 +149,44 @@ export function CeoRejectDialog({
   );
 }
 
+// Approve & Merge Dialog — simple confirmation for POST /tasks/{id}/approve-and-merge.
+// The backend endpoint accepts NO notes parameter, so no text input is needed here.
+interface ApproveAndMergeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+}
+
+export function ApproveAndMergeDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+}: ApproveAndMergeDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Approve &amp; Merge</DialogTitle>
+          <DialogDescription>
+            This will approve the completed work and merge the pull request into the
+            target branch. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={isPending}>
+            {isPending ? "Merging..." : "Approve & Merge"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // CEO Approve Dialog — the sign-off note is the audit record for merging to
 // production, so it is REQUIRED and must be substantive (>= 20 chars), matching
 // the server's CEO_NOTES_REQUIRED gate.

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -279,7 +279,7 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
         actions.push({ label: "Request Changes", action: "request-changes", icon: <ThumbsDown className="h-4 w-4 mr-2" /> });
         break;
       case TaskStatus.AWAITING_CEO_APPROVAL:
-        actions.push({ label: "Approve & Merge", action: "ceo-approve", icon: <ThumbsUp className="h-4 w-4 mr-2" /> });
+        actions.push({ label: "Approve & Merge", action: "approve-and-merge", icon: <ThumbsUp className="h-4 w-4 mr-2" /> });
         actions.push({ label: "Request Changes", action: "ceo-reject", icon: <ThumbsDown className="h-4 w-4 mr-2" /> });
         break;
       case TaskStatus.CANCELLED:

--- a/panel/src/hooks/use-tasks.ts
+++ b/panel/src/hooks/use-tasks.ts
@@ -291,6 +291,13 @@ export function useTaskLifecycle() {
     },
   });
 
+  // CEO gate #2: approve completed work and merge the PR.
+  // Calls POST /tasks/{id}/approve-and-merge with no request body.
+  const approveAndMerge = useMutation({
+    mutationFn: (taskId: string) => tasksApi.approveAndMerge(taskId),
+    onSuccess: invalidateTask,
+  });
+
   return {
     // Lifecycle
     claim,
@@ -320,6 +327,7 @@ export function useTaskLifecycle() {
     ceoApprove,
     ceoReject,
     escalateToCeo,
+    approveAndMerge,
   };
 }
 

--- a/panel/src/lib/api/tasks.ts
+++ b/panel/src/lib/api/tasks.ts
@@ -600,6 +600,14 @@ export const tasksApi = {
     return data;
   },
 
+  // CEO gate #2: approve the completed work and merge the PR.
+  // No request body — the backend endpoint accepts no notes parameter.
+  // May throw HTTP 400 with detail starting 'NO_PR' or 'Merge failed'.
+  approveAndMerge: async (taskId: string): Promise<Task> => {
+    const { data } = await api.post<Task>("/tasks/" + taskId + "/approve-and-merge");
+    return data;
+  },
+
   // CEO rejects a task (sends back for revision)
   ceoReject: async (taskId: string, notes: string): Promise<Task> => {
     if (isMockMode()) {


### PR DESCRIPTION
The "Approve & Merge" button in the task detail page currently calls POST /tasks/{id}/ceo-approve (the old endpoint). It must be re-wired to POST /tasks/{id}/approve-and-merge. Three files to change:

1. src/lib/api/tasks.ts — Add `approveAndMerge: async (taskId: string): Promise<Task>` to the `tasksApi` object. It calls `api.post<Task>('/tasks/' + taskId + '/approve-and-merge')` with no request body (the backend endpoint takes no body). Include a mock branch that sets status=COMPLETED.

2. src/hooks/use-tasks.ts — Add an `approveAndMerge` mutation inside `useTaskLifecycle()` that calls `tasksApi.approveAndMerge(taskId)` with `onSuccess: invalidateTask`. Export it in the returned object.

3. src/app/(dashboard)/tasks/[taskId]/page.tsx — The `case 'ceo-approve':` branch currently does `setApproveDialogOpen(true)` which opens CeoApproveDialog, whose onConfirm calls `handleCeoApprove(notes)` → `lifecycle.ceoApprove(...)`. Change `handleCeoApprove` to call `lifecycle.approveAndMerge.mutateAsync({ taskId: task.id })` instead. Parse the error detail to show specific toasts: if the HTTP 400 detail string starts with 'NO_PR', show toast.error('No PR attached — open a PR before approving & merging'); if it starts with 'Merge failed', show toast.error('Merge failed: <extracted reason>'); otherwise show the generic toast.error. The CeoApproveDialog minChars guard currently blocks confirm if notes are short — either set minChars to 0 or replace the dialog with a simple confirmation AlertDialog so the user is not required to type notes that are never sent to the backend. Error detail is accessible at err?.response?.data?.detail (axios) or err?.message.