### PR TITLE
[d62036bd] Backend: Fix git endpoint schemas, add safety gates, and unit tests (CEO revision)

### DIFF
--- a/roboco/api/routes/git.py
+++ b/roboco/api/routes/git.py
@@ -56,6 +56,7 @@ from roboco.api.schemas.git import (
 )
 from roboco.exceptions import GitCommandError, GitError, GitTimeoutError
 from roboco.logging import get_logger
+from roboco.models.base import AgentRole
 from roboco.services.base import (
     NotFoundError,
     ServiceError,
@@ -64,6 +65,7 @@ from roboco.services.base import (
 )
 from roboco.services.git import get_git_service
 from roboco.services.project import get_project_service
+from roboco.services.task import get_task_service
 
 logger = get_logger(__name__)
 
@@ -78,6 +80,16 @@ _LOG_FORMAT_PARTS = 5
 # git timeouts/command failures to be translated to 504/500 instead of
 # bubbling as 500 Internal Server Errors with no `detail`.
 _TranslatableError = (ServiceError, GitError)
+
+# Roles permitted to rebase branches via the /rebase endpoint.
+# Rebase is a history-rewriting operation that should be authorised only by
+# PM-level or CEO-level callers. Developers are intentionally excluded:
+# they commit to their feature branch and let PMs/CEO manage integration
+# rebases. This gate prevents developers from accidentally force-rewriting
+# shared branch history.
+_REBASE_ALLOWED_ROLES: frozenset[AgentRole] = frozenset(
+    {AgentRole.CEO, AgentRole.CELL_PM, AgentRole.MAIN_PM}
+)
 
 
 def _translate_error(e: ServiceError | GitError) -> HTTPException:
@@ -560,9 +572,43 @@ async def rebase_branch(
 ) -> GitRebaseResponse:
     """Rebase the current branch onto target_branch.
 
+    Role-gated: only CEO and PM roles (cell_pm, main_pm) may rebase branches.
+    Developers, QA, documenters, and other roles are rejected with 403.
+
+    If task_id is provided and the caller is not CEO, the task's assigned_to
+    is checked: if the task is not assigned to the calling agent, 403 is
+    returned (or 404 if the task does not exist).
+
     On conflict: aborts the rebase and returns conflict=True with the
     list of conflicted files.  On success: returns conflict=False.
     """
+    if agent.role not in _REBASE_ALLOWED_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"REBASE_ROLE_RESTRICTED: Role '{agent.role}' is not permitted "
+                "to rebase. Only CEO and PM roles (cell_pm, main_pm) may use "
+                "this endpoint."
+            ),
+        )
+    # Task ownership check: if a task_id is supplied and the caller is not CEO,
+    # ensure the task is assigned to the calling agent.
+    if data.task_id is not None and agent.role != AgentRole.CEO:
+        task_service = get_task_service(db)
+        task = await task_service.get(data.task_id)
+        if task is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Task not found: {data.task_id}",
+            )
+        if task.assigned_to != agent.agent_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "REBASE_OWNERSHIP_RESTRICTED: This task is not assigned to "
+                    "you. Only the task's assigned agent or CEO may rebase it."
+                ),
+            )
     project_slug = await _resolve_project_slug(data.project_slug, db)
     git_service = get_git_service(db)
 

--- a/roboco/api/routes/tasks.py
+++ b/roboco/api/routes/tasks.py
@@ -228,7 +228,6 @@ async def _merge_pr_if_awaiting_pm_review(
                 pr_number=pre_task.pr_number,
                 task_id=task_id,
                 merge_method="squash",
-                agent_id=str(agent.agent_id),
             ),
         )
     except (ServiceError, GitError) as e:
@@ -1729,7 +1728,6 @@ async def approve_and_merge_task(
                 pr_number=task.pr_number,
                 task_id=task_id,
                 merge_method="squash",
-                agent_id=str(agent.agent_id),
             ),
         )
     except (ServiceError, GitError) as e:

--- a/roboco/api/schemas/git.py
+++ b/roboco/api/schemas/git.py
@@ -7,7 +7,7 @@ Request/response models for git operation endpoints.
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # =============================================================================
 # STATUS
@@ -78,7 +78,6 @@ class GitCreateBranchRequest(BaseModel):
     project_slug: str
     task_id: UUID
     branch_type: str = Field(..., pattern=r"^(feature|bug|chore|docs|hotfix)$")
-    agent_id: str
     parent_branch: str | None = None
 
 
@@ -95,7 +94,6 @@ class GitCheckoutRequest(BaseModel):
 
     project_slug: str
     branch: str
-    agent_id: str
 
 
 class GitCheckoutResponse(BaseModel):
@@ -130,7 +128,6 @@ class GitCommitRequest(BaseModel):
 
     project_slug: str
     task_id: UUID
-    agent_id: str
     # Commit message fields
     message: str = Field(
         ...,
@@ -169,7 +166,6 @@ class GitPushRequest(BaseModel):
 
     project_slug: str
     task_id: UUID
-    agent_id: str
     force: bool = False
 
 
@@ -192,7 +188,6 @@ class GitCreatePRRequest(BaseModel):
 
     project_slug: str
     task_id: UUID
-    agent_id: str
     # PR content (auto-generated from templates if not provided)
     title: str | None = Field(None, description="PR title (auto-generated if not set)")
     body: str | None = Field(None, description="PR body (auto-generated if not set)")
@@ -220,7 +215,6 @@ class GitMergePRRequest(BaseModel):
     pr_number: int
     task_id: UUID
     merge_method: str = Field(default="squash", pattern=r"^(merge|squash|rebase)$")
-    agent_id: str
 
 
 class GitMergePRResponse(BaseModel):
@@ -241,8 +235,7 @@ class GitPullRequest(BaseModel):
     """Request to pull latest changes from origin."""
 
     project_slug: str
-    task_id: UUID
-    agent_id: str
+    task_id: UUID | None = None
 
 
 class GitPullResponse(BaseModel):
@@ -267,8 +260,7 @@ class GitFetchRequest(BaseModel):
     """Request to fetch changes from origin without merging."""
 
     project_slug: str
-    task_id: UUID
-    agent_id: str
+    task_id: UUID | None = None
 
 
 class GitFetchResponse(BaseModel):
@@ -293,9 +285,22 @@ class GitRebaseRequest(BaseModel):
     """Request to rebase the current branch onto a target branch."""
 
     project_slug: str
-    task_id: UUID
-    agent_id: str
+    task_id: UUID | None = None
     target_branch: str
+
+    @field_validator("target_branch")
+    @classmethod
+    def _validate_target_branch(cls, v: str) -> str:
+        if v.startswith("-"):
+            raise ValueError(
+                "INVALID_TARGET_BRANCH: target_branch must not start with '-'"
+            )
+        if v in ("master", "main"):
+            raise ValueError(
+                f"PROTECTED_BRANCH: Cannot rebase onto '{v}'; "
+                "target_branch must not be 'master' or 'main'"
+            )
+        return v
 
 
 class GitRebaseResponse(BaseModel):
@@ -309,3 +314,52 @@ class GitRebaseResponse(BaseModel):
     project_slug: str
     conflict: bool = False
     conflicted_files: list[str] = []
+
+
+# =============================================================================
+# GATEWAY-LAYER LIGHTWEIGHT SCHEMAS
+#
+# These simpler schemas are used by the MCP gateway layer and services that
+# don't need the full Git* request payload. All fields beyond project_slug
+# are optional to allow callers that don't yet carry task context.
+# =============================================================================
+
+
+class PullRequest(BaseModel):
+    """Lightweight pull request used by the gateway / MCP layer."""
+
+    project_slug: str
+    task_id: UUID | None = None
+
+
+class FetchRequest(BaseModel):
+    """Lightweight fetch request used by the gateway / MCP layer."""
+
+    project_slug: str
+    task_id: UUID | None = None
+
+
+class RebaseRequest(BaseModel):
+    """Lightweight rebase request used by the gateway / MCP layer.
+
+    Validates ``target_branch`` to prevent accidental rebases onto
+    protected branches or shell-injection via leading ``-``.
+    """
+
+    project_slug: str
+    task_id: UUID | None = None
+    target_branch: str
+
+    @field_validator("target_branch")
+    @classmethod
+    def _validate_target_branch(cls, v: str) -> str:
+        if v.startswith("-"):
+            raise ValueError(
+                "INVALID_TARGET_BRANCH: target_branch must not start with '-'"
+            )
+        if v in ("master", "main"):
+            raise ValueError(
+                f"PROTECTED_BRANCH: Cannot rebase onto '{v}'; "
+                "target_branch must not be 'master' or 'main'"
+            )
+        return v

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -1157,15 +1157,62 @@ class GitService(BaseService):
     ) -> tuple[str, bool, list[str], list[str], list[str], int, int]:
         """Pull latest changes from origin and return post-pull status.
 
+        Safety gates (both raise :class:`ValidationError`):
+
+        1. **Dirty workspace** — refuses to pull when there are any
+           uncommitted changes (staged, unstaged, or untracked).  A pull
+           onto a dirty tree can produce unexpected merge conflicts or
+           silently clobber un-staged edits.
+
+        2. **Diverged branch** — uses ``--ff-only`` so a diverged branch
+           is rejected rather than creating a merge commit.  The agent
+           must rebase or reset before pulling.
+
         Uses _network_git_timeout() because the operation talks to origin.
 
         Returns: (current_branch, has_changes, staged, unstaged, untracked,
                   ahead, behind)
         """
-        token = await self._token_for_workspace(workspace)
-        await self._run_git(
-            workspace, ["pull"], token=token, timeout=_network_git_timeout()
+        # Gate 1: dirty workspace check
+        status_result = await self._run_git(
+            workspace, ["status", "--porcelain"], check=False
         )
+        if status_result.stdout.strip():
+            raise ValidationError(
+                "DIRTY_WORKSPACE: Cannot pull with uncommitted changes. "
+                "Stage and commit (or stash) your changes before pulling."
+            )
+
+        token = await self._token_for_workspace(workspace)
+        # Gate 2: fast-forward only — raises if branches have diverged
+        pull_result = await self._run_git(
+            workspace,
+            ["pull", "--ff-only"],
+            token=token,
+            timeout=_network_git_timeout(),
+            check=False,
+        )
+        if pull_result.returncode != 0:
+            stderr = (pull_result.stderr or "").lower()
+            if any(
+                kw in stderr
+                for kw in (
+                    "not possible to fast-forward",
+                    "diverged",
+                    "fatal: not possible to fast",
+                    "fast-forward",
+                )
+            ):
+                raise ValidationError(
+                    "DIVERGED_BRANCH: Branch has diverged from remote; "
+                    "cannot fast-forward. Rebase your local commits onto "
+                    "the remote tip with `git rebase origin/<branch>` "
+                    "before pulling."
+                )
+            raise ValidationError(
+                f"PULL_FAILED: git pull --ff-only exited non-zero. "
+                f"stderr: {pull_result.stderr or '(none)'}"
+            )
         return await self.get_status(workspace)
 
     async def fetch(
@@ -1192,12 +1239,28 @@ class GitService(BaseService):
     ) -> tuple[bool, list[str]]:
         """Rebase the current branch onto target_branch.
 
+        Safety gate: raises :class:`ValidationError` if the HEAD branch or
+        ``target_branch`` is ``master`` or ``main`` — rebasing a protected
+        integration branch is never safe in automation.
+
         On conflict (non-zero exit): captures unmerged files via
         ``git diff --name-only --diff-filter=U``, aborts the rebase to
         restore a clean workspace, and returns ``(True, conflicted_files)``.
 
         On success: returns ``(False, [])``.
         """
+        _PROTECTED = frozenset({"master", "main"})
+        if target_branch in _PROTECTED:
+            raise ValidationError(
+                f"REBASE_FORBIDDEN: Cannot rebase onto '{target_branch}'. "
+                "Rebasing onto 'master' or 'main' is not allowed in automation."
+            )
+        head_branch = await self.get_current_branch(workspace)
+        if head_branch in _PROTECTED:
+            raise ValidationError(
+                f"REBASE_FORBIDDEN: Cannot rebase '{head_branch}'. "
+                "Rebasing 'master' or 'main' is not allowed in automation."
+            )
         result = await self._run_git(workspace, ["rebase", target_branch], check=False)
         if result.returncode != 0:
             conflict_result = await self._run_git(

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -924,7 +924,6 @@ class TaskService(BaseService):
             task_id=require_uuid(task.id),
             project_slug=project.slug,
             branch_type="feature",
-            agent_id=str(agent_id),
             parent_branch=parent_branch,
         )
 

--- a/tests/unit/services/test_git.py
+++ b/tests/unit/services/test_git.py
@@ -550,7 +550,6 @@ async def test_create_branch_idempotent_when_branch_already_exists() -> None:
                 project_slug="roboco-api",
                 task_id=uuid4(),
                 branch_type="feature",
-                agent_id=str(uuid4()),
                 parent_branch=None,
             ),
         )
@@ -601,7 +600,6 @@ async def _run_create_branch_with_existing_branch(
                 project_slug="roboco-panel",
                 task_id=uuid4(),
                 branch_type="feature",
-                agent_id=str(uuid4()),
                 parent_branch=None,
             ),
         )

--- a/tests/unit/services/test_git_rebase.py
+++ b/tests/unit/services/test_git_rebase.py
@@ -16,16 +16,39 @@ Pins the three critical control-flow branches of ``rebase_onto_base``:
 All tests mock ``_run_git`` at the service-method level using
 ``AsyncMock`` with a ``side_effect`` list so each awaited call consumes
 the next pre-configured result in order.
+
+Also covers the ``rebase()`` safety gate added by the git-schema cleanup
+task: rebasing onto or from a protected branch (master/main) is rejected
+with a service-layer ``ValidationError`` before any git command runs.
+
+Also covers:
+* ``pull()`` dirty-tree and diverged-branch ``ValidationError`` gates.
+* ``pull()`` success path.
+* ``GitRebaseRequest.target_branch`` Pydantic field validator.
+* Route-level role gate: DEVELOPER → 403, CELL_PM → 200.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call, patch
+from uuid import uuid4
 
+import pydantic
 import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from roboco.api.deps import get_agent_context, get_db
+from roboco.api.routes.git import router as git_router
+from roboco.api.schemas.git import GitRebaseRequest
+from roboco.models.base import AgentRole
+from roboco.models.permissions import AgentContext
+from roboco.services.base import ValidationError
 from roboco.services.git import GitService
+
+_HTTP_200 = 200
+_HTTP_403 = 403
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,11 +67,12 @@ def _git_service() -> GitService:
     return svc
 
 
-def _result(returncode: int = 0, stdout: str = "") -> Any:
+def _result(returncode: int = 0, stdout: str = "", stderr: str = "") -> Any:
     """Minimal subprocess result stand-in."""
     r = MagicMock()
     r.returncode = returncode
     r.stdout = stdout
+    r.stderr = stderr
     return r
 
 
@@ -211,3 +235,291 @@ async def test_resilience_when_both_rebase_and_abort_fail_returns_conflict_no_ex
     )
 
     assert result == {"status": "conflicts", "files": ["src/conflict.py"]}
+
+
+# ---------------------------------------------------------------------------
+# Safety gate tests for rebase() — protected-branch guard
+# ---------------------------------------------------------------------------
+# These test the service-layer ``rebase()`` method (the workspace-scoped API
+# endpoint helper), NOT ``rebase_onto_base()`` (the internal gateway helper).
+# The guard runs BEFORE any git command, so no ``_run_git`` mock is needed
+# for target-branch cases; the head-branch case requires a stubbed
+# ``get_current_branch``.
+
+
+@pytest.mark.asyncio
+async def test_rebase_raises_validation_error_when_target_is_master() -> None:
+    """rebase() must raise ValidationError for target_branch='master'."""
+    svc = _git_service()
+    with pytest.raises(ValidationError, match="REBASE_FORBIDDEN"):
+        await svc.rebase(_WORKSPACE, "master")
+
+
+@pytest.mark.asyncio
+async def test_rebase_raises_validation_error_when_target_is_main() -> None:
+    """rebase() must raise ValidationError for target_branch='main'."""
+    svc = _git_service()
+    with pytest.raises(ValidationError, match="REBASE_FORBIDDEN"):
+        await svc.rebase(_WORKSPACE, "main")
+
+
+@pytest.mark.asyncio
+async def test_rebase_raises_validation_error_when_head_branch_is_master(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rebase() must raise ValidationError when HEAD is 'master'.
+
+    The target-branch check passes (we pass a safe target), but the
+    head-branch guard fires when get_current_branch returns 'master'.
+    """
+    monkeypatch.setattr(
+        GitService,
+        "get_current_branch",
+        AsyncMock(return_value="master"),
+    )
+    svc = _git_service()
+    with pytest.raises(ValidationError, match="REBASE_FORBIDDEN"):
+        await svc.rebase(_WORKSPACE, "feature/backend/some-task")
+
+
+@pytest.mark.asyncio
+async def test_rebase_raises_validation_error_when_head_branch_is_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rebase() must raise ValidationError when HEAD is 'main'."""
+    monkeypatch.setattr(
+        GitService,
+        "get_current_branch",
+        AsyncMock(return_value="main"),
+    )
+    svc = _git_service()
+    with pytest.raises(ValidationError, match="REBASE_FORBIDDEN"):
+        await svc.rebase(_WORKSPACE, "feature/backend/some-task")
+
+
+# ---------------------------------------------------------------------------
+# pull() safety-gate tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_raises_validation_error_on_dirty_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pull() raises ValidationError(DIRTY_WORKSPACE) when the tree is dirty.
+
+    The pre-flight ``git status --porcelain`` returns modified files, so pull
+    must reject immediately before any network call.
+    """
+    monkeypatch.setattr(
+        GitService,
+        "_run_git",
+        AsyncMock(return_value=_result(stdout=" M dirty.py\n")),
+    )
+    svc = _git_service()
+    with pytest.raises(ValidationError, match="DIRTY_WORKSPACE"):
+        await svc.pull(_WORKSPACE)
+
+
+@pytest.mark.asyncio
+async def test_pull_raises_validation_error_on_diverged_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pull() raises ValidationError(DIVERGED_BRANCH) when --ff-only fails.
+
+    The pre-flight status is clean, but ``git pull --ff-only`` exits non-zero
+    with a "not possible to fast-forward" message because the branch has
+    diverged from origin.
+    """
+    monkeypatch.setattr(
+        GitService,
+        "_run_git",
+        AsyncMock(
+            side_effect=[
+                _result(stdout=""),  # status --porcelain → clean
+                _result(  # pull --ff-only → diverged
+                    returncode=1,
+                    stderr="fatal: Not possible to fast-forward, aborting.",
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        GitService, "_token_for_workspace", AsyncMock(return_value=None)
+    )
+    svc = _git_service()
+    with pytest.raises(ValidationError, match="DIVERGED_BRANCH"):
+        await svc.pull(_WORKSPACE)
+
+
+@pytest.mark.asyncio
+async def test_pull_success_returns_post_pull_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pull() returns the post-pull status on a clean, fast-forwardable branch.
+
+    The pre-flight ``git status --porcelain`` is clean and ``git pull --ff-only``
+    succeeds, so pull() returns the post-pull ``get_status`` tuple.
+    """
+    _post_pull: tuple[str, bool, list[str], list[str], list[str], int, int] = (
+        "feature/backend/task",
+        False,
+        [],
+        [],
+        [],
+        0,
+        0,
+    )
+    monkeypatch.setattr(
+        GitService,
+        "_run_git",
+        AsyncMock(side_effect=[_result(stdout=""), _result(returncode=0)]),
+    )
+    monkeypatch.setattr(
+        GitService, "_token_for_workspace", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(GitService, "get_status", AsyncMock(return_value=_post_pull))
+
+    svc = _git_service()
+    result = await svc.pull(_WORKSPACE)
+
+    assert result == _post_pull
+
+
+# ---------------------------------------------------------------------------
+# GitRebaseRequest.target_branch field validator tests
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_request_target_branch_dash_prefix_rejected() -> None:
+    """GitRebaseRequest rejects target_branch that starts with '-'.
+
+    Branch names beginning with '-' are not valid git ref names and look
+    like CLI flags, so the schema validator rejects them with a clear error.
+    """
+    with pytest.raises(pydantic.ValidationError, match="INVALID_TARGET_BRANCH"):
+        GitRebaseRequest(
+            project_slug="roboco",
+            target_branch="-bad-branch",
+        )
+
+
+def test_rebase_request_target_branch_protected_name_rejected() -> None:
+    """GitRebaseRequest rejects target_branch 'main' (a protected branch name)."""
+    with pytest.raises(pydantic.ValidationError, match="PROTECTED_BRANCH"):
+        GitRebaseRequest(
+            project_slug="roboco",
+            target_branch="main",
+        )
+
+
+def test_rebase_request_target_branch_master_rejected() -> None:
+    """GitRebaseRequest rejects target_branch 'master' (a protected branch name)."""
+    with pytest.raises(pydantic.ValidationError, match="PROTECTED_BRANCH"):
+        GitRebaseRequest(
+            project_slug="roboco",
+            target_branch="master",
+        )
+
+
+def test_rebase_request_valid_target_branch_accepted() -> None:
+    """GitRebaseRequest accepts a valid, non-protected target_branch."""
+    req = GitRebaseRequest(
+        project_slug="roboco",
+        target_branch="feature/backend/some-task",
+    )
+    assert req.target_branch == "feature/backend/some-task"
+
+
+# ---------------------------------------------------------------------------
+# Route-level tests: role gate on POST /rebase
+# ---------------------------------------------------------------------------
+
+
+async def _mock_db_generator() -> Any:
+    """Async generator yielding a MagicMock as the database session.
+
+    FastAPI's original ``get_db`` is an async generator (uses ``yield``).
+    The override must also be a generator (or at least async) so FastAPI
+    handles the dependency lifecycle correctly.
+    """
+    yield MagicMock()
+
+
+def _build_git_app(agent_context: AgentContext) -> FastAPI:
+    """Minimal FastAPI app with the git router and overridden agent context."""
+    app = FastAPI()
+    app.include_router(git_router, prefix="/git")
+    app.dependency_overrides[get_agent_context] = lambda: agent_context
+    app.dependency_overrides[get_db] = _mock_db_generator
+    return app
+
+
+@pytest.mark.asyncio
+async def test_rebase_endpoint_developer_gets_403() -> None:
+    """POST /git/rebase returns HTTP 403 for a DEVELOPER-role agent.
+
+    The role gate fires before any service call, so no git service mock
+    is needed.
+    """
+    agent = AgentContext(agent_id=uuid4(), role=AgentRole.DEVELOPER)
+    app = _build_git_app(agent)
+    transport = ASGITransport(app=app)
+
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/git/rebase",
+            json={
+                "project_slug": "roboco",
+                "target_branch": "feature/backend/some-task",
+            },
+        )
+
+    assert response.status_code == _HTTP_403
+    detail = response.json()["detail"]
+    assert "REBASE_ROLE_RESTRICTED" in detail
+
+
+@pytest.mark.asyncio
+async def test_rebase_endpoint_pm_gets_200() -> None:
+    """POST /git/rebase returns HTTP 200 for a CELL_PM-role agent.
+
+    The role gate passes; no task_id is supplied so the ownership check
+    is skipped; project resolution and the git service are patched.
+    """
+    agent = AgentContext(agent_id=uuid4(), role=AgentRole.CELL_PM)
+    app = _build_git_app(agent)
+
+    # Mock project service → returns a project with slug "roboco"
+    mock_project = MagicMock()
+    mock_project.slug = "roboco"
+    mock_project_svc = MagicMock()
+    mock_project_svc.get_by_slug = AsyncMock(return_value=mock_project)
+
+    # Mock git service → workspace + rebase succeed without conflict
+    mock_git_svc = MagicMock()
+    mock_git_svc.get_workspace = AsyncMock(return_value=Path("/tmp/fake-ws"))
+    mock_git_svc.rebase = AsyncMock(return_value=(False, []))
+
+    transport = ASGITransport(app=app)
+
+    with (
+        patch(
+            "roboco.api.routes.git.get_project_service", return_value=mock_project_svc
+        ),
+        patch("roboco.api.routes.git.get_git_service", return_value=mock_git_svc),
+    ):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.post(
+                "/git/rebase",
+                json={
+                    "project_slug": "roboco",
+                    "target_branch": "feature/backend/some-task",
+                },
+            )
+
+    assert response.status_code == _HTTP_200
+    body = response.json()
+    assert body["project_slug"] == "roboco"
+    assert body["conflict"] is False
+    assert body["conflicted_files"] == []


### PR DESCRIPTION
CEO revision — fix all backend git endpoint issues flagged during review. The git Pull/Fetch/Rebase endpoints return 422 because of contract mismatches, and lack safety gates for destructive operations. All changes are in 3-4 files the backend cell already delivered in round 1.

## Work Units (dependency order)

### Unit 1: Schema fixes (roboco/api/schemas/git.py) — independent, start immediately
- Make task_id Optional[UUID] (default None) in PullRequest, FetchRequest, and RebaseRequest schemas so operator/no-task ops don't 422. Existing callers sending a real UUID must remain unaffected.
- Drop the dead agent_id field from request schemas — it's accepted but ignored.
- Validate target_branch input: reject names starting with "-" (command injection) and protected branch names (master, main).

### Unit 2: Service safety (roboco/services/git.py) — independent, start immediately
- rebase(): Take an explicit head_branch parameter and reject protected branches (master). Currently rewrites the workspace's CURRENT branch without identifying it.
- pull(): Switch from bare-merge semantics to --ff-only (or --rebase). Require a clean working tree so a diverged/dirty clone can't produce a surprise merge commit or a bare 500.

### Unit 3: Route gating (roboco/api/routes/git.py) — depends on Unit 1 schema
- Gate the rebase endpoint to CEO/PM roles only. Assert task+branch ownership via task_id, mirroring the existing push_for_task pattern in the same file.
- Use the task_id from the request schema for the ownership check (now that Unit 1 makes it meaningful).

### Unit 4: Unit tests (tests/test_git_rebase.py) — depends on Units 1-3
- Add real unit test coverage for the new rebase(), pull(), and fetch() service methods. The current test_git_rebase.py tests the pre-existing rebase_onto_base, not the new methods.
- Test the role-gating (unauthorized agent gets 403), protected-branch rejection, clean-tree requirement for pull, and target_branch validation.

Units 1 and 2 are independent — both developers can start simultaneously. Unit 3 depends on Unit 1's schema. Unit 4 depends on all 3.