### PR TITLE
[e3e5ff9b] Add strategy-engine signals panel to Dashboard next to CEO Approval Queue

### DIFF
--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -9,6 +9,7 @@ import { ActiveBlockersPanel } from "./active-blockers-panel";
 import { RecentActivityFeed } from "./recent-activity-feed";
 import { QuickActionsBar } from "./quick-actions-bar";
 import { CeoApprovalQueue } from "./ceo-approval-queue";
+import { StrategySignalsPanel } from "./strategy-signals-panel";
 import type { Activity } from "./activity-item";
 import { Button } from "@/components/ui/button";
 import { UsageOverviewPanel } from "./usage-overview-panel";
@@ -70,10 +71,11 @@ export function CommandCenter() {
         />
       </section>
 
-      {/* CEO Approval Queue - Your primary action item */}
-      <section>
+      {/* CEO Approval Queue + Strategy Signals - side-by-side on lg+ */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <CeoApprovalQueue />
-      </section>
+        <StrategySignalsPanel />
+      </div>
 
       {/* Metrics, Alerts, and Usage Row */}
       <div className="grid grid-cols-1 lg:grid-cols-3 xl:grid-cols-3 2xl:grid-cols-3 gap-6">

--- a/panel/src/components/dashboard/index.ts
+++ b/panel/src/components/dashboard/index.ts
@@ -9,4 +9,5 @@ export { ActivityItem } from "./activity-item";
 export { QuickActionsBar } from "./quick-actions-bar";
 export { HealthIndicator } from "./health-indicator";
 export { CeoApprovalQueue } from "./ceo-approval-queue";
+export { StrategySignalsPanel } from "./strategy-signals-panel";
 export { UsageOverviewPanel } from "./usage-overview-panel";

--- a/panel/src/components/dashboard/strategy-signals-panel.tsx
+++ b/panel/src/components/dashboard/strategy-signals-panel.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { cockpitApi } from "@/lib/api/cockpit";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TrendingUp } from "lucide-react";
+
+interface StrategySignalsPanelProps {
+  className?: string;
+}
+
+export function StrategySignalsPanel({ className }: StrategySignalsPanelProps) {
+  const { data: summary, isLoading } = useQuery({
+    queryKey: ["cockpit", "summary"],
+    queryFn: () => cockpitApi.summary(),
+    refetchInterval: 30000,
+  });
+
+  const signals = summary?.signals ?? [];
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <TrendingUp className="h-5 w-5" />
+          Strategy Signals
+        </CardTitle>
+        <CardDescription>Live signals from the strategy engine</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : signals.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground">
+            <TrendingUp className="h-12 w-12 mx-auto mb-2 opacity-50" />
+            <p>No strategy signals right now</p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {signals.map((signal, index) => (
+              <div
+                key={index}
+                className="flex items-start gap-3 p-4 border rounded-lg hover:bg-muted/50 transition-colors"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <Badge variant="outline" className="text-xs">
+                      {signal.kind}
+                    </Badge>
+                  </div>
+                  <p className="font-medium text-sm">{signal.summary}</p>
+                  {signal.detail && (
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {signal.detail}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Create a new StrategySignalsPanel component at src/components/dashboard/strategy-signals-panel.tsx that fetches the cockpit summary (/api/cockpit/summary via the existing cockpitApi.summary() function) and renders the signals array. Each signal has the shape { kind: string; summary: string; detail: string }. Render each signal as a shadcn Card row showing the summary as the primary text and detail as a muted sub-line; optionally display kind as a small Badge. Show shadcn Skeleton placeholders (a few rows) while loading. Show a friendly empty state (e.g. a muted 'No signals right now' message inside the Card) when signals is empty. Use a 30-second refetchInterval consistent with other dashboard panels. Then integrate StrategySignalsPanel into src/components/dashboard/command-center.tsx by wrapping the existing CeoApprovalQueue section and the new StrategySignalsPanel together in a responsive grid: grid grid-cols-1 lg:grid-cols-2 gap-6 — so they are side-by-side on large screens and stacked on small screens. Do NOT remove or relocate any other existing dashboard sections; only change the CEO Approval Queue section from a plain &lt;section&gt; to this two-column grid. Export StrategySignalsPanel from src/components/dashboard/index.ts if that barrel file exists.