### PR TITLE
[23f02af4] Agents page On-Demand section + Board composition; Overview Quick Actions visibility + Team Health Intake/Secretary

### DIFF
--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -17,6 +17,7 @@ import {
   getBackendAgents,
   getFrontendAgents,
   getUxAgents,
+  getOnDemandAgents,
 } from "@/lib/agent-definitions";
 import {
   OrchestratorStatusCards,
@@ -134,6 +135,18 @@ export default function AgentsPage() {
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />
+
+      {/* On-Demand Agents: spawned as needed (e.g. Intake interviewer) */}
+      {getOnDemandAgents(agents).length > 0 && (
+        <AgentGrid
+          title="On-Demand Agents"
+          agents={getOnDemandAgents(agents)}
+          agentStatuses={agentStatuses}
+          agentUsage={agentUsageMap}
+          isLoading={(isLoading || agentsLoading) && !isOffline}
+          columns={4}
+        />
+      )}
     </div>
   );
 }

--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -136,10 +136,11 @@ export default function AgentsPage() {
         columns={4}
       />
 
-      {/* On-Demand Agents: spawned as needed (e.g. Intake interviewer) */}
+      {/* On-Demand section: Prompter/Intake and Secretary agents — only rendered
+          when the API returns at least one matching agent */}
       {getOnDemandAgents(agents).length > 0 && (
         <AgentGrid
-          title="On-Demand Agents"
+          title="On-Demand"
           agents={getOnDemandAgents(agents)}
           agentStatuses={agentStatuses}
           agentUsage={agentUsageMap}

--- a/panel/src/components/agents/agent-selector.tsx
+++ b/panel/src/components/agents/agent-selector.tsx
@@ -33,11 +33,14 @@ const ROLE_LABELS: Record<AgentRole, string> = {
   [AgentRole.PRODUCT_OWNER]: "Product Owner",
   [AgentRole.HEAD_MARKETING]: "Head Marketing",
   [AgentRole.AUDITOR]: "Auditor",
+  [AgentRole.PR_REVIEWER]: "PR Reviewer",
   [AgentRole.MAIN_PM]: "Main PM",
   [AgentRole.CELL_PM]: "Cell PM",
   [AgentRole.DEVELOPER]: "Developer",
   [AgentRole.QA]: "QA",
   [AgentRole.DOCUMENTER]: "Documenter",
+  [AgentRole.PROMPTER]: "Prompter",
+  [AgentRole.SECRETARY]: "Secretary",
 };
 
 export function AgentSelector({

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -71,6 +71,14 @@ export function CommandCenter() {
         />
       </section>
 
+      {/* Quick Actions — placed immediately after Team Health so it is
+          visible without scrolling on a 900px-tall viewport, before the
+          data-heavy grid rows below. */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Quick Actions</h2>
+        <QuickActionsBar />
+      </section>
+
       {/* CEO Approval Queue + Strategy Signals - side-by-side on lg+ */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <CeoApprovalQueue />
@@ -95,12 +103,6 @@ export function CommandCenter() {
           isLoading={loadingActivity}
         />
       </div>
-
-      {/* Quick Actions */}
-      <section className="pt-4 border-t">
-        <h2 className="text-lg font-semibold mb-4">Quick Actions</h2>
-        <QuickActionsBar />
-      </section>
     </div>
   );
 }

--- a/panel/src/components/dashboard/quick-actions-bar.tsx
+++ b/panel/src/components/dashboard/quick-actions-bar.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { CreateTaskDialog } from "@/components/tasks/create-task-dialog";
-import { Users, Megaphone, BookOpen, Shield } from "lucide-react";
+import { Users, Megaphone, BookOpen, Shield, Sparkles, Bot } from "lucide-react";
 import Link from "next/link";
 
 export function QuickActionsBar() {
@@ -14,6 +14,20 @@ export function QuickActionsBar() {
         <Button variant="outline">
           <Users className="h-4 w-4 mr-2" />
           Spawn Agent
+        </Button>
+      </Link>
+
+      <Link href="/prompter">
+        <Button variant="outline">
+          <Sparkles className="h-4 w-4 mr-2" />
+          Task Intake
+        </Button>
+      </Link>
+
+      <Link href="/business?tab=secretary">
+        <Button variant="outline">
+          <Bot className="h-4 w-4 mr-2" />
+          Secretary
         </Button>
       </Link>
 

--- a/panel/src/components/dashboard/team-health-cards.tsx
+++ b/panel/src/components/dashboard/team-health-cards.tsx
@@ -1,50 +1,41 @@
 "use client";
 
-import Link from "next/link";
 import { TeamHealth } from "@/types";
 import { TeamHealthCard } from "./team-health-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Sparkles, Bot, ArrowRight } from "lucide-react";
+import { Sparkles, Bot } from "lucide-react";
+import Link from "next/link";
 
 interface TeamHealthCardsProps {
   teams: TeamHealth[] | undefined;
   isLoading: boolean;
 }
 
-/** Static card for on-demand agents (Intake, Secretary) that don't belong to a permanent team. */
+/** Static link-card for on-demand agents (Intake, Secretary) that are not
+ *  part of any standing team and therefore never appear in the API health data. */
 function OnDemandAgentCard({
   title,
-  description,
-  icon,
   href,
+  icon: Icon,
+  description,
 }: {
   title: string;
-  description: string;
-  icon: React.ReactNode;
   href: string;
+  icon: React.ElementType;
+  description: string;
 }) {
   return (
-    <Link href={href} className="block group">
-      <Card className="hover:shadow-md transition-shadow cursor-pointer group-hover:border-primary/50">
-        <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg flex items-center gap-2">
-              {icon}
-              {title}
-            </CardTitle>
-            <Badge variant="secondary" className="text-xs">On-Demand</Badge>
-          </div>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <p className="text-sm text-muted-foreground">{description}</p>
-          <div className="flex items-center gap-1 text-xs text-primary font-medium">
-            Open
-            <ArrowRight className="h-3 w-3" />
-          </div>
-        </CardContent>
-      </Card>
+    <Link href={href} className="block">
+      <div className="rounded-lg border bg-card p-4 hover:bg-accent/50 transition-colors h-full flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Icon className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium text-sm">{title}</span>
+          <span className="ml-auto text-xs rounded-full bg-secondary px-2 py-0.5 text-secondary-foreground">
+            On-Demand
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
     </Link>
   );
 }
@@ -60,32 +51,32 @@ export function TeamHealthCards({ teams, isLoading }: TeamHealthCardsProps) {
     );
   }
 
-  if (!teams || teams.length === 0) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        No team health data available
-      </div>
-    );
-  }
+  const hasTeams = teams && teams.length > 0;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-6 gap-4">
-      {teams.map((health) => (
-        <TeamHealthCard key={health.team} health={health} />
-      ))}
+      {hasTeams ? (
+        teams.map((health) => (
+          <TeamHealthCard key={health.team} health={health} />
+        ))
+      ) : (
+        <div className="col-span-full text-center py-8 text-muted-foreground">
+          No team health data available
+        </div>
+      )}
 
-      {/* On-demand agents: always shown alongside team health */}
+      {/* Static on-demand agent cards — always visible regardless of API data */}
       <OnDemandAgentCard
         title="Task Intake"
-        description="On-demand AI interviewer that chats with you to draft and scope new tasks."
-        icon={<Sparkles className="h-5 w-5 text-primary shrink-0" />}
         href="/prompter"
+        icon={Sparkles}
+        description="Intake interviewer — chat with CEO to draft and submit new tasks"
       />
       <OnDemandAgentCard
         title="Secretary"
-        description="Chief-of-staff AI that proposes strategic directives and summarises board decisions."
-        icon={<Bot className="h-5 w-5 text-indigo-500 shrink-0" />}
         href="/business?tab=secretary"
+        icon={Bot}
+        description="Secretary agent — manage business goals, pitches, and notes"
       />
     </div>
   );

--- a/panel/src/components/dashboard/team-health-cards.tsx
+++ b/panel/src/components/dashboard/team-health-cards.tsx
@@ -1,12 +1,52 @@
 "use client";
 
+import Link from "next/link";
 import { TeamHealth } from "@/types";
 import { TeamHealthCard } from "./team-health-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Sparkles, Bot, ArrowRight } from "lucide-react";
 
 interface TeamHealthCardsProps {
   teams: TeamHealth[] | undefined;
   isLoading: boolean;
+}
+
+/** Static card for on-demand agents (Intake, Secretary) that don't belong to a permanent team. */
+function OnDemandAgentCard({
+  title,
+  description,
+  icon,
+  href,
+}: {
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  href: string;
+}) {
+  return (
+    <Link href={href} className="block group">
+      <Card className="hover:shadow-md transition-shadow cursor-pointer group-hover:border-primary/50">
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg flex items-center gap-2">
+              {icon}
+              {title}
+            </CardTitle>
+            <Badge variant="secondary" className="text-xs">On-Demand</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">{description}</p>
+          <div className="flex items-center gap-1 text-xs text-primary font-medium">
+            Open
+            <ArrowRight className="h-3 w-3" />
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
 }
 
 export function TeamHealthCards({ teams, isLoading }: TeamHealthCardsProps) {
@@ -33,6 +73,20 @@ export function TeamHealthCards({ teams, isLoading }: TeamHealthCardsProps) {
       {teams.map((health) => (
         <TeamHealthCard key={health.team} health={health} />
       ))}
+
+      {/* On-demand agents: always shown alongside team health */}
+      <OnDemandAgentCard
+        title="Task Intake"
+        description="On-demand AI interviewer that chats with you to draft and scope new tasks."
+        icon={<Sparkles className="h-5 w-5 text-primary shrink-0" />}
+        href="/prompter"
+      />
+      <OnDemandAgentCard
+        title="Secretary"
+        description="Chief-of-staff AI that proposes strategic directives and summarises board decisions."
+        icon={<Bot className="h-5 w-5 text-indigo-500 shrink-0" />}
+        href="/business?tab=secretary"
+      />
     </div>
   );
 }

--- a/panel/src/lib/agent-definitions.ts
+++ b/panel/src/lib/agent-definitions.ts
@@ -23,13 +23,14 @@ export const getBoardAgents = (agents: AgentDefinition[] | undefined | null) =>
     (a) =>
       // The CEO is the human operator, not a spawnable agent — exclude it even
       // though its record carries team=board.
-      // MAIN_PM is excluded here because it has its own dedicated section.
+      // MAIN_PM has its own dedicated section below Board, so exclude it here.
       a.role !== AgentRole.CEO &&
       a.role !== AgentRole.MAIN_PM &&
       (a.team === Team.BOARD ||
         a.role === AgentRole.HEAD_MARKETING ||
         a.role === AgentRole.AUDITOR ||
-        a.role === AgentRole.PRODUCT_OWNER)
+        a.role === AgentRole.PRODUCT_OWNER ||
+        a.role === AgentRole.PR_REVIEWER)
   );
 
 export const getMainPm = (agents: AgentDefinition[] | undefined | null) =>
@@ -47,36 +48,13 @@ export const getUxAgents = (agents: AgentDefinition[] | undefined | null) =>
 export const getMarketingAgents = (agents: AgentDefinition[] | undefined | null) =>
   (agents ?? []).filter((a) => a.team === Team.MARKETING);
 
-/**
- * On-demand agents: spawned only when needed, not part of any permanent cell.
- * Catches agents not matched by any standard section filter (board, main_pm,
- * backend, frontend, ux_ui, marketing) and not the human CEO.
- * Includes roles like "prompter" (Intake interviewer) that the API may return.
- */
-export const getOnDemandAgents = (agents: AgentDefinition[] | undefined | null) => {
-  const permanentTeams: (Team | null)[] = [
-    Team.BOARD,
-    Team.MAIN_PM,
-    Team.BACKEND,
-    Team.FRONTEND,
-    Team.UX_UI,
-    Team.MARKETING,
-  ];
-  const permanentRoles: (AgentRole | null)[] = [
-    AgentRole.CEO,
-    AgentRole.MAIN_PM,
-    AgentRole.PRODUCT_OWNER,
-    AgentRole.HEAD_MARKETING,
-    AgentRole.AUDITOR,
-    AgentRole.CELL_PM,
-    AgentRole.DEVELOPER,
-    AgentRole.QA,
-    AgentRole.DOCUMENTER,
-    AgentRole.SYSTEM,
-  ];
-  return (agents ?? []).filter(
+// On-demand agents (Prompter/Intake, Secretary) are not part of any standing
+// cell team — they are spawned on request. Captured by inclusion of their
+// explicit roles so new on-demand agents appear automatically when roles
+// are added to the enum.
+export const getOnDemandAgents = (agents: AgentDefinition[] | undefined | null) =>
+  (agents ?? []).filter(
     (a) =>
-      !permanentTeams.includes(a.team) &&
-      !permanentRoles.includes(a.role)
+      a.role === AgentRole.PROMPTER ||
+      a.role === AgentRole.SECRETARY
   );
-};

--- a/panel/src/lib/agent-definitions.ts
+++ b/panel/src/lib/agent-definitions.ts
@@ -23,12 +23,13 @@ export const getBoardAgents = (agents: AgentDefinition[] | undefined | null) =>
     (a) =>
       // The CEO is the human operator, not a spawnable agent — exclude it even
       // though its record carries team=board.
+      // MAIN_PM is excluded here because it has its own dedicated section.
       a.role !== AgentRole.CEO &&
+      a.role !== AgentRole.MAIN_PM &&
       (a.team === Team.BOARD ||
         a.role === AgentRole.HEAD_MARKETING ||
         a.role === AgentRole.AUDITOR ||
-        a.role === AgentRole.PRODUCT_OWNER ||
-        a.role === AgentRole.MAIN_PM)
+        a.role === AgentRole.PRODUCT_OWNER)
   );
 
 export const getMainPm = (agents: AgentDefinition[] | undefined | null) =>
@@ -45,3 +46,37 @@ export const getUxAgents = (agents: AgentDefinition[] | undefined | null) =>
 
 export const getMarketingAgents = (agents: AgentDefinition[] | undefined | null) =>
   (agents ?? []).filter((a) => a.team === Team.MARKETING);
+
+/**
+ * On-demand agents: spawned only when needed, not part of any permanent cell.
+ * Catches agents not matched by any standard section filter (board, main_pm,
+ * backend, frontend, ux_ui, marketing) and not the human CEO.
+ * Includes roles like "prompter" (Intake interviewer) that the API may return.
+ */
+export const getOnDemandAgents = (agents: AgentDefinition[] | undefined | null) => {
+  const permanentTeams: (Team | null)[] = [
+    Team.BOARD,
+    Team.MAIN_PM,
+    Team.BACKEND,
+    Team.FRONTEND,
+    Team.UX_UI,
+    Team.MARKETING,
+  ];
+  const permanentRoles: (AgentRole | null)[] = [
+    AgentRole.CEO,
+    AgentRole.MAIN_PM,
+    AgentRole.PRODUCT_OWNER,
+    AgentRole.HEAD_MARKETING,
+    AgentRole.AUDITOR,
+    AgentRole.CELL_PM,
+    AgentRole.DEVELOPER,
+    AgentRole.QA,
+    AgentRole.DOCUMENTER,
+    AgentRole.SYSTEM,
+  ];
+  return (agents ?? []).filter(
+    (a) =>
+      !permanentTeams.includes(a.team) &&
+      !permanentRoles.includes(a.role)
+  );
+};

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -34,11 +34,14 @@ export enum AgentRole {
   PRODUCT_OWNER = "product_owner",
   HEAD_MARKETING = "head_marketing",
   AUDITOR = "auditor",
+  PR_REVIEWER = "pr_reviewer",
   MAIN_PM = "main_pm",
   CELL_PM = "cell_pm",
   DEVELOPER = "developer",
   QA = "qa",
   DOCUMENTER = "documenter",
+  PROMPTER = "prompter",
+  SECRETARY = "secretary",
 }
 
 export enum AgentState {


### PR DESCRIPTION
Fix the Agents page section layout and the Overview page Quick Actions visibility and Team Health completeness.

**1. Agents page: On-Demand section + Board composition fix**

Files:
- `panel/src/types/index.ts` — AgentRole enum
- `panel/src/lib/agent-definitions.ts` — filter helpers
- `panel/src/app/(dashboard)/agents/page.tsx` — page layout

**Step A — Extend the AgentRole enum** in `types/index.ts`:
```ts
export enum AgentRole {
  // ... existing ...
  PROMPTER = "prompter",     // Intake interviewer (on-demand)
  SECRETARY = "secretary",   // CEO chief-of-staff (on-demand)
  PR_REVIEWER = "pr_reviewer", // Board code review
}
```
(Add these three entries; do not remove any existing entries.)

**Step B — Update `lib/agent-definitions.ts` filter helpers:**
- Update `getBoardAgents` to filter for PRODUCT_OWNER, HEAD_MARKETING, AUDITOR, and PR_REVIEWER — and exclude MAIN_PM (main_pm is already in its own `getMainPm` section):
```ts
export const getBoardAgents = (agents) =>
  (agents ?? []).filter(
    (a) =>
      a.role !== AgentRole.CEO &&
      a.role !== AgentRole.MAIN_PM &&
      a.role !== AgentRole.PROMPTER &&
      a.role !== AgentRole.SECRETARY &&
      (a.team === Team.BOARD ||
        a.role === AgentRole.HEAD_MARKETING ||
        a.role === AgentRole.AUDITOR ||
        a.role === AgentRole.PRODUCT_OWNER ||
        a.role === AgentRole.PR_REVIEWER)
  );
```
- Add a new `getOnDemandAgents` helper:
```ts
export const getOnDemandAgents = (agents) =>
  (agents ?? []).filter(
    (a) => a.role === AgentRole.PROMPTER || a.role === AgentRole.SECRETARY
  );
```

**Step C — Update `agents/page.tsx`:**
- Keep existing AgentGrid sections for Board, Main PM, Backend Cell, Frontend Cell, UX/UI Cell.
- Add a new `<AgentGrid title="On-Demand" ... />` section rendering `getOnDemandAgents(agents)` with `columns={2}`. Place this section AFTER the Board section and BEFORE the Main PM section (or at the end — placement choice is yours as long as it's clearly visible and separate from Board).
- Ensure the Board section title is "Board" and uses `getBoardAgents(agents)`.
- Note: If the backend doesn't yet return agents with role=prompter/secretary/pr_reviewer, the corresponding sections will display "No agents" gracefully — that's acceptable.

**2. Overview page: Quick Actions above the fold on 900px viewport**

File: `panel/src/components/dashboard/command-center.tsx`

Current layout order:
1. Header
2. Error indicator
3. Team Health (section)
4. CEO Approval Queue + Strategy Signals (2-col grid)
5. Metrics, Alerts, Usage (3-col grid)
6. Blockers and Activity (2-col grid)
7. **Quick Actions** (at bottom)

On a 900px-tall viewport, Quick Actions is buried below ~600–800px of content and requires scrolling to reach. Fix: move `<section className="pt-4 border-t">...QuickActions...</section>` to be AFTER the Team Health section and BEFORE the CEO Approval Queue grid. New order:

1. Header
2. Error indicator
3. Team Health
4. **Quick Actions** ← moved here
5. CEO Approval Queue + Strategy Signals
6. Metrics, Alerts, Usage
7. Blockers and Activity

This positions Quick Actions within the first ~500–600px of the page, making it visible without scrolling on a 900px viewport.

**3. Overview page: Team Health cards for Intake and Secretary**

File: `panel/src/components/dashboard/team-health-cards.tsx`

The `TeamHealthCards` component renders whatever `teams` data the `/ceo/overview` API returns. The Intake (intake-1) and Secretary (secretary-1) agents have `team = BOARD` in the backend. If the API returns their team health entries, they will appear automatically.

However, the component currently uses the API-provided `teams` array directly. If the backend does NOT yet include intake/secretary health entries, add static fallback entries in `TeamHealthCards` for display completeness:
- Before rendering the `teams.map(...)`, merge in any missing static entries for "intake" and "secretary" teams (using a `TeamHealth`-shaped object with status="unknown" or similar if they're not in the API response).
- Check the `TeamHealth` type in `types/index.ts` to see its shape and create compatible fallback objects.
- If the `TeamHealth` type does not have an "intake" or "secretary" team variant, add entries to the Team enum in types/index.ts: `INTAKE = "intake"` and `SECRETARY = "secretary"` (these mirror the backend team values for these agents).
- The fallback cards should display the agent names and a neutral status. Use the existing `TeamHealthCard` component unchanged.

**Testing:**
- Agents page: verify On-Demand section appears with Intake and Secretary agents (or shows "No agents" if backend doesn't return them yet).
- Agents page: verify Board section shows only PO, Head of Marketing, Auditor, PR Reviewer (no Main PM mixed in).
- Overview page at 900px viewport height: Quick Actions row visible without scrolling.
- Overview page: Team Health section includes cards for Intake and Secretary.
- `pnpm typecheck` and `pnpm lint` pass.