### PR TITLE
[401ddb40] Fix phantom fields in git.ts types and taskId coercion in git-browser.tsx

### DIFF
--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -115,7 +115,7 @@ function GitBrowserContent() {
       const result = await commit.mutateAsync({
         project_slug: projectSlug,
         message,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
       toast.success(`Committed: ${result.commit_hash.slice(0, 7)}`);
@@ -128,7 +128,7 @@ function GitBrowserContent() {
     try {
       const result = await push.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
         force,
       });
@@ -142,7 +142,7 @@ function GitBrowserContent() {
     try {
       const result = await createPR.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         title,
         body,
         agent_id: "ceo",
@@ -165,7 +165,7 @@ function GitBrowserContent() {
       const result = await mergePR.mutateAsync({
         project_slug: projectSlug,
         pr_number: prNumber,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
       toast.success(`Merged PR #${result.pr_number} → ${result.target_branch}`);
@@ -179,7 +179,6 @@ function GitBrowserContent() {
       const result = await pull.mutateAsync({
         project_slug: projectSlug,
         task_id: taskId || undefined,
-        agent_id: "ceo",
       });
       toast.success(`Pulled: now on ${result.current_branch}`);
     } catch {
@@ -192,7 +191,6 @@ function GitBrowserContent() {
       const result = await fetch.mutateAsync({
         project_slug: projectSlug,
         task_id: taskId || undefined,
-        agent_id: "ceo",
       });
       toast.success(`Fetched: now on ${result.current_branch}`);
     } catch {

--- a/panel/src/lib/api/git.ts
+++ b/panel/src/lib/api/git.ts
@@ -158,7 +158,7 @@ export const gitApi = {
     if (isMockMode()) {
       return {
         commit_hash: "abc123456789abcdef",
-        message: `[${request.task_id.slice(0, 8)}] ${request.message}`,
+        message: `[${request.task_id?.slice(0, 8) ?? "manual"}] ${request.message}`,
         files_changed: request.files?.length || 1,
         insertions: 10,
         deletions: 5,

--- a/panel/src/types/git.ts
+++ b/panel/src/types/git.ts
@@ -102,14 +102,14 @@ export interface GitMergePRResponse {
 export interface GitCommitRequest {
   project_slug: string;
   message: string;
-  task_id: string;
+  task_id?: string;
   agent_id: string;
   files?: string[] | null;
 }
 
 export interface GitPushRequest {
   project_slug: string;
-  task_id: string;
+  task_id?: string;
   agent_id: string;
   force?: boolean;
 }
@@ -132,7 +132,7 @@ export interface GitCheckoutRequest {
 
 export interface GitCreatePRRequest {
   project_slug: string;
-  task_id: string;
+  task_id?: string;
   title: string;
   body: string;
   agent_id: string;
@@ -143,7 +143,7 @@ export type MergeMethod = "merge" | "squash" | "rebase";
 export interface GitMergePRRequest {
   project_slug: string;
   pr_number: number;
-  task_id: string;
+  task_id?: string;
   merge_method?: MergeMethod;
   agent_id: string;
 }
@@ -151,8 +151,6 @@ export interface GitMergePRRequest {
 export interface GitPullRequest {
   project_slug: string;
   task_id?: string;
-  agent_id?: string;
-  remote?: string;
 }
 
 export interface GitPullResponse {
@@ -168,8 +166,6 @@ export interface GitPullResponse {
 export interface GitFetchRequest {
   project_slug: string;
   task_id?: string;
-  agent_id?: string;
-  remote?: string;
 }
 
 export interface GitFetchResponse {


### PR DESCRIPTION
Edit src/types/git.ts to remove the agent_id and remote phantom fields from the GitPullRequest and GitFetchRequest interfaces. Also change task_id from required (string) to optional (string | undefined) in GitCommitRequest, GitPushRequest, GitCreatePRRequest, and GitMergePRRequest. Then update src/components/git/git-browser.tsx: replace every occurrence of `taskId || "manual"` with `taskId || undefined` in the handleCommit, handlePush, handleCreatePR, and handleMergePR handlers so that no invalid non-UUID string is sent to the backend when the page is opened without a ?task= URL parameter. Also remove the `agent_id: "ceo"` property from the request objects passed to pull.mutateAsync and fetch.mutateAsync in handlePull and handleFetch since agent_id is no longer part of GitPullRequest and GitFetchRequest after the type cleanup. Ensure the build passes (pnpm typecheck) and that the git page still works correctly when a valid ?task= param IS provided.