### PR TITLE
fix(bash-guard): deny git verbs inside command substitutions

### DIFF
--- a/docker/scripts/bash-guard-hook.sh
+++ b/docker/scripts/bash-guard-hook.sh
@@ -36,12 +36,47 @@ except Exception:
 
 low=$(printf '%s' "$cmd" | tr "[:upper:]" "[:lower:]")
 
+# Pre-check: command substitutions ($(...) and backticks) are evaluated by
+# the shell BEFORE the wrapping command runs, regardless of whether they
+# appear inside echo, printf, or an unquoted heredoc body. The skeletonizer
+# below strips those wrappers and would otherwise hide a denied git op
+# nested in a substitution. Detect those nested ops up front and deny.
+#
+# Known trade-off: literal documentation that contains the exact string
+# "$(git ...)" inside a heredoc body (even a single-quoted one) is also
+# denied. Agents writing such a doc can split the string to avoid the
+# match, or use a non-substitution literal like "\$( git push )". The
+# security gain outweighs the rare doc collision.
+subst_git_deny=$(printf '%s' "$cmd" | python3 -c '
+import sys, re
+src = sys.stdin.read()
+verbs = r"(fetch|pull|push|clone|remote|ls-remote|checkout|commit|merge|rebase|reset|cherry-pick|revert|tag\s+-d|update-ref|reflog\s+delete)"
+git_re = re.compile(rf"(^|[\s;&|()])git\s+{verbs}", re.IGNORECASE)
+# $(...) with one level of nested parens tolerated.
+subst_re = re.compile(r"\$\(([^()]*(?:\([^()]*\)[^()]*)*)\)", re.DOTALL)
+# Backticks: simple, non-nested.
+backtick_re = re.compile(r"`([^`]*)`", re.DOTALL)
+for pat in (subst_re, backtick_re):
+    for m in pat.finditer(src):
+        if git_re.search(m.group(1)):
+            sys.stdout.write("yes")
+            sys.exit(0)
+sys.stdout.write("no")
+' 2>/dev/null)
+
+if [[ "$subst_git_deny" == "yes" ]]; then
+    echo "Denied: shell git verb inside a command substitution (\$(...) or backticks) is evaluated by the shell before the wrapping echo/printf/heredoc runs. Use the verb listed in your role's State→Verb table (e.g. commit, complete, i_am_done)." >&2
+    exit 2
+fi
+
 # Skeletonize the command for the git-ops check ONLY (#165): strip heredoc
 # bodies and echo/printf literal arguments. Those are data the shell writes
 # to a file, never commands the shell executes — so a README/heredoc that
 # merely documents `git commit` must not be mistaken for invoking git.
 # Quoted args to a shell interpreter (`bash -c "... && git fetch"`) ARE
 # executed, are not echo/printf/heredoc bodies, and so survive untouched.
+# Command substitutions inside these stripped regions are caught by the
+# pre-check above before we reach this stage.
 # Every other rule below still inspects the full command ($low).
 git_skel=$(printf '%s' "$cmd" | python3 -c '
 import sys, re

--- a/tests/unit/scripts/test_bash_guard.py
+++ b/tests/unit/scripts/test_bash_guard.py
@@ -253,6 +253,42 @@ def test_still_denies_printf_piped_into_git_apply_path() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Command-substitution bypass: the skeletonizer strips echo/printf/heredoc
+# wrappers, but the shell evaluates $(...) and `...` BEFORE the wrapping
+# command runs. A git op nested in a substitution slips past the deny rule
+# unless we detect it explicitly up front.
+# ---------------------------------------------------------------------------
+
+
+def test_denies_echo_with_git_in_command_substitution() -> None:
+    assert _run("echo $(git fetch origin)") == _DENIED
+
+
+def test_denies_printf_with_git_in_command_substitution() -> None:
+    assert _run('printf "%s" "$(git push)"') == _DENIED
+
+
+def test_denies_echo_with_git_in_backticks() -> None:
+    assert _run("echo `git push origin main`") == _DENIED
+
+
+def test_denies_unquoted_heredoc_body_with_git_substitution() -> None:
+    cmd = "cat <<EOF\n$(git pull)\nEOF"
+    assert _run(cmd) == _DENIED
+
+
+def test_denies_double_quoted_string_with_git_substitution() -> None:
+    """Inside double quotes, $(...) is still expanded — same risk as bare."""
+    assert _run('echo "starting $(git checkout main)"') == _DENIED
+
+
+def test_allows_substitution_that_is_not_a_git_verb() -> None:
+    """Pre-check must only fire on git verbs, not any $(...)."""
+    assert _run("echo $(date)") == _ALLOWED
+    assert _run('VAR="$(hostname)"') == _ALLOWED
+
+
+# ---------------------------------------------------------------------------
 # Task #175: interpreter/library-driven HTTP to an internal host. The
 # curl/wget rule only fires when the first token is an HTTP CLI; smoke-17
 # reached the orchestrator with forged X-Agent-* headers via a python3


### PR DESCRIPTION
## Summary

`docker/scripts/bash-guard-hook.sh` skeletonizes the command before applying its git deny-list — heredoc bodies and `echo`/`printf` args are stripped on the grounds that they're literal data the shell writes to a file. That's true for plain text, but `echo $(git fetch origin)` is evaluated by the shell **before** echo runs. The substitution executes the denied git op while the skeleton no longer contains `git fetch` / `git push`. The same trick works inside `printf` args, double-quoted strings, backticks, and unquoted heredoc bodies.

The hook's header documents its purpose as denying shell-level git network / auth ops; this bypass undermines that for any agent that can issue a Bash tool call.

## Reproduction

PreToolUse JSON payload with `tool_input.command` set to `echo $(git fetch origin)`:
- Before: hook exits 0 (allow); shell expands `$(git fetch origin)` and the denied op runs.
- After: hook exits 2 (deny).

## What changed

Add a pre-check that runs BEFORE the existing skeletonizer. It scans the raw command for git deny-list verbs nested inside `$(...)` substitutions or backticks; if found, the hook denies with a substitution-specific message that points back at the role's MCP verbs. Command substitutions are always expanded by the shell, so the check is safe to apply across all wrapping contexts.

## Trade-off

Literal documentation that contains the exact string `$(git ...)` (even inside a single-quoted heredoc, where it would otherwise remain literal) is also denied. The collision rate is low in practice — agents writing docs about command substitution can split the string or escape the dollar sign. The security benefit of catching the real bypass outweighs the rare false positive.

A fuller fix could parse heredoc openers to know which are quoted and skip the substitution scan for quoted bodies, but adds complexity without much surface gain.

## Tests

New denials covered:
- `echo $(git fetch origin)` — primary reproduction
- `printf "%s" "$(git push)"`
- `` echo `git push origin main` `` — backtick form
- `cat <<EOF` + body containing `$(git pull)` — unquoted heredoc form
- `echo "starting $(git checkout main)"` — double-quoted form

New allow guard:
- `echo $(date)` and `VAR="$(hostname)"` — must still pass

Existing benign cases (single-quoted heredoc git docs, plain echo text mentioning git, external curl, `bash -c "... && git fetch"`) verified unchanged by the local shell harness.

## How it was found

AntFleet's two-model security review (Claude Opus 4.7 + GPT-5) on a mirror of this repo. Both models independently flagged the same defect.

- Bench PR with full context: https://github.com/AntFleet/bench-roboco/pull/2
- Findings page: https://antfleet.dev/agents/0x48834d10268f799878d2da8af00933c4b501fba3
