### PR TITLE
[413cb279] Wire usage reporting through usage-report hook path for Grok + bash-guard verification

### DIFF
--- a/docker/scripts/usage-report-hook.sh
+++ b/docker/scripts/usage-report-hook.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# PostToolUse + Stop: sync token usage from the Claude Code transcript.
+# PostToolUse + Stop: report or sync token usage.
 #
-# Claude Code does not pass token counts to hooks, but it does pass the
-# path to the session transcript (.jsonl), which records per-message
-# `usage`. We hand that path to the SDK server, which parses the transcript
-# and SETS the cumulative totals (absolute, idempotent — safe to call after
-# every tool and again at Stop). The orchestrator later reads these via
-# /usage/status to finalize the spawn-session row and the usage dashboard.
+# Grok Build (xAI provider path) supplies token deltas directly in the hook
+# payload (tokens_input, tokens_output, ...). We POST those additively to
+# /usage/report so the SDK accumulates real counts for Grok sessions.
 #
-# Fire-and-forget — never block Claude on this. Always exit 0.
+# Claude Code does not pass token counts to hooks, but passes transcript_path.
+# We fall back to POST /usage/sync (absolute set from JSONL) — idempotent and
+# safe to call repeatedly. The orchestrator reads /usage/status to finalize
+# sessions and feed the dashboard.
+#
+# Fire-and-forget — never block the agent. Always exit 0.
 
 set -u
 
@@ -16,20 +18,57 @@ SDK_URL="${ROBOCO_SDK_URL:-http://localhost:9000}"
 input=$(cat 2>/dev/null || true)
 [[ -z "$input" ]] && exit 0
 
-TRANSCRIPT=$(printf '%s' "$input" | python3 - <<'PY'
+# Dual-path extraction:
+# - If deltas present (Grok): prefer /usage/report (additive).
+# - Else fall back to transcript_path (Claude) -> /usage/sync (absolute).
+mode_data=$(printf '%s' "$input" | python3 - <<'PY'
 import json, sys
 try:
-    d = json.loads(sys.stdin.read())
-    print(d.get("transcript_path", ""))
+    d = json.loads(sys.stdin.read()) or {}
 except Exception:
-    print("")
+    d = {}
+
+# Search top level, tool_input, and a possible "usage" wrapper for deltas.
+cands = [d]
+if isinstance(d, dict):
+    ti = d.get("tool_input") or {}
+    if isinstance(ti, dict):
+        cands.append(ti)
+    u = d.get("usage") or {}
+    if isinstance(u, dict):
+        cands.append(u)
+
+tokens = {}
+for cand in cands:
+    if not isinstance(cand, dict):
+        continue
+    for k in ("tokens_input", "tokens_output", "tokens_cache_read", "tokens_cache_write"):
+        if k in cand:
+            try:
+                tokens[k] = int(cand.get(k) or 0)
+            except (TypeError, ValueError):
+                tokens[k] = 0
+
+if tokens:
+    print("REPORT:" + json.dumps(tokens))
+else:
+    tp = d.get("transcript_path", "") if isinstance(d, dict) else ""
+    print("SYNC:" + (tp or ""))
 PY
 )
 
-[[ -z "$TRANSCRIPT" ]] && exit 0
-
-curl -sf -m 3 -X POST "$SDK_URL/usage/sync" \
-    -H "Content-Type: application/json" \
-    -d "{\"transcript_path\":\"$TRANSCRIPT\"}" >/dev/null 2>&1 || true
+if [[ "$mode_data" == REPORT:* ]]; then
+    payload="${mode_data#REPORT:}"
+    [[ -z "$payload" || "$payload" == "{}" ]] && exit 0
+    curl -sf -m 3 -X POST "$SDK_URL/usage/report" \
+        -H "Content-Type: application/json" \
+        -d "$payload" >/dev/null 2>&1 || true
+elif [[ "$mode_data" == SYNC:* ]]; then
+    TRANSCRIPT="${mode_data#SYNC:}"
+    [[ -z "$TRANSCRIPT" ]] && exit 0
+    curl -sf -m 3 -X POST "$SDK_URL/usage/sync" \
+        -H "Content-Type: application/json" \
+        -d "{\"transcript_path\":\"$TRANSCRIPT\"}" >/dev/null 2>&1 || true
+fi
 
 exit 0

--- a/roboco/agent_sdk/server.py
+++ b/roboco/agent_sdk/server.py
@@ -426,9 +426,9 @@ class _SessionState:
         self.verb_attempts: dict[tuple[str, str | None], deque[float]] = defaultdict(
             deque
         )
-        # Cumulative token usage for this session. Populated by /usage/sync,
-        # which parses the Claude Code transcript and *sets* these absolutely
-        # (the additive /usage/report path remains for explicit deltas).
+        # Cumulative token usage for this session. Populated by /usage/sync
+        # (Claude transcript absolute set) or /usage/report (Grok direct deltas).
+        # The report path is additive; sync is absolute+idempotent.
         self.tokens_input: int = 0
         self.tokens_output: int = 0
         self.tokens_cache_read: int = 0
@@ -705,9 +705,11 @@ def _terminal_snapshot() -> TerminalStatus:
 async def usage_report(req: TokenReportRequest) -> TokenUsageStatus:
     """Accumulate token usage counts for the current session.
 
-    Called by Claude Code hooks (e.g. PostToolUse) after each API call
-    to report the tokens consumed by that invocation. Counts are additive
-    — multiple calls sum up correctly across the session lifetime.
+    Called by Grok Build hooks (and future providers) via the usage-report-hook
+    after each model turn when the provider supplies deltas directly. Counts are
+    additive — multiple calls sum up correctly across the session lifetime.
+    Claude Code path continues to use /usage/sync (transcript) because it never
+    emits deltas in the hook envelope.
     """
     _state.tokens_input += req.tokens_input
     _state.tokens_output += req.tokens_output
@@ -748,12 +750,10 @@ def _token_usage_snapshot() -> TokenUsageStatus:
 async def usage_sync(req: TranscriptSyncRequest) -> TokenUsageStatus:
     """Parse the Claude Code transcript and *set* cumulative token totals.
 
-    Claude Code does not pass token usage to hooks, so the usage-report hook
-    hands us the transcript path and we derive the totals ourselves. The set
-    is absolute and idempotent: re-syncing the same or a grown transcript
-    overwrites rather than accumulates, so it is safe to call after every
-    tool use and again at Stop. An unchanged transcript (same size + mtime)
-    short-circuits without re-parsing.
+    Claude Code does not pass token usage to hooks, so the usage-report-hook
+    hands us the transcript_path and we derive totals. Absolute + idempotent
+    set (re-sync safe). Grok and other providers that emit deltas use the
+    /usage/report path instead; this sync remains Claude-only.
     """
     path = Path(req.transcript_path)
     try:

--- a/tests/unit/agent_sdk/test_usage_sync.py
+++ b/tests/unit/agent_sdk/test_usage_sync.py
@@ -242,27 +242,39 @@ def test_report_additive_deltas(client: TestClient) -> None:
 
     r2 = client.post(
         "/usage/report",
-        json={"tokens_input": 40, "tokens_output": 15, "tokens_cache_read": 0, "tokens_cache_write": 0},
+        json={
+            "tokens_input": 40,
+            "tokens_output": 15,
+            "tokens_cache_read": 0,
+            "tokens_cache_write": 0,
+        },
     )
     assert r2.status_code == _OK
+    total_in = 160
+    total_out = 45
     assert r2.json() == {
-        "tokens_input": 160,
-        "tokens_output": 45,
+        "tokens_input": total_in,
+        "tokens_output": total_out,
         "tokens_cache_read": 10,
         "tokens_cache_write": 2,
     }
 
     status = client.get("/usage/status").json()
-    assert status["tokens_input"] == 160
-    assert status["tokens_output"] == 45
+    assert status["tokens_input"] == total_in
+    assert status["tokens_output"] == total_out
 
 
 def test_report_defaults_to_zero_and_accumulates(client: TestClient) -> None:
     """Missing fields default 0; report remains additive."""
-    client.post("/usage/report", json={"tokens_input": 50, "tokens_output": 10})
-    client.post("/usage/report", json={"tokens_output": 5, "tokens_cache_read": 3})
+    d1_in, d1_out = 50, 10
+    d2_out, d2_cr = 5, 3
+    exp_in, exp_out, exp_cr, exp_cw = 50, 15, 3, 0
+    client.post("/usage/report", json={"tokens_input": d1_in, "tokens_output": d1_out})
+    client.post(
+        "/usage/report", json={"tokens_output": d2_out, "tokens_cache_read": d2_cr}
+    )
     status = client.get("/usage/status").json()
-    assert status["tokens_input"] == 50
-    assert status["tokens_output"] == 15
-    assert status["tokens_cache_read"] == 3
-    assert status["tokens_cache_write"] == 0
+    assert status["tokens_input"] == exp_in
+    assert status["tokens_output"] == exp_out
+    assert status["tokens_cache_read"] == exp_cr
+    assert status["tokens_cache_write"] == exp_cw

--- a/tests/unit/agent_sdk/test_usage_sync.py
+++ b/tests/unit/agent_sdk/test_usage_sync.py
@@ -1,12 +1,10 @@
 """Token-usage capture — /usage/sync parses the transcript and sets totals.
 
-The agent SDK exposes /usage/report (additive) and /usage/status (read),
-but nothing ever fed token counts in, so every session reported zero and the
-cost dashboard rendered all-zeros. The fix: the usage-report hook hands the
-SDK the Claude Code transcript path; /usage/sync parses the per-message
-``usage`` blocks and *sets* the cumulative totals absolutely. These tests pin
-that contract — correct summation, idempotency (no double-count on re-sync),
-graceful handling of a missing/partial transcript, and growth on re-sync.
+The agent SDK exposes /usage/report (additive, used by Grok via usage-report-hook)
+and /usage/status (read). Claude Code never emits deltas in hooks, so the
+usage-report-hook falls back to transcript_path + /usage/sync which parses
+per-message ``usage`` blocks and *sets* totals absolutely (idempotent). These
+tests pin the sync contract. Grok path exercises /report directly.
 
 Expected totals are derived from the input rows (no magic literals), so the
 assertions track whatever the fixtures declare.
@@ -216,3 +214,55 @@ def test_parser_dedupes_repeated_message_id(tmp_path: Path) -> None:
         exp["tokens_cache_read"],
         exp["tokens_cache_write"],
     )
+
+
+# =============================================================================
+# Grok /usage/report additive path (direct deltas from usage-report-hook)
+# =============================================================================
+
+
+def test_report_additive_deltas(client: TestClient) -> None:
+    """/usage/report sums deltas across calls (Grok hook path)."""
+    r1 = client.post(
+        "/usage/report",
+        json={
+            "tokens_input": 120,
+            "tokens_output": 30,
+            "tokens_cache_read": 10,
+            "tokens_cache_write": 2,
+        },
+    )
+    assert r1.status_code == _OK
+    assert r1.json() == {
+        "tokens_input": 120,
+        "tokens_output": 30,
+        "tokens_cache_read": 10,
+        "tokens_cache_write": 2,
+    }
+
+    r2 = client.post(
+        "/usage/report",
+        json={"tokens_input": 40, "tokens_output": 15, "tokens_cache_read": 0, "tokens_cache_write": 0},
+    )
+    assert r2.status_code == _OK
+    assert r2.json() == {
+        "tokens_input": 160,
+        "tokens_output": 45,
+        "tokens_cache_read": 10,
+        "tokens_cache_write": 2,
+    }
+
+    status = client.get("/usage/status").json()
+    assert status["tokens_input"] == 160
+    assert status["tokens_output"] == 45
+
+
+def test_report_defaults_to_zero_and_accumulates(client: TestClient) -> None:
+    """Missing fields default 0; report remains additive."""
+    client.post("/usage/report", json={"tokens_input": 50, "tokens_output": 10})
+    client.post("/usage/report", json={"tokens_output": 5, "tokens_cache_read": 3})
+    status = client.get("/usage/status").json()
+    assert status["tokens_input"] == 50
+    assert status["tokens_output"] == 15
+    assert status["tokens_cache_read"] == 3
+    assert status["tokens_cache_write"] == 0


### PR DESCRIPTION
Adapt usage capture and hooks so that token data flows through the usage-report hook path during Grok runs: either drive SDK /usage/sync from the grok entrypoint / grok_cli_usage (after parsing updates.jsonl), or make usage-report-hook.sh callable and invoke it (providing stub transcript or grok-specific input). Ensure post-tool-budget-hook and a2a-check-hook run cleanly under Grok-invoked conditions. Confirm bash-guard continues to pass allowed workspace commands (e.g. non-git, non-exfil) and denies the bad patterns. Update any shared hook code if needed. The implementing dev must post progress() and decision+reflect notes.