### PR TITLE
[3f35f502] Add case 'activate' and case 'start-revision' to handleAction switch in [taskId]/page.tsx

### DIFF
--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -106,6 +106,14 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
           await lifecycle.reopen.mutateAsync(task.id);
           toast.success("Task reopened");
           break;
+        case "activate":
+          await lifecycle.activate.mutateAsync(task.id);
+          toast.success("Task activated");
+          break;
+        case "start-revision":
+          await lifecycle.start.mutateAsync(task.id);
+          toast.success("Revision started");
+          break;
         // Git workflow actions
         case "docs-complete":
           setDocsCompleteDialogOpen(true);


### PR DESCRIPTION
In src/app/(dashboard)/tasks/[taskId]/page.tsx, the handleAction switch is missing two cases that the task-header.tsx UI already triggers:

1. case 'activate' — The "Activate Task" button is shown for BACKLOG-status tasks and fires handleAction("activate"). Currently falls through to default warn. Wire it to: await lifecycle.activate.mutateAsync(task.id); toast.success("Task activated");

2. case 'start-revision' — The "Start Revision" button is shown for NEEDS_REVISION-status tasks and fires handleAction("start-revision"). Currently falls through to default warn. Wire it to: await lifecycle.start.mutateAsync(task.id); toast.success("Task revision started");

Both lifecycle mutations are already available from useTaskLifecycle() which is already imported and destructured on line 37. No new imports, no new hooks, no new components — purely two additive case blocks in the existing switch statement.

The backend /start endpoint explicitly accepts needs_revision status (comment: "Cannot start task - invalid status (must be claimed, paused, or needs_revision)."), so lifecycle.start is the correct mutation for start-revision.

IMPORTANT: The branch feature/main_pm/a1e2bfb4 already carries 31 bug-fix files. Only [taskId]/page.tsx should be modified. Do not touch any other file.