### PR TITLE
fix(api): bind v1 role guard to HMAC token, not just header

### DIFF
--- a/roboco/api/routes/v1/_role_dep.py
+++ b/roboco/api/routes/v1/_role_dep.py
@@ -20,9 +20,30 @@ if TYPE_CHECKING:
 
 
 def _require_roles(allowed: frozenset[Role]) -> params.Depends:
+    # Deferred import to keep this dependency loadable from the router
+    # registration path without dragging the full deps module in at
+    # import time (avoids circular imports with routers that this module
+    # is imported from).
+    from roboco.api.deps import _check_agent_auth_token
+
     def _check(
+        x_agent_id: Annotated[str, Header(alias="X-Agent-ID")],
         x_agent_role: Annotated[str, Header(alias="X-Agent-Role")],
+        x_agent_team: Annotated[str | None, Header(alias="X-Agent-Team")] = None,
+        x_agent_token: Annotated[str | None, Header(alias="X-Agent-Token")] = None,
     ) -> None:
+        # Bind the role header to the agent's HMAC token BEFORE comparing
+        # against the allowed set. Without this, a caller could pass any
+        # X-Agent-Role and pass the role check by supplying only the header
+        # — the route-level dep is the only gate on these endpoints. Reuses
+        # the same token-validation primitive as get_agent_context so the
+        # HMAC contract stays centralized in roboco.api.deps. In dev mode
+        # (ROBOCO_AGENT_AUTH_REQUIRED unset), the token check is a no-op
+        # and the legacy header-only behavior is preserved; in prod mode
+        # the role header must be cryptographically bound to X-Agent-ID +
+        # X-Agent-Team via the orchestrator-issued token.
+        _check_agent_auth_token(x_agent_id, x_agent_role, x_agent_team, x_agent_token)
+
         # `Role` is a StrEnum, so the lowercase header string compares equal
         # to its matching member.
         if x_agent_role.lower() not in allowed:

--- a/tests/unit/api/test_v1_role_dep.py
+++ b/tests/unit/api/test_v1_role_dep.py
@@ -82,3 +82,53 @@ def test_dev_route_rejects_missing_role_header() -> None:
     # Missing X-Agent-Role => FastAPI 422 from header validation.
     # We just need it not to silently pass as 200.
     assert r.status_code != _HTTP_200
+
+
+_HTTP_401 = 401
+
+
+def test_dev_route_requires_token_when_auth_enabled(monkeypatch: object) -> None:
+    """When ROBOCO_AGENT_AUTH_REQUIRED=true, the role header alone is not
+    enough — a caller cannot pick an allowed role with just X-Agent-Role.
+    The HMAC token must be presented and verified against X-Agent-ID +
+    role + team. This is the regression for the auth bypass where the v1
+    role dep trusted the role header without authenticating the token."""
+    from pytest import MonkeyPatch  # noqa: PLC0415 — type-only import
+
+    assert isinstance(monkeypatch, MonkeyPatch)
+    monkeypatch.setenv("ROBOCO_AGENT_AUTH_REQUIRED", "true")
+
+    client = TestClient(_build_app())
+    r = client.post(
+        "/api/v1/flow/developer/give_me_work",
+        json={},
+        headers={
+            "X-Agent-ID": "00000000-0000-0000-0000-000000000001",
+            "X-Agent-Role": "developer",
+        },
+    )
+    # Missing X-Agent-Token + auth required => 401, not 200.
+    assert r.status_code == _HTTP_401
+
+
+def test_dev_route_rejects_invalid_token_even_in_dev(monkeypatch: object) -> None:
+    """Even with auth not strictly required, a presented token that does
+    not verify must be rejected — you can't bypass HMAC by supplying an
+    arbitrary string in the header."""
+    from pytest import MonkeyPatch  # noqa: PLC0415
+
+    assert isinstance(monkeypatch, MonkeyPatch)
+    monkeypatch.delenv("ROBOCO_AGENT_AUTH_REQUIRED", raising=False)
+    monkeypatch.setenv("ROBOCO_AGENT_AUTH_SECRET", "test-secret-not-used")
+
+    client = TestClient(_build_app())
+    r = client.post(
+        "/api/v1/flow/developer/give_me_work",
+        json={},
+        headers={
+            "X-Agent-ID": "00000000-0000-0000-0000-000000000001",
+            "X-Agent-Role": "developer",
+            "X-Agent-Token": "obviously-not-a-valid-hmac",
+        },
+    )
+    assert r.status_code == _HTTP_401


### PR DESCRIPTION
## Summary

`roboco/api/routes/v1/_role_dep.py::_require_roles` trusts the `X-Agent-Role` header without verifying the agent's HMAC token. The main agent-context dep (`get_agent_context` in `roboco/api/deps.py`) does enforce HMAC via `_check_agent_auth_token` when `ROBOCO_AGENT_AUTH_REQUIRED=true`, but the v1 flow routers use `_require_roles` instead and bypass that path entirely.

If a caller can reach a v1 endpoint, they can pick any allowed role with just `X-Agent-Role: developer` (or any other allowed value) and pass the guard without proving they hold the matching token.

## What changed

`_require_roles` now calls the same `_check_agent_auth_token` primitive that `get_agent_context` uses, before comparing the role to the allowed set:

- `ROBOCO_AGENT_AUTH_REQUIRED=true` + missing token → 401
- Any token presented + invalid HMAC → 401 (verified in dev too)
- Valid token + role not in allowed set → 403 (unchanged behavior)
- Auth-required unset (dev default) + role header alone → still accepted

This keeps the HMAC contract centralized in `roboco.api.deps` (the model's recommendation and is the minimum change that closes the gap. The import is deferred inside the closure to avoid pulling the full deps module at router-registration time.

## Tests

- New:  — auth required + missing token → 401
- New:  — invalid token → 401 regardless of 
- Existing tests pass unchanged (they don't set , so the token check is a no-op).

## How it was found

AntFleet's two-model security review (Claude Opus 4.7 + GPT-5) on a mirror of this repo. Both models independently flagged the same defect.

- Bench PR with full context: https://github.com/AntFleet/bench-roboco/pull/3
- Findings page: https://antfleet.dev/agents/0x48834d10268f799878d2da8af00933c4b501fba3
EOF
)