### PR TITLE
[551b1dbf] Panel-wide frontend UI standardization and page fixes

### DIFF
--- a/panel/src/app/(dashboard)/agents/page.tsx
+++ b/panel/src/app/(dashboard)/agents/page.tsx
@@ -17,6 +17,7 @@ import {
   getBackendAgents,
   getFrontendAgents,
   getUxAgents,
+  getOnDemandAgents,
 } from "@/lib/agent-definitions";
 import {
   OrchestratorStatusCards,
@@ -134,6 +135,19 @@ export default function AgentsPage() {
         isLoading={(isLoading || agentsLoading) && !isOffline}
         columns={4}
       />
+
+      {/* On-Demand section: Prompter/Intake and Secretary agents — only rendered
+          when the API returns at least one matching agent */}
+      {getOnDemandAgents(agents).length > 0 && (
+        <AgentGrid
+          title="On-Demand"
+          agents={getOnDemandAgents(agents)}
+          agentStatuses={agentStatuses}
+          agentUsage={agentUsageMap}
+          isLoading={(isLoading || agentsLoading) && !isOffline}
+          columns={4}
+        />
+      )}
     </div>
   );
 }

--- a/panel/src/app/(dashboard)/communications/page.tsx
+++ b/panel/src/app/(dashboard)/communications/page.tsx
@@ -53,13 +53,14 @@ function ChannelList({ channels, selectedId, onSelect, isLoading }: ChannelListP
           {title}
         </h4>
         {items.map((channel) => (
-          <button
+          <Button
             key={channel.id}
             onClick={() => onSelect(channel.id)}
+            variant="ghost"
             className={
-              "w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-left transition-colors " +
+              "w-full h-auto justify-start gap-2 px-3 py-2 text-sm font-normal whitespace-normal " +
               (selectedId === channel.id
-                ? "bg-primary text-primary-foreground"
+                ? "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
                 : "hover:bg-muted")
             }
           >
@@ -69,7 +70,7 @@ function ChannelList({ channels, selectedId, onSelect, isLoading }: ChannelListP
               <Hash className="h-4 w-4 shrink-0" />
             )}
             <span className="truncate">{channel.name}</span>
-          </button>
+          </Button>
         ))}
       </div>
     );
@@ -135,13 +136,14 @@ function GroupList({ channelId, selectedId, onSelect }: GroupListProps) {
     <ScrollArea className="h-full">
       <div className="p-2 space-y-1">
         {groups.map((group) => (
-          <button
+          <Button
             key={group.id}
             onClick={() => onSelect(group.id)}
+            variant="ghost"
             className={
-              "w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm text-left transition-colors " +
+              "w-full h-auto justify-between px-3 py-2 text-sm font-normal whitespace-normal " +
               (selectedId === group.id
-                ? "bg-primary text-primary-foreground"
+                ? "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground"
                 : "hover:bg-muted")
             }
           >
@@ -152,7 +154,7 @@ function GroupList({ channelId, selectedId, onSelect }: GroupListProps) {
             <Badge variant="secondary" className="text-xs shrink-0 ml-2">
               {group.total_messages}
             </Badge>
-          </button>
+          </Button>
         ))}
       </div>
     </ScrollArea>

--- a/panel/src/app/(dashboard)/metrics/page.tsx
+++ b/panel/src/app/(dashboard)/metrics/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import { useOrchestratorStatus } from "@/hooks/use-agents";
 import { useTasks } from "@/hooks/use-tasks";
 import {
@@ -14,10 +16,10 @@ import {
 } from "@/hooks/use-usage";
 import { TaskStatus, Team } from "@/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { OfflineState } from "@/components/ui/offline-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { OfflineState } from "@/components/ui/offline-state";
 import {
   UsageTimeSeriesChart,
   ModelUsageDonut,
@@ -34,12 +36,30 @@ import {
   Users,
   CheckCircle,
   XCircle,
-  RefreshCw,
   Zap,
   Timer,
   Coins,
   Sparkles,
 } from "lucide-react";
+import type { UsageProjection as UP, CacheEfficiencyResponse as CER } from "@/types";
+
+// ─── Humanized number formatting ─────────────────────────────────────────────
+
+/** Format counts with K/M suffix for values >= 1000. */
+function humanizeCount(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+/** Format token counts (same as humanizeCount but used for token display). */
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+// ─── Shared sub-components ────────────────────────────────────────────────────
 
 interface MetricCardProps {
   title: string;
@@ -51,6 +71,7 @@ interface MetricCardProps {
 }
 
 function MetricCard({ title, value, subtitle, icon, trend, trendValue }: MetricCardProps) {
+  const displayValue = typeof value === "number" ? humanizeCount(value) : value;
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
@@ -60,12 +81,12 @@ function MetricCard({ title, value, subtitle, icon, trend, trendValue }: MetricC
         {icon}
       </CardHeader>
       <CardContent>
-        <div className="text-2xl font-bold">{value}</div>
+        <div className="text-2xl font-bold">{displayValue}</div>
         {subtitle && (
           <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
         )}
         {trend && trendValue && (
-          <div className={"flex items-center gap-1 mt-2 text-xs " + 
+          <div className={"flex items-center gap-1 mt-2 text-xs " +
             (trend === "up" ? "text-green-600" : trend === "down" ? "text-red-600" : "text-gray-500")
           }>
             <TrendingUp className={"h-3 w-3 " + (trend === "down" ? "rotate-180" : "")} />
@@ -118,7 +139,9 @@ function TeamHealthCard({ team, activeTasks, blockedTasks, completedToday }: Tea
   );
 }
 
-export default function MetricsPage() {
+// ─── Performance tab content ─────────────────────────────────────────────────
+
+function PerformanceTabContent() {
   const { data: tasks, error: tasksError, refetch: refetchTasks } = useTasks();
   const { data: status, error: statusError, refetch: refetchStatus } = useOrchestratorStatus();
 
@@ -132,7 +155,6 @@ export default function MetricsPage() {
     refetchStatus();
   };
 
-  // Calculate metrics from local data
   const taskList = tasks || [];
   const agentList = status?.agents || [];
 
@@ -159,7 +181,7 @@ export default function MetricsPage() {
   const awaitingQa = taskList.filter((t) => t.status === TaskStatus.AWAITING_QA).length;
   const completed = taskList.filter((t) => t.status === TaskStatus.COMPLETED).length;
 
-  // Agent counts (from by_state if available, or count from agents array)
+  // Agent counts
   const runningAgents = status?.by_state?.running || agentList.filter((a) => a.state === "running").length;
   const idleAgents = status?.by_state?.idle || agentList.filter((a) => a.state === "idle" || a.state === "stopped").length;
   const waitingAgents = status?.waiting_count || agentList.filter((a) => a.state === "waiting_long").length;
@@ -170,164 +192,145 @@ export default function MetricsPage() {
     const teamTasks = taskList.filter((t) => t.team === team);
     return {
       team,
-      activeTasks: teamTasks.filter((t) => 
+      activeTasks: teamTasks.filter((t) =>
         [TaskStatus.IN_PROGRESS, TaskStatus.CLAIMED].includes(t.status)
       ).length,
       blockedTasks: teamTasks.filter((t) => t.status === TaskStatus.BLOCKED).length,
       completedToday: teamTasks.filter((t) => {
         if (!t.completed_at) return false;
-        const completed = new Date(t.completed_at);
+        const c = new Date(t.completed_at);
         const today = new Date();
-        return completed.toDateString() === today.toDateString();
+        return c.toDateString() === today.toDateString();
       }).length,
     };
   });
 
+  if (isOffline) {
+    return (
+      <OfflineState
+        title="Cannot Load Performance Metrics"
+        description="Start the RoboCo orchestrator to view performance analytics."
+        onRetry={refetch}
+      />
+    );
+  }
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Metrics</h1>
-          <p className="text-muted-foreground">
-            Performance analytics and operational insights
-          </p>
+      {/* Velocity Metrics */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Velocity</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
+          <MetricCard
+            title="Completed Today"
+            value={completedToday}
+            subtitle="Tasks finished"
+            icon={<Zap className="h-4 w-4 text-green-500" />}
+          />
+          <MetricCard
+            title="Completed This Week"
+            value={completedThisWeek}
+            subtitle="Rolling 7 days"
+            icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
+          />
+          <MetricCard
+            title="Total Completed"
+            value={completed}
+            subtitle="All time"
+            icon={<CheckCircle className="h-4 w-4 text-green-500" />}
+          />
+          <MetricCard
+            title="Completion Rate"
+            value={taskList.length > 0 ? Math.round((completed / taskList.length) * 100) + "%" : "0%"}
+            subtitle="Of all tasks"
+            icon={<Activity className="h-4 w-4 text-purple-500" />}
+          />
         </div>
-        <Button variant="outline" onClick={refetch}>
-          <RefreshCw className="h-4 w-4 mr-2" />
-          Refresh
-        </Button>
       </div>
 
-      {isOffline ? (
-        <OfflineState
-          title="Cannot Load Metrics"
-          description="Start the RoboCo orchestrator to view performance analytics."
-          onRetry={refetch}
-        />
-      ) : (
-        <>
-          {/* Velocity Metrics */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Velocity</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
-              <MetricCard
-                title="Completed Today"
-                value={completedToday}
-                subtitle="Tasks finished"
-                icon={<Zap className="h-4 w-4 text-green-500" />}
-              />
-              <MetricCard
-                title="Completed This Week"
-                value={completedThisWeek}
-                subtitle="Rolling 7 days"
-                icon={<TrendingUp className="h-4 w-4 text-blue-500" />}
-              />
-              <MetricCard
-                title="Total Completed"
-                value={completed}
-                subtitle="All time"
-                icon={<CheckCircle className="h-4 w-4 text-green-500" />}
-              />
-              <MetricCard
-                title="Completion Rate"
-                value={taskList.length > 0 ? Math.round((completed / taskList.length) * 100) + "%" : "0%"}
-                subtitle="Of all tasks"
-                icon={<Activity className="h-4 w-4 text-purple-500" />}
-              />
-            </div>
-          </div>
+      {/* Task Status */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Task Status</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-5">
+          <MetricCard
+            title="Pending"
+            value={pending}
+            icon={<Clock className="h-4 w-4 text-gray-500" />}
+          />
+          <MetricCard
+            title="In Progress"
+            value={inProgress}
+            icon={<Activity className="h-4 w-4 text-blue-500" />}
+          />
+          <MetricCard
+            title="Blocked"
+            value={blocked}
+            icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
+          />
+          <MetricCard
+            title="Awaiting QA"
+            value={awaitingQa}
+            icon={<Timer className="h-4 w-4 text-yellow-500" />}
+          />
+          <MetricCard
+            title="Completed"
+            value={completed}
+            icon={<CheckCircle className="h-4 w-4 text-green-500" />}
+          />
+        </div>
+      </div>
 
-          {/* Task Status */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Task Status</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-5">
-              <MetricCard
-                title="Pending"
-                value={pending}
-                icon={<Clock className="h-4 w-4 text-gray-500" />}
-              />
-              <MetricCard
-                title="In Progress"
-                value={inProgress}
-                icon={<Activity className="h-4 w-4 text-blue-500" />}
-              />
-              <MetricCard
-                title="Blocked"
-                value={blocked}
-                icon={<AlertTriangle className="h-4 w-4 text-red-500" />}
-              />
-              <MetricCard
-                title="Awaiting QA"
-                value={awaitingQa}
-                icon={<Timer className="h-4 w-4 text-yellow-500" />}
-              />
-              <MetricCard
-                title="Completed"
-                value={completed}
-                icon={<CheckCircle className="h-4 w-4 text-green-500" />}
-              />
-            </div>
-          </div>
+      {/* Agent Status */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Agent Status</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
+          <MetricCard
+            title="Running"
+            value={runningAgents}
+            subtitle="Active agents"
+            icon={<Users className="h-4 w-4 text-green-500" />}
+          />
+          <MetricCard
+            title="Idle"
+            value={idleAgents}
+            subtitle="Available"
+            icon={<Users className="h-4 w-4 text-gray-500" />}
+          />
+          <MetricCard
+            title="Waiting"
+            value={waitingAgents}
+            subtitle="Needs input"
+            icon={<Clock className="h-4 w-4 text-yellow-500" />}
+          />
+          <MetricCard
+            title="Errors"
+            value={errorAgents}
+            subtitle="Failed agents"
+            icon={<XCircle className="h-4 w-4 text-red-500" />}
+          />
+        </div>
+      </div>
 
-          {/* Agent Status */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Agent Status</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-4">
-              <MetricCard
-                title="Running"
-                value={runningAgents}
-                subtitle="Active agents"
-                icon={<Users className="h-4 w-4 text-green-500" />}
-              />
-              <MetricCard
-                title="Idle"
-                value={idleAgents}
-                subtitle="Available"
-                icon={<Users className="h-4 w-4 text-gray-500" />}
-              />
-              <MetricCard
-                title="Waiting"
-                value={waitingAgents}
-                subtitle="Needs input"
-                icon={<Clock className="h-4 w-4 text-yellow-500" />}
-              />
-              <MetricCard
-                title="Errors"
-                value={errorAgents}
-                subtitle="Failed agents"
-                icon={<XCircle className="h-4 w-4 text-red-500" />}
-              />
-            </div>
-          </div>
-
-          {/* Team Health */}
-          <div>
-            <h2 className="text-lg font-semibold mb-3">Team Health</h2>
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-6">
-              {teamMetrics.map((tm) => (
-                <TeamHealthCard
-                  key={tm.team}
-                  team={tm.team}
-                  activeTasks={tm.activeTasks}
-                  blockedTasks={tm.blockedTasks}
-                  completedToday={tm.completedToday}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* ─── Token Usage & Costs ─────────────────────────────────── */}
-          <TokenUsageCostsSection />
-        </>
-      )}
+      {/* Team Health */}
+      <div>
+        <h2 className="text-lg font-semibold mb-3">Team Health</h2>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 xl:grid-cols-5 2xl:grid-cols-6">
+          {teamMetrics.map((tm) => (
+            <TeamHealthCard
+              key={tm.team}
+              team={tm.team}
+              activeTasks={tm.activeTasks}
+              blockedTasks={tm.blockedTasks}
+              completedToday={tm.completedToday}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }
 
-// =============================================================================
-// TOKEN USAGE & COSTS SECTION
-// =============================================================================
+// ─── Token Usage & Costs tab content ─────────────────────────────────────────
 
 function TokenUsageCostsSection() {
   const { data: summary, isLoading: loadingSnap } = useUsageSummary("24h");
@@ -343,8 +346,6 @@ function TokenUsageCostsSection() {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-lg font-semibold">Token Usage &amp; Costs</h2>
-
       {/* Row 1 — Summary cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 2xl:grid-cols-6">
         <SummaryCard
@@ -411,19 +412,13 @@ function TokenUsageCostsSection() {
         <CacheEfficiencyCard cacheStats={cacheStats} isLoading={loadingCache} />
       </div>
 
-      {/* Row 5 — Sessions table (mock-mode only; empty in production) */}
+      {/* Row 5 — Sessions table */}
       <SessionsTable data={sessions} isLoading={loadingSessions} />
     </div>
   );
 }
 
 // ─── Helper sub-components ────────────────────────────────────────────────────
-
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
-  return String(n);
-}
 
 interface SummaryCardProps {
   title: string;
@@ -462,8 +457,6 @@ function SummaryCard({ title, value, icon, trend, isLoading }: SummaryCardProps)
     </Card>
   );
 }
-
-import type { UsageProjection as UP, CacheEfficiencyResponse as CER } from "@/types";
 
 interface ProjectionCardProps {
   projection: UP | undefined;
@@ -529,5 +522,95 @@ function CacheEfficiencyCard({ cacheStats, isLoading }: CacheEfficiencyCardProps
         )}
       </CardContent>
     </Card>
+  );
+}
+
+// ─── Tab types ────────────────────────────────────────────────────────────────
+
+type MetricsTab = "performance" | "token-usage";
+
+const VALID_METRICS_TABS: MetricsTab[] = ["performance", "token-usage"];
+
+function isValidMetricsTab(value: string | null): value is MetricsTab {
+  return VALID_METRICS_TABS.includes(value as MetricsTab);
+}
+
+// ─── Main page content (uses useSearchParams) ─────────────────────────────────
+
+function MetricsPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Read ?tab= from URL, default to "performance"
+  const rawTab = searchParams.get("tab");
+  const activeTab: MetricsTab = isValidMetricsTab(rawTab) ? rawTab : "performance";
+
+  function handleTabChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", value);
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Metrics</h1>
+          <p className="text-muted-foreground">
+            Performance analytics and operational insights
+          </p>
+        </div>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <TabsList>
+          <TabsTrigger value="performance">Performance</TabsTrigger>
+          <TabsTrigger value="token-usage">Token Usage</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="performance" className="mt-6">
+          <PerformanceTabContent />
+        </TabsContent>
+
+        <TabsContent value="token-usage" className="mt-6">
+          <TokenUsageCostsSection />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+// Wrap in Suspense for useSearchParams
+export default function MetricsPage() {
+  return (
+    <Suspense fallback={
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-9 w-32 mb-2" />
+            <Skeleton className="h-5 w-72" />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-28" />
+          <Skeleton className="h-9 w-28" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-16" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    }>
+      <MetricsPageContent />
+    </Suspense>
   );
 }

--- a/panel/src/app/(dashboard)/notifications/page.tsx
+++ b/panel/src/app/(dashboard)/notifications/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 import {
   useNotifications,
   useMarkNotificationRead,
@@ -105,17 +106,34 @@ function NotificationCard({ notification, onMarkRead, onAcknowledge }: Notificat
   );
 }
 
-export default function NotificationsPage() {
-  // Default to Unread: the actionable view. Landing on "All" buries new
-  // notifications under everything already seen.
-  const [activeTab, setActiveTab] = useState<"all" | "unread" | "pending">("unread");
-  
+type TabValue = "all" | "unread" | "pending";
+
+const VALID_TABS: TabValue[] = ["all", "unread", "pending"];
+
+function isValidTab(value: string | null): value is TabValue {
+  return VALID_TABS.includes(value as TabValue);
+}
+
+function NotificationsPageContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Read ?tab= from URL, default to "unread" (most actionable view)
+  const rawTab = searchParams.get("tab");
+  const activeTab: TabValue = isValidTab(rawTab) ? rawTab : "unread";
+
+  function handleTabChange(value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("tab", value);
+    router.push(`?${params.toString()}`);
+  }
+
   const { data, isLoading, error, refetch } = useNotifications(
     activeTab === "unread" ? { unread_only: true } :
     activeTab === "pending" ? { pending_ack_only: true } :
     undefined
   );
-  
+
   const markRead = useMarkNotificationRead();
   const acknowledge = useAcknowledgeNotification();
   const markAllRead = useMarkAllNotificationsRead();
@@ -219,7 +237,7 @@ export default function NotificationsPage() {
           onRetry={() => refetch()}
         />
       ) : (
-        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)}>
+        <Tabs value={activeTab} onValueChange={handleTabChange}>
           <TabsList>
             <TabsTrigger value="all">All</TabsTrigger>
             <TabsTrigger value="unread">
@@ -260,5 +278,48 @@ export default function NotificationsPage() {
         </Tabs>
       )}
     </div>
+  );
+}
+
+// Wrap in Suspense for useSearchParams
+export default function NotificationsPage() {
+  return (
+    <Suspense fallback={
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-9 w-48 mb-2" />
+            <Skeleton className="h-5 w-72" />
+          </div>
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-9 w-36" />
+            <Skeleton className="h-9 w-24" />
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-16" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-12" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <div className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <Skeleton className="h-20 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    }>
+      <NotificationsPageContent />
+    </Suspense>
   );
 }

--- a/panel/src/app/(dashboard)/settings/ai-providers/page.tsx
+++ b/panel/src/app/(dashboard)/settings/ai-providers/page.tsx
@@ -2,7 +2,7 @@ import { AIRoutingCard } from "@/components/settings/ai-routing-card";
 
 export default function AIProvidersPage() {
   return (
-    <div className="space-y-6 max-w-5xl">
+    <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold tracking-tight">AI Providers</h1>
         <p className="text-muted-foreground">

--- a/panel/src/app/(dashboard)/settings/page.tsx
+++ b/panel/src/app/(dashboard)/settings/page.tsx
@@ -43,7 +43,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="space-y-6 max-w-3xl">
+    <div className="space-y-6">
       {/* Header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
@@ -52,189 +52,192 @@ export default function SettingsPage() {
         </p>
       </div>
 
-      {/* Appearance */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Palette className="h-5 w-5" />
-            Appearance
-          </CardTitle>
-          <CardDescription>Customize the look and feel of the panel</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Theme</Label>
-              <p className="text-sm text-muted-foreground">
-                Select your preferred color scheme
-              </p>
+      {/* Cards grid — two columns on large screens */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Appearance */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Palette className="h-5 w-5" />
+              Appearance
+            </CardTitle>
+            <CardDescription>Customize the look and feel of the panel</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Theme</Label>
+                <p className="text-sm text-muted-foreground">
+                  Select your preferred color scheme
+                </p>
+              </div>
+              <Select value={theme} onValueChange={setTheme}>
+                <SelectTrigger className="w-auto min-w-28">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="light">Light</SelectItem>
+                  <SelectItem value="dark">Dark</SelectItem>
+                  <SelectItem value="system">System</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <Select value={theme} onValueChange={setTheme}>
-              <SelectTrigger className="w-auto min-w-28">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="light">Light</SelectItem>
-                <SelectItem value="dark">Dark</SelectItem>
-                <SelectItem value="system">System</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Collapsed Sidebar</Label>
-              <p className="text-sm text-muted-foreground">
-                Show icons only in the sidebar
-              </p>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Collapsed Sidebar</Label>
+                <p className="text-sm text-muted-foreground">
+                  Show icons only in the sidebar
+                </p>
+              </div>
+              <Switch
+                checked={sidebarCollapsed}
+                onCheckedChange={setSidebarCollapsed}
+              />
             </div>
-            <Switch
-              checked={sidebarCollapsed}
-              onCheckedChange={setSidebarCollapsed}
-            />
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Notifications */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Bell className="h-5 w-5" />
-            Notifications
-          </CardTitle>
-          <CardDescription>Configure how you receive updates</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Enable Notifications</Label>
-              <p className="text-sm text-muted-foreground">
-                Receive real-time notifications from agents
-              </p>
+        {/* Notifications */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bell className="h-5 w-5" />
+              Notifications
+            </CardTitle>
+            <CardDescription>Configure how you receive updates</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Enable Notifications</Label>
+                <p className="text-sm text-muted-foreground">
+                  Receive real-time notifications from agents
+                </p>
+              </div>
+              <Switch
+                checked={notificationsEnabled}
+                onCheckedChange={setNotificationsEnabled}
+              />
             </div>
-            <Switch
-              checked={notificationsEnabled}
-              onCheckedChange={setNotificationsEnabled}
-            />
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Sound Alerts</Label>
-              <p className="text-sm text-muted-foreground">
-                Play sound for important notifications
-              </p>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Sound Alerts</Label>
+                <p className="text-sm text-muted-foreground">
+                  Play sound for important notifications
+                </p>
+              </div>
+              <Switch
+                checked={soundEnabled}
+                onCheckedChange={setSoundEnabled}
+                disabled={!notificationsEnabled}
+              />
             </div>
-            <Switch
-              checked={soundEnabled}
-              onCheckedChange={setSoundEnabled}
-              disabled={!notificationsEnabled}
-            />
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Data & Refresh */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Server className="h-5 w-5" />
-            Data & Refresh
-          </CardTitle>
-          <CardDescription>Configure data fetching behavior</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Auto Refresh</Label>
-              <p className="text-sm text-muted-foreground">
-                Automatically refresh data periodically
-              </p>
+        {/* Data & Refresh */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Server className="h-5 w-5" />
+              Data & Refresh
+            </CardTitle>
+            <CardDescription>Configure data fetching behavior</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Auto Refresh</Label>
+                <p className="text-sm text-muted-foreground">
+                  Automatically refresh data periodically
+                </p>
+              </div>
+              <Switch
+                checked={autoRefresh}
+                onCheckedChange={setAutoRefresh}
+              />
             </div>
-            <Switch
-              checked={autoRefresh}
-              onCheckedChange={setAutoRefresh}
-            />
-          </div>
-          <Separator />
-          <div className="flex items-center justify-between">
-            <div>
-              <Label>Refresh Interval</Label>
-              <p className="text-sm text-muted-foreground">
-                How often to fetch new data (seconds)
-              </p>
+            <Separator />
+            <div className="flex items-center justify-between">
+              <div>
+                <Label>Refresh Interval</Label>
+                <p className="text-sm text-muted-foreground">
+                  How often to fetch new data (seconds)
+                </p>
+              </div>
+              <Select
+                value={refreshInterval}
+                onValueChange={setRefreshInterval}
+                disabled={!autoRefresh}
+              >
+                <SelectTrigger className="w-auto min-w-20">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="10">10s</SelectItem>
+                  <SelectItem value="30">30s</SelectItem>
+                  <SelectItem value="60">1m</SelectItem>
+                  <SelectItem value="300">5m</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <Select
-              value={refreshInterval}
-              onValueChange={setRefreshInterval}
-              disabled={!autoRefresh}
-            >
-              <SelectTrigger className="w-auto min-w-20">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="10">10s</SelectItem>
-                <SelectItem value="30">30s</SelectItem>
-                <SelectItem value="60">1m</SelectItem>
-                <SelectItem value="300">5m</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
 
-      {/* Transcript Retention (panel-tunable; persisted server-side) */}
-      <TranscriptRetentionCard />
+        {/* Transcript Retention (panel-tunable; persisted server-side) */}
+        <TranscriptRetentionCard />
 
-      {/* Connection Info */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            Connection Info
-          </CardTitle>
-          <CardDescription>Backend API configuration (read-only)</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Label>API URL</Label>
-            <Input value={API_URL} readOnly className="bg-muted" />
-          </div>
-          <div className="space-y-2">
-            <Label>WebSocket URL</Label>
-            <Input value={WS_URL} readOnly className="bg-muted" />
-          </div>
-          <p className="text-xs text-muted-foreground">
-            These values are configured via environment variables (NEXT_PUBLIC_API_URL, NEXT_PUBLIC_WS_URL)
-          </p>
-        </CardContent>
-      </Card>
+        {/* Connection Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Settings className="h-5 w-5" />
+              Connection Info
+            </CardTitle>
+            <CardDescription>Backend API configuration (read-only)</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>API URL</Label>
+              <Input value={API_URL} readOnly className="bg-muted" />
+            </div>
+            <div className="space-y-2">
+              <Label>WebSocket URL</Label>
+              <Input value={WS_URL} readOnly className="bg-muted" />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              These values are configured via environment variables (NEXT_PUBLIC_API_URL, NEXT_PUBLIC_WS_URL)
+            </p>
+          </CardContent>
+        </Card>
 
-      {/* User Info */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <User className="h-5 w-5" />
-            User Info
-          </CardTitle>
-          <CardDescription>Your account information</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="flex items-center gap-4">
-            <div className="h-16 w-16 rounded-full bg-primary flex items-center justify-center">
-              <span className="text-primary-foreground font-bold text-2xl">CEO</span>
+        {/* User Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <User className="h-5 w-5" />
+              User Info
+            </CardTitle>
+            <CardDescription>Your account information</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex items-center gap-4">
+              <div className="h-16 w-16 rounded-full bg-primary flex items-center justify-center">
+                <span className="text-primary-foreground font-bold text-2xl">CEO</span>
+              </div>
+              <div>
+                <p className="font-semibold text-lg">Renzo</p>
+                <p className="text-sm text-muted-foreground">Chief Executive Officer</p>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Agent ID: 00000000-0000-0000-0000-000000000001
+                </p>
+              </div>
             </div>
-            <div>
-              <p className="font-semibold text-lg">Renzo</p>
-              <p className="text-sm text-muted-foreground">Chief Executive Officer</p>
-              <p className="text-xs text-muted-foreground mt-1">
-                Agent ID: 00000000-0000-0000-0000-000000000001
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
 
       {/* Save Button */}
       <div className="flex justify-end">

--- a/panel/src/components/agents/agent-selector.tsx
+++ b/panel/src/components/agents/agent-selector.tsx
@@ -33,11 +33,14 @@ const ROLE_LABELS: Record<AgentRole, string> = {
   [AgentRole.PRODUCT_OWNER]: "Product Owner",
   [AgentRole.HEAD_MARKETING]: "Head Marketing",
   [AgentRole.AUDITOR]: "Auditor",
+  [AgentRole.PR_REVIEWER]: "PR Reviewer",
   [AgentRole.MAIN_PM]: "Main PM",
   [AgentRole.CELL_PM]: "Cell PM",
   [AgentRole.DEVELOPER]: "Developer",
   [AgentRole.QA]: "QA",
   [AgentRole.DOCUMENTER]: "Documenter",
+  [AgentRole.PROMPTER]: "Prompter",
+  [AgentRole.SECRETARY]: "Secretary",
 };
 
 export function AgentSelector({

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -341,8 +341,8 @@ function GoalsForm({ goals, refetch }: GoalsFormProps) {
           )}
         </div>
 
-        {/* Hidden — just to make the refetch prop used */}
-        <button type="button" className="hidden" onClick={refetch} />
+        {/* Hidden — keeps the refetch prop wired up for future use */}
+        <Button type="button" className="hidden" onClick={refetch} />
       </CardContent>
     </Card>
   );

--- a/panel/src/components/business/secretary-tab.tsx
+++ b/panel/src/components/business/secretary-tab.tsx
@@ -245,7 +245,7 @@ export function SecretaryTab() {
         </CardHeader>
         <CardContent className="flex flex-1 flex-col gap-4">
           <ChatMessages messages={messages} streaming={streaming} />
-          <div className="flex gap-2">
+          <div className="flex items-stretch gap-2">
             <Textarea
               value={input}
               onChange={(e) => setInput(e.target.value)}

--- a/panel/src/components/communications/channel-item.tsx
+++ b/panel/src/components/communications/channel-item.tsx
@@ -2,6 +2,7 @@
 
 import { Channel } from "@/types";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Hash, Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -19,12 +20,13 @@ export function ChannelItem({
   unreadCount = 0,
 }: ChannelItemProps) {
   return (
-    <button
+    <Button
       onClick={onClick}
+      variant="ghost"
       className={cn(
-        "w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left transition-colors",
+        "w-full h-auto justify-start gap-2 px-2 py-1.5 font-normal whitespace-normal",
         isSelected
-          ? "bg-primary/10 text-primary"
+          ? "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary"
           : "text-muted-foreground hover:bg-muted hover:text-foreground"
       )}
     >
@@ -39,6 +41,6 @@ export function ChannelItem({
           {unreadCount}
         </Badge>
       )}
-    </button>
+    </Button>
   );
 }

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -71,6 +71,14 @@ export function CommandCenter() {
         />
       </section>
 
+      {/* Quick Actions — placed immediately after Team Health so it is
+          visible without scrolling on a 900px-tall viewport, before the
+          data-heavy grid rows below. */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Quick Actions</h2>
+        <QuickActionsBar />
+      </section>
+
       {/* CEO Approval Queue + Strategy Signals - side-by-side on lg+ */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <CeoApprovalQueue />
@@ -95,12 +103,6 @@ export function CommandCenter() {
           isLoading={loadingActivity}
         />
       </div>
-
-      {/* Quick Actions */}
-      <section className="pt-4 border-t">
-        <h2 className="text-lg font-semibold mb-4">Quick Actions</h2>
-        <QuickActionsBar />
-      </section>
     </div>
   );
 }

--- a/panel/src/components/dashboard/quick-actions-bar.tsx
+++ b/panel/src/components/dashboard/quick-actions-bar.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { CreateTaskDialog } from "@/components/tasks/create-task-dialog";
-import { Users, Megaphone, BookOpen, Shield } from "lucide-react";
+import { Users, Megaphone, BookOpen, Shield, Sparkles, Bot } from "lucide-react";
 import Link from "next/link";
 
 export function QuickActionsBar() {
@@ -14,6 +14,20 @@ export function QuickActionsBar() {
         <Button variant="outline">
           <Users className="h-4 w-4 mr-2" />
           Spawn Agent
+        </Button>
+      </Link>
+
+      <Link href="/prompter">
+        <Button variant="outline">
+          <Sparkles className="h-4 w-4 mr-2" />
+          Task Intake
+        </Button>
+      </Link>
+
+      <Link href="/business?tab=secretary">
+        <Button variant="outline">
+          <Bot className="h-4 w-4 mr-2" />
+          Secretary
         </Button>
       </Link>
 

--- a/panel/src/components/dashboard/team-health-cards.tsx
+++ b/panel/src/components/dashboard/team-health-cards.tsx
@@ -3,10 +3,41 @@
 import { TeamHealth } from "@/types";
 import { TeamHealthCard } from "./team-health-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Sparkles, Bot } from "lucide-react";
+import Link from "next/link";
 
 interface TeamHealthCardsProps {
   teams: TeamHealth[] | undefined;
   isLoading: boolean;
+}
+
+/** Static link-card for on-demand agents (Intake, Secretary) that are not
+ *  part of any standing team and therefore never appear in the API health data. */
+function OnDemandAgentCard({
+  title,
+  href,
+  icon: Icon,
+  description,
+}: {
+  title: string;
+  href: string;
+  icon: React.ElementType;
+  description: string;
+}) {
+  return (
+    <Link href={href} className="block">
+      <div className="rounded-lg border bg-card p-4 hover:bg-accent/50 transition-colors h-full flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Icon className="h-4 w-4 text-muted-foreground" />
+          <span className="font-medium text-sm">{title}</span>
+          <span className="ml-auto text-xs rounded-full bg-secondary px-2 py-0.5 text-secondary-foreground">
+            On-Demand
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+    </Link>
+  );
 }
 
 export function TeamHealthCards({ teams, isLoading }: TeamHealthCardsProps) {
@@ -20,19 +51,33 @@ export function TeamHealthCards({ teams, isLoading }: TeamHealthCardsProps) {
     );
   }
 
-  if (!teams || teams.length === 0) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        No team health data available
-      </div>
-    );
-  }
+  const hasTeams = teams && teams.length > 0;
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-6 gap-4">
-      {teams.map((health) => (
-        <TeamHealthCard key={health.team} health={health} />
-      ))}
+      {hasTeams ? (
+        teams.map((health) => (
+          <TeamHealthCard key={health.team} health={health} />
+        ))
+      ) : (
+        <div className="col-span-full text-center py-8 text-muted-foreground">
+          No team health data available
+        </div>
+      )}
+
+      {/* Static on-demand agent cards — always visible regardless of API data */}
+      <OnDemandAgentCard
+        title="Task Intake"
+        href="/prompter"
+        icon={Sparkles}
+        description="Intake interviewer — chat with CEO to draft and submit new tasks"
+      />
+      <OnDemandAgentCard
+        title="Secretary"
+        href="/business?tab=secretary"
+        icon={Bot}
+        description="Secretary agent — manage business goals, pitches, and notes"
+      />
     </div>
   );
 }

--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -16,12 +16,26 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   GitCommit,
   Upload,
   GitPullRequest,
   GitMerge,
   RefreshCw,
   ArrowUp,
+  Download,
+  RefreshCcw,
+  GitGraph,
 } from "lucide-react";
 
 interface GitActionsPanelProps {
@@ -33,10 +47,16 @@ interface GitActionsPanelProps {
   onPush: (force?: boolean) => void;
   onCreatePR: (title: string, body: string) => void;
   onMergePR: (prNumber: number) => void;
+  onPull: () => void;
+  onFetch: () => void;
+  onRebase: () => void;
   isCommitting: boolean;
   isPushing: boolean;
   isCreatingPR: boolean;
   isMerging: boolean;
+  isPulling: boolean;
+  isFetching: boolean;
+  isRebasing: boolean;
 }
 
 export function GitActionsPanel({
@@ -48,10 +68,16 @@ export function GitActionsPanel({
   onPush,
   onCreatePR,
   onMergePR,
+  onPull,
+  onFetch,
+  onRebase,
   isCommitting,
   isPushing,
   isCreatingPR,
   isMerging,
+  isPulling,
+  isFetching,
+  isRebasing,
 }: GitActionsPanelProps) {
   void _agentId; // Reserved for future use
   const [showCommitDialog, setShowCommitDialog] = useState(false);
@@ -301,6 +327,74 @@ export function GitActionsPanel({
             </DialogFooter>
           </DialogContent>
         </Dialog>
+
+        {/* Pull Action */}
+        <Button
+          className="w-full justify-start"
+          variant="outline"
+          disabled={isPulling}
+          onClick={onPull}
+        >
+          {isPulling ? (
+            <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4 mr-2" />
+          )}
+          Pull from Remote
+        </Button>
+
+        {/* Fetch Action */}
+        <Button
+          className="w-full justify-start"
+          variant="outline"
+          disabled={isFetching}
+          onClick={onFetch}
+        >
+          {isFetching ? (
+            <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <RefreshCcw className="h-4 w-4 mr-2" />
+          )}
+          Fetch Remote
+        </Button>
+
+        {/* Rebase Action — destructive, requires confirmation */}
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              className="w-full justify-start"
+              variant="outline"
+              disabled={isRebasing}
+            >
+              {isRebasing ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <GitGraph className="h-4 w-4 mr-2" />
+              )}
+              Rebase onto Remote
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent className="border-destructive bg-destructive/5">
+            <AlertDialogHeader>
+              <AlertDialogTitle>Rebase onto remote?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will rewrite the commit history of branch{" "}
+                <strong>{status?.current_branch}</strong> by replaying commits
+                on top of the latest remote. A force-push will be required
+                afterward. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={onRebase}
+              >
+                Rebase
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {/* Status Summary */}
         {status && (

--- a/panel/src/components/git/git-branch-panel.tsx
+++ b/panel/src/components/git/git-branch-panel.tsx
@@ -164,14 +164,15 @@ export function GitBranchPanel({
               </h4>
               <div className="space-y-0.5">
                 {localBranches.map((branch) => (
-                  <button
+                  <Button
                     key={branch.name}
                     onClick={() => !branch.is_current && onCheckout(branch.name)}
                     disabled={branch.is_current || isCheckingOut}
+                    variant="ghost"
                     className={
-                      "w-full flex items-center justify-between px-2 py-1.5 rounded text-sm text-left transition-colors " +
+                      "w-full h-auto justify-between px-2 py-1.5 text-sm font-normal whitespace-normal " +
                       (branch.is_current
-                        ? "bg-primary/10 text-primary"
+                        ? "bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary"
                         : "hover:bg-muted")
                     }
                   >
@@ -188,7 +189,7 @@ export function GitBranchPanel({
                         {branch.last_commit.slice(0, 7)}
                       </span>
                     )}
-                  </button>
+                  </Button>
                 ))}
               </div>
             </div>
@@ -202,16 +203,17 @@ export function GitBranchPanel({
                 </h4>
                 <div className="space-y-0.5">
                   {remoteBranches.map((branch) => (
-                    <button
+                    <Button
                       key={branch.name}
                       onClick={() => onCheckout(branch.name)}
                       disabled={isCheckingOut}
-                      className="w-full flex items-center justify-between px-2 py-1.5 rounded text-sm text-left transition-colors hover:bg-muted"
+                      variant="ghost"
+                      className="w-full h-auto justify-start px-2 py-1.5 text-sm font-normal whitespace-normal hover:bg-muted"
                     >
                       <span className="truncate font-mono text-xs text-muted-foreground">
                         {branch.name}
                       </span>
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -49,7 +49,7 @@ function GitBrowserContent() {
   const { data: unstagedDiff, isLoading: loadingUnstagedDiff } = useGitDiff(projectSlug, false, undefined, !!projectSlug);
 
   // Git operations
-  const { commit, push, createBranch, checkout, createPR, mergePR } = useGitOperations();
+  const { commit, push, createBranch, checkout, createPR, mergePR, pull, fetch, rebase } = useGitOperations();
 
   // Update URL params
   const updateParams = useCallback(
@@ -174,6 +174,44 @@ function GitBrowserContent() {
     }
   };
 
+  const handlePull = async () => {
+    try {
+      const result = await pull.mutateAsync({
+        project_slug: projectSlug,
+        task_id: taskId || "manual",
+        agent_id: "ceo",
+      });
+      toast.success(`Pulled ${result.commits_received} commits from ${result.remote}`);
+    } catch {
+      toast.error("Failed to pull from remote");
+    }
+  };
+
+  const handleFetch = async () => {
+    try {
+      const result = await fetch.mutateAsync({
+        project_slug: projectSlug,
+        agent_id: "ceo",
+      });
+      toast.success(`Fetched ${result.refs_updated} refs from ${result.remote}`);
+    } catch {
+      toast.error("Failed to fetch from remote");
+    }
+  };
+
+  const handleRebase = async () => {
+    try {
+      const result = await rebase.mutateAsync({
+        project_slug: projectSlug,
+        task_id: taskId || "manual",
+        agent_id: "ceo",
+      });
+      toast.success(`Rebased ${result.commits_rebased} commits onto ${result.onto}`);
+    } catch {
+      toast.error("Failed to rebase");
+    }
+  };
+
   // Check offline
   const isOffline = projectsError && (
     projectsError.message?.includes("Network Error") ||
@@ -258,10 +296,16 @@ function GitBrowserContent() {
               onPush={handlePush}
               onCreatePR={handleCreatePR}
               onMergePR={handleMergePR}
+              onPull={handlePull}
+              onFetch={handleFetch}
+              onRebase={handleRebase}
               isCommitting={commit.isPending}
               isPushing={push.isPending}
               isCreatingPR={createPR.isPending}
               isMerging={mergePR.isPending}
+              isPulling={pull.isPending}
+              isFetching={fetch.isPending}
+              isRebasing={rebase.isPending}
             />
           </div>
 

--- a/panel/src/components/git/git-log-panel.tsx
+++ b/panel/src/components/git/git-log-panel.tsx
@@ -3,8 +3,10 @@
 import { GitLogResponse, CommitInfo } from "@/types/git";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import { GitCommit, User, Calendar } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 
@@ -68,15 +70,14 @@ export function GitLogPanel({
         <ScrollArea className="h-80">
           <div className="p-4 space-y-0">
             {log.commits.map((commit, index) => (
-              <button
+              <Button
                 key={commit.hash}
                 onClick={() => onSelectCommit?.(commit)}
-                className={
-                  "w-full text-left p-3 rounded-lg transition-colors relative " +
-                  (selectedHash === commit.hash
-                    ? "bg-primary/10"
-                    : "hover:bg-muted")
-                }
+                variant="ghost"
+                className={cn(
+                  "w-full h-auto justify-start text-left p-3 font-normal whitespace-normal relative",
+                  selectedHash === commit.hash ? "bg-primary/10 hover:bg-primary/10" : ""
+                )}
               >
                 {/* Timeline line */}
                 {index < log.commits.length - 1 && (
@@ -123,7 +124,7 @@ export function GitLogPanel({
                     </div>
                   </div>
                 </div>
-              </button>
+              </Button>
             ))}
           </div>
         </ScrollArea>

--- a/panel/src/components/journals/agent-item.tsx
+++ b/panel/src/components/journals/agent-item.tsx
@@ -4,6 +4,7 @@ import { Agent } from "@/types";
 import { User } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { Button } from "@/components/ui/button";
 
 interface AgentItemProps {
   agent: Agent;
@@ -14,12 +15,13 @@ interface AgentItemProps {
 
 export function AgentItem({ agent, isSelected, onClick, hasEntries }: AgentItemProps) {
   return (
-    <button
+    <Button
       onClick={onClick}
+      variant="ghost"
       className={cn(
-        "w-full flex items-center gap-3 p-2 rounded-lg text-left transition-colors",
+        "w-full h-auto justify-start gap-3 p-2 font-normal whitespace-normal",
         isSelected
-          ? "bg-primary/10 border border-primary/30"
+          ? "bg-primary/10 border border-primary/30 hover:bg-primary/10"
           : "hover:bg-muted/50"
       )}
     >
@@ -37,6 +39,6 @@ export function AgentItem({ agent, isSelected, onClick, hasEntries }: AgentItemP
           {agent.role.replace(/_/g, " ")}
         </p>
       </div>
-    </button>
+    </Button>
   );
 }

--- a/panel/src/components/journals/agent-list.tsx
+++ b/panel/src/components/journals/agent-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Agent, Team, AgentRole } from "@/types";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AgentItem } from "./agent-item";
 
@@ -84,7 +83,7 @@ export function AgentList({
   const grouped = groupByTeam(agents);
 
   return (
-    <ScrollArea className="h-[calc(100vh-200px)]">
+    <div className="overflow-y-auto max-h-[calc(100vh-200px)]">
       <div className="p-2 space-y-4">
         {Object.entries(grouped).map(([teamKey, teamAgents]) => {
           if (teamAgents.length === 0) return null;
@@ -108,6 +107,6 @@ export function AgentList({
           );
         })}
       </div>
-    </ScrollArea>
+    </div>
   );
 }

--- a/panel/src/components/kanban/core/kanban-board.tsx
+++ b/panel/src/components/kanban/core/kanban-board.tsx
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { RefreshCw } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import {
   DndContext,
@@ -64,6 +64,7 @@ export function KanbanBoard({
   const updateTask = useUpdateTask();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [pendingNotesAction, setPendingNotesAction] = useState<PendingNotesAction | null>(null);
+  const [activeColumnIndex, setActiveColumnIndex] = useState(0);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -293,7 +294,56 @@ export function KanbanBoard({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
       >
-        <div className="flex gap-4 overflow-x-auto pb-4">
+        {/* Mobile: single-column view with prev/next navigator (hidden on sm+) */}
+        <div className="sm:hidden">
+          <div className="flex items-center gap-2 mb-4">
+            <Button
+              variant="outline"
+              size="icon"
+              className="min-h-11 min-w-11 shrink-0"
+              onClick={() => setActiveColumnIndex((i) => Math.max(0, i - 1))}
+              disabled={activeColumnIndex === 0}
+              aria-label="Previous column"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </Button>
+            <p className="flex-1 text-center text-sm font-semibold">
+              <span className="text-muted-foreground font-normal text-xs mr-1">
+                {activeColumnIndex + 1}/{columns.length}
+              </span>
+              {columns[activeColumnIndex]?.title}
+            </p>
+            <Button
+              variant="outline"
+              size="icon"
+              className="min-h-11 min-w-11 shrink-0"
+              onClick={() =>
+                setActiveColumnIndex((i) => Math.min(columns.length - 1, i + 1))
+              }
+              disabled={activeColumnIndex === columns.length - 1}
+              aria-label="Next column"
+            >
+              <ChevronRight className="h-5 w-5" />
+            </Button>
+          </div>
+          {columns[activeColumnIndex] && (
+            <KanbanColumn
+              key={columns[activeColumnIndex].id}
+              id={columns[activeColumnIndex].id}
+              title={columns[activeColumnIndex].title}
+              status={columns[activeColumnIndex].status}
+              tasks={tasksByStatus[columns[activeColumnIndex].status] || []}
+              color={columns[activeColumnIndex].color}
+              isLoading={isLoading}
+              onAction={handleAction}
+              showQaActions={showQaActions}
+              className="w-full sm:w-full"
+            />
+          )}
+        </div>
+
+        {/* Desktop: horizontal scrolling layout (shown at sm+, i.e. >= 640px) */}
+        <div className="hidden sm:flex gap-4 overflow-x-auto pb-4">
           {columns.map((col) => (
             <KanbanColumn
               key={col.id}

--- a/panel/src/components/kanban/core/kanban-card.tsx
+++ b/panel/src/components/kanban/core/kanban-card.tsx
@@ -183,7 +183,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-7 text-muted-foreground hover:text-foreground"
+                  className="min-h-11 text-muted-foreground hover:text-foreground"
                   onClick={(e) => e.stopPropagation()}
                   disabled={isBacklog}
                 >
@@ -210,7 +210,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-7 text-green-600 hover:text-green-700 hover:bg-green-50"
+                    className="min-h-11 text-green-600 hover:text-green-700 hover:bg-green-50"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("pass-qa", task.id);
@@ -222,7 +222,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-7 text-red-600 hover:text-red-700 hover:bg-red-50"
+                    className="min-h-11 text-red-600 hover:text-red-700 hover:bg-red-50"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("fail-qa", task.id);
@@ -238,7 +238,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="h-6 w-6"
+                    className="h-11 w-11"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("move-forward", task.id);

--- a/panel/src/components/kanban/core/kanban-column.tsx
+++ b/panel/src/components/kanban/core/kanban-column.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { KanbanCard } from "./kanban-card";
 import { useDroppable } from "@dnd-kit/core";
+import { cn } from "@/lib/utils";
 
 interface KanbanColumnProps {
   id: string;
@@ -16,6 +17,8 @@ interface KanbanColumnProps {
   isLoading: boolean;
   onAction?: (action: string, taskId: string) => void;
   showQaActions?: boolean;
+  /** Extra Tailwind classes forwarded to the root element (e.g. w-full for mobile). */
+  className?: string;
 }
 
 export function KanbanColumn({
@@ -27,6 +30,7 @@ export function KanbanColumn({
   isLoading,
   onAction,
   showQaActions,
+  className,
 }: KanbanColumnProps) {
   void _id; // Reserved for future use
   const { setNodeRef, isOver } = useDroppable({
@@ -36,9 +40,12 @@ export function KanbanColumn({
   return (
     <div
       ref={setNodeRef}
-      className={`flex flex-col rounded-lg p-3 w-72 shrink-0 sm:w-80 ${color} ${
-        isOver ? "ring-2 ring-primary ring-offset-2" : ""
-      }`}
+      className={cn(
+        "flex flex-col rounded-lg p-3 w-72 shrink-0 sm:w-80",
+        color,
+        isOver && "ring-2 ring-primary ring-offset-2",
+        className,
+      )}
     >
       <div className="flex items-center justify-between mb-3">
         <h3 className="font-semibold text-sm text-gray-800 dark:text-gray-100">{title}</h3>

--- a/panel/src/components/knowledge-base/kb-category-nav.tsx
+++ b/panel/src/components/knowledge-base/kb-category-nav.tsx
@@ -3,6 +3,8 @@
 import { KBIndexType, KBStats } from "@/types";
 import { FileText, MessageSquare, BookOpen, ChevronRight, AlertTriangle, Scale, GitBranch, ClipboardCheck, Lightbulb } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 const categoryConfig: Record<KBIndexType, { label: string; description: string; icon: React.ReactNode }> = {
   [KBIndexType.DOCUMENTATION]: {
@@ -90,17 +92,19 @@ export function KBCategoryNav({
         const isSelected = selectedCategory === type;
 
         return (
-          <button
+          <Button
             key={type}
             onClick={() => onSelectCategory(type)}
-            className={`w-full flex items-center gap-3 p-3 rounded-lg border transition-colors text-left ${
+            variant="outline"
+            className={cn(
+              "w-full h-auto justify-start gap-3 p-3 font-normal whitespace-normal",
               isSelected
                 ? "bg-primary/10 border-primary"
                 : "hover:bg-muted/50 border-transparent hover:border-border"
-            }`}
+            )}
           >
             <div className="shrink-0">{config.icon}</div>
-            <div className="flex-1 min-w-0">
+            <div className="flex-1 min-w-0 text-left">
               <div className="flex items-center justify-between">
                 <span className="font-medium text-sm">{config.label}</span>
                 <span className="text-xs text-muted-foreground">
@@ -109,8 +113,8 @@ export function KBCategoryNav({
               </div>
               <p className="text-xs text-muted-foreground truncate">{config.description}</p>
             </div>
-            <ChevronRight className={`h-4 w-4 text-muted-foreground shrink-0 transition-transform ${isSelected ? "rotate-90" : ""}`} />
-          </button>
+            <ChevronRight className={cn("h-4 w-4 text-muted-foreground shrink-0 transition-transform", isSelected && "rotate-90")} />
+          </Button>
         );
       })}
     </div>

--- a/panel/src/components/knowledge-base/kb-filters.tsx
+++ b/panel/src/components/knowledge-base/kb-filters.tsx
@@ -2,6 +2,7 @@
 
 import { KBIndexType } from "@/types";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
 import { FileText, MessageSquare, BookOpen, AlertTriangle, Scale, GitBranch, ClipboardCheck, Lightbulb } from "lucide-react";
 
 const indexTypeConfig: Record<KBIndexType, { label: string; icon: React.ReactNode }> = {
@@ -36,12 +37,14 @@ export function KBFilters({ selectedTypes, onTypesChange }: KBFiltersProps) {
       <div className="flex items-center justify-between">
         <span className="text-sm font-medium">Filter by type</span>
         {selectedTypes.length > 0 && (
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onTypesChange([])}
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="h-auto py-0 px-1 text-xs text-muted-foreground hover:text-foreground"
           >
             Clear
-          </button>
+          </Button>
         )}
       </div>
       <div className="space-y-2">

--- a/panel/src/components/knowledge-base/kb-search-bar.tsx
+++ b/panel/src/components/knowledge-base/kb-search-bar.tsx
@@ -64,12 +64,14 @@ export function KBSearchBar({
           className="pl-9 pr-9"
         />
         {localValue && (
-          <button
+          <Button
+            variant="ghost"
+            size="icon-sm"
             onClick={handleClear}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />
-          </button>
+          </Button>
         )}
       </div>
       {onSearch && (

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -69,7 +69,7 @@ export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -12,12 +12,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ModelUsageSlice } from "@/types";
 
+// Semantic color palette: blue (informational), amber (warning), green (success),
+// red (error/blocked), purple (supplemental)
 const CHART_COLORS = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
+  "#3b82f6", // blue-500  — informational
+  "#f59e0b", // amber-500 — warning / pending
+  "#22c55e", // green-500 — success / healthy
+  "#ef4444", // red-500   — error / blocked
+  "#a855f7", // purple-500 — supplemental
 ];
 
 interface ModelUsageDonutProps {

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -66,7 +66,7 @@ export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="var(--chart-2)" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -58,12 +58,12 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
             >
               <defs>
                 <linearGradient id="fillInput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.1} />
                 </linearGradient>
                 <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="#f59e0b" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
@@ -93,14 +93,14 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 type="monotone"
                 dataKey="Input"
                 stackId="1"
-                stroke="var(--chart-1)"
+                stroke="#3b82f6"
                 fill="url(#fillInput)"
               />
               <Area
                 type="monotone"
                 dataKey="Output"
                 stackId="1"
-                stroke="var(--chart-2)"
+                stroke="#f59e0b"
                 fill="url(#fillOutput)"
               />
             </AreaChart>

--- a/panel/src/components/products/product-table.tsx
+++ b/panel/src/components/products/product-table.tsx
@@ -60,12 +60,13 @@ export function ProductTable({ products, isLoading }: ProductTableProps) {
               <TableRow key={product.id}>
                 <TableCell>
                   <div>
-                    <button
+                    <Button
                       onClick={() => setEditingProductId(product.id)}
-                      className="font-medium hover:underline text-left"
+                      variant="link"
+                      className="h-auto p-0 font-medium text-foreground"
                     >
                       {product.name}
-                    </button>
+                    </Button>
                     <p className="text-xs text-muted-foreground font-mono">{product.slug}</p>
                   </div>
                 </TableCell>

--- a/panel/src/components/projects/project-table.tsx
+++ b/panel/src/components/projects/project-table.tsx
@@ -129,12 +129,13 @@ export function ProjectTable({ projects, isLoading }: ProjectTableProps) {
               <TableRow key={project.id}>
                 <TableCell>
                   <div>
-                    <button
+                    <Button
                       onClick={() => setEditingProjectId(project.id)}
-                      className="font-medium hover:underline text-left"
+                      variant="link"
+                      className="h-auto p-0 font-medium text-foreground"
                     >
                       {project.name}
-                    </button>
+                    </Button>
                     <p className="text-xs text-muted-foreground font-mono">
                       {project.slug}
                     </p>

--- a/panel/src/components/settings/ai-routing-card.tsx
+++ b/panel/src/components/settings/ai-routing-card.tsx
@@ -42,6 +42,8 @@ import { toast } from "sonner";
 import { AssignmentScope, ModelProvider } from "@/types";
 import type { RoutingMode, SelfHostedTestResult } from "@/lib/api/providers";
 import { SelfHostedSection } from "@/components/settings/self-hosted-section";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 
 // Matches the roboco agents_config AGENT_ROLE_MAP / AGENT_TEAM_MAP.
 // Hard-coded so Mix mode shows a stable 18-row picker without an extra
@@ -254,13 +256,13 @@ export function AIRoutingCard() {
           <div className="flex items-center justify-between">
             <Label className="text-sm font-medium">Ollama Cloud API key</Label>
             {hasOllamaKey ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+              <Badge className="bg-emerald-500/10 text-emerald-600 border-0">
                 <KeyRound className="h-3 w-3" /> key set
-              </span>
+              </Badge>
             ) : (
-              <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+              <Badge className="bg-amber-500/10 text-amber-600 border-0">
                 <Key className="h-3 w-3" /> not set
-              </span>
+              </Badge>
             )}
           </div>
           <div className="flex gap-2">
@@ -278,13 +280,13 @@ export function AIRoutingCard() {
             </Button>
           </div>
           {hasOllamaKey ? (
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
+            <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+              <Checkbox
                 checked={clearKey}
-                onChange={(e) => {
-                  setClearKey(e.target.checked);
-                  if (e.target.checked) setApiKey("");
+                onCheckedChange={(checked) => {
+                  const next = checked === true;
+                  setClearKey(next);
+                  if (next) setApiKey("");
                 }}
               />
               Clear the stored key
@@ -543,29 +545,27 @@ function ModeButton({
   highlight?: boolean;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="outline"
       onClick={onClick}
       disabled={disabled}
       className={
-        "rounded-md border p-3 text-left transition-colors " +
-        (active || highlight
-          ? "border-primary bg-primary/5"
-          : "hover:bg-muted") +
-        (disabled ? " cursor-not-allowed opacity-50" : "")
+        "h-auto flex-col items-start justify-start p-3 whitespace-normal " +
+        (active || highlight ? "border-primary bg-primary/5" : "")
       }
     >
-      <div className="flex items-center gap-2 text-sm font-medium">
+      <div className="flex w-full items-center gap-2 text-sm font-medium">
         {icon}
         <span>{label}</span>
         {active ? (
-          <span className="ml-auto rounded-full bg-primary/15 px-2 py-0.5 text-xs text-primary">
+          <Badge className="ml-auto bg-primary/15 text-primary border-0 text-xs">
             active
-          </span>
+          </Badge>
         ) : null}
       </div>
-      <p className="mt-1 text-xs text-muted-foreground">{description}</p>
-    </button>
+      <p className="mt-1 text-xs text-muted-foreground font-normal">{description}</p>
+    </Button>
   );
 }
 

--- a/panel/src/components/settings/self-hosted-section.tsx
+++ b/panel/src/components/settings/self-hosted-section.tsx
@@ -146,14 +146,14 @@ export function SelfHostedSection({
         <Server className="h-4 w-4 text-muted-foreground" />
         <Label className="text-sm font-medium">Self-Hosted LLM</Label>
         {testResult?.ok === true && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600">
+          <Badge className="bg-emerald-500/10 text-emerald-600 border-0">
             <CheckCircle2 className="h-3 w-3" /> connected
-          </span>
+          </Badge>
         )}
         {testResult?.ok === false && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-600">
+          <Badge className="bg-red-500/10 text-red-600 border-0">
             <XCircle className="h-3 w-3" /> error
-          </span>
+          </Badge>
         )}
       </div>
 
@@ -194,10 +194,12 @@ export function SelfHostedSection({
               }
               className="pr-10"
             />
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="icon-sm"
               onClick={() => setShowToken((v) => !v)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
               aria-label={showToken ? "Hide token" : "Show token"}
             >
               {showToken ? (
@@ -205,7 +207,7 @@ export function SelfHostedSection({
               ) : (
                 <Eye className="h-4 w-4" />
               )}
-            </button>
+            </Button>
           </div>
           <Button onClick={handleSave} disabled={saveConfig.isPending}>
             {saveConfig.isPending ? "Saving…" : "Save"}
@@ -243,17 +245,17 @@ export function SelfHostedSection({
 
         {/* Inline result badge */}
         {testResult?.ok === true && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-400">
+          <Badge className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 border-0 px-3 py-1 text-xs">
             <CheckCircle2 className="h-3.5 w-3.5" />
             Connected &mdash; {testResult.model_count ?? 0} model
             {(testResult.model_count ?? 0) === 1 ? "" : "s"} available
-          </span>
+          </Badge>
         )}
         {testResult?.ok === false && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-red-500/10 px-3 py-1 text-xs font-medium text-red-700 dark:text-red-400">
+          <Badge className="bg-red-500/10 text-red-700 dark:text-red-400 border-0 px-3 py-1 text-xs">
             <XCircle className="h-3.5 w-3.5" />
             {testResult.error ?? "Connection failed"}
-          </span>
+          </Badge>
         )}
       </div>
 

--- a/panel/src/components/tasks/dependency-selector.tsx
+++ b/panel/src/components/tasks/dependency-selector.tsx
@@ -7,9 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Search, X, Link2, Check } from "lucide-react";
+import { Search, X, Link2 } from "lucide-react";
 
 interface DependencySelectorProps {
   selectedIds: string[];
@@ -114,22 +115,22 @@ export function DependencySelector({
                 {filteredTasks.map((task) => {
                   const isSelected = selectedIds.includes(task.id);
                   return (
-                    <button
+                    <Button
                       key={task.id}
                       type="button"
-                      className={`w-full flex items-center gap-2 p-2 rounded-md text-left hover:bg-muted transition-colors ${
-                        isSelected ? "bg-primary/10" : ""
+                      variant="ghost"
+                      className={`w-full h-auto justify-start gap-2 p-2 font-normal whitespace-normal ${
+                        isSelected ? "bg-primary/10 hover:bg-primary/10" : ""
                       }`}
                       onClick={() => toggleTask(task.id)}
                     >
-                      <div
-                        className={`h-4 w-4 rounded border flex items-center justify-center shrink-0 ${
-                          isSelected ? "bg-primary border-primary" : "border-muted-foreground"
-                        }`}
-                      >
-                        {isSelected && <Check className="h-3 w-3 text-primary-foreground" />}
-                      </div>
-                      <div className="flex-1 min-w-0">
+                      <Checkbox
+                        checked={isSelected}
+                        tabIndex={-1}
+                        className="pointer-events-none shrink-0"
+                        aria-hidden
+                      />
+                      <div className="flex-1 min-w-0 text-left">
                         <p className="text-sm truncate">{task.title}</p>
                         <div className="flex items-center gap-2 text-xs text-muted-foreground">
                           <Badge variant="outline" className="font-mono text-xs">
@@ -138,7 +139,7 @@ export function DependencySelector({
                           <span className="capitalize">{task.status.replace(/_/g, " ")}</span>
                         </div>
                       </div>
-                    </button>
+                    </Button>
                   );
                 })}
               </div>

--- a/panel/src/components/tasks/task-table.tsx
+++ b/panel/src/components/tasks/task-table.tsx
@@ -180,15 +180,16 @@ function SortableHeader({ label, field, sortConfig, onSort, className }: Sortabl
 
   return (
     <TableHead className={className}>
-      <button
+      <Button
         onClick={() => onSort(field)}
-        className="flex items-center gap-1 hover:text-foreground transition-colors -ml-2 px-2 py-1 rounded hover:bg-muted"
+        variant="ghost"
+        className="h-auto -ml-2 px-2 py-1 gap-1 font-normal"
       >
         {label}
         {!isActive && <ArrowUpDown className="h-4 w-4 text-muted-foreground" />}
         {direction === "asc" && <ArrowUp className="h-4 w-4" />}
         {direction === "desc" && <ArrowDown className="h-4 w-4" />}
-      </button>
+      </Button>
     </TableHead>
   );
 }
@@ -479,16 +480,18 @@ export function TaskTable({
                         style={{ paddingLeft: `${node.depth * 1.5}rem` }}
                       >
                         {hasChildren ? (
-                          <button
+                          <Button
                             onClick={() => toggleExpand(task.id)}
-                            className="p-0.5 hover:bg-muted rounded shrink-0"
+                            variant="ghost"
+                            size="icon-sm"
+                            className="p-0.5 h-5 w-5 shrink-0"
                           >
                             {isExpanded ? (
                               <ChevronDown className="h-4 w-4" />
                             ) : (
                               <ChevronRightIcon className="h-4 w-4" />
                             )}
-                          </button>
+                          </Button>
                         ) : (
                           <span className="w-5 shrink-0" />
                         )}

--- a/panel/src/hooks/use-git.ts
+++ b/panel/src/hooks/use-git.ts
@@ -23,6 +23,12 @@ import type {
   GitCreatePRResponse,
   GitMergePRRequest,
   GitMergePRResponse,
+  GitPullRequest,
+  GitPullResponse,
+  GitFetchRequest,
+  GitFetchResponse,
+  GitRebaseRequest,
+  GitRebaseResponse,
 } from "@/types/git";
 
 // =============================================================================
@@ -226,6 +232,60 @@ export function useMergePR() {
   });
 }
 
+/**
+ * Pull latest changes from remote
+ */
+export function useGitPull() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GitPullResponse, Error, GitPullRequest>({
+    mutationFn: (request) => gitApi.pull(request),
+    onSuccess: (_, variables) => {
+      // Invalidate status and log after pull
+      queryClient.invalidateQueries({ queryKey: gitKeys.status(variables.project_slug) });
+      queryClient.invalidateQueries({
+        queryKey: [...gitKeys.all, "log", variables.project_slug],
+      });
+    },
+  });
+}
+
+/**
+ * Fetch refs from remote without merging
+ */
+export function useGitFetch() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GitFetchResponse, Error, GitFetchRequest>({
+    mutationFn: (request) => gitApi.fetch(request),
+    onSuccess: (_, variables) => {
+      // Invalidate status after fetch
+      queryClient.invalidateQueries({ queryKey: gitKeys.status(variables.project_slug) });
+    },
+  });
+}
+
+/**
+ * Rebase current branch onto remote (destructive — rewrites history)
+ */
+export function useGitRebase() {
+  const queryClient = useQueryClient();
+
+  return useMutation<GitRebaseResponse, Error, GitRebaseRequest>({
+    mutationFn: (request) => gitApi.rebase(request),
+    onSuccess: (_, variables) => {
+      // Invalidate everything after rebase since history has changed
+      queryClient.invalidateQueries({ queryKey: gitKeys.status(variables.project_slug) });
+      queryClient.invalidateQueries({
+        queryKey: [...gitKeys.all, "log", variables.project_slug],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [...gitKeys.all, "diff", variables.project_slug],
+      });
+    },
+  });
+}
+
 // =============================================================================
 // Bundled Hook for Git Operations
 // =============================================================================
@@ -240,6 +300,9 @@ export function useGitOperations() {
   const checkout = useCheckout();
   const createPR = useCreatePR();
   const mergePR = useMergePR();
+  const pull = useGitPull();
+  const fetch = useGitFetch();
+  const rebase = useGitRebase();
 
   return {
     commit,
@@ -248,5 +311,8 @@ export function useGitOperations() {
     checkout,
     createPR,
     mergePR,
+    pull,
+    fetch,
+    rebase,
   };
 }

--- a/panel/src/lib/agent-definitions.ts
+++ b/panel/src/lib/agent-definitions.ts
@@ -23,12 +23,14 @@ export const getBoardAgents = (agents: AgentDefinition[] | undefined | null) =>
     (a) =>
       // The CEO is the human operator, not a spawnable agent — exclude it even
       // though its record carries team=board.
+      // MAIN_PM has its own dedicated section below Board, so exclude it here.
       a.role !== AgentRole.CEO &&
+      a.role !== AgentRole.MAIN_PM &&
       (a.team === Team.BOARD ||
         a.role === AgentRole.HEAD_MARKETING ||
         a.role === AgentRole.AUDITOR ||
         a.role === AgentRole.PRODUCT_OWNER ||
-        a.role === AgentRole.MAIN_PM)
+        a.role === AgentRole.PR_REVIEWER)
   );
 
 export const getMainPm = (agents: AgentDefinition[] | undefined | null) =>
@@ -45,3 +47,14 @@ export const getUxAgents = (agents: AgentDefinition[] | undefined | null) =>
 
 export const getMarketingAgents = (agents: AgentDefinition[] | undefined | null) =>
   (agents ?? []).filter((a) => a.team === Team.MARKETING);
+
+// On-demand agents (Prompter/Intake, Secretary) are not part of any standing
+// cell team — they are spawned on request. Captured by inclusion of their
+// explicit roles so new on-demand agents appear automatically when roles
+// are added to the enum.
+export const getOnDemandAgents = (agents: AgentDefinition[] | undefined | null) =>
+  (agents ?? []).filter(
+    (a) =>
+      a.role === AgentRole.PROMPTER ||
+      a.role === AgentRole.SECRETARY
+  );

--- a/panel/src/lib/api/git.ts
+++ b/panel/src/lib/api/git.ts
@@ -23,6 +23,12 @@ import type {
   GitCreatePRResponse,
   GitMergePRRequest,
   GitMergePRResponse,
+  GitPullRequest,
+  GitPullResponse,
+  GitFetchRequest,
+  GitFetchResponse,
+  GitRebaseRequest,
+  GitRebaseResponse,
 } from "@/types/git";
 
 // =============================================================================
@@ -237,6 +243,53 @@ export const gitApi = {
       };
     }
     const { data } = await api.post<GitMergePRResponse>("/git/pr/merge", request);
+    return data;
+  },
+
+  /**
+   * Pull latest changes from remote
+   */
+  pull: async (request: GitPullRequest): Promise<GitPullResponse> => {
+    if (isMockMode()) {
+      return {
+        project_slug: request.project_slug,
+        branch: "feature/backend/abc12345",
+        commits_received: 2,
+        remote: request.remote ?? "origin",
+      };
+    }
+    const { data } = await api.post<GitPullResponse>("/git/pull", request);
+    return data;
+  },
+
+  /**
+   * Fetch refs from remote without merging
+   */
+  fetch: async (request: GitFetchRequest): Promise<GitFetchResponse> => {
+    if (isMockMode()) {
+      return {
+        project_slug: request.project_slug,
+        remote: request.remote ?? "origin",
+        refs_updated: 3,
+      };
+    }
+    const { data } = await api.post<GitFetchResponse>("/git/fetch", request);
+    return data;
+  },
+
+  /**
+   * Rebase current branch onto remote (destructive — rewrites history)
+   */
+  rebase: async (request: GitRebaseRequest): Promise<GitRebaseResponse> => {
+    if (isMockMode()) {
+      return {
+        project_slug: request.project_slug,
+        branch: "feature/backend/abc12345",
+        onto: request.onto ?? "origin/main",
+        commits_rebased: 3,
+      };
+    }
+    const { data } = await api.post<GitRebaseResponse>("/git/rebase", request);
     return data;
   },
 };

--- a/panel/src/types/git.ts
+++ b/panel/src/types/git.ts
@@ -147,3 +147,43 @@ export interface GitMergePRRequest {
   merge_method?: MergeMethod;
   agent_id: string;
 }
+
+export interface GitPullRequest {
+  project_slug: string;
+  task_id: string;
+  agent_id: string;
+  remote?: string;
+}
+
+export interface GitPullResponse {
+  project_slug: string;
+  branch: string;
+  commits_received: number;
+  remote: string;
+}
+
+export interface GitFetchRequest {
+  project_slug: string;
+  agent_id: string;
+  remote?: string;
+}
+
+export interface GitFetchResponse {
+  project_slug: string;
+  remote: string;
+  refs_updated: number;
+}
+
+export interface GitRebaseRequest {
+  project_slug: string;
+  task_id: string;
+  agent_id: string;
+  onto?: string;
+}
+
+export interface GitRebaseResponse {
+  project_slug: string;
+  branch: string;
+  onto: string;
+  commits_rebased: number;
+}

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -34,11 +34,14 @@ export enum AgentRole {
   PRODUCT_OWNER = "product_owner",
   HEAD_MARKETING = "head_marketing",
   AUDITOR = "auditor",
+  PR_REVIEWER = "pr_reviewer",
   MAIN_PM = "main_pm",
   CELL_PM = "cell_pm",
   DEVELOPER = "developer",
   QA = "qa",
   DOCUMENTER = "documenter",
+  PROMPTER = "prompter",
+  SECRETARY = "secretary",
 }
 
 export enum AgentState {


### PR DESCRIPTION
Goal: Bring every control-panel page to the Knowledge Base page's standard — consistent component vocabulary, URL-persisted state, full-width responsive design, single-scroll contexts, mobile usability, and accessibility. This is the bulk of the root task: 12 acceptance criteria spanning 10+ panel pages.

Cross-cell dependency: The Git page UI (Pull/Fetch/Rebase buttons + destructive Rebase confirmation) depends on backend endpoints being delivered by the Backend cell (task 4c179e3a). Sequence this work unit last; all other items are independent of backend.

Constraints:
- KB page (knowledge-base-browser.tsx) is the canonical reference for useSearchParams tab pattern, component vocabulary, and layout.
- Secretary input row now lives in /business page (secretary-tab.tsx within the Business page) after recent consolidation — reference /business, not standalone /secretary.
- Recent Business page consolidation and 26-bug-fix batch shipped this week — no regressions on those files.
- HoM UX guardrails: Rebase gets destructive-action confirmation (red-tinted dialog, explicit branch name, not Enter-to-confirm); Metrics uses humanized numbers (1.2M not 1,234,567) and semantic chart colors; URL state must survive both refresh AND browser back/forward.
- PO confirmed defect locations: command-center.tsx:97-101, agent-definitions.ts:31, kanban-column.tsx:39, agent-list.tsx:87, notifications/page.tsx:111, settings/page.tsx:46, secretary-tab.tsx:248, metrics/page.tsx.

Work units — independently shippable, dependency-ordered for parallel dev tracks:

**Track A (page-specific fixes — all independent of each other):**
1. Notifications: replace useState with useSearchParams for tab persistence (notifications/page.tsx:111)
2. Journals: eliminate nested scrollbar in agent-list.tsx:87 — single scroll context only
3. Agents: fix agent-definitions.ts:31 — remove MAIN_PM from Board filter, add On-Demand section for Intake/Secretary, Board = exactly PO/HoM/Auditor/PR Reviewer
4. Overview: reorder command-center.tsx so Quick Actions is visible without scrolling at 900px viewport; add Intake and Secretary to Team Health cards
5. Settings + AI Providers: remove max-w constraints, add multi-column layout at >= 1024px viewport
6. Secretary: add items-end to flex container in secretary-tab.tsx:248 for consistent button height
7. Metrics: split into Performance + Token Usage tabs with useSearchParams persistence, humanized number formatting, semantic chart colors

**Track B (mobile + cross-cutting — can overlap with Track A):**
8. Kanban: mobile viewport handling at 375px — column selector or swipe navigation, >= 44px touch targets
9. Component vocabulary audit: replace all custom-styled buttons/inputs/cards/badges with shared components/ui/ across all pages
10. Git page UI: wire Pull/Fetch/Rebase buttons to new backend endpoints (BLOCKED on backend cell), destructive-action confirmation for Rebase

Both FE devs can work in parallel — e.g., dev-1 takes Track A items 1-4, dev-2 takes items 5-8, then both converge on items 9-10.