### PR TITLE
[b124eedd] Wire activate and start-revision actions in task detail page

### DIFF
--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -106,6 +106,14 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
           await lifecycle.reopen.mutateAsync(task.id);
           toast.success("Task reopened");
           break;
+        case "activate":
+          await lifecycle.activate.mutateAsync(task.id);
+          toast.success("Task activated");
+          break;
+        case "start-revision":
+          await lifecycle.start.mutateAsync(task.id);
+          toast.success("Revision started");
+          break;
         // Git workflow actions
         case "docs-complete":
           setDocsCompleteDialogOpen(true);


### PR DESCRIPTION
## CEO Go-Blocking Defect — Third Revision

The CEO rejected PR #175 a second time with one go-blocking defect. The previous revision pass added "Activate Task" (BACKLOG) and "Start Revision" (NEEDS_REVISION) buttons to task-header.tsx, but the dispatching switch in `[taskId]/page.tsx:handleAction` (lines 60-165) has **no case for "activate" or "start-revision"** — they fall to `default: console.warn("Unknown action")`. The buttons appear functional but do nothing, which is worse than the original dead-end.

## The Fix (~15 lines in page.tsx)

In `panel/src/app/(dashboard)/tasks/[taskId]/page.tsx`, add two cases to the `handleAction` switch:

1. **`case "activate"`**: Wire to `lifecycle.activate.mutateAsync(task.id)` — this mutation ALREADY EXISTS in `use-tasks.ts` (line 226) and `tasksApi.activate` (line 320) posts to `/tasks/{taskId}/activate`. Just add the case, toast success, and break.

2. **`case "start-revision"`**: The dev must determine the correct backend transition for NEEDS_REVISION → work state. Options: (a) use `lifecycle.claim.mutateAsync(task.id)` to re-claim for revision, (b) use `lifecycle.start.mutateAsync(task.id)` to begin work, or (c) add a `startRevision` API method if the backend has a dedicated endpoint. Check the backend API first.

## What Already Works

The existing branch (PR #175) has 31 files of correct fixes. task-header.tsx already dispatches the right action strings. The ONLY gap is the two missing switch cases in page.tsx. This is purely additive — zero risk to existing work.

## Constraints

- Single file change: `panel/src/app/(dashboard)/tasks/[taskId]/page.tsx`
- Possibly `use-tasks.ts` and `tasks.ts` if a new `startRevision` mutation is needed
- Must toast on success and call `refetch()` like the other cases
- QA must verify: open a BACKLOG task → click "Activate Task" → confirm it transitions; open a NEEDS_REVISION task → click "Start Revision" → confirm it transitions