### PR TITLE
[b1c59206] Git page: Pull, Fetch, Rebase buttons wired to backend; Rebase destructive confirmation dialog

### DIFF
--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -16,12 +16,26 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   GitCommit,
   Upload,
   GitPullRequest,
   GitMerge,
   RefreshCw,
   ArrowUp,
+  Download,
+  RefreshCcw,
+  GitGraph,
 } from "lucide-react";
 
 interface GitActionsPanelProps {
@@ -33,10 +47,16 @@ interface GitActionsPanelProps {
   onPush: (force?: boolean) => void;
   onCreatePR: (title: string, body: string) => void;
   onMergePR: (prNumber: number) => void;
+  onPull: () => void;
+  onFetch: () => void;
+  onRebase: () => void;
   isCommitting: boolean;
   isPushing: boolean;
   isCreatingPR: boolean;
   isMerging: boolean;
+  isPulling: boolean;
+  isFetching: boolean;
+  isRebasing: boolean;
 }
 
 export function GitActionsPanel({
@@ -48,10 +68,16 @@ export function GitActionsPanel({
   onPush,
   onCreatePR,
   onMergePR,
+  onPull,
+  onFetch,
+  onRebase,
   isCommitting,
   isPushing,
   isCreatingPR,
   isMerging,
+  isPulling,
+  isFetching,
+  isRebasing,
 }: GitActionsPanelProps) {
   void _agentId; // Reserved for future use
   const [showCommitDialog, setShowCommitDialog] = useState(false);
@@ -301,6 +327,73 @@ export function GitActionsPanel({
             </DialogFooter>
           </DialogContent>
         </Dialog>
+
+        {/* Pull Action */}
+        <Button
+          className="w-full justify-start"
+          variant="outline"
+          disabled={isPulling}
+          onClick={onPull}
+        >
+          {isPulling ? (
+            <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4 mr-2" />
+          )}
+          Pull from Remote
+        </Button>
+
+        {/* Fetch Action */}
+        <Button
+          className="w-full justify-start"
+          variant="outline"
+          disabled={isFetching}
+          onClick={onFetch}
+        >
+          {isFetching ? (
+            <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <RefreshCcw className="h-4 w-4 mr-2" />
+          )}
+          Fetch Remote
+        </Button>
+
+        {/* Rebase Action — destructive, requires confirmation */}
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              className="w-full justify-start"
+              variant="outline"
+              disabled={isRebasing}
+            >
+              {isRebasing ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <GitGraph className="h-4 w-4 mr-2" />
+              )}
+              Rebase onto Remote
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Rebase onto remote?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will rewrite your local commit history by replaying your
+                commits on top of the latest remote branch. Any force-push will
+                be required afterward. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={onRebase}
+              >
+                Rebase
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {/* Status Summary */}
         {status && (

--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -374,13 +374,14 @@ export function GitActionsPanel({
               Rebase onto Remote
             </Button>
           </AlertDialogTrigger>
-          <AlertDialogContent>
+          <AlertDialogContent className="border-destructive bg-destructive/5">
             <AlertDialogHeader>
               <AlertDialogTitle>Rebase onto remote?</AlertDialogTitle>
               <AlertDialogDescription>
-                This will rewrite your local commit history by replaying your
-                commits on top of the latest remote branch. Any force-push will
-                be required afterward. This action cannot be undone.
+                This will rewrite the commit history of branch{" "}
+                <strong>{status?.current_branch}</strong> by replaying commits
+                on top of the latest remote. A force-push will be required
+                afterward. This action cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -49,7 +49,7 @@ function GitBrowserContent() {
   const { data: unstagedDiff, isLoading: loadingUnstagedDiff } = useGitDiff(projectSlug, false, undefined, !!projectSlug);
 
   // Git operations
-  const { commit, push, createBranch, checkout, createPR, mergePR } = useGitOperations();
+  const { commit, push, createBranch, checkout, createPR, mergePR, pull, fetch, rebase } = useGitOperations();
 
   // Update URL params
   const updateParams = useCallback(
@@ -174,6 +174,44 @@ function GitBrowserContent() {
     }
   };
 
+  const handlePull = async () => {
+    try {
+      const result = await pull.mutateAsync({
+        project_slug: projectSlug,
+        task_id: taskId || "manual",
+        agent_id: "ceo",
+      });
+      toast.success(`Pulled ${result.commits_received} commits from ${result.remote}`);
+    } catch {
+      toast.error("Failed to pull from remote");
+    }
+  };
+
+  const handleFetch = async () => {
+    try {
+      const result = await fetch.mutateAsync({
+        project_slug: projectSlug,
+        agent_id: "ceo",
+      });
+      toast.success(`Fetched ${result.refs_updated} refs from ${result.remote}`);
+    } catch {
+      toast.error("Failed to fetch from remote");
+    }
+  };
+
+  const handleRebase = async () => {
+    try {
+      const result = await rebase.mutateAsync({
+        project_slug: projectSlug,
+        task_id: taskId || "manual",
+        agent_id: "ceo",
+      });
+      toast.success(`Rebased ${result.commits_rebased} commits onto ${result.onto}`);
+    } catch {
+      toast.error("Failed to rebase");
+    }
+  };
+
   // Check offline
   const isOffline = projectsError && (
     projectsError.message?.includes("Network Error") ||
@@ -258,10 +296,16 @@ function GitBrowserContent() {
               onPush={handlePush}
               onCreatePR={handleCreatePR}
               onMergePR={handleMergePR}
+              onPull={handlePull}
+              onFetch={handleFetch}
+              onRebase={handleRebase}
               isCommitting={commit.isPending}
               isPushing={push.isPending}
               isCreatingPR={createPR.isPending}
               isMerging={mergePR.isPending}
+              isPulling={pull.isPending}
+              isFetching={fetch.isPending}
+              isRebasing={rebase.isPending}
             />
           </div>
 

--- a/panel/src/hooks/use-git.ts
+++ b/panel/src/hooks/use-git.ts
@@ -23,6 +23,12 @@ import type {
   GitCreatePRResponse,
   GitMergePRRequest,
   GitMergePRResponse,
+  GitPullRequest,
+  GitPullResponse,
+  GitFetchRequest,
+  GitFetchResponse,
+  GitRebaseRequest,
+  GitRebaseResponse,
 } from "@/types/git";
 
 // =============================================================================
@@ -226,6 +232,60 @@ export function useMergePR() {
   });
 }
 
+/**
+ * Pull latest changes from remote
+ */
+export function useGitPull() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GitPullResponse, Error, GitPullRequest>({
+    mutationFn: (request) => gitApi.pull(request),
+    onSuccess: (_, variables) => {
+      // Invalidate status and log after pull
+      queryClient.invalidateQueries({ queryKey: gitKeys.status(variables.project_slug) });
+      queryClient.invalidateQueries({
+        queryKey: [...gitKeys.all, "log", variables.project_slug],
+      });
+    },
+  });
+}
+
+/**
+ * Fetch refs from remote without merging
+ */
+export function useGitFetch() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GitFetchResponse, Error, GitFetchRequest>({
+    mutationFn: (request) => gitApi.fetch(request),
+    onSuccess: (_, variables) => {
+      // Invalidate status after fetch
+      queryClient.invalidateQueries({ queryKey: gitKeys.status(variables.project_slug) });
+    },
+  });
+}
+
+/**
+ * Rebase current branch onto remote (destructive — rewrites history)
+ */
+export function useGitRebase() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GitRebaseResponse, Error, GitRebaseRequest>({
+    mutationFn: (request) => gitApi.rebase(request),
+    onSuccess: (_, variables) => {
+      // Invalidate everything after rebase since history has changed
+      queryClient.invalidateQueries({ queryKey: gitKeys.status(variables.project_slug) });
+      queryClient.invalidateQueries({
+        queryKey: [...gitKeys.all, "log", variables.project_slug],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...gitKeys.all, "diff", variables.project_slug],
+      });
+    },
+  });
+}
+
 // =============================================================================
 // Bundled Hook for Git Operations
 // =============================================================================
@@ -240,6 +300,9 @@ export function useGitOperations() {
   const checkout = useCheckout();
   const createPR = useCreatePR();
   const mergePR = useMergePR();
+  const pull = useGitPull();
+  const fetch = useGitFetch();
+  const rebase = useGitRebase();
 
   return {
     commit,
@@ -248,5 +311,8 @@ export function useGitOperations() {
     checkout,
     createPR,
     mergePR,
+    pull,
+    fetch,
+    rebase,
   };
 }

--- a/panel/src/lib/api/git.ts
+++ b/panel/src/lib/api/git.ts
@@ -23,6 +23,12 @@ import type {
   GitCreatePRResponse,
   GitMergePRRequest,
   GitMergePRResponse,
+  GitPullRequest,
+  GitPullResponse,
+  GitFetchRequest,
+  GitFetchResponse,
+  GitRebaseRequest,
+  GitRebaseResponse,
 } from "@/types/git";
 
 // =============================================================================
@@ -237,6 +243,53 @@ export const gitApi = {
       };
     }
     const { data } = await api.post<GitMergePRResponse>("/git/pr/merge", request);
+    return data;
+  },
+
+  /**
+   * Pull latest changes from remote
+   */
+  pull: async (request: GitPullRequest): Promise<GitPullResponse> => {
+    if (isMockMode()) {
+      return {
+        project_slug: request.project_slug,
+        branch: "feature/backend/abc12345",
+        commits_received: 2,
+        remote: request.remote ?? "origin",
+      };
+    }
+    const { data } = await api.post<GitPullResponse>("/git/pull", request);
+    return data;
+  },
+
+  /**
+   * Fetch refs from remote without merging
+   */
+  fetch: async (request: GitFetchRequest): Promise<GitFetchResponse> => {
+    if (isMockMode()) {
+      return {
+        project_slug: request.project_slug,
+        remote: request.remote ?? "origin",
+        refs_updated: 3,
+      };
+    }
+    const { data } = await api.post<GitFetchResponse>("/git/fetch", request);
+    return data;
+  },
+
+  /**
+   * Rebase current branch onto remote (destructive — rewrites history)
+   */
+  rebase: async (request: GitRebaseRequest): Promise<GitRebaseResponse> => {
+    if (isMockMode()) {
+      return {
+        project_slug: request.project_slug,
+        branch: "feature/backend/abc12345",
+        onto: request.onto ?? "origin/main",
+        commits_rebased: 3,
+      };
+    }
+    const { data } = await api.post<GitRebaseResponse>("/git/rebase", request);
     return data;
   },
 };

--- a/panel/src/types/git.ts
+++ b/panel/src/types/git.ts
@@ -147,3 +147,43 @@ export interface GitMergePRRequest {
   merge_method?: MergeMethod;
   agent_id: string;
 }
+
+export interface GitPullRequest {
+  project_slug: string;
+  task_id: string;
+  agent_id: string;
+  remote?: string;
+}
+
+export interface GitPullResponse {
+  project_slug: string;
+  branch: string;
+  commits_received: number;
+  remote: string;
+}
+
+export interface GitFetchRequest {
+  project_slug: string;
+  agent_id: string;
+  remote?: string;
+}
+
+export interface GitFetchResponse {
+  project_slug: string;
+  remote: string;
+  refs_updated: number;
+}
+
+export interface GitRebaseRequest {
+  project_slug: string;
+  task_id: string;
+  agent_id: string;
+  onto?: string;
+}
+
+export interface GitRebaseResponse {
+  project_slug: string;
+  branch: string;
+  onto: string;
+  commits_rebased: number;
+}


### PR DESCRIPTION
Add Pull, Fetch, and Rebase operations to the Git page, wire them to backend API endpoints, and implement a destructive confirmation dialog for the Rebase action.

**Context:**
The Git page (`panel/src/app/(dashboard)/git/page.tsx` → `GitBrowser` component) currently shows Push but lacks Pull, Fetch, and Rebase operations. The backend git API (`/git/pull`, `/git/fetch`, `/git/rebase`) may or may not exist — check `roboco/api/routes/git.py` and `roboco/api/schemas/git.py` to confirm. If endpoints don't exist, add mock implementations in the frontend API client and document with a `// TODO: wire to backend when endpoint ships` comment.

**Step 1 — Extend types in `panel/src/types/git.ts`**

Add request/response types:
```ts
export interface GitPullRequest {
  project_slug: string;
  agent_id: string;
  rebase?: boolean; // optional: pull --rebase
}

export interface GitPullResponse {
  project_slug: string;
  branch: string;
  commits_received: number;
  fast_forward: boolean;
}

export interface GitFetchRequest {
  project_slug: string;
  agent_id: string;
}

export interface GitFetchResponse {
  project_slug: string;
  refs_updated: number;
  behind: number; // how many commits behind after fetch
}

export interface GitRebaseRequest {
  project_slug: string;
  agent_id: string;
  onto?: string; // target branch, defaults to tracking branch
}

export interface GitRebaseResponse {
  project_slug: string;
  branch: string;
  commits_rebased: number;
  onto: string;
}
```

**Step 2 — Add API methods to `panel/src/lib/api/git.ts`**

Add inside the `gitApi` object:
```ts
pull: async (request: GitPullRequest): Promise<GitPullResponse> => {
  if (isMockMode()) {
    return { project_slug: request.project_slug, branch: "main", commits_received: 2, fast_forward: true };
  }
  // TODO: wire to backend when /git/pull endpoint ships
  const { data } = await api.post<GitPullResponse>("/git/pull", request);
  return data;
},

fetch: async (request: GitFetchRequest): Promise<GitFetchResponse> => {
  if (isMockMode()) {
    return { project_slug: request.project_slug, refs_updated: 3, behind: 1 };
  }
  // TODO: wire to backend when /git/fetch endpoint ships
  const { data } = await api.post<GitFetchResponse>("/git/fetch", request);
  return data;
},

rebase: async (request: GitRebaseRequest): Promise<GitRebaseResponse> => {
  if (isMockMode()) {
    return { project_slug: request.project_slug, branch: "feature/x", commits_rebased: 3, onto: "main" };
  }
  // TODO: wire to backend when /git/rebase endpoint ships
  const { data } = await api.post<GitRebaseResponse>("/git/rebase", request);
  return data;
},
```

**Step 3 — Add React Query mutation hooks to `panel/src/hooks/use-git.ts`**

Following the same pattern as `useGitPush`:
```ts
export function useGitPull() { ... }
export function useGitFetch() { ... }
export function useGitRebase() { ... }
```
Each invalidates the `gitKeys.status(projectSlug)` and `gitKeys.log(projectSlug)` queries on success so the branch status display updates.

**Step 4 — Update `git-actions-panel.tsx` props and buttons**

Add to the `GitActionsPanelProps` interface:
```ts
onPull: () => void;
onFetch: () => void;
onRebase: (onto?: string) => void;
isPulling: boolean;
isFetching: boolean;
isRebasing: boolean;
currentBranch?: string; // needed for destructive dialog label
```

Add three new buttons:
- **Pull from Remote** — standard `<Button>` with `<GitPullRequest>` icon (Lucide). Calls `onPull()` directly (non-destructive). Disabled when `isPulling`.
- **Fetch from Remote** — standard `<Button variant="outline">` with `<Download>` icon (Lucide). Calls `onFetch()` directly. Disabled when `isFetching`.
- **Rebase onto Base** — opens a destructive `<AlertDialog>` from `components/ui/alert-dialog.tsx`.

**Rebase AlertDialog spec:**
- Trigger: `<Button variant="destructive">` with a rebase/arrow icon.
- `<AlertDialogContent>` with red-tinted background: add `className="border-destructive bg-destructive/5"`.
- `<AlertDialogTitle>`: "Rebase branch?"
- `<AlertDialogDescription>`: `"This will rebase {currentBranch} onto its tracking branch. This is a destructive operation that rewrites history. You cannot undo this from the panel."` — the branch name `{currentBranch}` must appear explicitly in the dialog text.
- `<AlertDialogCancel>`: "Cancel" (default/outline styling)
- `<AlertDialogAction>`: "Rebase" — styled with `className="bg-destructive text-destructive-foreground hover:bg-destructive/90"`. This button must be clicked (Enter key must NOT trigger it — the AlertDialog component's default behavior should handle this as AlertDialogAction requires explicit click).
- On confirm: call `onRebase()`.

**Step 5 — Wire handlers in `git-browser.tsx`**

Add `handlePull`, `handleFetch`, `handleRebase` handlers (pattern: same as `handlePush`). On success, call `refetchStatus()` and `refetchLog()` to update the branch status display. Pass all three as props to `<GitActionsPanel>`.

**Testing:**
- In mock mode: clicking Pull, Fetch, and Rebase trigger (confirm) all show toast success messages and the git status panel refreshes.
- The Rebase AlertDialog: explicitly shows the current branch name in the dialog body; clicking Cancel dismisses without action; clicking "Rebase" fires the handler; pressing Enter on the dialog does NOT trigger the Rebase action.
- Run `pnpm typecheck` and `pnpm lint`.