### PR TITLE
[be6a17fc] UI polish: Secretary design-system, KB aria-label, Metrics chart tokens, Kanban mobile touch targets

### DIFF
--- a/panel/src/components/kanban/core/kanban-card.tsx
+++ b/panel/src/components/kanban/core/kanban-card.tsx
@@ -183,7 +183,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="min-h-11 text-muted-foreground hover:text-foreground"
+                  className="max-sm:min-h-11 text-muted-foreground hover:text-foreground"
                   onClick={(e) => e.stopPropagation()}
                   disabled={isBacklog}
                 >
@@ -210,7 +210,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="min-h-11 text-green-600 hover:text-green-700 hover:bg-green-50"
+                    className="max-sm:min-h-11 text-green-600 hover:text-green-700 hover:bg-green-50"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("pass-qa", task.id);
@@ -222,7 +222,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="min-h-11 text-red-600 hover:text-red-700 hover:bg-red-50"
+                    className="max-sm:min-h-11 text-red-600 hover:text-red-700 hover:bg-red-50"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("fail-qa", task.id);

--- a/panel/src/components/knowledge-base/kb-search-bar.tsx
+++ b/panel/src/components/knowledge-base/kb-search-bar.tsx
@@ -68,6 +68,7 @@ export function KBSearchBar({
             variant="ghost"
             size="icon-sm"
             onClick={handleClear}
+            aria-label="Clear search"
             className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -69,7 +69,7 @@ export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -12,14 +12,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ModelUsageSlice } from "@/types";
 
-// Semantic color palette: blue (informational), amber (warning), green (success),
-// red (error/blocked), purple (supplemental)
+// Design-system chart tokens — resolves to theme-aware palette
 const CHART_COLORS = [
-  "#3b82f6", // blue-500  — informational
-  "#f59e0b", // amber-500 — warning / pending
-  "#22c55e", // green-500 — success / healthy
-  "#ef4444", // red-500   — error / blocked
-  "#a855f7", // purple-500 — supplemental
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
 ];
 
 interface ModelUsageDonutProps {

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -66,7 +66,7 @@ export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -58,12 +58,12 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
             >
               <defs>
                 <linearGradient id="fillInput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0.1} />
                 </linearGradient>
                 <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="#f59e0b" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
@@ -93,14 +93,14 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 type="monotone"
                 dataKey="Input"
                 stackId="1"
-                stroke="#3b82f6"
+                stroke="var(--chart-1)"
                 fill="url(#fillInput)"
               />
               <Area
                 type="monotone"
                 dataKey="Output"
                 stackId="1"
-                stroke="#f59e0b"
+                stroke="var(--chart-2)"
                 fill="url(#fillOutput)"
               />
             </AreaChart>


### PR DESCRIPTION
Apply four targeted UI polish fixes across four separate files. These are CEO-identified regressions that must be fixed.

CONTEXT: The previous Panel-wide UI standardization task introduced some fixes but left gaps. This subtask closes all 4 remaining gaps.

FILES TO MODIFY:

1. panel/src/components/business/secretary-tab.tsx
   — Verify and ensure the entire Secretary tab uses ONLY shared components/ui/ vocabulary. Specifically:
     * The Start button must use <Button> from @/components/ui/button (not a raw <button>)
     * Message bubbles (ChatMessages component): user bubbles use bg-primary / text-primary-foreground; assistant bubbles use bg-muted. These design-system tokens are acceptable. No raw hex colors allowed. No inline style attributes.
     * If there are any remaining raw HTML elements (<button>, <input>, <select>) not from components/ui/, replace them with the appropriate shared component.
     * The Send button must also use <Button>.

2. panel/src/components/knowledge-base/kb-search-bar.tsx
   — The clear (X) button is missing aria-label. Add aria-label='Clear search' to whatever element renders the X icon (whether it is a raw <button> or the <Button> component). This is a WCAG accessibility requirement.

3. Metrics chart colors — replace ALL hard-coded hex values with CSS custom properties in these 4 files:
   a. panel/src/components/metrics/model-usage-donut.tsx — CHART_COLORS array has hex values like '#3b82f6', '#f59e0b', '#22c55e', '#ef4444', '#a855f7'. Replace with: ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)', 'var(--chart-5)']
   b. panel/src/components/metrics/usage-time-series-chart.tsx — stopColor="#3b82f6" and stopColor="#f59e0b" in linearGradient defs, and stroke="#3b82f6" / stroke="#f59e0b" on Area components. Replace with var(--chart-1) and var(--chart-2).
   c. panel/src/components/metrics/agent-usage-chart.tsx — fill="#3b82f6" on the Bar component. Replace with fill="var(--chart-1)".
   d. panel/src/components/metrics/team-usage-chart.tsx — fill="#3b82f6" on the Bar component. Replace with fill="var(--chart-2)" (or var(--chart-1) if that is the only bar — use consistent chart token ordering).

4. panel/src/components/kanban/core/kanban-card.tsx
   — There are button elements with className="min-h-11 ..." (where min-h-11 = 44px minimum height for touch targets). These 44px targets are for mobile usability and must NOT apply on desktop viewports. Change every occurrence of 'min-h-11' to 'max-sm:min-h-11' so the touch target only applies at viewport widths below the 'sm' breakpoint. Do a grep for 'min-h-11' in the file and update every match.

Run pnpm lint && pnpm typecheck after all edits. No TypeScript errors allowed.