### PR TITLE
[78a2464d] Frontend: wire Approve & Merge to correct route + source status dropdown from backend

### DIFF
--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
+import axios from "axios";
 import { useTask, useTaskLifecycle } from "@/hooks/use-tasks";
 import { useProject } from "@/hooks/use-projects";
 import { useCreateBranch, useCreatePR, useMergePR } from "@/hooks/use-git";
@@ -9,6 +10,7 @@ import { TaskHeader, TaskMetadata, TaskTabs } from "@/components/tasks/task-deta
 import { ApproveAndStartButton } from "@/components/tasks/approve-and-start-button";
 import {
   EscalateToCeoDialog,
+  ApproveAndMergeDialog,
   CeoApproveDialog,
   CeoRejectDialog,
   CreateBranchDialog,
@@ -39,6 +41,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   // Dialog states
   const [escalateDialogOpen, setEscalateDialogOpen] = useState(false);
+  const [approveAndMergeDialogOpen, setApproveAndMergeDialogOpen] = useState(false);
   const [approveDialogOpen, setApproveDialogOpen] = useState(false);
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
   const [branchDialogOpen, setBranchDialogOpen] = useState(false);
@@ -110,6 +113,9 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         case "submit-pm-review":
           setSubmitPmReviewDialogOpen(true);
           return; // Don't refetch yet — dialog collects the required note
+        case "approve-and-merge":
+          setApproveAndMergeDialogOpen(true);
+          return; // Don't refetch yet — dialog handles confirmation
         case "ceo-approve":
           setApproveDialogOpen(true);
           return; // Don't refetch yet — dialog collects the required note
@@ -187,6 +193,30 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
       refetch();
     } catch (err) {
       toast.error("Failed to request changes");
+      console.error(err);
+    }
+  };
+
+  const handleApproveAndMerge = async () => {
+    if (!task) return;
+    try {
+      await lifecycle.approveAndMerge.mutateAsync(task.id);
+      toast.success("Task approved and PR merged");
+      setApproveAndMergeDialogOpen(false);
+      refetch();
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const detail = (err.response?.data as { detail?: string } | undefined)?.detail ?? "";
+        if (typeof detail === "string" && detail.startsWith("NO_PR")) {
+          toast.error("No PR found for this task. Create a pull request before merging.");
+        } else if (typeof detail === "string" && detail.startsWith("Merge failed")) {
+          toast.error("Merge failed: " + (detail.slice("Merge failed".length).replace(/^[: ]+/, "") || "the merge could not be completed"));
+        } else {
+          toast.error("Failed to approve and merge task");
+        }
+      } else {
+        toast.error("Failed to approve and merge task");
+      }
       console.error(err);
     }
   };
@@ -422,6 +452,13 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         onOpenChange={setEscalateDialogOpen}
         onConfirm={handleEscalateToCeo}
         isPending={lifecycle.escalateToCeo.isPending}
+      />
+
+      <ApproveAndMergeDialog
+        open={approveAndMergeDialogOpen}
+        onOpenChange={setApproveAndMergeDialogOpen}
+        onConfirm={handleApproveAndMerge}
+        isPending={lifecycle.approveAndMerge.isPending}
       />
 
       <CeoApproveDialog

--- a/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
+++ b/panel/src/components/tasks/task-detail/task-action-dialogs.tsx
@@ -149,6 +149,44 @@ export function CeoRejectDialog({
   );
 }
 
+// Approve & Merge Dialog — simple confirmation for POST /tasks/{id}/approve-and-merge.
+// The backend endpoint accepts NO notes parameter, so no text input is needed here.
+interface ApproveAndMergeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isPending?: boolean;
+}
+
+export function ApproveAndMergeDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+}: ApproveAndMergeDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Approve &amp; Merge</DialogTitle>
+          <DialogDescription>
+            This will approve the completed work and merge the pull request into the
+            target branch. This action cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={onConfirm} disabled={isPending}>
+            {isPending ? "Merging..." : "Approve & Merge"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // CEO Approve Dialog — the sign-off note is the audit record for merging to
 // production, so it is REQUIRED and must be substantive (>= 20 chars), matching
 // the server's CEO_NOTES_REQUIRED gate.

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -279,7 +279,7 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
         actions.push({ label: "Request Changes", action: "request-changes", icon: <ThumbsDown className="h-4 w-4 mr-2" /> });
         break;
       case TaskStatus.AWAITING_CEO_APPROVAL:
-        actions.push({ label: "Approve & Merge", action: "ceo-approve", icon: <ThumbsUp className="h-4 w-4 mr-2" /> });
+        actions.push({ label: "Approve & Merge", action: "approve-and-merge", icon: <ThumbsUp className="h-4 w-4 mr-2" /> });
         actions.push({ label: "Request Changes", action: "ceo-reject", icon: <ThumbsDown className="h-4 w-4 mr-2" /> });
         break;
       case TaskStatus.CANCELLED:

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -51,24 +51,6 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { TaskTypeBadge } from "../task-type-badge";
 
-// Valid next statuses per current status (for the status dropdown)
-const validNextStatuses: Record<TaskStatus, TaskStatus[]> = {
-  [TaskStatus.BACKLOG]: [TaskStatus.PENDING],
-  [TaskStatus.PENDING]: [TaskStatus.CLAIMED, TaskStatus.CANCELLED],
-  [TaskStatus.CLAIMED]: [TaskStatus.IN_PROGRESS, TaskStatus.PENDING, TaskStatus.CANCELLED],
-  [TaskStatus.IN_PROGRESS]: [TaskStatus.BLOCKED, TaskStatus.PAUSED, TaskStatus.VERIFYING, TaskStatus.CANCELLED],
-  [TaskStatus.BLOCKED]: [TaskStatus.IN_PROGRESS],
-  [TaskStatus.PAUSED]: [TaskStatus.IN_PROGRESS],
-  [TaskStatus.VERIFYING]: [TaskStatus.AWAITING_QA, TaskStatus.CANCELLED],
-  [TaskStatus.NEEDS_REVISION]: [TaskStatus.CLAIMED],
-  [TaskStatus.AWAITING_QA]: [TaskStatus.AWAITING_DOCUMENTATION, TaskStatus.NEEDS_REVISION],
-  [TaskStatus.AWAITING_DOCUMENTATION]: [TaskStatus.AWAITING_PM_REVIEW],
-  [TaskStatus.AWAITING_PM_REVIEW]: [TaskStatus.COMPLETED, TaskStatus.AWAITING_CEO_APPROVAL, TaskStatus.NEEDS_REVISION],
-  [TaskStatus.AWAITING_CEO_APPROVAL]: [TaskStatus.COMPLETED, TaskStatus.NEEDS_REVISION, TaskStatus.CANCELLED],
-  [TaskStatus.COMPLETED]: [],
-  [TaskStatus.CANCELLED]: [TaskStatus.PENDING],
-};
-
 // Status badge colors
 const statusColors: Record<TaskStatus, string> = {
   [TaskStatus.BACKLOG]: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
@@ -113,10 +95,10 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
   const router = useRouter();
   const deleteTask = useDeleteTask();
   const updateTask = useUpdateTask();
-  // Fetch valid next statuses from GET /tasks/{id}/valid-transitions; falls back
-  // to the hardcoded validNextStatuses map if the endpoint errors or returns 404.
-  const { data: validTransitionsData } = useTaskValidTransitions(task.id);
-  const nextStatuses: TaskStatus[] = validTransitionsData ?? validNextStatuses[task.status];
+  // Fetch valid next statuses from GET /tasks/{id}/valid-transitions.
+  // Falls back to [] while loading or on error — the Select is disabled during loading.
+  const { data: validTransitionsData, isLoading: isTransitionsLoading } = useTaskValidTransitions(task.id);
+  const nextStatuses: TaskStatus[] = validTransitionsData ?? [];
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   // Inline editing states
@@ -335,9 +317,12 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
               </h1>
             )}
 
-            {/* Status Dropdown — only current status + valid next statuses */}
+            {/* Status Dropdown — only current status + valid next statuses from backend */}
             <Select value={task.status} onValueChange={(v) => handleStatusChange(v as TaskStatus)}>
-              <SelectTrigger className={`w-auto h-7 text-xs font-medium border-0 ${statusColors[task.status]}`}>
+              <SelectTrigger
+                className={`w-auto h-7 text-xs font-medium border-0 ${statusColors[task.status]}`}
+                disabled={isTransitionsLoading}
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -347,8 +332,8 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
                     {statusLabels[task.status]}
                   </span>
                 </SelectItem>
-                {/* nextStatuses sourced from useTaskValidTransitions (GET /tasks/{id}/valid-transitions)
-                    with graceful fallback to the hardcoded validNextStatuses map */}
+                {/* nextStatuses sourced exclusively from useTaskValidTransitions
+                    (GET /tasks/{id}/valid-transitions) — no local fallback array */}
                 {nextStatuses.map((status) => (
                   <SelectItem key={status} value={status}>
                     <span className={`px-2 py-0.5 rounded ${statusColors[status]}`}>

--- a/panel/src/hooks/use-tasks.ts
+++ b/panel/src/hooks/use-tasks.ts
@@ -291,6 +291,13 @@ export function useTaskLifecycle() {
     },
   });
 
+  // CEO gate #2: approve completed work and merge the PR.
+  // Calls POST /tasks/{id}/approve-and-merge with no request body.
+  const approveAndMerge = useMutation({
+    mutationFn: (taskId: string) => tasksApi.approveAndMerge(taskId),
+    onSuccess: invalidateTask,
+  });
+
   return {
     // Lifecycle
     claim,
@@ -320,6 +327,7 @@ export function useTaskLifecycle() {
     ceoApprove,
     ceoReject,
     escalateToCeo,
+    approveAndMerge,
   };
 }
 

--- a/panel/src/lib/api/tasks.ts
+++ b/panel/src/lib/api/tasks.ts
@@ -600,6 +600,14 @@ export const tasksApi = {
     return data;
   },
 
+  // CEO gate #2: approve the completed work and merge the PR.
+  // No request body — the backend endpoint accepts no notes parameter.
+  // May throw HTTP 400 with detail starting 'NO_PR' or 'Merge failed'.
+  approveAndMerge: async (taskId: string): Promise<Task> => {
+    const { data } = await api.post<Task>("/tasks/" + taskId + "/approve-and-merge");
+    return data;
+  },
+
   // CEO rejects a task (sends back for revision)
   ceoReject: async (taskId: string, notes: string): Promise<Task> => {
     if (isMockMode()) {

--- a/panel/src/lib/api/tasks.ts
+++ b/panel/src/lib/api/tasks.ts
@@ -406,8 +406,13 @@ export const tasksApi = {
 
   // Returns the valid next statuses for a task from GET /tasks/{id}/valid-transitions
   getValidTransitions: async (taskId: string): Promise<TaskStatus[]> => {
-    const { data } = await api.get<TaskStatus[]>("/tasks/" + taskId + "/valid-transitions");
-    return data;
+    if (isMockMode()) {
+      return [];
+    }
+    const { data } = await api.get<{ valid_statuses: TaskStatus[] }>(
+      "/tasks/" + taskId + "/valid-transitions"
+    );
+    return data.valid_statuses;
   },
 
   // =========================================================================

--- a/roboco/api/routes/tasks.py
+++ b/roboco/api/routes/tasks.py
@@ -38,11 +38,13 @@ from roboco.api.schemas.tasks import (
     TaskSessionLinkResponse,
     TaskUpdate,
     TeamTasksQuery,
+    ValidTransitionsResponse,
     enrich_task_with_context,
     task_list_to_response,
     task_to_response,
     transform_update_data,
 )
+from roboco.enforcement import get_valid_transitions
 from roboco.exceptions import GitError, TaskLifecycleError
 from roboco.foundation.policy import task_completeness as tc
 from roboco.models.base import AgentRole, TaskStatus, Team
@@ -461,6 +463,26 @@ async def get_lifecycle_transitions() -> dict[str, list[str]]:
         src.value: sorted(tgt.value for tgt in targets)
         for src, targets in STATUS_GRAPH.items()
     }
+
+
+@router.get("/{task_id}/valid-transitions", response_model=ValidTransitionsResponse)
+async def get_valid_transitions_for_task(
+    task_id: UUID,
+    db: DbSession,
+) -> ValidTransitionsResponse:
+    """Return valid next statuses for a task given its current state.
+
+    Uses the canonical lifecycle enforcement layer so the response is always
+    in sync with what the backend will actually allow.
+    """
+    service = get_task_service(db)
+    task = await service.get(task_id)
+    if not task:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
+    valid_statuses = get_valid_transitions(task.status)
+    return ValidTransitionsResponse(valid_statuses=[TaskStatus(s) for s in valid_statuses])
 
 
 @router.get("/{task_id}", response_model=TaskResponse)

--- a/roboco/api/schemas/tasks.py
+++ b/roboco/api/schemas/tasks.py
@@ -519,6 +519,12 @@ class TaskCountResponse(BaseModel):
     counts: dict[str, int]
 
 
+class ValidTransitionsResponse(BaseModel):
+    """Valid next statuses for a task given its current state."""
+
+    valid_statuses: list[TaskStatus]
+
+
 class ListTasksQuery(BaseModel):
     """Query params for listing tasks."""
 


### PR DESCRIPTION
CEO final-round rework — 2 frontend blockers. Independent of backend cell (backend route POST /tasks/{id}/approve-and-merge already exists and is correct). Can split across two devs — different components/files.

**Work units (independent, can be parallel on two devs):**

**Unit A — Wire Approve & Merge button (blocker, CEO item 4):** The new POST /tasks/{id}/approve-and-merge route exists on the backend and correctly merges + completes + resolves coordination-root tasks via product_id. But it has ZERO callers — the UI button still calls the old POST /tasks/{id}/ceo-approve which only approves (no git merge), leaving the PR open. The 'Merge PR' action resolves project via useProject(task.project_id ?? '') → null for coordination-root → 'Project not found' → CEO can't merge root tasks in the UI. Fix: add tasksApi.approveAndMerge function calling POST /tasks/{id}/approve-and-merge, create a mutation hook, wire the 'Approve & Merge' button to use it. Surface NO_PR and merge-failed as toasts/error UI. Verify end-to-end: a coordination-root task (project_id null, product_id set) merges + completes from the UI.

**Unit B — Status dropdown from backend lifecycle (blocker, CEO item 5):** The panel calls GET /tasks/{id}/valid-transitions but the backend only has GET /tasks/lifecycle-transitions (different path AND shape) → the FE call 404s → retry:false silently falls back to the hardcoded validNextStatuses map (task-header.tsx:53-69), which has drifted from STATUS_GRAPH in 10 of 14 states (offers invalid transitions like cancelled→pending, omits valid ones). Fix: source the dropdown from the backend for real. Simplest path: consume the existing GET /tasks/lifecycle-transitions graph endpoint, index it by the task's current status to get valid next states. Alternative: add GET /tasks/{id}/valid-transitions on backend (requires BE coordination). Remove or deprecate the hardcoded validNextStatuses map. Verify the dropdown matches the canonical state machine — no invalid transitions offered, no valid transitions missing.

**Constraints:** Each unit needs individual QA verification. Don't gestalt-approve — AC#4 and AC#10 each have distinct checks. CEO mandates `make quality` green before submission.