### PR TITLE
[cca8d0c0] Fix rebase placeholder and surface real backend error in git-browser.tsx

### DIFF
--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -388,7 +388,7 @@ export function GitActionsPanel({
             <div className="px-6 py-2 space-y-2">
               <label className="text-sm font-medium">Target branch</label>
               <Input
-                placeholder="e.g. main or origin/main"
+                placeholder="Remote ref (e.g. origin/HEAD)"
                 value={rebaseTargetBranch}
                 onChange={(e) => setRebaseTargetBranch(e.target.value)}
               />

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -29,6 +29,7 @@ import { GitDiffViewer } from "./git-diff-viewer";
 import { GitActionsPanel } from "./git-actions-panel";
 import { GitBranch, RefreshCw, FolderGit2 } from "lucide-react";
 import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/api/client";
 
 function GitBrowserContent() {
   const router = useRouter();
@@ -215,8 +216,8 @@ function GitBrowserContent() {
       } else {
         toast.success("Rebase completed successfully");
       }
-    } catch {
-      toast.error("Failed to rebase");
+    } catch (error) {
+      toast.error(getErrorMessage(error));
     }
   };
 


### PR DESCRIPTION
Two targeted fixes in the git rebase UI: (1) In src/components/git/git-actions-panel.tsx, change the Input placeholder for the rebase target_branch field from 'e.g. main or origin/main' to a value that does not suggest any protected branch name (for example 'e.g. origin/develop' or 'e.g. origin/my-feature'). Protected branches such as 'main', 'master', and 'develop' should not appear in the placeholder. (2) In src/components/git/git-browser.tsx, update the handleRebase catch block to extract and display the real backend error message instead of the generic hardcoded 'Failed to rebase'. The axios error carries the backend detail at error.response?.data?.detail; use that string in the toast.error call, falling back to the generic message only if no detail is present. Do not change any other handler or type — scope is strictly these two changes.