### PR TITLE
[d0593fe3] Fix git schemas and add service-layer safety gates

### DIFF
--- a/roboco/api/routes/tasks.py
+++ b/roboco/api/routes/tasks.py
@@ -228,7 +228,6 @@ async def _merge_pr_if_awaiting_pm_review(
                 pr_number=pre_task.pr_number,
                 task_id=task_id,
                 merge_method="squash",
-                agent_id=str(agent.agent_id),
             ),
         )
     except (ServiceError, GitError) as e:
@@ -1729,7 +1728,6 @@ async def approve_and_merge_task(
                 pr_number=task.pr_number,
                 task_id=task_id,
                 merge_method="squash",
-                agent_id=str(agent.agent_id),
             ),
         )
     except (ServiceError, GitError) as e:

--- a/roboco/api/schemas/git.py
+++ b/roboco/api/schemas/git.py
@@ -7,7 +7,7 @@ Request/response models for git operation endpoints.
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # =============================================================================
 # STATUS
@@ -78,7 +78,6 @@ class GitCreateBranchRequest(BaseModel):
     project_slug: str
     task_id: UUID
     branch_type: str = Field(..., pattern=r"^(feature|bug|chore|docs|hotfix)$")
-    agent_id: str
     parent_branch: str | None = None
 
 
@@ -95,7 +94,6 @@ class GitCheckoutRequest(BaseModel):
 
     project_slug: str
     branch: str
-    agent_id: str
 
 
 class GitCheckoutResponse(BaseModel):
@@ -130,7 +128,6 @@ class GitCommitRequest(BaseModel):
 
     project_slug: str
     task_id: UUID
-    agent_id: str
     # Commit message fields
     message: str = Field(
         ...,
@@ -169,7 +166,6 @@ class GitPushRequest(BaseModel):
 
     project_slug: str
     task_id: UUID
-    agent_id: str
     force: bool = False
 
 
@@ -192,7 +188,6 @@ class GitCreatePRRequest(BaseModel):
 
     project_slug: str
     task_id: UUID
-    agent_id: str
     # PR content (auto-generated from templates if not provided)
     title: str | None = Field(None, description="PR title (auto-generated if not set)")
     body: str | None = Field(None, description="PR body (auto-generated if not set)")
@@ -220,7 +215,6 @@ class GitMergePRRequest(BaseModel):
     pr_number: int
     task_id: UUID
     merge_method: str = Field(default="squash", pattern=r"^(merge|squash|rebase)$")
-    agent_id: str
 
 
 class GitMergePRResponse(BaseModel):
@@ -241,8 +235,7 @@ class GitPullRequest(BaseModel):
     """Request to pull latest changes from origin."""
 
     project_slug: str
-    task_id: UUID
-    agent_id: str
+    task_id: UUID | None = None
 
 
 class GitPullResponse(BaseModel):
@@ -267,8 +260,7 @@ class GitFetchRequest(BaseModel):
     """Request to fetch changes from origin without merging."""
 
     project_slug: str
-    task_id: UUID
-    agent_id: str
+    task_id: UUID | None = None
 
 
 class GitFetchResponse(BaseModel):
@@ -293,9 +285,22 @@ class GitRebaseRequest(BaseModel):
     """Request to rebase the current branch onto a target branch."""
 
     project_slug: str
-    task_id: UUID
-    agent_id: str
+    task_id: UUID | None = None
     target_branch: str
+
+    @field_validator("target_branch")
+    @classmethod
+    def _validate_target_branch(cls, v: str) -> str:
+        if v.startswith("-"):
+            raise ValueError(
+                "INVALID_TARGET_BRANCH: target_branch must not start with '-'"
+            )
+        if v in ("master", "main"):
+            raise ValueError(
+                f"PROTECTED_BRANCH: Cannot rebase onto '{v}'; "
+                "target_branch must not be 'master' or 'main'"
+            )
+        return v
 
 
 class GitRebaseResponse(BaseModel):
@@ -309,3 +314,52 @@ class GitRebaseResponse(BaseModel):
     project_slug: str
     conflict: bool = False
     conflicted_files: list[str] = []
+
+
+# =============================================================================
+# GATEWAY-LAYER LIGHTWEIGHT SCHEMAS
+#
+# These simpler schemas are used by the MCP gateway layer and services that
+# don't need the full Git* request payload. All fields beyond project_slug
+# are optional to allow callers that don't yet carry task context.
+# =============================================================================
+
+
+class PullRequest(BaseModel):
+    """Lightweight pull request used by the gateway / MCP layer."""
+
+    project_slug: str
+    task_id: UUID | None = None
+
+
+class FetchRequest(BaseModel):
+    """Lightweight fetch request used by the gateway / MCP layer."""
+
+    project_slug: str
+    task_id: UUID | None = None
+
+
+class RebaseRequest(BaseModel):
+    """Lightweight rebase request used by the gateway / MCP layer.
+
+    Validates ``target_branch`` to prevent accidental rebases onto
+    protected branches or shell-injection via leading ``-``.
+    """
+
+    project_slug: str
+    task_id: UUID | None = None
+    target_branch: str
+
+    @field_validator("target_branch")
+    @classmethod
+    def _validate_target_branch(cls, v: str) -> str:
+        if v.startswith("-"):
+            raise ValueError(
+                "INVALID_TARGET_BRANCH: target_branch must not start with '-'"
+            )
+        if v in ("master", "main"):
+            raise ValueError(
+                f"PROTECTED_BRANCH: Cannot rebase onto '{v}'; "
+                "target_branch must not be 'master' or 'main'"
+            )
+        return v

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -1157,15 +1157,62 @@ class GitService(BaseService):
     ) -> tuple[str, bool, list[str], list[str], list[str], int, int]:
         """Pull latest changes from origin and return post-pull status.
 
+        Safety gates (both raise :class:`ValidationError`):
+
+        1. **Dirty workspace** — refuses to pull when there are any
+           uncommitted changes (staged, unstaged, or untracked).  A pull
+           onto a dirty tree can produce unexpected merge conflicts or
+           silently clobber un-staged edits.
+
+        2. **Diverged branch** — uses ``--ff-only`` so a diverged branch
+           is rejected rather than creating a merge commit.  The agent
+           must rebase or reset before pulling.
+
         Uses _network_git_timeout() because the operation talks to origin.
 
         Returns: (current_branch, has_changes, staged, unstaged, untracked,
                   ahead, behind)
         """
-        token = await self._token_for_workspace(workspace)
-        await self._run_git(
-            workspace, ["pull"], token=token, timeout=_network_git_timeout()
+        # Gate 1: dirty workspace check
+        status_result = await self._run_git(
+            workspace, ["status", "--porcelain"], check=False
         )
+        if status_result.stdout.strip():
+            raise ValidationError(
+                "DIRTY_WORKSPACE: Cannot pull with uncommitted changes. "
+                "Stage and commit (or stash) your changes before pulling."
+            )
+
+        token = await self._token_for_workspace(workspace)
+        # Gate 2: fast-forward only — raises if branches have diverged
+        pull_result = await self._run_git(
+            workspace,
+            ["pull", "--ff-only"],
+            token=token,
+            timeout=_network_git_timeout(),
+            check=False,
+        )
+        if pull_result.returncode != 0:
+            stderr = (pull_result.stderr or "").lower()
+            if any(
+                kw in stderr
+                for kw in (
+                    "not possible to fast-forward",
+                    "diverged",
+                    "fatal: not possible to fast",
+                    "fast-forward",
+                )
+            ):
+                raise ValidationError(
+                    "DIVERGED_BRANCH: Branch has diverged from remote; "
+                    "cannot fast-forward. Rebase your local commits onto "
+                    "the remote tip with `git rebase origin/<branch>` "
+                    "before pulling."
+                )
+            raise ValidationError(
+                f"PULL_FAILED: git pull --ff-only exited non-zero. "
+                f"stderr: {pull_result.stderr or '(none)'}"
+            )
         return await self.get_status(workspace)
 
     async def fetch(
@@ -1192,12 +1239,28 @@ class GitService(BaseService):
     ) -> tuple[bool, list[str]]:
         """Rebase the current branch onto target_branch.
 
+        Safety gate: raises :class:`ValidationError` if the HEAD branch or
+        ``target_branch`` is ``master`` or ``main`` — rebasing a protected
+        integration branch is never safe in automation.
+
         On conflict (non-zero exit): captures unmerged files via
         ``git diff --name-only --diff-filter=U``, aborts the rebase to
         restore a clean workspace, and returns ``(True, conflicted_files)``.
 
         On success: returns ``(False, [])``.
         """
+        _PROTECTED = frozenset({"master", "main"})
+        if target_branch in _PROTECTED:
+            raise ValidationError(
+                f"REBASE_FORBIDDEN: Cannot rebase onto '{target_branch}'. "
+                "Rebasing onto 'master' or 'main' is not allowed in automation."
+            )
+        head_branch = await self.get_current_branch(workspace)
+        if head_branch in _PROTECTED:
+            raise ValidationError(
+                f"REBASE_FORBIDDEN: Cannot rebase '{head_branch}'. "
+                "Rebasing 'master' or 'main' is not allowed in automation."
+            )
         result = await self._run_git(workspace, ["rebase", target_branch], check=False)
         if result.returncode != 0:
             conflict_result = await self._run_git(

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -924,7 +924,6 @@ class TaskService(BaseService):
             task_id=require_uuid(task.id),
             project_slug=project.slug,
             branch_type="feature",
-            agent_id=str(agent_id),
             parent_branch=parent_branch,
         )
 

--- a/tests/unit/services/test_git.py
+++ b/tests/unit/services/test_git.py
@@ -550,7 +550,6 @@ async def test_create_branch_idempotent_when_branch_already_exists() -> None:
                 project_slug="roboco-api",
                 task_id=uuid4(),
                 branch_type="feature",
-                agent_id=str(uuid4()),
                 parent_branch=None,
             ),
         )
@@ -601,7 +600,6 @@ async def _run_create_branch_with_existing_branch(
                 project_slug="roboco-panel",
                 task_id=uuid4(),
                 branch_type="feature",
-                agent_id=str(uuid4()),
                 parent_branch=None,
             ),
         )


### PR DESCRIPTION
Make the following changes to roboco/api/schemas/git.py:

1. REMOVE the `agent_id: str` field from every git request schema that carries it: GitCreateBranchRequest, GitCheckoutRequest, GitCommitRequest, GitPushRequest, GitCreatePRRequest, and GitMergePRRequest. Agent identity is already known from the JWT/session via CurrentAgentContext — carrying it in the request body is dead weight that causes 422 validation failures on callers that omit it.

2. ADD three new request schemas — PullRequest, FetchRequest, RebaseRequest — each with a `project_slug: str` field and `task_id: Optional[UUID] = None`. These are the bodies that the new pull, fetch, and rebase endpoints will consume. Callers that omit task_id must NOT receive a 422 — the field is optional with a None default.

3. ADD `target_branch` field-level validation to RebaseRequest (and anywhere else target_branch appears as an input): reject names whose first character is '-' (shell-injection risk) and reject the literal protected names 'master' and 'main' with a clear Pydantic ValidationError message.

Make the following changes to roboco/services/git.py:

4. ADD a `pull()` method to GitService. It must:
   - Check the working tree is clean BEFORE attempting any git operation (use `git status --porcelain`; raise ValidationError with message like "DIRTY_TREE: Working tree has uncommitted changes — stash or discard before pulling" if any output is present).
   - Run `git pull --ff-only` (NOT plain `git pull`).
   - If the pull exits non-zero because branches have diverged, raise ValidationError with a message clearly stating the branches have diverged and a merge/rebase is needed before a fast-forward pull is possible.
   - Use the existing `_run_git` for subprocess management and token injection.

5. MODIFY `rebase_onto_base()` (or add a public `rebase()` method that delegates to it): reject any call where head_branch OR base_branch equals 'master' or 'main' (case-sensitive) by raising ValidationError with message like "PROTECTED_BRANCH: Cannot rebase onto or from protected branch '<name>'". The existing `rebase_onto_base` is an internal primitive — if you create a public `rebase()` wrapper, have it validate then call `rebase_onto_base`.