### PR TITLE
[de95ce94] Fix 3 rebase integration tests to use non-protected target_branch

### DIFF
--- a/tests/integration/test_git_routes.py
+++ b/tests/integration/test_git_routes.py
@@ -85,6 +85,59 @@ async def git_client(
     app.dependency_overrides.clear()
 
 
+@pytest_asyncio.fixture
+async def pm_git_client(
+    db_session: AsyncSession,
+) -> AsyncIterator[dict]:
+    """Like git_client but with CELL_PM role — required for the rebase endpoint."""
+    agent = AgentTable(
+        id=uuid4(),
+        name="PM",
+        slug=f"be-pm-{uuid4().hex[:8]}",
+        role=AgentRole.CELL_PM,
+        team=Team.BACKEND,
+        status=AgentStatus.ACTIVE,
+        model_config={},
+        system_prompt="pm",
+        capabilities=[],
+        permissions={},
+        metrics={},
+    )
+    db_session.add(agent)
+    await db_session.flush()
+    project = ProjectTable(
+        id=uuid4(),
+        name="GitProj",
+        slug=f"git-proj-{uuid4().hex[:6]}",
+        git_url="https://example.com/r.git",
+        assigned_cell=Team.BACKEND,
+        created_by=agent.id,
+    )
+    db_session.add(project)
+    await db_session.flush()
+
+    app = FastAPI()
+    app.include_router(git_router, prefix="/api/git")
+
+    async def _override_db() -> AsyncGenerator[AsyncSession]:
+        yield db_session
+
+    async def _override_agent() -> AgentContext:
+        return AgentContext(
+            agent_id=cast("uuid.UUID", agent.id),
+            role=AgentRole.CELL_PM,
+            team=Team.BACKEND,
+        )
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_agent_context] = _override_agent
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield {"client": client, "agent": agent, "project": project, "db": db_session}
+    app.dependency_overrides.clear()
+
+
 _HDR = {"X-Agent-ID": str(uuid4()), "X-Agent-Role": "developer"}
 
 
@@ -793,19 +846,17 @@ async def test_fetch_git_command_error(git_client: dict) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rebase_success(git_client: dict) -> None:
+async def test_rebase_success(pm_git_client: dict) -> None:
     with patch("roboco.api.routes.git.get_git_service") as mock_get:
         svc = AsyncMock()
         svc.get_workspace = AsyncMock(return_value="/tmp/ws")
         svc.rebase = AsyncMock(return_value=(False, []))
         mock_get.return_value = svc
-        response = await git_client["client"].post(
+        response = await pm_git_client["client"].post(
             "/api/git/rebase",
             json={
-                "project_slug": git_client["project"].slug,
-                "task_id": str(uuid4()),
-                "agent_id": str(uuid4()),
-                "target_branch": "main",
+                "project_slug": pm_git_client["project"].slug,
+                "target_branch": "develop",
             },
             headers=_HDR,
         )
@@ -816,19 +867,17 @@ async def test_rebase_success(git_client: dict) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rebase_conflict(git_client: dict) -> None:
+async def test_rebase_conflict(pm_git_client: dict) -> None:
     with patch("roboco.api.routes.git.get_git_service") as mock_get:
         svc = AsyncMock()
         svc.get_workspace = AsyncMock(return_value="/tmp/ws")
         svc.rebase = AsyncMock(return_value=(True, ["src/foo.py", "src/bar.py"]))
         mock_get.return_value = svc
-        response = await git_client["client"].post(
+        response = await pm_git_client["client"].post(
             "/api/git/rebase",
             json={
-                "project_slug": git_client["project"].slug,
-                "task_id": str(uuid4()),
-                "agent_id": str(uuid4()),
-                "target_branch": "main",
+                "project_slug": pm_git_client["project"].slug,
+                "target_branch": "develop",
             },
             headers=_HDR,
         )
@@ -839,19 +888,17 @@ async def test_rebase_conflict(git_client: dict) -> None:
 
 
 @pytest.mark.asyncio
-async def test_rebase_git_command_error(git_client: dict) -> None:
+async def test_rebase_git_command_error(pm_git_client: dict) -> None:
     with patch("roboco.api.routes.git.get_git_service") as mock_get:
         svc = AsyncMock()
         svc.get_workspace = AsyncMock(return_value="/tmp/ws")
         svc.rebase = AsyncMock(side_effect=GitCommandError("rebase", "fatal error"))
         mock_get.return_value = svc
-        response = await git_client["client"].post(
+        response = await pm_git_client["client"].post(
             "/api/git/rebase",
             json={
-                "project_slug": git_client["project"].slug,
-                "task_id": str(uuid4()),
-                "agent_id": str(uuid4()),
-                "target_branch": "main",
+                "project_slug": pm_git_client["project"].slug,
+                "target_branch": "develop",
             },
             headers=_HDR,
         )


### PR DESCRIPTION
In tests/integration/test_git_routes.py, the three rebase integration tests (test_rebase_success, test_rebase_conflict, test_rebase_git_command_error) each send "target_branch": "main" in the POST /api/git/rebase request body. The GitRebaseRequest Pydantic validator rejects "main" and "master" with a PROTECTED_BRANCH ValueError, so these tests receive a 422 before the mocked service is even called — they cannot pass in any environment.

Fix: change "target_branch": "main" to a valid non-protected branch name (e.g., "feature/staging", "develop", or "integration") in each of the three affected tests. The mocked git service already returns the expected values (success, conflict, and GitCommandError respectively), so the only change needed is this target_branch value.

Verify by running the 3 tests directly:
  uv run pytest tests/integration/test_git_routes.py::test_rebase_success tests/integration/test_git_routes.py::test_rebase_conflict tests/integration/test_git_routes.py::test_rebase_git_command_error -v

Also run the full integration test suite to confirm no regressions:
  uv run pytest tests/integration/test_git_routes.py -v

Then run ruff format/check and pytest on the full suite before marking done.