### PR TITLE
[94015c6d] Frontend R3: Fix legacy git taskId coercion + rebase placeholder + phantom fields

### DIFF
--- a/panel/src/components/git/git-actions-panel.tsx
+++ b/panel/src/components/git/git-actions-panel.tsx
@@ -388,7 +388,7 @@ export function GitActionsPanel({
             <div className="px-6 py-2 space-y-2">
               <label className="text-sm font-medium">Target branch</label>
               <Input
-                placeholder="e.g. main or origin/main"
+                placeholder="Remote ref (e.g. origin/HEAD)"
                 value={rebaseTargetBranch}
                 onChange={(e) => setRebaseTargetBranch(e.target.value)}
               />

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -29,6 +29,7 @@ import { GitDiffViewer } from "./git-diff-viewer";
 import { GitActionsPanel } from "./git-actions-panel";
 import { GitBranch, RefreshCw, FolderGit2 } from "lucide-react";
 import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/api/client";
 
 function GitBrowserContent() {
   const router = useRouter();
@@ -213,8 +214,8 @@ function GitBrowserContent() {
       } else {
         toast.success("Rebase completed successfully");
       }
-    } catch {
-      toast.error("Failed to rebase");
+    } catch (error) {
+      toast.error(getErrorMessage(error));
     }
   };
 

--- a/panel/src/components/git/git-browser.tsx
+++ b/panel/src/components/git/git-browser.tsx
@@ -115,7 +115,7 @@ function GitBrowserContent() {
       const result = await commit.mutateAsync({
         project_slug: projectSlug,
         message,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
       toast.success(`Committed: ${result.commit_hash.slice(0, 7)}`);
@@ -128,7 +128,7 @@ function GitBrowserContent() {
     try {
       const result = await push.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
         force,
       });
@@ -142,7 +142,7 @@ function GitBrowserContent() {
     try {
       const result = await createPR.mutateAsync({
         project_slug: projectSlug,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         title,
         body,
         agent_id: "ceo",
@@ -165,7 +165,7 @@ function GitBrowserContent() {
       const result = await mergePR.mutateAsync({
         project_slug: projectSlug,
         pr_number: prNumber,
-        task_id: taskId || "manual",
+        task_id: taskId || undefined,
         agent_id: "ceo",
       });
       toast.success(`Merged PR #${result.pr_number} → ${result.target_branch}`);
@@ -179,7 +179,6 @@ function GitBrowserContent() {
       const result = await pull.mutateAsync({
         project_slug: projectSlug,
         task_id: taskId || undefined,
-        agent_id: "ceo",
       });
       toast.success(`Pulled: now on ${result.current_branch}`);
     } catch {
@@ -192,7 +191,6 @@ function GitBrowserContent() {
       const result = await fetch.mutateAsync({
         project_slug: projectSlug,
         task_id: taskId || undefined,
-        agent_id: "ceo",
       });
       toast.success(`Fetched: now on ${result.current_branch}`);
     } catch {

--- a/panel/src/lib/api/git.ts
+++ b/panel/src/lib/api/git.ts
@@ -158,7 +158,7 @@ export const gitApi = {
     if (isMockMode()) {
       return {
         commit_hash: "abc123456789abcdef",
-        message: `[${request.task_id.slice(0, 8)}] ${request.message}`,
+        message: `[${request.task_id?.slice(0, 8) ?? "manual"}] ${request.message}`,
         files_changed: request.files?.length || 1,
         insertions: 10,
         deletions: 5,

--- a/panel/src/types/git.ts
+++ b/panel/src/types/git.ts
@@ -102,14 +102,14 @@ export interface GitMergePRResponse {
 export interface GitCommitRequest {
   project_slug: string;
   message: string;
-  task_id: string;
+  task_id?: string;
   agent_id: string;
   files?: string[] | null;
 }
 
 export interface GitPushRequest {
   project_slug: string;
-  task_id: string;
+  task_id?: string;
   agent_id: string;
   force?: boolean;
 }
@@ -132,7 +132,7 @@ export interface GitCheckoutRequest {
 
 export interface GitCreatePRRequest {
   project_slug: string;
-  task_id: string;
+  task_id?: string;
   title: string;
   body: string;
   agent_id: string;
@@ -143,7 +143,7 @@ export type MergeMethod = "merge" | "squash" | "rebase";
 export interface GitMergePRRequest {
   project_slug: string;
   pr_number: number;
-  task_id: string;
+  task_id?: string;
   merge_method?: MergeMethod;
   agent_id: string;
 }
@@ -151,8 +151,6 @@ export interface GitMergePRRequest {
 export interface GitPullRequest {
   project_slug: string;
   task_id?: string;
-  agent_id?: string;
-  remote?: string;
 }
 
 export interface GitPullResponse {
@@ -168,8 +166,6 @@ export interface GitPullResponse {
 export interface GitFetchRequest {
   project_slug: string;
   task_id?: string;
-  agent_id?: string;
-  remote?: string;
 }
 
 export interface GitFetchResponse {


### PR DESCRIPTION
CEO's second rejection on PR #194 — the 4 legacy git handlers in git-browser.tsx send task_id: taskId || "manual" when no ?task= is in the URL, which 422s against the backend's UUID validator. The new pull/fetch/rebase handlers were already fixed in Round 2, but the legacy 4 (Commit, Push, Create-PR, Merge-PR) were missed.

**Work units (all independent once BE ships schema change):**

1. **taskId coercion fix (MUST-FIX, HIGH):** In panel/src/components/git/git-browser.tsx, change the 4 legacy handlers (lines ~118/131/145/168) from `task_id: taskId || "manual"` to `task_id: taskId || undefined`. The backend is being updated in parallel to accept Optional task_id on these schemas. This is the merge-blocker.

2. **Rebase placeholder fix (MED):** In panel/src/components/git/git-actions-panel.tsx (~line 391), the rebase target_branch placeholder suggests "main" — the backend hard-rejects this as PROTECTED_BRANCH → 422. handleRebase swallows it as generic "Failed to rebase". Fix: change placeholder to a safe example (e.g. "feature/...") and surface the real backend error message in the toast instead of a generic failure.

3. **Phantom FE fields cleanup (MED):** In panel/src/types/git.ts, GitPullRequest and GitFetchRequest declare agent_id and remote fields the backend doesn't accept (harmless via extra=ignore but a lying contract). Drop them.

**Cross-cell dependency:** This task depends on the backend making task_id Optional on the 4 legacy schemas. Wait for BE to ship before sending undefined.