### PR TITLE
[af918771] Backend: Add completed_30d and median_lead_time_hours to CockpitService

### DIFF
--- a/roboco/api/schemas/cockpit.py
+++ b/roboco/api/schemas/cockpit.py
@@ -10,6 +10,8 @@ class DeliverySummary(BaseModel):
     in_flight: int
     blocked: int
     awaiting_ceo: int
+    completed_30d: int = 0
+    median_lead_time_hours: float | None = None
 
 
 class SpendSummary(BaseModel):

--- a/roboco/services/cockpit.py
+++ b/roboco/services/cockpit.py
@@ -39,8 +39,10 @@ class CockpitService(BaseService):
     service_name = "cockpit"
 
     async def summary(self) -> dict[str, Any]:
+        task_svc = get_task_service(self.session)
         goals = await get_company_goals_service(self.session).get()
-        counts = await get_task_service(self.session).count_by_status()
+        counts = await task_svc.count_by_status()
+        delivery_stats = await task_svc.get_delivery_stats_30d()
         usage_svc = get_usage_service(self.session)
         spend = await usage_svc.get_summary("30d")
         projection = await usage_svc.get_projection()
@@ -60,6 +62,8 @@ class CockpitService(BaseService):
                 "in_flight": counts.get("in_progress", 0) + counts.get("claimed", 0),
                 "blocked": counts.get("blocked", 0),
                 "awaiting_ceo": counts.get("awaiting_ceo_approval", 0),
+                "completed_30d": delivery_stats["completed_30d"],
+                "median_lead_time_hours": delivery_stats["median_lead_time_hours"],
             },
             "spend": {
                 "spend_30d_usd": round(spend_30d, 2),

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -5404,6 +5404,44 @@ class TaskService(BaseService):
         result = await self.session.execute(query)
         return {row[0].value: row[1] for row in result.all()}
 
+    async def get_delivery_stats_30d(self) -> dict[str, Any]:
+        """Return completed-task count and median lead time for the last 30 days.
+
+        Queries tasks WHERE status=completed AND completed_at IS NOT NULL AND
+        completed_at >= now()-30d.  Lead time is ``completed_at - created_at``
+        expressed in hours; the median is computed with :func:`statistics.median`.
+
+        Returns::
+
+            {
+                "completed_30d": int,
+                "median_lead_time_hours": float | None,  # None when no tasks
+            }
+        """
+        import statistics
+
+        cutoff = datetime.now(UTC) - timedelta(days=30)
+        result = await self.session.execute(
+            select(TaskTable.created_at, TaskTable.completed_at).where(
+                TaskTable.status == TaskStatus.COMPLETED,
+                TaskTable.completed_at.is_not(None),
+                TaskTable.completed_at >= cutoff,
+            )
+        )
+        rows = result.all()
+        completed_30d = len(rows)
+        median_lead_time_hours: float | None = None
+        if rows:
+            lead_times = [
+                (row.completed_at - row.created_at).total_seconds() / 3600
+                for row in rows
+            ]
+            median_lead_time_hours = float(statistics.median(lead_times))
+        return {
+            "completed_30d": completed_30d,
+            "median_lead_time_hours": median_lead_time_hours,
+        }
+
     async def count_by_team(self) -> dict[str, int]:
         """Count tasks by team."""
         result = await self.session.execute(

--- a/tests/unit/services/test_cockpit.py
+++ b/tests/unit/services/test_cockpit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -15,12 +16,15 @@ from roboco.models.permissions import AgentContext
 from roboco.services import cockpit as cm
 from roboco.services.cockpit import CockpitService
 from roboco.services.strategy_engine import StrategyObservation
+from roboco.services.task import TaskService
 
 _IN_PROGRESS = 2
 _CLAIMED = 1
 _BLOCKED = 3
 _BUDGET = 100.0
 _SPEND_30D = 150.0
+_COMPLETED_30D = 5
+_MEDIAN_LEAD_TIME = 12.5
 
 
 def _agent(role: AgentRole) -> AgentContext:
@@ -44,10 +48,17 @@ def _patch(monkeypatch: pytest.MonkeyPatch) -> None:
         "blocked": _BLOCKED,
         "awaiting_ceo_approval": 1,
     }
+    delivery_stats = {
+        "completed_30d": _COMPLETED_30D,
+        "median_lead_time_hours": _MEDIAN_LEAD_TIME,
+    }
     monkeypatch.setattr(
         cm,
         "get_task_service",
-        lambda _s: MagicMock(count_by_status=AsyncMock(return_value=counts)),
+        lambda _s: MagicMock(
+            count_by_status=AsyncMock(return_value=counts),
+            get_delivery_stats_30d=AsyncMock(return_value=delivery_stats),
+        ),
     )
     usage = MagicMock(
         get_summary=AsyncMock(return_value={"total_cost_usd": _SPEND_30D}),
@@ -82,6 +93,8 @@ async def test_summary_aggregates(monkeypatch: pytest.MonkeyPatch) -> None:
     assert out["north_star"] == "Win the market"
     assert out["delivery"]["in_flight"] == _IN_PROGRESS + _CLAIMED
     assert out["delivery"]["blocked"] == _BLOCKED
+    assert out["delivery"]["completed_30d"] == _COMPLETED_30D
+    assert out["delivery"]["median_lead_time_hours"] == _MEDIAN_LEAD_TIME
     assert out["spend"]["spend_30d_usd"] == _SPEND_30D
     assert out["spend"]["over_budget"] is True
     assert out["pending_pitches"] == 1
@@ -106,6 +119,8 @@ async def test_route_ok_for_ceo(monkeypatch: pytest.MonkeyPatch) -> None:
             "in_flight": 0,
             "blocked": 0,
             "awaiting_ceo": 0,
+            "completed_30d": 0,
+            "median_lead_time_hours": None,
         },
         "spend": {
             "spend_30d_usd": 0.0,
@@ -153,3 +168,48 @@ async def test_signals_route_ok_for_ceo(monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(croute, "get_cockpit_service", lambda _db: svc)
     resp = await croute.cockpit_signals(MagicMock(), _agent(AgentRole.CEO))
     assert resp.signals[0].kind == "idle"
+
+
+@pytest.mark.asyncio
+async def test_get_delivery_stats_30d_no_tasks() -> None:
+    """When no completed tasks exist in the 30d window, returns zeros and None."""
+    session = MagicMock()
+    execute_result = MagicMock()
+    execute_result.all.return_value = []
+    session.execute = AsyncMock(return_value=execute_result)
+    stats = await TaskService(session).get_delivery_stats_30d()
+    assert stats["completed_30d"] == 0
+    assert stats["median_lead_time_hours"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_delivery_stats_30d_with_tasks() -> None:
+    """With completed tasks, returns count and median lead time in hours."""
+    now = datetime.now(UTC)
+    # Three tasks with lead times of 2h, 4h, 6h → median = 4h
+    rows = [
+        MagicMock(created_at=now - timedelta(hours=2), completed_at=now),
+        MagicMock(created_at=now - timedelta(hours=4), completed_at=now),
+        MagicMock(created_at=now - timedelta(hours=6), completed_at=now),
+    ]
+    session = MagicMock()
+    execute_result = MagicMock()
+    execute_result.all.return_value = rows
+    session.execute = AsyncMock(return_value=execute_result)
+    stats = await TaskService(session).get_delivery_stats_30d()
+    assert stats["completed_30d"] == len(rows)
+    assert stats["median_lead_time_hours"] == pytest.approx(4.0, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_get_delivery_stats_30d_single_task() -> None:
+    """With a single task, median equals that task's lead time."""
+    now = datetime.now(UTC)
+    rows = [MagicMock(created_at=now - timedelta(hours=10), completed_at=now)]
+    session = MagicMock()
+    execute_result = MagicMock()
+    execute_result.all.return_value = rows
+    session.execute = AsyncMock(return_value=execute_result)
+    stats = await TaskService(session).get_delivery_stats_30d()
+    assert stats["completed_30d"] == 1
+    assert stats["median_lead_time_hours"] == pytest.approx(10.0, abs=0.01)


### PR DESCRIPTION
**Goal:** Extend the existing CockpitService.summary() response to include two new metrics the Company Scorecard needs — completed_30d (count of tasks completed in the last 30 days) and median_lead_time_hours (median of created_at→completed_at for tasks completed in the last 30 days). The frontend consumes the cockpit summary to render the scorecard; these two fields are currently missing.

**Constraints:**
- Lead time MUST be median(created_at → completed_at) — total lead time, NOT cycle time (started_at → completed_at). PO explicitly clarified this. Use SQL percentile_cont(0.5) or Python statistics.median.
- When zero tasks have been completed in 30 days, median_lead_time_hours must be null (not 0). Frontend will display 'No data yet' for null.
- No new endpoint or metrics pipeline — extend the existing CockpitService.summary() and its schemas (DeliverySummary, VelocityMetrics).
- TaskTable already has created_at, started_at, completed_at columns — no migration needed.
- Existing cockpit data (in_flight, blocked, awaiting_ceo, spend_30d, budget_cap, over_budget) must continue working unchanged.

**Work units (independently shippable, in dependency order):**
1. Add completed_30d to DeliverySummary schema and CockpitService.summary() — count tasks with completed_at in last 30 days. Independent of unit 2.
2. Add median_lead_time_hours to VelocityMetrics/DeliverySummary and CockpitService — compute median(created_at→completed_at) for tasks completed in last 30 days, null when no tasks qualify. Independent of unit 1.

Both units are independent and can be built in parallel by two developers, then merged. Tests must cover the zero-completed edge case for median_lead_time_hours.