### PR TITLE
[435b37b4] URL-persisted tab state: Notifications page + Metrics Performance/Token Usage tabs

### DIFF
--- a/panel/src/app/(dashboard)/metrics/page.tsx
+++ b/panel/src/app/(dashboard)/metrics/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { useOrchestratorStatus } from "@/hooks/use-agents";
 import { useTasks } from "@/hooks/use-tasks";
 import {
@@ -14,10 +16,10 @@ import {
 } from "@/hooks/use-usage";
 import { TaskStatus, Team } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { OfflineState } from "@/components/ui/offline-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { OfflineState } from "@/components/ui/offline-state";
 import {
   UsageTimeSeriesChart,
   ModelUsageDonut,
@@ -34,12 +36,30 @@ import {
   Users,
   CheckCircle,
   XCircle,
-  RefreshCw,
   Zap,
   Timer,
   Coins,
   Sparkles,
 } from "lucide-react";
+import type { UsageProjection as UP, CacheEfficiencyResponse as CER } from "@/types";
+
+// ─── Humanized number formatting ─────────────────────────────────────────────
+
+/** Format counts with K/M suffix for values >= 1000. */
+function humanizeCount(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+/** Format token counts (same as humanizeCount but used for token display). */
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+// ─── Shared sub-components ────────────────────────────────────────────────────
 
 interface MetricCardProps {
   title: string;
@@ -51,6 +71,7 @@ interface MetricCardProps {
 }
 
 function MetricCard({ title, value, subtitle, icon, trend, trendValue }: MetricCardProps) {
+  const displayValue = typeof value === "number" ? humanizeCount(value) : value;
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
@@ -60,12 +81,12 @@ function MetricCard({ title, value, subtitle, icon, trend, trendValue }: MetricC
         {icon}
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-bold">{value}</div>
+        <div className="text-2xl font-bold">{displayValue}</div>
         {subtitle && (
           <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
         )}
         {trend && trendValue && (
-          <div className={"flex items-center gap-1 mt-2 text-xs " + 
+          <div className={"flex items-center gap-1 mt-2 text-xs " +
             (trend === "up" ? "text-green-600" : trend === "down" ? "text-red-600" : "text-gray-500")
           }>
             <TrendingUp className={"h-3 w-3 " + (trend === "down" ? "rotate-180" : "")} />
@@ -118,7 +139,9 @@ function TeamHealthCard({ team, activeTasks, blockedTasks, completedToday }: Tea
   );
 }
 
-export default function MetricsPage() {
+// ─── Performance tab content ─────────────────────────────────────────────────
+
+function PerformanceTabContent() {
   const { data: tasks, error: tasksError, refetch: refetchTasks } = useTasks();
   const { data: status, error: statusError, refetch: refetchStatus } = useOrchestratorStatus();
 
@@ -132,7 +155,6 @@ export default function MetricsPage() {
     refetchStatus();
   };
 
-  // Calculate metrics from local data
   const taskList = tasks || [];
   const agentList = status?.agents || [];
 
@@ -159,7 +181,7 @@ export default function MetricsPage() {
   const awaitingQa = taskList.filter((t) => t.status === TaskStatus.AWAITING_QA).length;
   const completed = taskList.filter((t) => t.status === TaskStatus.COMPLETED).length;
 
-  // Agent counts (from by_state if available, or count from agents array)
+  // Agent counts
   const runningAgents = status?.by_state?.running || agentList.filter((a) => a.state === "running").length;
   const idleAgents = status?.by_state?.idle || agentList.filter((a) => a.state === "idle" || a.state === "stopped").length;
   const waitingAgents = status?.waiting_count || agentList.filter((a) => a.state === "waiting_long").length;
@@ -170,164 +192,145 @@ export default function MetricsPage() {
     const teamTasks = taskList.filter((t) => t.team === team);
     return {
       team,
-      activeTasks: teamTasks.filter((t) => 
+      activeTasks: teamTasks.filter((t) =>
         [TaskStatus.IN_PROGRESS, TaskStatus.CLAIMED].includes(t.status)
       ).length,
       blockedTasks: teamTasks.filter((t) => t.status === TaskStatus.BLOCKED).length,
       completedToday: teamTasks.filter((t) => {
         if (!t.completed_at) return false;
-        const completed = new Date(t.completed_at);
+        const c = new Date(t.completed_at);
         const today = new Date();
-        return completed.toDateString() === today.toDateString();
+        return c.toDateString() === today.toDateString();
       }).length,
     };
   });
 
+  if (isOffline) {
+    return (
+      <OfflineState
+        title="Cannot Load Performance Metrics"
+        description="Start the RoboCo orchestrator to view performance analytics."
+        onRetry={refetch}
+      />
+    );
+  }
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Metrics</h1>
-          <p className="text-muted-foreground">
-            Performance analytics and operational insights
-          </p>
+      {/* Velocity Metrics */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Velocity</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
+          <MetricCard
+            title="Completed Today"
+            value={completedToday}
+            subtitle="Tasks finished"
+            icon={<Zap className="h-4 w-4 text-green-500" />}
+          />
+          <MetricCard
+            title="Completed This Week"
+            value={completedThisWeek}
+            subtitle="Rolling 7 days"
+            icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
+          />
+          <MetricCard
+            title="Total Completed"
+            value={completed}
+            subtitle="All time"
+            icon={<CheckCircle className="h-4 w-4 text-green-500" />}
+          />
+          <MetricCard
+            title="Completion Rate"
+            value={taskList.length > 0 ? Math.round((completed / taskList.length) * 100) + "%" : "0%"}
+            subtitle="Of all tasks"
+            icon={<Activity className="h-4 w-4 text-purple-500" />}
+          />
         </div>
-        <Button variant="outline" onClick={refetch}>
-          <RefreshCw className="h-4 w-4 mr-2" />
-          Refresh
-        </Button>
       </div>
 
-      {isOffline ? (
-        <OfflineState
-          title="Cannot Load Metrics"
-          description="Start the RoboCo orchestrator to view performance analytics."
-          onRetry={refetch}
-        />
-      ) : (
-        <>
-          {/* Velocity Metrics */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Velocity</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
-              <MetricCard
-                title="Completed Today"
-                value={completedToday}
-                subtitle="Tasks finished"
-                icon={<Zap className="h-4 w-4 text-green-500" />}
-              />
-              <MetricCard
-                title="Completed This Week"
-                value={completedThisWeek}
-                subtitle="Rolling 7 days"
-                icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
-              />
-              <MetricCard
-                title="Total Completed"
-                value={completed}
-                subtitle="All time"
-                icon={<CheckCircle className="h-4 w-4 text-green-500" />}
-              />
-              <MetricCard
-                title="Completion Rate"
-                value={taskList.length > 0 ? Math.round((completed / taskList.length) * 100) + "%" : "0%"}
-                subtitle="Of all tasks"
-                icon={<Activity className="h-4 w-4 text-purple-500" />}
-              />
-            </div>
-          </div>
+      {/* Task Status */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Task Status</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-5">
+          <MetricCard
+            title="Pending"
+            value={pending}
+            icon={<Clock className="h-4 w-4 text-gray-500" />}
+          />
+          <MetricCard
+            title="In Progress"
+            value={inProgress}
+            icon={<Activity className="h-4 w-4 text-blue-500" />}
+          />
+          <MetricCard
+            title="Blocked"
+            value={blocked}
+            icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
+          />
+          <MetricCard
+            title="Awaiting QA"
+            value={awaitingQa}
+            icon={<Timer className="h-4 w-4 text-yellow-500" />}
+          />
+          <MetricCard
+            title="Completed"
+            value={completed}
+            icon={<CheckCircle className="h-4 w-4 text-green-500" />}
+          />
+        </div>
+      </div>
 
-          {/* Task Status */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Task Status</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-5">
-              <MetricCard
-                title="Pending"
-                value={pending}
-                icon={<Clock className="h-4 w-4 text-gray-500" />}
-              />
-              <MetricCard
-                title="In Progress"
-                value={inProgress}
-                icon={<Activity className="h-4 w-4 text-blue-500" />}
-              />
-              <MetricCard
-                title="Blocked"
-                value={blocked}
-                icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
-              />
-              <MetricCard
-                title="Awaiting QA"
-                value={awaitingQa}
-                icon={<Timer className="h-4 w-4 text-yellow-500" />}
-              />
-              <MetricCard
-                title="Completed"
-                value={completed}
-                icon={<CheckCircle className="h-4 w-4 text-green-500" />}
-              />
-            </div>
-          </div>
+      {/* Agent Status */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Agent Status</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
+          <MetricCard
+            title="Running"
+            value={runningAgents}
+            subtitle="Active agents"
+            icon={<Users className="h-4 w-4 text-green-500" />}
+          />
+          <MetricCard
+            title="Idle"
+            value={idleAgents}
+            subtitle="Available"
+            icon={<Users className="h-4 w-4 text-gray-500" />}
+          />
+          <MetricCard
+            title="Waiting"
+            value={waitingAgents}
+            subtitle="Needs input"
+            icon={<Clock className="h-4 w-4 text-yellow-500" />}
+          />
+          <MetricCard
+            title="Errors"
+            value={errorAgents}
+            subtitle="Failed agents"
+            icon={<XCircle className="h-4 w-4 text-red-500" />}
+          />
+        </div>
+      </div>
 
-          {/* Agent Status */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Agent Status</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
-              <MetricCard
-                title="Running"
-                value={runningAgents}
-                subtitle="Active agents"
-                icon={<Users className="h-4 w-4 text-green-500" />}
-              />
-              <MetricCard
-                title="Idle"
-                value={idleAgents}
-                subtitle="Available"
-                icon={<Users className="h-4 w-4 text-gray-500" />}
-              />
-              <MetricCard
-                title="Waiting"
-                value={waitingAgents}
-                subtitle="Needs input"
-                icon={<Clock className="h-4 w-4 text-yellow-500" />}
-              />
-              <MetricCard
-                title="Errors"
-                value={errorAgents}
-                subtitle="Failed agents"
-                icon={<XCircle className="h-4 w-4 text-red-500" />}
-              />
-            </div>
-          </div>
-
-          {/* Team Health */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Team Health</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-6">
-              {teamMetrics.map((tm) => (
-                <TeamHealthCard
-                  key={tm.team}
-                  team={tm.team}
-                  activeTasks={tm.activeTasks}
-                  blockedTasks={tm.blockedTasks}
-                  completedToday={tm.completedToday}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* ─── Token Usage & Costs ─────────────────────────────────── */}
-          <TokenUsageCostsSection />
-        </>
-      )}
+      {/* Team Health */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Team Health</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-6">
+          {teamMetrics.map((tm) => (
+            <TeamHealthCard
+              key={tm.team}
+              team={tm.team}
+              activeTasks={tm.activeTasks}
+              blockedTasks={tm.blockedTasks}
+              completedToday={tm.completedToday}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
 
-// =============================================================================
-// TOKEN USAGE & COSTS SECTION
-// =============================================================================
+// ─── Token Usage & Costs tab content ─────────────────────────────────────────
 
 function TokenUsageCostsSection() {
   const { data: summary, isLoading: loadingSnap } = useUsageSummary("24h");
@@ -343,8 +346,6 @@ function TokenUsageCostsSection() {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-lg font-semibold">Token Usage &amp; Costs</h2>
-
       {/* Row 1 — Summary cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 2xl:grid-cols-6">
         <SummaryCard
@@ -411,19 +412,13 @@ function TokenUsageCostsSection() {
         <CacheEfficiencyCard cacheStats={cacheStats} isLoading={loadingCache} />
       </div>
 
-      {/* Row 5 — Sessions table (mock-mode only; empty in production) */}
+      {/* Row 5 — Sessions table */}
       <SessionsTable data={sessions} isLoading={loadingSessions} />
     </div>
   );
 }
 
 // ─── Helper sub-components ────────────────────────────────────────────────────
-
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
-  return String(n);
-}
 
 interface SummaryCardProps {
   title: string;
@@ -462,8 +457,6 @@ function SummaryCard({ title, value, icon, trend, isLoading }: SummaryCardProps)
     </Card>
   );
 }
-
-import type { UsageProjection as UP, CacheEfficiencyResponse as CER } from "@/types";
 
 interface ProjectionCardProps {
   projection: UP | undefined;
@@ -529,5 +522,95 @@ function CacheEfficiencyCard({ cacheStats, isLoading }: CacheEfficiencyCardProps
         )}
       </CardContent>
     </Card>
+  );
+}
+
+// ─── Tab types ────────────────────────────────────────────────────────────────
+
+type MetricsTab = "performance" | "token-usage";
+
+const VALID_METRICS_TABS: MetricsTab[] = ["performance", "token-usage"];
+
+function isValidMetricsTab(value: string | null): value is MetricsTab {
+  return VALID_METRICS_TABS.includes(value as MetricsTab);
+}
+
+// ─── Main page content (uses useSearchParams) ─────────────────────────────────
+
+function MetricsPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Read ?tab= from URL, default to "performance"
+  const rawTab = searchParams.get("tab");
+  const activeTab: MetricsTab = isValidMetricsTab(rawTab) ? rawTab : "performance";
+
+  function handleTabChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", value);
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Metrics</h1>
+          <p className="text-muted-foreground">
+            Performance analytics and operational insights
+          </p>
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList>
+          <TabsTrigger value="performance">Performance</TabsTrigger>
+          <TabsTrigger value="token-usage">Token Usage</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="performance" className="mt-6">
+          <PerformanceTabContent />
+        </TabsContent>
+
+        <TabsContent value="token-usage" className="mt-6">
+          <TokenUsageCostsSection />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// Wrap in Suspense for useSearchParams
+export default function MetricsPage() {
+  return (
+    <Suspense fallback={
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-9 w-32 mb-2" />
+            <Skeleton className="h-5 w-72" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-28" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-16" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    }>
+      <MetricsPageContent />
+    </Suspense>
   );
 }

--- a/panel/src/app/(dashboard)/notifications/page.tsx
+++ b/panel/src/app/(dashboard)/notifications/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import {
   useNotifications,
   useMarkNotificationRead,
@@ -105,17 +106,34 @@ function NotificationCard({ notification, onMarkRead, onAcknowledge }: Notificat
   );
 }
 
-export default function NotificationsPage() {
-  // Default to Unread: the actionable view. Landing on "All" buries new
-  // notifications under everything already seen.
-  const [activeTab, setActiveTab] = useState<"all" | "unread" | "pending">("unread");
-  
+type TabValue = "all" | "unread" | "pending";
+
+const VALID_TABS: TabValue[] = ["all", "unread", "pending"];
+
+function isValidTab(value: string | null): value is TabValue {
+  return VALID_TABS.includes(value as TabValue);
+}
+
+function NotificationsPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Read ?tab= from URL, default to "unread" (most actionable view)
+  const rawTab = searchParams.get("tab");
+  const activeTab: TabValue = isValidTab(rawTab) ? rawTab : "unread";
+
+  function handleTabChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", value);
+    router.push(`?${params.toString()}`);
+  }
+
   const { data, isLoading, error, refetch } = useNotifications(
     activeTab === "unread" ? { unread_only: true } :
     activeTab === "pending" ? { pending_ack_only: true } :
     undefined
   );
-  
+
   const markRead = useMarkNotificationRead();
   const acknowledge = useAcknowledgeNotification();
   const markAllRead = useMarkAllNotificationsRead();
@@ -219,7 +237,7 @@ export default function NotificationsPage() {
           onRetry={() => refetch()}
         />
       ) : (
-        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)}>
+        <Tabs value={activeTab} onValueChange={handleTabChange}>
           <TabsList>
             <TabsTrigger value="all">All</TabsTrigger>
             <TabsTrigger value="unread">
@@ -260,5 +278,48 @@ export default function NotificationsPage() {
         </Tabs>
       )}
     </div>
+  );
+}
+
+// Wrap in Suspense for useSearchParams
+export default function NotificationsPage() {
+  return (
+    <Suspense fallback={
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-9 w-48 mb-2" />
+            <Skeleton className="h-5 w-72" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-9 w-36" />
+            <Skeleton className="h-9 w-24" />
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-16" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-12" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <Skeleton className="h-20 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    }>
+      <NotificationsPageContent />
+    </Suspense>
   );
 }

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -69,7 +69,7 @@ export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -12,12 +12,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ModelUsageSlice } from "@/types";
 
+// Semantic color palette: blue (informational), amber (warning), green (success),
+// red (error/blocked), purple (supplemental)
 const CHART_COLORS = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
+  "#3b82f6", // blue-500  — informational
+  "#f59e0b", // amber-500 — warning / pending
+  "#22c55e", // green-500 — success / healthy
+  "#ef4444", // red-500   — error / blocked
+  "#a855f7", // purple-500 — supplemental
 ];
 
 interface ModelUsageDonutProps {

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -66,7 +66,7 @@ export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="var(--chart-2)" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -58,12 +58,12 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
             >
               <defs>
                 <linearGradient id="fillInput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.1} />
                 </linearGradient>
                 <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#f59e0b" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
@@ -93,14 +93,14 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 type="monotone"
                 dataKey="Input"
                 stackId="1"
-                stroke="var(--chart-1)"
+                stroke="#3b82f6"
                 fill="url(#fillInput)"
               />
               <Area
                 type="monotone"
                 dataKey="Output"
                 stackId="1"
-                stroke="var(--chart-2)"
+                stroke="#f59e0b"
                 fill="url(#fillOutput)"
               />
             </AreaChart>


### PR DESCRIPTION
Convert Notifications page tab selection to URL state, and add tabbed navigation to the Metrics page with URL-persisted tab selection, humanized number formatting, and semantic chart colors.

**1. Notifications page — URL-persisted tab**
File: `panel/src/app/(dashboard)/notifications/page.tsx`
- The page currently uses `useState<"all" | "unread" | "pending">` for `activeTab`. Replace this with `useSearchParams` + `useRouter`, following the exact same pattern used in `kanban/page.tsx`.
- Wrap the inner component in `<Suspense>` just like `KanbanPage` does (required for `useSearchParams` in Next.js App Router).
- Read tab from `searchParams.get("tab")` defaulting to `"unread"`.
- On tab change call `router.replace(`/notifications?tab=${newValue}`)` (use `replace` not `push` to keep back-forward clean).
- The tab parameter survives full page refresh (it's in the URL) and browser back/forward (history stack is preserved).
- Do not change the Notifications data-fetching logic or card layout.

**2. Metrics page — Performance / Token Usage tabs with URL state**
File: `panel/src/app/(dashboard)/metrics/page.tsx`
- Add a top-level `Tabs` (from `components/ui/tabs`) with two tabs: `"performance"` and `"usage"`.
- Tab selection must be URL-persisted: read from `searchParams.get("tab")`, default to `"performance"`, use `router.replace` on change.
- Wrap the inner component in `<Suspense>` (needed for `useSearchParams`).
- **Performance tab** contains: the existing Velocity, Task Status, Agent Status, and Team Health sections (all the parts above `<TokenUsageCostsSection />`).
- **Token Usage tab** contains: the existing `<TokenUsageCostsSection />` component.
- Tab titles in the TabsList: "Performance" and "Token Usage".

**3. Humanized number formatting throughout Metrics**
- The `fmtTokens` helper already handles M/K suffixes. Verify it's applied to ALL numeric values displayed in MetricCard across the Velocity, Task Status, and Agent Status sections — currently they receive raw numbers which might display as e.g. `1234567`. Apply `fmtTokens` (or a similarly named general formatter) to any count metric > 999.
- For the TeamHealthCard's `activeTasks`, `blockedTasks`, `completedToday` values, these are likely small integers — no formatting needed, but add the formatter as a pass-through so it's consistent.

**4. Semantic chart colors in Recharts components**
Files: `panel/src/components/metrics/*.tsx` (UsageTimeSeriesChart, AgentUsageChart, TeamUsageChart, ModelUsageDonut)
- Audit the `fill` / `stroke` / `color` props passed to Recharts `<Bar>`, `<Line>`, `<Cell>`, `<Pie>` elements.
- Apply semantic color mapping:
  - Success / healthy / completed → green (`hsl(var(--chart-1))` or `text-green-500` derived hex `#22c55e`)
  - Error / blocked / failed → red (`#ef4444`)
  - Warning / pending / attention → amber (`#f59e0b`)
  - Informational / neutral → blue (`#3b82f6`)
  - Secondary data series → purple (`#8b5cf6`)
- If the charts use a fixed color array, replace it with a named semantic array exported from a `chart-colors.ts` lib file so the mapping is documented and consistent.

**Testing:**
- Navigate to /notifications, switch to Pending tab, hit reload — tab must remain Pending.
- Navigate to /metrics, switch to Token Usage tab, hit reload — tab must remain Token Usage.
- Use browser back button from Token Usage → must return to previous URL (not navigate away from Metrics).
- Run `pnpm typecheck` and `pnpm lint`.