### PR TITLE
fix(retention): narrow agent-owned dir match to path-boundary prefix

### DIFF
--- a/roboco/runtime/transcript_retention.py
+++ b/roboco/runtime/transcript_retention.py
@@ -26,15 +26,24 @@ def is_agent_owned_dir(dir_name: str, workspaces_root: str) -> bool:
     Agents run either at the image WORKDIR ``/app`` (review/coordinate roles →
     the shared ``-app`` dir) or in a per-agent clone under the workspaces root
     (authoring roles). Claude Code encodes the cwd into the dir name by replacing
-    ``/`` with ``-``, so those dirs are ``-app`` and anything starting with the
-    encoded workspaces root (e.g. ``-data-workspaces``). The operator's own
-    sessions live under their real cwd (``-Users-…``, ``-home-…``) and are never
-    matched.
+    ``/`` with ``-``, so those dirs are ``-app`` and either the encoded
+    workspaces root (e.g. ``-data-workspaces``) or one of its descendants
+    (``-data-workspaces-<agent>``). Sibling cwds like ``/data/workspaces-old``
+    or ``/data/workspaces2`` encode to ``-data-workspaces-old`` and
+    ``-data-workspaces2``; a raw ``startswith(encoded_root)`` would treat those
+    as agent-owned and prune unrelated operator transcripts.
+
+    We require either an exact match against the encoded root or a path-boundary
+    prefix (``encoded_root + "-"``) — that boundary character comes from the
+    original ``/`` separator and is the encoding's only signal that the next
+    component is a descendant rather than a sibling.
     """
     if dir_name == "-app":
         return True
     encoded_root = workspaces_root.rstrip("/").replace("/", "-")
-    return bool(encoded_root) and dir_name.startswith(encoded_root)
+    if not encoded_root:
+        return False
+    return dir_name == encoded_root or dir_name.startswith(encoded_root + "-")
 
 
 def _is_old_transcript(path: Path, cutoff_epoch: float) -> bool:

--- a/tests/unit/runtime/test_transcript_retention.py
+++ b/tests/unit/runtime/test_transcript_retention.py
@@ -44,6 +44,46 @@ def test_is_agent_owned_dir_handles_root_slash_safely() -> None:
     assert is_agent_owned_dir("-app", "/") is True
 
 
+def test_is_agent_owned_dir_rejects_non_separator_sibling_prefixes() -> None:
+    # Sibling cwds whose encoded form continues with a non-separator char must
+    # not be matched. /data/workspaces2 encodes to -data-workspaces2 and was
+    # caught by the previous raw prefix check; the path-boundary check rejects
+    # it because the next char after the encoded root is '2', not '-'.
+    assert is_agent_owned_dir("-data-workspaces", WORKSPACES) is True
+    assert is_agent_owned_dir("-data-workspaces2", WORKSPACES) is False
+    assert is_agent_owned_dir("-data-workspaces2-project", WORKSPACES) is False
+    assert is_agent_owned_dir("-data-workspacesBackup", WORKSPACES) is False
+    # NOTE: -data-workspaces-old-project is fundamentally ambiguous — it could
+    # encode either /data/workspaces/old-project (descendant, agent-owned) OR
+    # /data/workspaces-old/project (sibling, operator-owned). The encoding is
+    # lossy and cannot distinguish these from the dir name alone. The path-
+    # boundary fix narrows the false-positive surface but does not eliminate
+    # it for sibling roots whose name itself contains '-'. A complete fix
+    # would require a spawn-time marker file inside the agent's project dir.
+
+
+def test_select_ignores_non_separator_sibling_prefix_dirs(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    old_agent = _touch(
+        projects / "-data-workspaces-roboco-be-dev-1" / "old.jsonl", age_days=30
+    )
+    # Sibling roots whose encoded form continues with a non-separator char —
+    # these were the easy false positives the raw startswith check made.
+    sibling2 = _touch(
+        projects / "-data-workspaces2-project" / "old.jsonl", age_days=99
+    )
+    sibling_backup = _touch(
+        projects / "-data-workspacesBackup-project" / "old.jsonl", age_days=99
+    )
+
+    cutoff = time.time() - 14 * _DAY
+    prunable = set(select_prunable_transcripts(projects, WORKSPACES, cutoff))
+
+    assert old_agent in prunable
+    assert sibling2 not in prunable
+    assert sibling_backup not in prunable
+
+
 def test_select_prunes_only_old_agent_transcripts(tmp_path: Path) -> None:
     projects = tmp_path / "projects"
     old_app = _touch(projects / "-app" / "old.jsonl", age_days=30)


### PR DESCRIPTION
## Summary

`is_agent_owned_dir` uses `dir_name.startswith(encoded_root)` to decide whether a `~/.claude/projects/<encoded-cwd>/` subdir belongs to an agent and is safe to prune. That raw prefix check matches sibling cwds whose encoded name happens to continue with a non-separator character — e.g. with `workspaces_root = "/data/workspaces"`, encoded `-data-workspaces` matches `-data-workspaces2`, `-data-workspacesBackup`, etc. The module's docstring promises to never delete operator sessions, so those false positives result in silent data loss.

## What changed

Tighten the match to require either an exact match against the encoded root or a path-boundary prefix (`encoded_root + "-"`). The boundary character comes from the original `/` separator and is the only signal the encoding preserves that the next component is a true descendant rather than a sibling.

## Residual ambiguity (not fixed by this PR)

The Claude Code encoding `path.replace("/", "-")` is lossy: `/data/workspaces/old-project` and `/data/workspaces-old/project` both encode to `-data-workspaces-old-project`. From the encoded dir name alone these are indistinguishable, so any sibling root whose own name contains `-` (e.g. `/data/workspaces-old`) can still produce a name that matches the boundary check. The PR's docstring acknowledges this; the cleanest complete fix would be a marker file written by the agent at spawn time, scoped to a follow-up PR.

## Tests

- New: `test_is_agent_owned_dir_rejects_non_separator_sibling_prefixes` (`-data-workspaces2`, `-data-workspacesBackup`)
- New: `test_select_ignores_non_separator_sibling_prefix_dirs` (end-to-end through `select_prunable_transcripts`)
- Existing tests unchanged.

## How it was found

AntFleet's two-model security review (Claude Opus 4.7 + GPT-5) on a mirror of this repo. Both models independently flagged the same defect.

- Bench PR with full context: https://github.com/AntFleet/bench-roboco/pull/2
- Findings page: https://antfleet.dev/agents/0x48834d10268f799878d2da8af00933c4b501fba3