### PR TITLE
[1ec787b2] Design-system sweep: Settings/AI-Providers full-width layout, scrollbar fixes, Secretary button, component audit

### DIFF
--- a/panel/src/app/(dashboard)/communications/page.tsx
+++ b/panel/src/app/(dashboard)/communications/page.tsx
@@ -53,13 +53,14 @@ function ChannelList({ channels, selectedId, onSelect, isLoading }: ChannelListP
           {title}
         </h4>
         {items.map((channel) => (
-          <button
+          <Button
             key={channel.id}
             onClick={() => onSelect(channel.id)}
+            variant="ghost"
             className={
-              "w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-left transition-colors " +
+              "w-full h-auto justify-start gap-2 px-3 py-2 text-sm font-normal whitespace-normal " +
               (selectedId === channel.id
-                ? "bg-primary text-primary-foreground"
+                ? "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
                 : "hover:bg-muted")
             }
           >
@@ -69,7 +70,7 @@ function ChannelList({ channels, selectedId, onSelect, isLoading }: ChannelListP
               <Hash className="h-4 w-4 shrink-0" />
             )}
             <span className="truncate">{channel.name}</span>
-          </button>
+          </Button>
         ))}
       </div>
     );
@@ -135,13 +136,14 @@ function GroupList({ channelId, selectedId, onSelect }: GroupListProps) {
     <ScrollArea className="h-full">
       <div className="p-2 space-y-1">
         {groups.map((group) => (
-          <button
+          <Button
             key={group.id}
             onClick={() => onSelect(group.id)}
+            variant="ghost"
             className={
-              "w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm text-left transition-colors " +
+              "w-full h-auto justify-between px-3 py-2 text-sm font-normal whitespace-normal " +
               (selectedId === group.id
-                ? "bg-primary text-primary-foreground"
+                ? "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
                 : "hover:bg-muted")
             }
           >
@@ -152,7 +154,7 @@ function GroupList({ channelId, selectedId, onSelect }: GroupListProps) {
             <Badge variant="secondary" className="text-xs shrink-0 ml-2">
               {group.total_messages}
             </Badge>
-          </button>
+          </Button>
         ))}
       </div>
     </ScrollArea>

--- a/panel/src/app/(dashboard)/settings/ai-providers/page.tsx
+++ b/panel/src/app/(dashboard)/settings/ai-providers/page.tsx
@@ -2,7 +2,7 @@ import { AIRoutingCard } from "@/components/settings/ai-routing-card";
 
 export default function AIProvidersPage() {
   return (
-    <div className="space-y-6 max-w-5xl">
+    <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">AI Providers</h1>
         <p className="text-muted-foreground">

--- a/panel/src/app/(dashboard)/settings/page.tsx
+++ b/panel/src/app/(dashboard)/settings/page.tsx
@@ -43,7 +43,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       {/* Header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
@@ -52,189 +52,192 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      {/* Appearance */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Palette className="h-5 w-5" />
-            Appearance
-          </CardTitle>
-          <CardDescription>Customize the look and feel of the panel</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Theme</Label>
-              <p className="text-sm text-muted-foreground">
-                Select your preferred color scheme
-              </p>
+      {/* Cards grid — two columns on large screens */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Appearance */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Palette className="h-5 w-5" />
+              Appearance
+            </CardTitle>
+            <CardDescription>Customize the look and feel of the panel</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Theme</Label>
+                <p className="text-sm text-muted-foreground">
+                  Select your preferred color scheme
+                </p>
+              </div>
+              <Select value={theme} onValueChange={setTheme}>
+                <SelectTrigger className="w-auto min-w-28">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="light">Light</SelectItem>
+                  <SelectItem value="dark">Dark</SelectItem>
+                  <SelectItem value="system">System</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <Select value={theme} onValueChange={setTheme}>
-              <SelectTrigger className="w-auto min-w-28">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="light">Light</SelectItem>
-                <SelectItem value="dark">Dark</SelectItem>
-                <SelectItem value="system">System</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Collapsed Sidebar</Label>
-              <p className="text-sm text-muted-foreground">
-                Show icons only in the sidebar
-              </p>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Collapsed Sidebar</Label>
+                <p className="text-sm text-muted-foreground">
+                  Show icons only in the sidebar
+                </p>
+              </div>
+              <Switch
+                checked={sidebarCollapsed}
+                onCheckedChange={setSidebarCollapsed}
+              />
             </div>
-            <Switch
-              checked={sidebarCollapsed}
-              onCheckedChange={setSidebarCollapsed}
-            />
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Notifications */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Bell className="h-5 w-5" />
-            Notifications
-          </CardTitle>
-          <CardDescription>Configure how you receive updates</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Enable Notifications</Label>
-              <p className="text-sm text-muted-foreground">
-                Receive real-time notifications from agents
-              </p>
+        {/* Notifications */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bell className="h-5 w-5" />
+              Notifications
+            </CardTitle>
+            <CardDescription>Configure how you receive updates</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Enable Notifications</Label>
+                <p className="text-sm text-muted-foreground">
+                  Receive real-time notifications from agents
+                </p>
+              </div>
+              <Switch
+                checked={notificationsEnabled}
+                onCheckedChange={setNotificationsEnabled}
+              />
             </div>
-            <Switch
-              checked={notificationsEnabled}
-              onCheckedChange={setNotificationsEnabled}
-            />
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Sound Alerts</Label>
-              <p className="text-sm text-muted-foreground">
-                Play sound for important notifications
-              </p>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Sound Alerts</Label>
+                <p className="text-sm text-muted-foreground">
+                  Play sound for important notifications
+                </p>
+              </div>
+              <Switch
+                checked={soundEnabled}
+                onCheckedChange={setSoundEnabled}
+                disabled={!notificationsEnabled}
+              />
             </div>
-            <Switch
-              checked={soundEnabled}
-              onCheckedChange={setSoundEnabled}
-              disabled={!notificationsEnabled}
-            />
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Data & Refresh */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Server className="h-5 w-5" />
-            Data & Refresh
-          </CardTitle>
-          <CardDescription>Configure data fetching behavior</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Auto Refresh</Label>
-              <p className="text-sm text-muted-foreground">
-                Automatically refresh data periodically
-              </p>
+        {/* Data & Refresh */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Server className="h-5 w-5" />
+              Data & Refresh
+            </CardTitle>
+            <CardDescription>Configure data fetching behavior</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Auto Refresh</Label>
+                <p className="text-sm text-muted-foreground">
+                  Automatically refresh data periodically
+                </p>
+              </div>
+              <Switch
+                checked={autoRefresh}
+                onCheckedChange={setAutoRefresh}
+              />
             </div>
-            <Switch
-              checked={autoRefresh}
-              onCheckedChange={setAutoRefresh}
-            />
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Refresh Interval</Label>
-              <p className="text-sm text-muted-foreground">
-                How often to fetch new data (seconds)
-              </p>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Refresh Interval</Label>
+                <p className="text-sm text-muted-foreground">
+                  How often to fetch new data (seconds)
+                </p>
+              </div>
+              <Select
+                value={refreshInterval}
+                onValueChange={setRefreshInterval}
+                disabled={!autoRefresh}
+              >
+                <SelectTrigger className="w-auto min-w-20">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="10">10s</SelectItem>
+                  <SelectItem value="30">30s</SelectItem>
+                  <SelectItem value="60">1m</SelectItem>
+                  <SelectItem value="300">5m</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <Select
-              value={refreshInterval}
-              onValueChange={setRefreshInterval}
-              disabled={!autoRefresh}
-            >
-              <SelectTrigger className="w-auto min-w-20">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="10">10s</SelectItem>
-                <SelectItem value="30">30s</SelectItem>
-                <SelectItem value="60">1m</SelectItem>
-                <SelectItem value="300">5m</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Transcript Retention (panel-tunable; persisted server-side) */}
-      <TranscriptRetentionCard />
+        {/* Transcript Retention (panel-tunable; persisted server-side) */}
+        <TranscriptRetentionCard />
 
-      {/* Connection Info */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            Connection Info
-          </CardTitle>
-          <CardDescription>Backend API configuration (read-only)</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label>API URL</Label>
-            <Input value={API_URL} readOnly className="bg-muted" />
-          </div>
-          <div className="space-y-2">
-            <Label>WebSocket URL</Label>
-            <Input value={WS_URL} readOnly className="bg-muted" />
-          </div>
-          <p className="text-xs text-muted-foreground">
-            These values are configured via environment variables (NEXT_PUBLIC_API_URL, NEXT_PUBLIC_WS_URL)
-          </p>
-        </CardContent>
-      </Card>
+        {/* Connection Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Settings className="h-5 w-5" />
+              Connection Info
+            </CardTitle>
+            <CardDescription>Backend API configuration (read-only)</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>API URL</Label>
+              <Input value={API_URL} readOnly className="bg-muted" />
+            </div>
+            <div className="space-y-2">
+              <Label>WebSocket URL</Label>
+              <Input value={WS_URL} readOnly className="bg-muted" />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              These values are configured via environment variables (NEXT_PUBLIC_API_URL, NEXT_PUBLIC_WS_URL)
+            </p>
+          </CardContent>
+        </Card>
 
-      {/* User Info */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <User className="h-5 w-5" />
-            User Info
-          </CardTitle>
-          <CardDescription>Your account information</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 rounded-full bg-primary flex items-center justify-center">
-              <span className="text-primary-foreground font-bold text-2xl">CEO</span>
+        {/* User Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <User className="h-5 w-5" />
+              User Info
+            </CardTitle>
+            <CardDescription>Your account information</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-4">
+              <div className="h-16 w-16 rounded-full bg-primary flex items-center justify-center">
+                <span className="text-primary-foreground font-bold text-2xl">CEO</span>
+              </div>
+              <div>
+                <p className="font-semibold text-lg">Renzo</p>
+                <p className="text-sm text-muted-foreground">Chief Executive Officer</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Agent ID: 00000000-0000-0000-0000-000000000001
+                </p>
+              </div>
             </div>
-            <div>
-              <p className="font-semibold text-lg">Renzo</p>
-              <p className="text-sm text-muted-foreground">Chief Executive Officer</p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Agent ID: 00000000-0000-0000-0000-000000000001
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
 
       {/* Save Button */}
       <div className="flex justify-end">

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -341,8 +341,8 @@ function GoalsForm({ goals, refetch }: GoalsFormProps) {
           )}
         </div>
 
-        {/* Hidden — just to make the refetch prop used */}
-        <button type="button" className="hidden" onClick={refetch} />
+        {/* Hidden — keeps the refetch prop wired up for future use */}
+        <Button type="button" className="hidden" onClick={refetch} />
       </CardContent>
     </Card>
   );

--- a/panel/src/components/business/secretary-tab.tsx
+++ b/panel/src/components/business/secretary-tab.tsx
@@ -245,7 +245,7 @@ export function SecretaryTab() {
         </CardHeader>
         <CardContent className="flex flex-1 flex-col gap-4">
           <ChatMessages messages={messages} streaming={streaming} />
-          <div className="flex gap-2">
+          <div className="flex items-stretch gap-2">
             <Textarea
               value={input}
               onChange={(e) => setInput(e.target.value)}

--- a/panel/src/components/communications/channel-item.tsx
+++ b/panel/src/components/communications/channel-item.tsx
@@ -2,6 +2,7 @@
 
 import { Channel } from "@/types";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Hash, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -19,12 +20,13 @@ export function ChannelItem({
   unreadCount = 0,
 }: ChannelItemProps) {
   return (
-    <button
+    <Button
       onClick={onClick}
+      variant="ghost"
       className={cn(
-        "w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition-colors",
+        "w-full h-auto justify-start gap-2 px-2 py-1.5 font-normal whitespace-normal",
         isSelected
-          ? "bg-primary/10 text-primary"
+          ? "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary"
           : "text-muted-foreground hover:bg-muted hover:text-foreground"
       )}
     >
@@ -39,6 +41,6 @@ export function ChannelItem({
           {unreadCount}
         </Badge>
       )}
-    </button>
+    </Button>
   );
 }

--- a/panel/src/components/git/git-branch-panel.tsx
+++ b/panel/src/components/git/git-branch-panel.tsx
@@ -164,14 +164,15 @@ export function GitBranchPanel({
               </h4>
               <div className="space-y-0.5">
                 {localBranches.map((branch) => (
-                  <button
+                  <Button
                     key={branch.name}
                     onClick={() => !branch.is_current && onCheckout(branch.name)}
                     disabled={branch.is_current || isCheckingOut}
+                    variant="ghost"
                     className={
-                      "w-full flex items-center justify-between px-2 py-1.5 rounded text-sm text-left transition-colors " +
+                      "w-full h-auto justify-between px-2 py-1.5 text-sm font-normal whitespace-normal " +
                       (branch.is_current
-                        ? "bg-primary/10 text-primary"
+                        ? "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary"
                         : "hover:bg-muted")
                     }
                   >
@@ -188,7 +189,7 @@ export function GitBranchPanel({
                         {branch.last_commit.slice(0, 7)}
                       </span>
                     )}
-                  </button>
+                  </Button>
                 ))}
               </div>
             </div>
@@ -202,16 +203,17 @@ export function GitBranchPanel({
                 </h4>
                 <div className="space-y-0.5">
                   {remoteBranches.map((branch) => (
-                    <button
+                    <Button
                       key={branch.name}
                       onClick={() => onCheckout(branch.name)}
                       disabled={isCheckingOut}
-                      className="w-full flex items-center justify-between px-2 py-1.5 rounded text-sm text-left transition-colors hover:bg-muted"
+                      variant="ghost"
+                      className="w-full h-auto justify-start px-2 py-1.5 text-sm font-normal whitespace-normal hover:bg-muted"
                     >
                       <span className="truncate font-mono text-xs text-muted-foreground">
                         {branch.name}
                       </span>
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>

--- a/panel/src/components/git/git-log-panel.tsx
+++ b/panel/src/components/git/git-log-panel.tsx
@@ -3,8 +3,10 @@
 import { GitLogResponse, CommitInfo } from "@/types/git";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import { GitCommit, User, Calendar } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
@@ -68,15 +70,14 @@ export function GitLogPanel({
         <ScrollArea className="h-80">
           <div className="p-4 space-y-0">
             {log.commits.map((commit, index) => (
-              <button
+              <Button
                 key={commit.hash}
                 onClick={() => onSelectCommit?.(commit)}
-                className={
-                  "w-full text-left p-3 rounded-lg transition-colors relative " +
-                  (selectedHash === commit.hash
-                    ? "bg-primary/10"
-                    : "hover:bg-muted")
-                }
+                variant="ghost"
+                className={cn(
+                  "w-full h-auto justify-start text-left p-3 font-normal whitespace-normal relative",
+                  selectedHash === commit.hash ? "bg-primary/10 hover:bg-primary/10" : ""
+                )}
               >
                 {/* Timeline line */}
                 {index < log.commits.length - 1 && (
@@ -123,7 +124,7 @@ export function GitLogPanel({
                     </div>
                   </div>
                 </div>
-              </button>
+              </Button>
             ))}
           </div>
         </ScrollArea>

--- a/panel/src/components/journals/agent-item.tsx
+++ b/panel/src/components/journals/agent-item.tsx
@@ -4,6 +4,7 @@ import { Agent } from "@/types";
 import { User } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { Button } from "@/components/ui/button";
 
 interface AgentItemProps {
   agent: Agent;
@@ -14,12 +15,13 @@ interface AgentItemProps {
 
 export function AgentItem({ agent, isSelected, onClick, hasEntries }: AgentItemProps) {
   return (
-    <button
+    <Button
       onClick={onClick}
+      variant="ghost"
       className={cn(
-        "w-full flex items-center gap-3 p-2 rounded-lg text-left transition-colors",
+        "w-full h-auto justify-start gap-3 p-2 font-normal whitespace-normal",
         isSelected
-          ? "bg-primary/10 border border-primary/30"
+          ? "bg-primary/10 border border-primary/30 hover:bg-primary/10"
           : "hover:bg-muted/50"
       )}
     >
@@ -37,6 +39,6 @@ export function AgentItem({ agent, isSelected, onClick, hasEntries }: AgentItemP
           {agent.role.replace(/_/g, " ")}
         </p>
       </div>
-    </button>
+    </Button>
   );
 }

--- a/panel/src/components/journals/agent-list.tsx
+++ b/panel/src/components/journals/agent-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Agent, Team, AgentRole } from "@/types";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AgentItem } from "./agent-item";
 
@@ -84,7 +83,7 @@ export function AgentList({
   const grouped = groupByTeam(agents);
 
   return (
-    <ScrollArea className="h-[calc(100vh-200px)]">
+    <div className="overflow-y-auto max-h-[calc(100vh-200px)]">
       <div className="p-2 space-y-4">
         {Object.entries(grouped).map(([teamKey, teamAgents]) => {
           if (teamAgents.length === 0) return null;
@@ -108,6 +107,6 @@ export function AgentList({
           );
         })}
       </div>
-    </ScrollArea>
+    </div>
   );
 }

--- a/panel/src/components/knowledge-base/kb-category-nav.tsx
+++ b/panel/src/components/knowledge-base/kb-category-nav.tsx
@@ -3,6 +3,8 @@
 import { KBIndexType, KBStats } from "@/types";
 import { FileText, MessageSquare, BookOpen, ChevronRight, AlertTriangle, Scale, GitBranch, ClipboardCheck, Lightbulb } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const categoryConfig: Record<KBIndexType, { label: string; description: string; icon: React.ReactNode }> = {
   [KBIndexType.DOCUMENTATION]: {
@@ -90,17 +92,19 @@ export function KBCategoryNav({
         const isSelected = selectedCategory === type;
 
         return (
-          <button
+          <Button
             key={type}
             onClick={() => onSelectCategory(type)}
-            className={`w-full flex items-center gap-3 p-3 rounded-lg border transition-colors text-left ${
+            variant="outline"
+            className={cn(
+              "w-full h-auto justify-start gap-3 p-3 font-normal whitespace-normal",
               isSelected
                 ? "bg-primary/10 border-primary"
                 : "hover:bg-muted/50 border-transparent hover:border-border"
-            }`}
+            )}
           >
             <div className="shrink-0">{config.icon}</div>
-            <div className="flex-1 min-w-0">
+            <div className="flex-1 min-w-0 text-left">
               <div className="flex items-center justify-between">
                 <span className="font-medium text-sm">{config.label}</span>
                 <span className="text-xs text-muted-foreground">
@@ -109,8 +113,8 @@ export function KBCategoryNav({
               </div>
               <p className="text-xs text-muted-foreground truncate">{config.description}</p>
             </div>
-            <ChevronRight className={`h-4 w-4 text-muted-foreground shrink-0 transition-transform ${isSelected ? "rotate-90" : ""}`} />
-          </button>
+            <ChevronRight className={cn("h-4 w-4 text-muted-foreground shrink-0 transition-transform", isSelected && "rotate-90")} />
+          </Button>
         );
       })}
     </div>

--- a/panel/src/components/knowledge-base/kb-filters.tsx
+++ b/panel/src/components/knowledge-base/kb-filters.tsx
@@ -2,6 +2,7 @@
 
 import { KBIndexType } from "@/types";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
 import { FileText, MessageSquare, BookOpen, AlertTriangle, Scale, GitBranch, ClipboardCheck, Lightbulb } from "lucide-react";
 
 const indexTypeConfig: Record<KBIndexType, { label: string; icon: React.ReactNode }> = {
@@ -36,12 +37,14 @@ export function KBFilters({ selectedTypes, onTypesChange }: KBFiltersProps) {
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">Filter by type</span>
         {selectedTypes.length > 0 && (
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onTypesChange([])}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="h-auto py-0 px-1 text-xs text-muted-foreground hover:text-foreground"
           >
             Clear
-          </button>
+          </Button>
         )}
       </div>
       <div className="space-y-2">

--- a/panel/src/components/knowledge-base/kb-search-bar.tsx
+++ b/panel/src/components/knowledge-base/kb-search-bar.tsx
@@ -64,12 +64,14 @@ export function KBSearchBar({
           className="pl-9 pr-9"
         />
         {localValue && (
-          <button
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={handleClear}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />
-          </button>
+          </Button>
         )}
       </div>
       {onSearch && (

--- a/panel/src/components/products/product-table.tsx
+++ b/panel/src/components/products/product-table.tsx
@@ -60,12 +60,13 @@ export function ProductTable({ products, isLoading }: ProductTableProps) {
               <TableRow key={product.id}>
                 <TableCell>
                   <div>
-                    <button
+                    <Button
                       onClick={() => setEditingProductId(product.id)}
-                      className="font-medium hover:underline text-left"
+                      variant="link"
+                      className="h-auto p-0 font-medium text-foreground"
                     >
                       {product.name}
-                    </button>
+                    </Button>
                     <p className="text-xs text-muted-foreground font-mono">{product.slug}</p>
                   </div>
                 </TableCell>

--- a/panel/src/components/projects/project-table.tsx
+++ b/panel/src/components/projects/project-table.tsx
@@ -129,12 +129,13 @@ export function ProjectTable({ projects, isLoading }: ProjectTableProps) {
               <TableRow key={project.id}>
                 <TableCell>
                   <div>
-                    <button
+                    <Button
                       onClick={() => setEditingProjectId(project.id)}
-                      className="font-medium hover:underline text-left"
+                      variant="link"
+                      className="h-auto p-0 font-medium text-foreground"
                     >
                       {project.name}
-                    </button>
+                    </Button>
                     <p className="text-xs text-muted-foreground font-mono">
                       {project.slug}
                     </p>

--- a/panel/src/components/settings/ai-routing-card.tsx
+++ b/panel/src/components/settings/ai-routing-card.tsx
@@ -42,6 +42,8 @@ import { toast } from "sonner";
 import { AssignmentScope, ModelProvider } from "@/types";
 import type { RoutingMode, SelfHostedTestResult } from "@/lib/api/providers";
 import { SelfHostedSection } from "@/components/settings/self-hosted-section";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 
 // Matches the roboco agents_config AGENT_ROLE_MAP / AGENT_TEAM_MAP.
 // Hard-coded so Mix mode shows a stable 18-row picker without an extra
@@ -254,13 +256,13 @@ export function AIRoutingCard() {
           <div className="flex items-center justify-between">
             <Label className="text-sm font-medium">Ollama Cloud API key</Label>
             {hasOllamaKey ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+              <Badge className="bg-emerald-500/10 text-emerald-600 border-0">
                 <KeyRound className="h-3 w-3" /> key set
-              </span>
+              </Badge>
             ) : (
-              <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+              <Badge className="bg-amber-500/10 text-amber-600 border-0">
                 <Key className="h-3 w-3" /> not set
-              </span>
+              </Badge>
             )}
           </div>
           <div className="flex gap-2">
@@ -278,13 +280,13 @@ export function AIRoutingCard() {
             </Button>
           </div>
           {hasOllamaKey ? (
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
+            <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+              <Checkbox
                 checked={clearKey}
-                onChange={(e) => {
-                  setClearKey(e.target.checked);
-                  if (e.target.checked) setApiKey("");
+                onCheckedChange={(checked) => {
+                  const next = checked === true;
+                  setClearKey(next);
+                  if (next) setApiKey("");
                 }}
               />
               Clear the stored key
@@ -543,29 +545,27 @@ function ModeButton({
   highlight?: boolean;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="outline"
       onClick={onClick}
       disabled={disabled}
       className={
-        "rounded-md border p-3 text-left transition-colors " +
-        (active || highlight
-          ? "border-primary bg-primary/5"
-          : "hover:bg-muted") +
-        (disabled ? " cursor-not-allowed opacity-50" : "")
+        "h-auto flex-col items-start justify-start p-3 whitespace-normal " +
+        (active || highlight ? "border-primary bg-primary/5" : "")
       }
     >
-      <div className="flex items-center gap-2 text-sm font-medium">
+      <div className="flex w-full items-center gap-2 text-sm font-medium">
         {icon}
         <span>{label}</span>
         {active ? (
-          <span className="ml-auto rounded-full bg-primary/15 px-2 py-0.5 text-xs text-primary">
+          <Badge className="ml-auto bg-primary/15 text-primary border-0 text-xs">
             active
-          </span>
+          </Badge>
         ) : null}
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">{description}</p>
-    </button>
+      <p className="mt-1 text-xs text-muted-foreground font-normal">{description}</p>
+    </Button>
   );
 }
 

--- a/panel/src/components/settings/self-hosted-section.tsx
+++ b/panel/src/components/settings/self-hosted-section.tsx
@@ -146,14 +146,14 @@ export function SelfHostedSection({
         <Server className="h-4 w-4 text-muted-foreground" />
         <Label className="text-sm font-medium">Self-Hosted LLM</Label>
         {testResult?.ok === true && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+          <Badge className="bg-emerald-500/10 text-emerald-600 border-0">
             <CheckCircle2 className="h-3 w-3" /> connected
-          </span>
+          </Badge>
         )}
         {testResult?.ok === false && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-600">
+          <Badge className="bg-red-500/10 text-red-600 border-0">
             <XCircle className="h-3 w-3" /> error
-          </span>
+          </Badge>
         )}
       </div>
 
@@ -194,10 +194,12 @@ export function SelfHostedSection({
               }
               className="pr-10"
             />
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="icon-sm"
               onClick={() => setShowToken((v) => !v)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
               aria-label={showToken ? "Hide token" : "Show token"}
             >
               {showToken ? (
@@ -205,7 +207,7 @@ export function SelfHostedSection({
               ) : (
                 <Eye className="h-4 w-4" />
               )}
-            </button>
+            </Button>
           </div>
           <Button onClick={handleSave} disabled={saveConfig.isPending}>
             {saveConfig.isPending ? "Saving…" : "Save"}
@@ -243,17 +245,17 @@ export function SelfHostedSection({
 
         {/* Inline result badge */}
         {testResult?.ok === true && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+          <Badge className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-0 px-3 py-1 text-xs">
             <CheckCircle2 className="h-3.5 w-3.5" />
             Connected &mdash; {testResult.model_count ?? 0} model
             {(testResult.model_count ?? 0) === 1 ? "" : "s"} available
-          </span>
+          </Badge>
         )}
         {testResult?.ok === false && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-3 py-1 text-xs font-medium text-red-700 dark:text-red-400">
+          <Badge className="bg-red-500/10 text-red-700 dark:text-red-400 border-0 px-3 py-1 text-xs">
             <XCircle className="h-3.5 w-3.5" />
             {testResult.error ?? "Connection failed"}
-          </span>
+          </Badge>
         )}
       </div>
 

--- a/panel/src/components/tasks/dependency-selector.tsx
+++ b/panel/src/components/tasks/dependency-selector.tsx
@@ -7,9 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Search, X, Link2, Check } from "lucide-react";
+import { Search, X, Link2 } from "lucide-react";
 
 interface DependencySelectorProps {
   selectedIds: string[];
@@ -114,22 +115,22 @@ export function DependencySelector({
                 {filteredTasks.map((task) => {
                   const isSelected = selectedIds.includes(task.id);
                   return (
-                    <button
+                    <Button
                       key={task.id}
                       type="button"
-                      className={`w-full flex items-center gap-2 p-2 rounded-md text-left hover:bg-muted transition-colors ${
-                        isSelected ? "bg-primary/10" : ""
+                      variant="ghost"
+                      className={`w-full h-auto justify-start gap-2 p-2 font-normal whitespace-normal ${
+                        isSelected ? "bg-primary/10 hover:bg-primary/10" : ""
                       }`}
                       onClick={() => toggleTask(task.id)}
                     >
-                      <div
-                        className={`h-4 w-4 rounded border flex items-center justify-center shrink-0 ${
-                          isSelected ? "bg-primary border-primary" : "border-muted-foreground"
-                        }`}
-                      >
-                        {isSelected && <Check className="h-3 w-3 text-primary-foreground" />}
-                      </div>
-                      <div className="flex-1 min-w-0">
+                      <Checkbox
+                        checked={isSelected}
+                        tabIndex={-1}
+                        className="pointer-events-none shrink-0"
+                        aria-hidden
+                      />
+                      <div className="flex-1 min-w-0 text-left">
                         <p className="text-sm truncate">{task.title}</p>
                         <div className="flex items-center gap-2 text-xs text-muted-foreground">
                           <Badge variant="outline" className="font-mono text-xs">
@@ -138,7 +139,7 @@ export function DependencySelector({
                           <span className="capitalize">{task.status.replace(/_/g, " ")}</span>
                         </div>
                       </div>
-                    </button>
+                    </Button>
                   );
                 })}
               </div>

--- a/panel/src/components/tasks/task-table.tsx
+++ b/panel/src/components/tasks/task-table.tsx
@@ -180,15 +180,16 @@ function SortableHeader({ label, field, sortConfig, onSort, className }: Sortabl
 
   return (
     <TableHead className={className}>
-      <button
+      <Button
         onClick={() => onSort(field)}
-        className="flex items-center gap-1 hover:text-foreground transition-colors -ml-2 px-2 py-1 rounded hover:bg-muted"
+        variant="ghost"
+        className="h-auto -ml-2 px-2 py-1 gap-1 font-normal"
       >
         {label}
         {!isActive && <ArrowUpDown className="h-4 w-4 text-muted-foreground" />}
         {direction === "asc" && <ArrowUp className="h-4 w-4" />}
         {direction === "desc" && <ArrowDown className="h-4 w-4" />}
-      </button>
+      </Button>
     </TableHead>
   );
 }
@@ -479,16 +480,18 @@ export function TaskTable({
                         style={{ paddingLeft: `${node.depth * 1.5}rem` }}
                       >
                         {hasChildren ? (
-                          <button
+                          <Button
                             onClick={() => toggleExpand(task.id)}
-                            className="p-0.5 hover:bg-muted rounded shrink-0"
+                            variant="ghost"
+                            size="icon-sm"
+                            className="p-0.5 h-5 w-5 shrink-0"
                           >
                             {isExpanded ? (
                               <ChevronDown className="h-4 w-4" />
                             ) : (
                               <ChevronRightIcon className="h-4 w-4" />
                             )}
-                          </button>
+                          </Button>
                         ) : (
                           <span className="w-5 shrink-0" />
                         )}


### PR DESCRIPTION
Fix five acceptance criteria related to layout, scrollbars, and component standardization across the panel.

**1. Settings page full-width multi-column layout (viewport >= 1024px)**
File: `panel/src/app/(dashboard)/settings/page.tsx`
- Remove the `max-w-3xl` class from the outer `<div className="space-y-6 max-w-3xl">` wrapper.
- Reorganize the section Cards into a two-column grid at >=1024px. Suggested structure: at `lg:` breakpoint, place Appearance + Notifications on the left column and Data & Refresh + Connection Info + User Info on the right. The Transcript Retention and Save button span full width. Use `grid grid-cols-1 lg:grid-cols-2 gap-6` for the section layout, keeping `space-y-6` for the top-level container.

**2. AI Providers page full-width multi-column layout (viewport >= 1024px)**
File: `panel/src/app/(dashboard)/settings/ai-providers/page.tsx`
- Remove the `max-w-5xl` class from the wrapper `<div className="space-y-6 max-w-5xl">`.
- The AIRoutingCard component itself (`panel/src/components/settings/ai-routing-card.tsx`) should expand to the container's full width. If it has an internal fixed-width constraint, remove it too and let it be responsive.

**3. Journals AgentList nested scrollbar elimination**
File: `panel/src/components/journals/agent-list.tsx`
- The component currently renders a `<ScrollArea>` that wraps the entire agent list. The parent `JournalsPage` places this inside a `<Card>` inside the grid. This creates a nested scroll context when the main page itself scrolls.
- Replace the `<ScrollArea>` wrapper with a plain `<div className="max-h-[calc(100vh-280px)] overflow-y-auto space-y-1">` (adjust the calc offset to match header + padding height so the list stays within the viewport without the page scrolling).
- Verify no other `overflow: auto / scroll` wrapper exists in the parent chain for this component.

**4. Secretary input row button consistent height**
File: `panel/src/components/business/secretary-tab.tsx`
- In the chat input row `<div className="flex gap-2">` that contains the `<Textarea>` and `<Button>`, add `items-stretch` to the flex container: `<div className="flex gap-2 items-stretch">`.
- Change the Button to `className="self-stretch"` (or ensure no fixed height overrides it) so it grows with the Textarea when the user enters multiple lines.
- If the Button uses a fixed icon-only layout, change to `size="default"` with the icon so the height is flex-driven.

**5. Design-system component audit (global sweep)**
- Search for `<button` (lowercase) tags, inline `style={{ background: ... }}` on interactive elements, and hardcoded color classes like `bg-blue-500 text-white` on interactive elements outside `components/ui/`. Replace with the equivalent `<Button variant="...">` from `components/ui/button.tsx`.
- Search for `<input` (lowercase) tags not wrapped in the `<Input>` component. Replace with `<Input>` from `components/ui/input.tsx`.
- Search for hand-rolled card-like divs with `rounded`, `shadow`, `border p-4` that replicate `<Card>`. Replace with `<Card><CardContent>`.
- Search for hand-rolled badge `<span className="... px-2 py-0.5 rounded-full ...">` elements. Replace with `<Badge>`.
- Do NOT change components that intentionally extend or wrap the ui/ components (e.g., a styled wrapper that imports from ui/ is fine). Only target raw HTML elements that bypass the design system.
- Run `pnpm typecheck` and `pnpm lint` to verify no regressions.