### PR TITLE
[219c539b] Make task_id Optional in git request schemas and update service methods

### DIFF
--- a/roboco/api/schemas/git.py
+++ b/roboco/api/schemas/git.py
@@ -127,7 +127,7 @@ class GitCommitRequest(BaseModel):
     """Request to create a commit."""
 
     project_slug: str
-    task_id: UUID
+    task_id: UUID | None = None
     # Commit message fields
     message: str = Field(
         ...,
@@ -165,7 +165,7 @@ class GitPushRequest(BaseModel):
     """Request to push commits."""
 
     project_slug: str
-    task_id: UUID
+    task_id: UUID | None = None
     force: bool = False
 
 
@@ -187,7 +187,7 @@ class GitCreatePRRequest(BaseModel):
     """Request to create a pull request."""
 
     project_slug: str
-    task_id: UUID
+    task_id: UUID | None = None
     # PR content (auto-generated from templates if not provided)
     title: str | None = Field(None, description="PR title (auto-generated if not set)")
     body: str | None = Field(None, description="PR body (auto-generated if not set)")
@@ -213,7 +213,7 @@ class GitMergePRRequest(BaseModel):
 
     project_slug: str
     pr_number: int
-    task_id: UUID
+    task_id: UUID | None = None
     merge_method: str = Field(default="squash", pattern=r"^(merge|squash|rebase)$")
 
 

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -530,10 +530,13 @@ class GitService(BaseService):
     ) -> tuple[str, str, int, int, int]:
         """Create a git commit with template-based message.
 
+        When ``request.task_id`` is ``None`` the traceability template is
+        skipped and a plain conventional-commit message is built instead
+        (``type(scope): description``).  The git commit still happens; the
+        commit is just not linked to any task record.
+
         Returns: (commit_hash, full_message, files_changed, insertions, deletions)
         """
-        task_id = request.task_id
-
         # Stage files. Large changesets get the longer commit-timeout budget
         # (see `git_commit_timeout_seconds`) — the same reason the gateway
         # `commit()` adapter uses it.
@@ -544,30 +547,42 @@ class GitService(BaseService):
         else:
             await self._run_git(workspace, ["add", "-A"], timeout=commit_timeout)
 
-        # Get task info for commit template
-        task_service = get_task_service(self.session)
-        task = await task_service.get(task_id)
+        if request.task_id is not None:
+            # Get task info for commit template
+            task_service = get_task_service(self.session)
+            task = await task_service.get(request.task_id)
 
-        # Get root task ID (walk up hierarchy)
-        root_task_id = await get_root_task_id(task_id, task_service)
+            # Get root task ID (walk up hierarchy)
+            root_task_id = await get_root_task_id(request.task_id, task_service)
 
-        # Get session ID
-        session_id = self._get_primary_session_id(task)
+            # Get session ID
+            session_id = self._get_primary_session_id(task)
 
-        # Build commit message using template
-        commit_ctx = CommitContext(
-            task_id=str(task_id),
-            root_task_id=str(root_task_id),
-            agent_slug=str(agent_id),
-            session_id=session_id,
-            commit_type=request.commit_type,
-            scope=request.scope,
-            description=request.message,
-            body=request.body,
-        )
-        full_message = build_commit_message(
-            commit_ctx, settings.public_base_url.rstrip("/") + "/api"
-        )
+            # Build commit message using template
+            commit_ctx = CommitContext(
+                task_id=str(request.task_id),
+                root_task_id=str(root_task_id),
+                agent_slug=str(agent_id),
+                session_id=session_id,
+                commit_type=request.commit_type,
+                scope=request.scope,
+                description=request.message,
+                body=request.body,
+            )
+            full_message = build_commit_message(
+                commit_ctx, settings.public_base_url.rstrip("/") + "/api"
+            )
+        else:
+            # No task context — use plain conventional-commit format so the
+            # git op still proceeds without raising CommitMessageError.
+            type_scope = (
+                f"{request.commit_type}({request.scope})"
+                if request.scope
+                else request.commit_type
+            )
+            full_message = f"{type_scope}: {request.message}"
+            if request.body:
+                full_message = f"{full_message}\n\n{request.body}"
 
         # Create commit with agent attribution
         author = f"{agent_id} <{agent_id}@roboco.ai>"
@@ -680,12 +695,18 @@ class GitService(BaseService):
         commit itself, and commit-to-task linking. Raises typed service
         errors; the API layer translates them to HTTP status codes.
 
+        When ``data.task_id`` is ``None`` the ownership, assignment, and
+        branch-mismatch checks are skipped — the git commit proceeds
+        unconditionally, and no commit-to-task linking is recorded.
+
         Returns: (commit_hash, full_message, files_changed, insertions, deletions)
         """
-        task = await self._assert_task_owned_with_branch(data.task_id, agent_id)
-
-        workspace = await self.get_workspace(data.project_slug, agent_id)
-        await self._assert_on_task_branch(workspace, task.branch_name)
+        if data.task_id is not None:
+            task = await self._assert_task_owned_with_branch(data.task_id, agent_id)
+            workspace = await self.get_workspace(data.project_slug, agent_id)
+            await self._assert_on_task_branch(workspace, task.branch_name)
+        else:
+            workspace = await self.get_workspace(data.project_slug, agent_id)
 
         (
             commit_hash,
@@ -695,9 +716,10 @@ class GitService(BaseService):
             deletions,
         ) = await self.create_commit(workspace, agent_id, data)
 
-        await self._link_commit_to_task(
-            data.task_id, commit_hash, data.message, agent_id
-        )
+        if data.task_id is not None:
+            await self._link_commit_to_task(
+                data.task_id, commit_hash, data.message, agent_id
+            )
 
         return commit_hash, full_message, files_changed, insertions, deletions
 
@@ -1108,6 +1130,10 @@ class GitService(BaseService):
         preconditions. Raises typed service errors; the API layer
         translates them to HTTP status codes.
 
+        When ``data.task_id`` is ``None`` the ownership and branch-mismatch
+        checks are skipped — the push proceeds unconditionally (force-push
+        role check still applies).
+
         Returns: (branch, commits_pushed)
         """
         if getattr(data, "force", False) and agent_role != AgentRole.CEO:
@@ -1121,10 +1147,12 @@ class GitService(BaseService):
                 ),
             )
 
-        task = await self._assert_task_owned_with_branch(data.task_id, agent_id)
-
-        workspace = await self.get_workspace(data.project_slug, agent_id)
-        await self._assert_on_task_branch(workspace, task.branch_name)
+        if data.task_id is not None:
+            task = await self._assert_task_owned_with_branch(data.task_id, agent_id)
+            workspace = await self.get_workspace(data.project_slug, agent_id)
+            await self._assert_on_task_branch(workspace, task.branch_name)
+        else:
+            workspace = await self.get_workspace(data.project_slug, agent_id)
 
         return await self.push(workspace, getattr(data, "force", False))
 
@@ -1565,26 +1593,37 @@ class GitService(BaseService):
     ) -> tuple[int, str, str, str, str]:
         """Create a pull request via the GitHub REST API.
 
+        When ``request.task_id`` is ``None`` the task lookup, target-branch
+        resolution, and template generation are skipped.  The PR targets the
+        project's default branch and uses ``request.title`` / ``request.body``
+        directly (falling back to ``source_branch`` / ``""`` when absent).
+
         Returns: (pr_number, pr_url, title, source_branch, target_branch)
         """
-        task_service = get_task_service(self.session)
-        task = await task_service.get(request.task_id)
-        if not task:
-            raise NotFoundError("Task", str(request.task_id))
-
         source_branch = await self.get_current_branch(workspace)
         default_branch = await self._project_default_branch(request.project_slug)
         git_token = await self._get_project_token_or_raise(request.project_slug)
 
-        target_branch = await self._resolve_pr_target_branch(
-            request, task, default_branch
-        )
-        target_branch = await self._pr_base_on_remote(
-            workspace, target_branch, default_branch, git_token, request.task_id
-        )
-        pr_title, pr_body = await self._generate_pr_title_body(
-            request, task, source_branch, target_branch, request.task_id
-        )
+        if request.task_id is not None:
+            task_service = get_task_service(self.session)
+            task = await task_service.get(request.task_id)
+            if not task:
+                raise NotFoundError("Task", str(request.task_id))
+            target_branch = await self._resolve_pr_target_branch(
+                request, task, default_branch
+            )
+            target_branch = await self._pr_base_on_remote(
+                workspace, target_branch, default_branch, git_token, request.task_id
+            )
+            pr_title, pr_body = await self._generate_pr_title_body(
+                request, task, source_branch, target_branch, request.task_id
+            )
+        else:
+            # No task context: target the default branch directly, use provided
+            # title/body or fall back to minimal defaults.
+            target_branch = default_branch
+            pr_title = request.title or source_branch
+            pr_body = request.body or ""
 
         owner, repo = self._parse_github_remote(workspace)
         resp = await self._post_pr(
@@ -1856,9 +1895,14 @@ class GitService(BaseService):
     ) -> tuple[int, str, str, str, str]:
         """Preconditions + PR creation + state sync.
 
+        When ``data.task_id`` is ``None`` the ownership/state gate and the
+        post-creation task-state sync are both skipped — the GitHub PR is still
+        created, but no task record is updated.
+
         Returns: (pr_number, pr_url, title, source_branch, target_branch)
         """
-        await self._assert_pr_create_allowed(data.task_id, agent_id)
+        if data.task_id is not None:
+            await self._assert_pr_create_allowed(data.task_id, agent_id)
 
         workspace = await self.get_workspace(data.project_slug, agent_id)
         (
@@ -1869,7 +1913,8 @@ class GitService(BaseService):
             target_branch,
         ) = await self.create_pull_request(workspace, data)
 
-        await self._record_pr_atomically(data.task_id, pr_number, pr_url)
+        if data.task_id is not None:
+            await self._record_pr_atomically(data.task_id, pr_number, pr_url)
         return pr_number, pr_url, title, source_branch, target_branch
 
     async def _call_merge_api(
@@ -2139,40 +2184,58 @@ class GitService(BaseService):
     ) -> tuple[str, str]:
         """Role-gated merge + work-session record + auto-complete.
 
+        When ``data.task_id`` is ``None`` the task lookup, role gate,
+        work-session update, and auto-complete are all skipped — the GitHub PR
+        merge still happens using the caller-provided ``project_slug`` and
+        ``pr_number``.
+
         Returns: (target_branch, merge_commit)
         """
-        task_service = get_task_service(self.session)
-        work_session_service = get_work_session_service(self.session)
+        if data.task_id is not None:
+            task_service = get_task_service(self.session)
+            work_session_service = get_work_session_service(self.session)
 
-        task = await task_service.get(data.task_id)
-        if not task:
-            raise NotFoundError(resource_type="Task", resource_id=str(data.task_id))
-        self._assert_merge_role(self._status_value(task), agent_role)
+            task = await task_service.get(data.task_id)
+            if not task:
+                raise NotFoundError(resource_type="Task", resource_id=str(data.task_id))
+            self._assert_merge_role(self._status_value(task), agent_role)
 
-        # A coordination root has no project of its own, so the CEO's merge
-        # request can't carry a project_slug. Resolve the root's repo from its
-        # product server-side; non-root tasks keep the client-provided slug.
-        project_slug = data.project_slug
-        if task.project_id is None:
-            root_project = await self._project_for_task(task)
-            if root_project is not None:
-                project_slug = root_project.slug
+            # A coordination root has no project of its own, so the CEO's merge
+            # request can't carry a project_slug. Resolve the root's repo from
+            # its product server-side; non-root tasks keep the client slug.
+            project_slug = data.project_slug
+            if task.project_id is None:
+                root_project = await self._project_for_task(task)
+                if root_project is not None:
+                    project_slug = root_project.slug
 
-        workspace = await self.get_workspace(project_slug, agent_id)
-        target_branch, merge_commit = await self.merge_pull_request(
-            workspace=workspace,
-            pr_number=data.pr_number,
-            merge_method=data.merge_method,
-            project_slug=project_slug,
-        )
-
-        if task.work_session_id:
-            await work_session_service.merge_pr(
-                require_uuid(task.work_session_id), agent_id
+            workspace = await self.get_workspace(project_slug, agent_id)
+            target_branch, merge_commit = await self.merge_pull_request(
+                workspace=workspace,
+                pr_number=data.pr_number,
+                merge_method=data.merge_method,
+                project_slug=project_slug,
             )
 
-        await self._auto_complete_on_merge(data.task_id, agent_id, agent_role)
-        await self.session.commit()
+            if task.work_session_id:
+                await work_session_service.merge_pr(
+                    require_uuid(task.work_session_id), agent_id
+                )
+
+            await self._auto_complete_on_merge(data.task_id, agent_id, agent_role)
+            await self.session.commit()
+        else:
+            # No task context — proceed directly to the merge without
+            # role/ownership checks or post-merge state transitions.
+            project_slug = data.project_slug
+            workspace = await self.get_workspace(project_slug, agent_id)
+            target_branch, merge_commit = await self.merge_pull_request(
+                workspace=workspace,
+                pr_number=data.pr_number,
+                merge_method=data.merge_method,
+                project_slug=project_slug,
+            )
+
         return target_branch, merge_commit
 
     # =========================================================================

--- a/tests/integration/test_git_routes.py
+++ b/tests/integration/test_git_routes.py
@@ -858,5 +858,96 @@ async def test_rebase_git_command_error(git_client: dict) -> None:
     assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
+# ---------------------------------------------------------------------------
+# task_id Optional — no 422 when task_id is omitted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_commit_without_task_id_no_422(git_client: dict) -> None:
+    """POST /commit without task_id must not return 422 (schema validation error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.commit_for_task = AsyncMock(
+            return_value=("abc123", "feat: add thing", 1, 5, 2)
+        )
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/commit",
+            json={
+                "project_slug": git_client["project"].slug,
+                "agent_id": str(uuid4()),
+                "message": "add a new thing",
+                "commit_type": "feat",
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_push_without_task_id_no_422(git_client: dict) -> None:
+    """POST /push without task_id must not return 422 (schema validation error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.push_for_task = AsyncMock(return_value=("feature/x", 3))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/push",
+            json={
+                "project_slug": git_client["project"].slug,
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_create_pr_without_task_id_no_422(git_client: dict) -> None:
+    """POST /pr/create without task_id must not return 422 (schema validation error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.create_pr_for_task = AsyncMock(
+            return_value=(
+                7,
+                "https://github.com/x/y/pull/7",
+                "feat: add thing",
+                "feat/x",
+                "main",
+            )
+        )
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/pr/create",
+            json={
+                "project_slug": git_client["project"].slug,
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_without_task_id_no_422(git_client: dict) -> None:
+    """POST /pr/merge without task_id must not return 422 (schema validation error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_get:
+        svc = AsyncMock()
+        svc.merge_pr_for_task = AsyncMock(return_value=("main", "deadbeef"))
+        mock_get.return_value = svc
+        response = await git_client["client"].post(
+            "/api/git/pr/merge",
+            json={
+                "project_slug": git_client["project"].slug,
+                "pr_number": 99,
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != HTTPStatus.UNPROCESSABLE_ENTITY
+    assert response.status_code == HTTPStatus.OK
+
+
 # Re-export to keep import alive (TC reorders imports)
 _ = SimpleNamespace

--- a/tests/unit/api/routes/test_git_optional_task_id.py
+++ b/tests/unit/api/routes/test_git_optional_task_id.py
@@ -1,0 +1,332 @@
+"""Unit tests: task_id is Optional in git request schemas and service methods.
+
+These tests verify:
+- The four git schemas accept None task_id (no 422 on absent field).
+- Existing callers that pass task_id still work (regression).
+- The HTTP endpoints return 200 when task_id is omitted.
+
+All tests run without a real database or git process.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from roboco.api.deps import get_agent_context, get_db
+from roboco.api.routes.git import router as git_router
+from roboco.api.schemas.git import (
+    GitCommitRequest,
+    GitCreatePRRequest,
+    GitMergePRRequest,
+    GitPushRequest,
+)
+from roboco.models.base import AgentRole, Team
+from roboco.models.permissions import AgentContext
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, AsyncIterator
+
+_HTTP_UNPROCESSABLE = 422
+_HTTP_OK = 200
+
+_AGENT_ID = uuid4()
+_TASK_ID = uuid4()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — no real DB required
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncIterator[AsyncClient]:  # type: ignore[type-arg]
+    """FastAPI test client with mocked auth + DB; no Postgres needed."""
+    app = FastAPI()
+    app.include_router(git_router, prefix="/api/git")
+
+    async def _mock_db() -> AsyncGenerator:  # type: ignore[type-arg]
+        yield AsyncMock()  # DB session is never touched in these tests
+
+    async def _mock_agent() -> AgentContext:
+        return AgentContext(
+            agent_id=cast("uuid.UUID", _AGENT_ID),
+            role=AgentRole.DEVELOPER,
+            team=Team.BACKEND,
+        )
+
+    app.dependency_overrides[get_db] = _mock_db
+    app.dependency_overrides[get_agent_context] = _mock_agent
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+_HDR = {"X-Agent-ID": str(_AGENT_ID), "X-Agent-Role": "developer"}
+
+# ---------------------------------------------------------------------------
+# Schema unit tests — direct Pydantic validation, no HTTP needed
+# ---------------------------------------------------------------------------
+
+
+def test_commit_request_task_id_optional() -> None:
+    """GitCommitRequest accepts a missing task_id (defaults to None)."""
+    req = GitCommitRequest(
+        project_slug="roboco",
+        agent_id=str(_AGENT_ID),
+        message="add something new here",
+        commit_type="feat",
+    )
+    assert req.task_id is None
+
+
+def test_commit_request_task_id_present() -> None:
+    """GitCommitRequest still accepts an explicit task_id (regression)."""
+    req = GitCommitRequest(
+        project_slug="roboco",
+        task_id=_TASK_ID,
+        agent_id=str(_AGENT_ID),
+        message="add something new here",
+        commit_type="feat",
+    )
+    assert req.task_id == _TASK_ID
+
+
+def test_push_request_task_id_optional() -> None:
+    """GitPushRequest accepts a missing task_id (defaults to None)."""
+    req = GitPushRequest(project_slug="roboco")
+    assert req.task_id is None
+
+
+def test_push_request_task_id_present() -> None:
+    """GitPushRequest still accepts an explicit task_id (regression)."""
+    req = GitPushRequest(project_slug="roboco", task_id=_TASK_ID)
+    assert req.task_id == _TASK_ID
+
+
+def test_create_pr_request_task_id_optional() -> None:
+    """GitCreatePRRequest accepts a missing task_id (defaults to None)."""
+    req = GitCreatePRRequest(project_slug="roboco")
+    assert req.task_id is None
+
+
+def test_create_pr_request_task_id_present() -> None:
+    """GitCreatePRRequest still accepts an explicit task_id (regression)."""
+    req = GitCreatePRRequest(project_slug="roboco", task_id=_TASK_ID)
+    assert req.task_id == _TASK_ID
+
+
+def test_merge_pr_request_task_id_optional() -> None:
+    """GitMergePRRequest accepts a missing task_id (defaults to None)."""
+    req = GitMergePRRequest(project_slug="roboco", pr_number=42)
+    assert req.task_id is None
+
+
+def test_merge_pr_request_task_id_present() -> None:
+    """GitMergePRRequest still accepts an explicit task_id (regression)."""
+    req = GitMergePRRequest(project_slug="roboco", pr_number=42, task_id=_TASK_ID)
+    assert req.task_id == _TASK_ID
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests — verify no 422 when task_id is absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_commit_without_task_id_returns_200_not_422(
+    client: AsyncClient,
+) -> None:
+    """POST /commit without task_id must not return 422 (schema error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.commit_for_task = AsyncMock(
+            return_value=("deadbeef", "feat: add something", 1, 5, 2)
+        )
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/commit",
+            json={
+                "project_slug": "roboco",
+                "agent_id": str(_AGENT_ID),
+                "message": "add something new",
+                "commit_type": "feat",
+                # task_id intentionally omitted
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != _HTTP_UNPROCESSABLE, (
+        f"Expected no 422, got {response.status_code}: {response.text}"
+    )
+    assert response.status_code == _HTTP_OK
+
+
+@pytest.mark.asyncio
+async def test_push_without_task_id_returns_200_not_422(
+    client: AsyncClient,
+) -> None:
+    """POST /push without task_id must not return 422 (schema error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.push_for_task = AsyncMock(return_value=("feature/x", 3))
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/push",
+            json={
+                "project_slug": "roboco",
+                # task_id intentionally omitted
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != _HTTP_UNPROCESSABLE, (
+        f"Expected no 422, got {response.status_code}: {response.text}"
+    )
+    assert response.status_code == _HTTP_OK
+
+
+@pytest.mark.asyncio
+async def test_create_pr_without_task_id_returns_200_not_422(
+    client: AsyncClient,
+) -> None:
+    """POST /pr/create without task_id must not return 422 (schema error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.create_pr_for_task = AsyncMock(
+            return_value=(
+                7,
+                "https://github.com/x/y/pull/7",
+                "feat: add thing",
+                "feature/x",
+                "main",
+            )
+        )
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/pr/create",
+            json={
+                "project_slug": "roboco",
+                # task_id intentionally omitted
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != _HTTP_UNPROCESSABLE, (
+        f"Expected no 422, got {response.status_code}: {response.text}"
+    )
+    assert response.status_code == _HTTP_OK
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_without_task_id_returns_200_not_422(
+    client: AsyncClient,
+) -> None:
+    """POST /pr/merge without task_id must not return 422 (schema error)."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.merge_pr_for_task = AsyncMock(return_value=("main", "deadbeef"))
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/pr/merge",
+            json={
+                "project_slug": "roboco",
+                "pr_number": 99,
+                # task_id intentionally omitted
+            },
+            headers=_HDR,
+        )
+    assert response.status_code != _HTTP_UNPROCESSABLE, (
+        f"Expected no 422, got {response.status_code}: {response.text}"
+    )
+    assert response.status_code == _HTTP_OK
+
+
+# ---------------------------------------------------------------------------
+# Regression: existing callers that pass task_id still get 200
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_commit_with_task_id_still_works(client: AsyncClient) -> None:
+    """POST /commit with task_id (regression) must still return 200."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.commit_for_task = AsyncMock(
+            return_value=("abc123", "fix(auth): correct thing", 2, 10, 3)
+        )
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/commit",
+            json={
+                "project_slug": "roboco",
+                "task_id": str(_TASK_ID),
+                "agent_id": str(_AGENT_ID),
+                "message": "correct the auth flow",
+                "commit_type": "fix",
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == _HTTP_OK
+
+
+@pytest.mark.asyncio
+async def test_push_with_task_id_still_works(client: AsyncClient) -> None:
+    """POST /push with task_id (regression) must still return 200."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.push_for_task = AsyncMock(return_value=("feature/x", 2))
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/push",
+            json={
+                "project_slug": "roboco",
+                "task_id": str(_TASK_ID),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == _HTTP_OK
+
+
+@pytest.mark.asyncio
+async def test_create_pr_with_task_id_still_works(client: AsyncClient) -> None:
+    """POST /pr/create with task_id (regression) must still return 200."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.create_pr_for_task = AsyncMock(
+            return_value=(5, "https://github.com/x/y/pull/5", "T", "feat", "main")
+        )
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/pr/create",
+            json={
+                "project_slug": "roboco",
+                "task_id": str(_TASK_ID),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == _HTTP_OK
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_with_task_id_still_works(client: AsyncClient) -> None:
+    """POST /pr/merge with task_id (regression) must still return 200."""
+    with patch("roboco.api.routes.git.get_git_service") as mock_svc:
+        svc = AsyncMock()
+        svc.merge_pr_for_task = AsyncMock(return_value=("main", "cafebabe"))
+        mock_svc.return_value = svc
+        response = await client.post(
+            "/api/git/pr/merge",
+            json={
+                "project_slug": "roboco",
+                "pr_number": 5,
+                "task_id": str(_TASK_ID),
+            },
+            headers=_HDR,
+        )
+    assert response.status_code == _HTTP_OK

--- a/tests/unit/api/routes/test_git_optional_task_id.py
+++ b/tests/unit/api/routes/test_git_optional_task_id.py
@@ -10,8 +10,7 @@ All tests run without a real database or git process.
 
 from __future__ import annotations
 
-import uuid
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -46,17 +45,17 @@ _TASK_ID = uuid4()
 
 
 @pytest_asyncio.fixture
-async def client() -> AsyncIterator[AsyncClient]:  # type: ignore[type-arg]
+async def client() -> AsyncIterator[AsyncClient]:
     """FastAPI test client with mocked auth + DB; no Postgres needed."""
     app = FastAPI()
     app.include_router(git_router, prefix="/api/git")
 
-    async def _mock_db() -> AsyncGenerator:  # type: ignore[type-arg]
+    async def _mock_db() -> AsyncGenerator:
         yield AsyncMock()  # DB session is never touched in these tests
 
     async def _mock_agent() -> AgentContext:
         return AgentContext(
-            agent_id=cast("uuid.UUID", _AGENT_ID),
+            agent_id=_AGENT_ID,
             role=AgentRole.DEVELOPER,
             team=Team.BACKEND,
         )
@@ -81,7 +80,6 @@ def test_commit_request_task_id_optional() -> None:
     """GitCommitRequest accepts a missing task_id (defaults to None)."""
     req = GitCommitRequest(
         project_slug="roboco",
-        agent_id=str(_AGENT_ID),
         message="add something new here",
         commit_type="feat",
     )
@@ -93,7 +91,6 @@ def test_commit_request_task_id_present() -> None:
     req = GitCommitRequest(
         project_slug="roboco",
         task_id=_TASK_ID,
-        agent_id=str(_AGENT_ID),
         message="add something new here",
         commit_type="feat",
     )


### PR DESCRIPTION
In roboco/api/schemas/git.py, change task_id from UUID (required) to `UUID | None = None` on four request schemas: GitCommitRequest, GitPushRequest, GitCreatePRRequest, and GitMergePRRequest. After this change, callers who omit task_id entirely (or send null) must receive a successful response (200), not a 422 validation error.

Then update roboco/services/git.py to handle task_id=None gracefully in four service methods:
- commit_for_task: if data.task_id is None, skip _assert_task_owned_with_branch, _assert_on_task_branch, and _link_commit_to_task — call create_commit directly
- push_for_task: if data.task_id is None, skip _assert_task_owned_with_branch and _assert_on_task_branch — push the current workspace branch directly (force-push gate still applies)
- create_pr_for_task: if data.task_id is None, skip _assert_pr_create_allowed and _record_pr_atomically — call create_pull_request directly and return its result
- merge_pr_for_task: if data.task_id is None, skip task lookup, role-based status gating, and auto-complete — call merge_pull_request directly and return (target_branch, merge_commit)

Add or extend tests (unit or integration) to verify:
1. Sending no task_id to POST /commit, /push, /pr/create, /pr/merge returns 200 (not 422)
2. Sending a valid task_id still works correctly (no regression)

Run `uv run ruff format . && uv run ruff check . && uv run mypy roboco/ && uv run pytest` and ensure all pass before marking done.