### PR TITLE
[72de8a65] Fix git control contract: types, API shapes, request fields, and toast handlers

### DIFF
--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -49,7 +49,7 @@ interface GitActionsPanelProps {
   onMergePR: (prNumber: number) => void;
   onPull: () => void;
   onFetch: () => void;
-  onRebase: () => void;
+  onRebase: (targetBranch: string) => void;
   isCommitting: boolean;
   isPushing: boolean;
   isCreatingPR: boolean;
@@ -87,6 +87,7 @@ export function GitActionsPanel({
   const [prTitle, setPrTitle] = useState("");
   const [prBody, setPrBody] = useState("");
   const [mergePrNumber, setMergePrNumber] = useState("");
+  const [rebaseTargetBranch, setRebaseTargetBranch] = useState("");
 
   const hasStagedChanges = (status?.staged_files.length ?? 0) > 0;
   const hasUnpushedCommits = (status?.ahead ?? 0) > 0;
@@ -376,19 +377,33 @@ export function GitActionsPanel({
           </AlertDialogTrigger>
           <AlertDialogContent className="border-destructive bg-destructive/5">
             <AlertDialogHeader>
-              <AlertDialogTitle>Rebase onto remote?</AlertDialogTitle>
+              <AlertDialogTitle>Rebase onto target branch?</AlertDialogTitle>
               <AlertDialogDescription>
                 This will rewrite the commit history of branch{" "}
                 <strong>{status?.current_branch}</strong> by replaying commits
-                on top of the latest remote. A force-push will be required
-                afterward. This action cannot be undone.
+                on top of the specified target branch. A force-push will be
+                required afterward. This action cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
+            <div className="px-6 py-2 space-y-2">
+              <label className="text-sm font-medium">Target branch</label>
+              <Input
+                placeholder="e.g. main or origin/main"
+                value={rebaseTargetBranch}
+                onChange={(e) => setRebaseTargetBranch(e.target.value)}
+              />
+            </div>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogCancel onClick={() => setRebaseTargetBranch("")}>
+                Cancel
+              </AlertDialogCancel>
               <AlertDialogAction
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                onClick={onRebase}
+                disabled={!rebaseTargetBranch.trim()}
+                onClick={() => {
+                  onRebase(rebaseTargetBranch.trim());
+                  setRebaseTargetBranch("");
+                }}
               >
                 Rebase
               </AlertDialogAction>

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -178,10 +178,10 @@ function GitBrowserContent() {
     try {
       const result = await pull.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
-      toast.success(`Pulled ${result.commits_received} commits from ${result.remote}`);
+      toast.success(`Pulled: now on ${result.current_branch}`);
     } catch {
       toast.error("Failed to pull from remote");
     }
@@ -191,22 +191,30 @@ function GitBrowserContent() {
     try {
       const result = await fetch.mutateAsync({
         project_slug: projectSlug,
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
-      toast.success(`Fetched ${result.refs_updated} refs from ${result.remote}`);
+      toast.success(`Fetched: now on ${result.current_branch}`);
     } catch {
       toast.error("Failed to fetch from remote");
     }
   };
 
-  const handleRebase = async () => {
+  const handleRebase = async (targetBranch: string) => {
     try {
       const result = await rebase.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        target_branch: targetBranch,
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
-      toast.success(`Rebased ${result.commits_rebased} commits onto ${result.onto}`);
+      if (result.conflict) {
+        toast.warning(
+          `Rebase conflicts in: ${result.conflicted_files.join(", ") || "unknown files"}`
+        );
+      } else {
+        toast.success("Rebase completed successfully");
+      }
     } catch {
       toast.error("Failed to rebase");
     }

--- a/panel/src/lib/api/git.ts
+++ b/panel/src/lib/api/git.ts
@@ -252,10 +252,13 @@ export const gitApi = {
   pull: async (request: GitPullRequest): Promise<GitPullResponse> => {
     if (isMockMode()) {
       return {
-        project_slug: request.project_slug,
-        branch: "feature/backend/abc12345",
-        commits_received: 2,
-        remote: request.remote ?? "origin",
+        current_branch: "feature/backend/abc12345",
+        has_changes: false,
+        staged_files: [],
+        unstaged_files: [],
+        untracked_files: [],
+        ahead: 0,
+        behind: 0,
       };
     }
     const { data } = await api.post<GitPullResponse>("/git/pull", request);
@@ -268,9 +271,13 @@ export const gitApi = {
   fetch: async (request: GitFetchRequest): Promise<GitFetchResponse> => {
     if (isMockMode()) {
       return {
-        project_slug: request.project_slug,
-        remote: request.remote ?? "origin",
-        refs_updated: 3,
+        current_branch: "feature/backend/abc12345",
+        has_changes: false,
+        staged_files: [],
+        unstaged_files: [],
+        untracked_files: [],
+        ahead: 0,
+        behind: 0,
       };
     }
     const { data } = await api.post<GitFetchResponse>("/git/fetch", request);
@@ -278,15 +285,13 @@ export const gitApi = {
   },
 
   /**
-   * Rebase current branch onto remote (destructive — rewrites history)
+   * Rebase current branch onto target branch (destructive — rewrites history)
    */
   rebase: async (request: GitRebaseRequest): Promise<GitRebaseResponse> => {
     if (isMockMode()) {
       return {
-        project_slug: request.project_slug,
-        branch: "feature/backend/abc12345",
-        onto: request.onto ?? "origin/main",
-        commits_rebased: 3,
+        conflict: false,
+        conflicted_files: [],
       };
     }
     const { data } = await api.post<GitRebaseResponse>("/git/rebase", request);

--- a/panel/src/types/git.ts
+++ b/panel/src/types/git.ts
@@ -150,40 +150,46 @@ export interface GitMergePRRequest {
 
 export interface GitPullRequest {
   project_slug: string;
-  task_id: string;
-  agent_id: string;
+  task_id?: string;
+  agent_id?: string;
   remote?: string;
 }
 
 export interface GitPullResponse {
-  project_slug: string;
-  branch: string;
-  commits_received: number;
-  remote: string;
+  current_branch: string;
+  has_changes: boolean;
+  staged_files: string[];
+  unstaged_files: string[];
+  untracked_files: string[];
+  ahead: number;
+  behind: number;
 }
 
 export interface GitFetchRequest {
   project_slug: string;
-  agent_id: string;
+  task_id?: string;
+  agent_id?: string;
   remote?: string;
 }
 
 export interface GitFetchResponse {
-  project_slug: string;
-  remote: string;
-  refs_updated: number;
+  current_branch: string;
+  has_changes: boolean;
+  staged_files: string[];
+  unstaged_files: string[];
+  untracked_files: string[];
+  ahead: number;
+  behind: number;
 }
 
 export interface GitRebaseRequest {
   project_slug: string;
-  task_id: string;
-  agent_id: string;
-  onto?: string;
+  target_branch: string;
+  task_id?: string;
+  agent_id?: string;
 }
 
 export interface GitRebaseResponse {
-  project_slug: string;
-  branch: string;
-  onto: string;
-  commits_rebased: number;
+  conflict: boolean;
+  conflicted_files: string[];
 }


### PR DESCRIPTION
Fix the git layer end-to-end across 5 files so Pull, Fetch, and Rebase work correctly against the actual backend API.

CONTEXT: The backend (roboco/api/schemas/git.py — read it in the fe-pm workspace at /data/workspaces/roboco-panel/frontend/fe-pm/roboco/api/schemas/git.py) added Pull, Fetch, and Rebase endpoints. The frontend types and handlers were wired up incorrectly. Fix ALL bugs listed below.

ACTUAL BACKEND SHAPES (source of truth — read the file to verify):
- GitPullResponse: same fields as GitStatusResponse — {project_slug, current_branch, has_changes, staged_files[], unstaged_files[], untracked_files[], ahead, behind}
- GitFetchResponse: same shape as GitPullResponse
- GitRebaseResponse: {project_slug, conflict: bool, conflicted_files: string[]}
- GitRebaseRequest: {project_slug, task_id: UUID, agent_id: str, target_branch: str} — target_branch REQUIRED

FILES TO MODIFY:
1. panel/src/types/git.ts — fix all 3 response interfaces + rename GitRebaseRequest.onto to target_branch
2. panel/src/lib/api/git.ts — update pull/fetch/rebase functions to use corrected types
3. panel/src/hooks/use-git.ts — update Pull/Fetch/Rebase mutations
4. panel/src/components/git/git-browser.tsx — fix handlers (task_id fallback, target_branch, toast messages)
5. panel/src/components/git/git-actions-panel.tsx — add target_branch Input to Rebase AlertDialog

TASK_ID FIX: Check if GitPullRequest, GitFetchRequest, GitRebaseRequest in the backend schema have task_id as required UUID. If so, update them to Optional[UUID] = None (add the Pydantic schema change too). In the frontend, send task_id: taskId || undefined (omitting when empty). If backend cannot be made Optional, disable the Pull/Rebase buttons when taskId URL param is absent.

REBASE DIALOG: The AlertDialog for Rebase in git-actions-panel.tsx must include an Input field (label: 'Target branch', placeholder: 'e.g. main'). The onRebase prop changes from () => void to (targetBranch: string) => void. The AlertDialogAction calls onRebase(targetBranch). Update git-browser.tsx handleRebase to accept and use targetBranch.

TOAST FIXES:
- handlePull: use result.current_branch — e.g. toast.success('Pulled — now on branch ' + result.current_branch + ' (' + result.behind + ' behind)')
- handleFetch: use result.current_branch — e.g. toast.success('Fetched — branch ' + result.current_branch + ', ' + result.behind + ' behind remote')
- handleRebase: result.conflict ? toast.warning('Rebase conflict: ' + result.conflicted_files.join(', ')) : toast.success('Rebase complete — no conflicts')

Run pnpm lint && pnpm typecheck before committing.