### PR TITLE
[4c179e3a] Add git pull, fetch, and rebase backend endpoints

### DIFF
--- a/roboco/api/routes/git.py
+++ b/roboco/api/routes/git.py
@@ -41,11 +41,17 @@ from roboco.api.schemas.git import (
     GitCreatePRRequest,
     GitCreatePRResponse,
     GitDiffResponse,
+    GitFetchRequest,
+    GitFetchResponse,
     GitLogResponse,
     GitMergePRRequest,
     GitMergePRResponse,
+    GitPullRequest,
+    GitPullResponse,
     GitPushRequest,
     GitPushResponse,
+    GitRebaseRequest,
+    GitRebaseResponse,
     GitStatusResponse,
 )
 from roboco.exceptions import GitCommandError, GitError, GitTimeoutError
@@ -471,4 +477,105 @@ async def merge_pull_request(
         merged=True,
         merge_commit=merge_commit,
         target_branch=target_branch,
+    )
+
+
+@router.post("/pull", response_model=GitPullResponse)
+async def pull_commits(
+    data: GitPullRequest,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> GitPullResponse:
+    """Pull latest changes from origin into the agent workspace."""
+    project_slug = await _resolve_project_slug(data.project_slug, db)
+    git_service = get_git_service(db)
+
+    try:
+        workspace = await git_service.get_workspace(project_slug, agent.agent_id)
+        (
+            current_branch,
+            has_changes,
+            staged,
+            unstaged,
+            untracked,
+            ahead,
+            behind,
+        ) = await git_service.pull(workspace)
+    except _TranslatableError as e:
+        raise _translate_error(e) from e
+
+    return GitPullResponse(
+        project_slug=project_slug,
+        current_branch=current_branch,
+        has_changes=has_changes,
+        staged_files=staged,
+        unstaged_files=unstaged,
+        untracked_files=untracked,
+        ahead=ahead,
+        behind=behind,
+    )
+
+
+@router.post("/fetch", response_model=GitFetchResponse)
+async def fetch_commits(
+    data: GitFetchRequest,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> GitFetchResponse:
+    """Fetch changes from origin without merging."""
+    project_slug = await _resolve_project_slug(data.project_slug, db)
+    git_service = get_git_service(db)
+
+    try:
+        workspace = await git_service.get_workspace(project_slug, agent.agent_id)
+        (
+            current_branch,
+            has_changes,
+            staged,
+            unstaged,
+            untracked,
+            ahead,
+            behind,
+        ) = await git_service.fetch(workspace)
+    except _TranslatableError as e:
+        raise _translate_error(e) from e
+
+    return GitFetchResponse(
+        project_slug=project_slug,
+        current_branch=current_branch,
+        has_changes=has_changes,
+        staged_files=staged,
+        unstaged_files=unstaged,
+        untracked_files=untracked,
+        ahead=ahead,
+        behind=behind,
+    )
+
+
+@router.post("/rebase", response_model=GitRebaseResponse)
+async def rebase_branch(
+    data: GitRebaseRequest,
+    db: DbSession,
+    agent: CurrentAgentContext,
+) -> GitRebaseResponse:
+    """Rebase the current branch onto target_branch.
+
+    On conflict: aborts the rebase and returns conflict=True with the
+    list of conflicted files.  On success: returns conflict=False.
+    """
+    project_slug = await _resolve_project_slug(data.project_slug, db)
+    git_service = get_git_service(db)
+
+    try:
+        workspace = await git_service.get_workspace(project_slug, agent.agent_id)
+        conflict, conflicted_files = await git_service.rebase(
+            workspace, data.target_branch
+        )
+    except _TranslatableError as e:
+        raise _translate_error(e) from e
+
+    return GitRebaseResponse(
+        project_slug=project_slug,
+        conflict=conflict,
+        conflicted_files=conflicted_files,
     )

--- a/roboco/api/schemas/git.py
+++ b/roboco/api/schemas/git.py
@@ -230,3 +230,82 @@ class GitMergePRResponse(BaseModel):
     merged: bool
     merge_commit: str | None = None
     target_branch: str
+
+
+# =============================================================================
+# PULL
+# =============================================================================
+
+
+class GitPullRequest(BaseModel):
+    """Request to pull latest changes from origin."""
+
+    project_slug: str
+    task_id: UUID
+    agent_id: str
+
+
+class GitPullResponse(BaseModel):
+    """Response from git pull — branch status after the pull."""
+
+    project_slug: str
+    current_branch: str
+    has_changes: bool
+    staged_files: list[str] = []
+    unstaged_files: list[str] = []
+    untracked_files: list[str] = []
+    ahead: int = 0
+    behind: int = 0
+
+
+# =============================================================================
+# FETCH
+# =============================================================================
+
+
+class GitFetchRequest(BaseModel):
+    """Request to fetch changes from origin without merging."""
+
+    project_slug: str
+    task_id: UUID
+    agent_id: str
+
+
+class GitFetchResponse(BaseModel):
+    """Response from git fetch — branch status after the fetch."""
+
+    project_slug: str
+    current_branch: str
+    has_changes: bool
+    staged_files: list[str] = []
+    unstaged_files: list[str] = []
+    untracked_files: list[str] = []
+    ahead: int = 0
+    behind: int = 0
+
+
+# =============================================================================
+# REBASE
+# =============================================================================
+
+
+class GitRebaseRequest(BaseModel):
+    """Request to rebase the current branch onto a target branch."""
+
+    project_slug: str
+    task_id: UUID
+    agent_id: str
+    target_branch: str
+
+
+class GitRebaseResponse(BaseModel):
+    """Response from git rebase.
+
+    On success: conflict=False, conflicted_files=[].
+    On conflict: conflict=True, conflicted_files lists the unmerged paths;
+    the rebase has been aborted so the workspace is clean.
+    """
+
+    project_slug: str
+    conflict: bool = False
+    conflicted_files: list[str] = []

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -1149,6 +1149,72 @@ class GitService(BaseService):
         return pushed
 
     # =========================================================================
+    # PULL / FETCH / REBASE METHODS
+    # =========================================================================
+
+    async def pull(
+        self, workspace: Path
+    ) -> tuple[str, bool, list[str], list[str], list[str], int, int]:
+        """Pull latest changes from origin and return post-pull status.
+
+        Uses _network_git_timeout() because the operation talks to origin.
+
+        Returns: (current_branch, has_changes, staged, unstaged, untracked,
+                  ahead, behind)
+        """
+        token = await self._token_for_workspace(workspace)
+        await self._run_git(
+            workspace, ["pull"], token=token, timeout=_network_git_timeout()
+        )
+        return await self.get_status(workspace)
+
+    async def fetch(
+        self, workspace: Path
+    ) -> tuple[str, bool, list[str], list[str], list[str], int, int]:
+        """Fetch changes from origin without merging and return post-fetch status.
+
+        Uses _network_git_timeout() because the operation talks to origin.
+
+        Returns: (current_branch, has_changes, staged, unstaged, untracked,
+                  ahead, behind)
+        """
+        token = await self._token_for_workspace(workspace)
+        await self._run_git(
+            workspace,
+            ["fetch", "origin"],
+            token=token,
+            timeout=_network_git_timeout(),
+        )
+        return await self.get_status(workspace)
+
+    async def rebase(
+        self, workspace: Path, target_branch: str
+    ) -> tuple[bool, list[str]]:
+        """Rebase the current branch onto target_branch.
+
+        On conflict (non-zero exit): captures unmerged files via
+        ``git diff --name-only --diff-filter=U``, aborts the rebase to
+        restore a clean workspace, and returns ``(True, conflicted_files)``.
+
+        On success: returns ``(False, [])``.
+        """
+        result = await self._run_git(workspace, ["rebase", target_branch], check=False)
+        if result.returncode != 0:
+            conflict_result = await self._run_git(
+                workspace,
+                ["diff", "--name-only", "--diff-filter=U"],
+                check=False,
+            )
+            conflicted_files = [
+                f.strip()
+                for f in conflict_result.stdout.strip().split("\n")
+                if f.strip()
+            ]
+            await self._run_git(workspace, ["rebase", "--abort"], check=False)
+            return True, conflicted_files
+        return False, []
+
+    # =========================================================================
     # PR METHODS
     # =========================================================================
 

--- a/tests/integration/test_git_routes.py
+++ b/tests/integration/test_git_routes.py
@@ -681,5 +681,182 @@ async def test_status_generic_service_error(git_client: dict) -> None:
     assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+# ---------------------------------------------------------------------------
+# pull
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_success(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        svc.pull = AsyncMock(return_value=("main", False, [], [], [], 0, 0))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/pull",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["current_branch"] == "main"
+    assert "ahead" in data
+    assert "behind" in data
+    assert "has_changes" in data
+    assert "staged_files" in data
+    assert "unstaged_files" in data
+    assert "untracked_files" in data
+
+
+@pytest.mark.asyncio
+async def test_pull_git_command_error(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        svc.pull = AsyncMock(side_effect=GitCommandError("pull", "network error"))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/pull",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# fetch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_success(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        _ahead = 2
+        _behind = 1
+        svc.fetch = AsyncMock(
+            return_value=("feature/x", True, ["a.py"], [], [], _ahead, _behind)
+        )
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/fetch",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["current_branch"] == "feature/x"
+    assert data["ahead"] == _ahead
+    assert data["behind"] == _behind
+    assert data["has_changes"] is True
+    assert "staged_files" in data
+    assert "unstaged_files" in data
+    assert "untracked_files" in data
+
+
+@pytest.mark.asyncio
+async def test_fetch_git_command_error(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        svc.fetch = AsyncMock(side_effect=GitCommandError("fetch", "network error"))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/fetch",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# rebase
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebase_success(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        svc.rebase = AsyncMock(return_value=(False, []))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/rebase",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+                "target_branch": "main",
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["conflict"] is False
+    assert data["conflicted_files"] == []
+
+
+@pytest.mark.asyncio
+async def test_rebase_conflict(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        svc.rebase = AsyncMock(return_value=(True, ["src/foo.py", "src/bar.py"]))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/rebase",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+                "target_branch": "main",
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["conflict"] is True
+    assert data["conflicted_files"] == ["src/foo.py", "src/bar.py"]
+
+
+@pytest.mark.asyncio
+async def test_rebase_git_command_error(git_client: dict) -> None:
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.get_workspace = AsyncMock(return_value="/tmp/ws")
+        svc.rebase = AsyncMock(side_effect=GitCommandError("rebase", "fatal error"))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/rebase",
+            json={
+                "project_slug": git_client["project"].slug,
+                "task_id": str(uuid4()),
+                "agent_id": str(uuid4()),
+                "target_branch": "main",
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
 # Re-export to keep import alive (TC reorders imports)
 _ = SimpleNamespace

--- a/tests/unit/services/test_git_rebase.py
+++ b/tests/unit/services/test_git_rebase.py
@@ -1,0 +1,213 @@
+"""Unit tests for GitService rebase conflict-state handling.
+
+Pins the three critical control-flow branches of ``rebase_onto_base``:
+
+1. **Success** — the underlying ``git rebase`` exits 0 → method returns a
+   non-conflict result dict and never calls ``git rebase --abort``.
+2. **Conflict** — ``git rebase`` exits non-zero → method calls
+   ``git diff --name-only --diff-filter=U`` to collect conflicted files,
+   calls ``git rebase --abort`` to restore the workspace, and returns a
+   conflict result dict.
+3. **Resilience** — both ``git rebase`` and ``git rebase --abort`` exit
+   non-zero (e.g. abort fails mid-stream).  The method must still return
+   the conflict dict without propagating an exception, because both are
+   invoked with ``check=False``.
+
+All tests mock ``_run_git`` at the service-method level using
+``AsyncMock`` with a ``side_effect`` list so each awaited call consumes
+the next pre-configured result in order.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+from roboco.services.git import GitService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HEAD = "feature/backend/root--task"
+_BASE = "feature/backend/root"
+_WORKSPACE = Path("/tmp/fake-ws")
+_TOKEN = "ghp_fake"
+
+
+def _git_service() -> GitService:
+    """Instantiate GitService without a real DB session."""
+    svc = GitService.__new__(GitService)
+    svc.log = MagicMock()  # silence warning/info calls
+    return svc
+
+
+def _result(returncode: int = 0, stdout: str = "") -> Any:
+    """Minimal subprocess result stand-in."""
+    r = MagicMock()
+    r.returncode = returncode
+    r.stdout = stdout
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_path_returns_rebased_and_does_not_call_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When git rebase exits 0 the method returns a non-conflict result and
+    never invokes ``git rebase --abort``.
+
+    Call sequence for the success path (rebase OK, 2 unique commits):
+      [0] fetch origin
+      [1] checkout HEAD branch
+      [2] reset --hard origin/HEAD
+      [3] rebase origin/BASE          ← exits 0
+      [4] rev-list --count            ← returns "2"
+      [5] push --force-with-lease     ← pushes the rebased branch
+    """
+    run = AsyncMock(
+        side_effect=[
+            _result(),  # [0] fetch
+            _result(),  # [1] checkout
+            _result(),  # [2] reset
+            _result(),  # [3] rebase ← success
+            _result(stdout="2\n"),  # [4] rev-list
+            _result(),  # [5] push
+        ]
+    )
+    monkeypatch.setattr(GitService, "_run_git", run)
+
+    svc = _git_service()
+    result = await svc.rebase_onto_base(
+        _WORKSPACE,
+        head_branch=_HEAD,
+        base_branch=_BASE,
+        git_token=_TOKEN,
+    )
+
+    assert result == {"status": "rebased", "unique_commits": 2}
+
+    # Verify abort was never called
+    abort_call = call(_WORKSPACE, ["rebase", "--abort"], check=False)
+    assert abort_call not in run.call_args_list, (
+        "git rebase --abort must NOT be called on a clean rebase"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — conflict path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_conflict_path_calls_diff_then_abort_and_returns_conflict_files(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When git rebase exits non-zero the method:
+
+    * calls ``git diff --name-only --diff-filter=U`` to identify conflicted files,
+    * calls ``git rebase --abort`` to restore the workspace,
+    * returns ``{"status": "conflicts", "files": [<conflicted files>]}``.
+
+    Call sequence:
+      [0] fetch origin
+      [1] checkout HEAD branch
+      [2] reset --hard origin/HEAD
+      [3] rebase origin/BASE          ← exits 1 (conflict)
+      [4] diff --name-only            ← lists conflicted files
+      [5] rebase --abort              ← exits 0
+    """
+    run = AsyncMock(
+        side_effect=[
+            _result(),  # [0] fetch
+            _result(),  # [1] checkout
+            _result(),  # [2] reset
+            _result(returncode=1),  # [3] rebase ← conflict
+            _result(stdout="src/a.py\nsrc/b.py\n"),  # [4] diff
+            _result(),  # [5] rebase --abort
+        ]
+    )
+    monkeypatch.setattr(GitService, "_run_git", run)
+
+    svc = _git_service()
+    result = await svc.rebase_onto_base(
+        _WORKSPACE,
+        head_branch=_HEAD,
+        base_branch=_BASE,
+        git_token=_TOKEN,
+    )
+
+    assert result == {"status": "conflicts", "files": ["src/a.py", "src/b.py"]}
+
+    # Verify the diff call was made with the correct flags
+    diff_call = call(
+        _WORKSPACE,
+        ["diff", "--name-only", "--diff-filter=U"],
+        check=False,
+    )
+    assert diff_call in run.call_args_list, (
+        "git diff --name-only --diff-filter=U must be called to collect conflicted"
+        " files"
+    )
+
+    # Verify abort was called
+    abort_call = call(_WORKSPACE, ["rebase", "--abort"], check=False)
+    assert abort_call in run.call_args_list, (
+        "git rebase --abort must be called to restore the workspace after a conflict"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — resilience: both rebase and abort exit non-zero
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resilience_when_both_rebase_and_abort_fail_returns_conflict_no_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``git rebase`` exits non-zero AND ``git rebase --abort`` also
+    exits non-zero, the method must still return a conflict result dict
+    without raising an exception.
+
+    Both are called with ``check=False`` so a non-zero exit code from
+    either command produces a result object (not a raised exception).
+
+    Call sequence:
+      [0] fetch origin
+      [1] checkout HEAD branch
+      [2] reset --hard origin/HEAD
+      [3] rebase origin/BASE          ← exits 1 (conflict)
+      [4] diff --name-only            ← lists conflicted files
+      [5] rebase --abort              ← exits 1 (abort also fails)
+    """
+    run = AsyncMock(
+        side_effect=[
+            _result(),  # [0] fetch
+            _result(),  # [1] checkout
+            _result(),  # [2] reset
+            _result(returncode=1),  # [3] rebase ← conflict
+            _result(stdout="src/conflict.py\n"),  # [4] diff
+            _result(returncode=1),  # [5] rebase --abort ← also fails
+        ]
+    )
+    monkeypatch.setattr(GitService, "_run_git", run)
+
+    svc = _git_service()
+
+    # Must not raise even though both rebase and abort return non-zero
+    result = await svc.rebase_onto_base(
+        _WORKSPACE,
+        head_branch=_HEAD,
+        base_branch=_BASE,
+        git_token=_TOKEN,
+    )
+
+    assert result == {"status": "conflicts", "files": ["src/conflict.py"]}


### PR DESCRIPTION
Goal: Provide three new REST API endpoints (git pull, git fetch, git rebase) that the panel's Git page UI will consume. These wrap the existing _run_git primitives already used by Commit/Push/Create PR/Merge PR in git-actions-panel.tsx — the plumbing exists, you're exposing it.

Cross-cell blocker: The Frontend cell cannot wire the Git page's Pull/Fetch/Rebase buttons until these endpoints exist and return updated branch status. Ship fast to unblock FE.

Constraints:
- Each endpoint must return the updated branch status after execution so the UI can refresh without a separate status call.
- The rebase endpoint must accept a target branch parameter (the confirmation dialog and destructive-action UX is frontend's responsibility, but the endpoint must support the operation cleanly).
- Follow the existing endpoint patterns in the git router — same auth, same error shapes, same response envelope.
- No regressions on existing git endpoints (commit, push, create-pr, merge-pr).

Work units (independently shippable, dependency-free):
1. Git pull endpoint — wrap _run_git pull, return branch status
2. Git fetch endpoint — wrap _run_git fetch, return branch status
3. Git rebase endpoint — wrap _run_git rebase with target branch param, return branch status + handle conflict state

All three are independent of each other — both backend devs can work in parallel (e.g., one takes pull+fetch, the other takes rebase since it has the conflict-handling edge case).