### PR TITLE
[3f305ed9] Frontend: Fix git control contract, complete Secretary restyling, and apply polish (CEO revision)

### DIFF
--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -49,7 +49,7 @@ interface GitActionsPanelProps {
   onMergePR: (prNumber: number) => void;
   onPull: () => void;
   onFetch: () => void;
-  onRebase: () => void;
+  onRebase: (targetBranch: string) => void;
   isCommitting: boolean;
   isPushing: boolean;
   isCreatingPR: boolean;
@@ -87,6 +87,7 @@ export function GitActionsPanel({
   const [prTitle, setPrTitle] = useState("");
   const [prBody, setPrBody] = useState("");
   const [mergePrNumber, setMergePrNumber] = useState("");
+  const [rebaseTargetBranch, setRebaseTargetBranch] = useState("");
 
   const hasStagedChanges = (status?.staged_files.length ?? 0) > 0;
   const hasUnpushedCommits = (status?.ahead ?? 0) > 0;
@@ -376,19 +377,33 @@ export function GitActionsPanel({
           </AlertDialogTrigger>
           <AlertDialogContent className="border-destructive bg-destructive/5">
             <AlertDialogHeader>
-              <AlertDialogTitle>Rebase onto remote?</AlertDialogTitle>
+              <AlertDialogTitle>Rebase onto target branch?</AlertDialogTitle>
               <AlertDialogDescription>
                 This will rewrite the commit history of branch{" "}
                 <strong>{status?.current_branch}</strong> by replaying commits
-                on top of the latest remote. A force-push will be required
-                afterward. This action cannot be undone.
+                on top of the specified target branch. A force-push will be
+                required afterward. This action cannot be undone.
               </AlertDialogDescription>
             </AlertDialogHeader>
+            <div className="px-6 py-2 space-y-2">
+              <label className="text-sm font-medium">Target branch</label>
+              <Input
+                placeholder="e.g. main or origin/main"
+                value={rebaseTargetBranch}
+                onChange={(e) => setRebaseTargetBranch(e.target.value)}
+              />
+            </div>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogCancel onClick={() => setRebaseTargetBranch("")}>
+                Cancel
+              </AlertDialogCancel>
               <AlertDialogAction
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                onClick={onRebase}
+                disabled={!rebaseTargetBranch.trim()}
+                onClick={() => {
+                  onRebase(rebaseTargetBranch.trim());
+                  setRebaseTargetBranch("");
+                }}
               >
                 Rebase
               </AlertDialogAction>

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -178,10 +178,10 @@ function GitBrowserContent() {
     try {
       const result = await pull.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
-      toast.success(`Pulled ${result.commits_received} commits from ${result.remote}`);
+      toast.success(`Pulled: now on ${result.current_branch}`);
     } catch {
       toast.error("Failed to pull from remote");
     }
@@ -191,22 +191,30 @@ function GitBrowserContent() {
     try {
       const result = await fetch.mutateAsync({
         project_slug: projectSlug,
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
-      toast.success(`Fetched ${result.refs_updated} refs from ${result.remote}`);
+      toast.success(`Fetched: now on ${result.current_branch}`);
     } catch {
       toast.error("Failed to fetch from remote");
     }
   };
 
-  const handleRebase = async () => {
+  const handleRebase = async (targetBranch: string) => {
     try {
       const result = await rebase.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        target_branch: targetBranch,
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
-      toast.success(`Rebased ${result.commits_rebased} commits onto ${result.onto}`);
+      if (result.conflict) {
+        toast.warning(
+          `Rebase conflicts in: ${result.conflicted_files.join(", ") || "unknown files"}`
+        );
+      } else {
+        toast.success("Rebase completed successfully");
+      }
     } catch {
       toast.error("Failed to rebase");
     }

--- a/panel/src/components/kanban/core/kanban-card.tsx
+++ b/panel/src/components/kanban/core/kanban-card.tsx
@@ -183,7 +183,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="min-h-11 text-muted-foreground hover:text-foreground"
+                  className="max-sm:min-h-11 text-muted-foreground hover:text-foreground"
                   onClick={(e) => e.stopPropagation()}
                   disabled={isBacklog}
                 >
@@ -210,7 +210,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="min-h-11 text-green-600 hover:text-green-700 hover:bg-green-50"
+                    className="max-sm:min-h-11 text-green-600 hover:text-green-700 hover:bg-green-50"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("pass-qa", task.id);
@@ -222,7 +222,7 @@ export function KanbanCard({ task, onAction, showQaActions, isDragging: isDraggi
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="min-h-11 text-red-600 hover:text-red-700 hover:bg-red-50"
+                    className="max-sm:min-h-11 text-red-600 hover:text-red-700 hover:bg-red-50"
                     onClick={(e) => {
                       e.stopPropagation();
                       onAction("fail-qa", task.id);

--- a/panel/src/components/knowledge-base/kb-search-bar.tsx
+++ b/panel/src/components/knowledge-base/kb-search-bar.tsx
@@ -68,6 +68,7 @@ export function KBSearchBar({
             variant="ghost"
             size="icon-sm"
             onClick={handleClear}
+            aria-label="Clear search"
             className="absolute right-1 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />

--- a/panel/src/components/metrics/agent-usage-chart.tsx
+++ b/panel/src/components/metrics/agent-usage-chart.tsx
@@ -69,7 +69,7 @@ export function AgentUsageChart({ data, isLoading }: AgentUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/model-usage-donut.tsx
+++ b/panel/src/components/metrics/model-usage-donut.tsx
@@ -12,14 +12,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ModelUsageSlice } from "@/types";
 
-// Semantic color palette: blue (informational), amber (warning), green (success),
-// red (error/blocked), purple (supplemental)
+// Design-system chart tokens — resolves to theme-aware palette
 const CHART_COLORS = [
-  "#3b82f6", // blue-500  — informational
-  "#f59e0b", // amber-500 — warning / pending
-  "#22c55e", // green-500 — success / healthy
-  "#ef4444", // red-500   — error / blocked
-  "#a855f7", // purple-500 — supplemental
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
 ];
 
 interface ModelUsageDonutProps {

--- a/panel/src/components/metrics/team-usage-chart.tsx
+++ b/panel/src/components/metrics/team-usage-chart.tsx
@@ -66,7 +66,7 @@ export function TeamUsageChart({ data, isLoading }: TeamUsageChartProps) {
                 ]}
                 contentStyle={{ fontSize: 12 }}
               />
-              <Bar dataKey="Tokens" fill="#3b82f6" radius={[3, 3, 0, 0]} />
+              <Bar dataKey="Tokens" fill="var(--chart-1)" radius={[3, 3, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         )}

--- a/panel/src/components/metrics/usage-time-series-chart.tsx
+++ b/panel/src/components/metrics/usage-time-series-chart.tsx
@@ -58,12 +58,12 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
             >
               <defs>
                 <linearGradient id="fillInput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="var(--chart-1)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-1)" stopOpacity={0.1} />
                 </linearGradient>
                 <linearGradient id="fillOutput" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#f59e0b" stopOpacity={0.8} />
-                  <stop offset="95%" stopColor="#f59e0b" stopOpacity={0.1} />
+                  <stop offset="5%" stopColor="var(--chart-2)" stopOpacity={0.8} />
+                  <stop offset="95%" stopColor="var(--chart-2)" stopOpacity={0.1} />
                 </linearGradient>
               </defs>
               <CartesianGrid strokeDasharray="3 3" className="opacity-20" />
@@ -93,14 +93,14 @@ export function UsageTimeSeriesChart({ data, isLoading }: UsageTimeSeriesChartPr
                 type="monotone"
                 dataKey="Input"
                 stackId="1"
-                stroke="#3b82f6"
+                stroke="var(--chart-1)"
                 fill="url(#fillInput)"
               />
               <Area
                 type="monotone"
                 dataKey="Output"
                 stackId="1"
-                stroke="#f59e0b"
+                stroke="var(--chart-2)"
                 fill="url(#fillOutput)"
               />
             </AreaChart>

--- a/panel/src/lib/api/git.ts
+++ b/panel/src/lib/api/git.ts
@@ -252,10 +252,13 @@ export const gitApi = {
   pull: async (request: GitPullRequest): Promise<GitPullResponse> => {
     if (isMockMode()) {
       return {
-        project_slug: request.project_slug,
-        branch: "feature/backend/abc12345",
-        commits_received: 2,
-        remote: request.remote ?? "origin",
+        current_branch: "feature/backend/abc12345",
+        has_changes: false,
+        staged_files: [],
+        unstaged_files: [],
+        untracked_files: [],
+        ahead: 0,
+        behind: 0,
       };
     }
     const { data } = await api.post<GitPullResponse>("/git/pull", request);
@@ -268,9 +271,13 @@ export const gitApi = {
   fetch: async (request: GitFetchRequest): Promise<GitFetchResponse> => {
     if (isMockMode()) {
       return {
-        project_slug: request.project_slug,
-        remote: request.remote ?? "origin",
-        refs_updated: 3,
+        current_branch: "feature/backend/abc12345",
+        has_changes: false,
+        staged_files: [],
+        unstaged_files: [],
+        untracked_files: [],
+        ahead: 0,
+        behind: 0,
       };
     }
     const { data } = await api.post<GitFetchResponse>("/git/fetch", request);
@@ -278,15 +285,13 @@ export const gitApi = {
   },
 
   /**
-   * Rebase current branch onto remote (destructive — rewrites history)
+   * Rebase current branch onto target branch (destructive — rewrites history)
    */
   rebase: async (request: GitRebaseRequest): Promise<GitRebaseResponse> => {
     if (isMockMode()) {
       return {
-        project_slug: request.project_slug,
-        branch: "feature/backend/abc12345",
-        onto: request.onto ?? "origin/main",
-        commits_rebased: 3,
+        conflict: false,
+        conflicted_files: [],
       };
     }
     const { data } = await api.post<GitRebaseResponse>("/git/rebase", request);

--- a/panel/src/types/git.ts
+++ b/panel/src/types/git.ts
@@ -150,40 +150,46 @@ export interface GitMergePRRequest {
 
 export interface GitPullRequest {
   project_slug: string;
-  task_id: string;
-  agent_id: string;
+  task_id?: string;
+  agent_id?: string;
   remote?: string;
 }
 
 export interface GitPullResponse {
-  project_slug: string;
-  branch: string;
-  commits_received: number;
-  remote: string;
+  current_branch: string;
+  has_changes: boolean;
+  staged_files: string[];
+  unstaged_files: string[];
+  untracked_files: string[];
+  ahead: number;
+  behind: number;
 }
 
 export interface GitFetchRequest {
   project_slug: string;
-  agent_id: string;
+  task_id?: string;
+  agent_id?: string;
   remote?: string;
 }
 
 export interface GitFetchResponse {
-  project_slug: string;
-  remote: string;
-  refs_updated: number;
+  current_branch: string;
+  has_changes: boolean;
+  staged_files: string[];
+  unstaged_files: string[];
+  untracked_files: string[];
+  ahead: number;
+  behind: number;
 }
 
 export interface GitRebaseRequest {
   project_slug: string;
-  task_id: string;
-  agent_id: string;
-  onto?: string;
+  target_branch: string;
+  task_id?: string;
+  agent_id?: string;
 }
 
 export interface GitRebaseResponse {
-  project_slug: string;
-  branch: string;
-  onto: string;
-  commits_rebased: number;
+  conflict: boolean;
+  conflicted_files: string[];
 }


### PR DESCRIPTION
CEO revision — fix all frontend issues flagged during review. The git buttons return 422 due to contract mismatches with the real backend, Secretary restyling was half-done, and 3 polish items touch files already modified in round 1. The FE git fixes (Units 1-2) depend on the backend schema changes shipping first; the rest (Units 3-4) are independent and can start immediately.

## Work Units (parallelism notes)

### Unit 1: Git browser contract fix (panel/src/components/git/git-browser.tsx) — BLOCKED on backend schema changes
- MUST-FIX: Send `target_branch` instead of the unused `onto` field for Rebase requests.
- MUST-FIX: Send a real task UUID for Pull/Rebase (or omit task_id if backend relaxes to Optional). Currently sends the literal string "manual" which fails UUID validation. For Fetch, send task_id or omit if Optional.
- CEO note: "mock mode hid this; green CI is not evidence the feature works — test against the live orchestrator."

### Unit 2: Git types and toast alignment (panel/src/types/git.ts + toast handlers) — BLOCKED on backend schema changes
- MUST-FIX: Align PullResponse, FetchResponse, RebaseResponse types to the actual backend response shape in roboco/api/schemas/git.py. The backend returns git-status fields + conflict/conflicted_files. The frontend currently reads fictional fields: commits_received, remote, refs_updated, commits_rebased, onto — none of which the backend returns.
- Update success-toast handlers to display meaningful info from the real response (e.g. current_branch, conflict status, conflicted_files).

### Unit 3: Secretary Start button + message bubbles (panel/src/components/business/secretary-tab.tsx) — INDEPENDENT, start immediately
- ALSO (CEO): The input-row wrapper got items-stretch in round 1, but the Secretary "Start" button and message bubbles were NOT restyled. Apply shared components/ui/ vocabulary to these 2 elements so the entire Secretary tab uses the design system consistently.

### Unit 4: Polish items — INDEPENDENT, start immediately
- aria-label="Clear search" on the KB search clear (X) button (accessibility).
- Metrics charts: switch from hard-coded hex color values to var(--chart-N) CSS custom properties so charts follow the theme (in the Metrics page chart components).
- Kanban 44px min-height touch targets: gate behind max-sm: media query (Tailwind) so they only apply on mobile viewports, not all viewports.

Units 1 and 2 are the cross-cell dependency — sequence them after backend ships its schema changes. Units 3 and 4 are independent and can start immediately with the second developer.