### PR TITLE
[aa8d21d4] Extend Grok CLI to install full set of runtime hooks

### DIFF
--- a/docker/agent-grok.Dockerfile
+++ b/docker/agent-grok.Dockerfile
@@ -17,15 +17,15 @@ RUN npm install -g @xai-official/grok 2>/dev/null || \
      bash /tmp/grok-install.sh) || \
     echo "Grok CLI install attempted; verify grok binary in PATH at runtime"
 
-# Grok entrypoint wrapper (provides SDK startup + briefing + full hooks activation via settings)
+# Grok entrypoint wrapper (invokes grok_cli_config at start to write
+# config.toml + AGENTS.md + full hooks JSONs + role args; then execs grok).
 COPY docker/scripts/grok-cli-agent-entrypoint.sh /app/scripts/grok-cli-agent-entrypoint.sh
 RUN chmod 0755 /app/scripts/grok-cli-agent-entrypoint.sh
 
-# Prepare ~/.grok so that the mounted user-settings.json is discoverable
-# even before the first grok run (grok inspect / hooks loader expects it).
+# Prepare ~/.grok dir (grok_cli_config writes user-settings/hooks inside).
 RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent || true
 
 USER agent
 
-# Entrypoint runs sdk hooks then exec grok with orchestrator-supplied flags.
+# Entrypoint: grok_cli_config (AC2) then exec grok (hooks fire on events).
 ENTRYPOINT ["/app/scripts/grok-cli-agent-entrypoint.sh"]

--- a/docker/agent-grok.Dockerfile
+++ b/docker/agent-grok.Dockerfile
@@ -1,0 +1,31 @@
+# =============================================================================
+# Agent Grok Image (xAI / Grok Build CLI)
+# =============================================================================
+# Extends the agent-base (which has Python, uv, all hook scripts, SDK).
+# Installs the official Grok CLI (@xai-official/grok or install script) and
+# overrides entrypoint with a wrapper that ensures the full set of runtime
+# hooks + SDK server are active for Grok sessions (sdk-startup first, then
+# grok -p using the mounted ~/.grok/user-settings.json that carries the hooks).
+# =============================================================================
+
+FROM roboco-agent-base
+
+# Install Grok CLI. Prefer npm for reliability in build envs; fallback to
+# official curl installer. The CLI binary is "grok".
+RUN npm install -g @xai-official/grok 2>/dev/null || \
+    (curl -fsSL https://x.ai/cli/install.sh -o /tmp/grok-install.sh && \
+     bash /tmp/grok-install.sh) || \
+    echo "Grok CLI install attempted; verify grok binary in PATH at runtime"
+
+# Grok entrypoint wrapper (provides SDK startup + briefing + full hooks activation via settings)
+COPY docker/scripts/grok-cli-agent-entrypoint.sh /app/scripts/grok-cli-agent-entrypoint.sh
+RUN chmod 0755 /app/scripts/grok-cli-agent-entrypoint.sh
+
+# Prepare ~/.grok so that the mounted user-settings.json is discoverable
+# even before the first grok run (grok inspect / hooks loader expects it).
+RUN mkdir -p /home/agent/.grok && chown -R agent:agent /home/agent || true
+
+USER agent
+
+# Entrypoint runs sdk hooks then exec grok with orchestrator-supplied flags.
+ENTRYPOINT ["/app/scripts/grok-cli-agent-entrypoint.sh"]

--- a/docker/scripts/grok-cli-agent-entrypoint.sh
+++ b/docker/scripts/grok-cli-agent-entrypoint.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Grok CLI agent entrypoint wrapper.
+#
+# Responsibilities for full runtime hooks parity:
+# - Start the SDK server (and emit briefing) via sdk-startup-hook.sh BEFORE grok -p.
+#   This satisfies SessionStart equivalent + A2A/budget/usage counters.
+# - Grok discovers and activates the other hooks (PreToolUse, PostToolUse, Stop,
+#   UserPromptSubmit, PreCompact, SessionEnd) from the mounted
+#   /home/agent/.grok/user-settings.json (populated by orchestrator with identical
+#   command registrations as Claude).
+# - Exec the real `grok` CLI in headless mode with streaming-json, MCP, prompt.
+#
+# The scripts are CLI-agnostic (read JSON events from stdin, POST to localhost:9000).
+# This entrypoint + generated user-settings gives the "full set".
+#
+# Orchestrator sets ROBOCO_INITIAL_PROMPT (and CLAUDE_CODE_SUBAGENT_MODEL etc)
+# via -e; entrypoint builds the clean grok argv and execs (no forwarded flags).
+set -euo pipefail
+
+# Match the robust uv env pinning used by Claude hooks + mcp-config.
+export UV_PROJECT_ENVIRONMENT=/app/.venv
+export PYTHONUNBUFFERED=1
+
+AGENT_ID="${ROBOCO_AGENT_ID:-unknown}"
+echo "[grok-entrypoint] agent=${AGENT_ID} starting full instrumentation..."
+
+# 1. SDK startup + briefing (SessionStart hook equivalent). Idempotent.
+if [ -x /app/scripts/sdk-startup-hook.sh ]; then
+    # Run in subshell so set -e doesn't kill us on non-fatal inside hook
+    (/app/scripts/sdk-startup-hook.sh || echo "[grok-entrypoint] sdk-startup-hook completed with notes") 2>&1 | cat
+else
+    echo "[grok-entrypoint] WARNING: sdk-startup-hook.sh missing"
+fi
+
+# 2. Ensure grok can find its user-settings (hooks) and home.
+mkdir -p /home/agent/.grok /tmp/grok-logs
+# (the settings file is bind-mounted ro by orchestrator when provider=xai)
+
+# 3. Reconstruct the prompt. Prefer env injected by orchestrator; fall back.
+INITIAL_PROMPT="${ROBOCO_INITIAL_PROMPT:-${PROMPT:-}}"
+if [ -z "${INITIAL_PROMPT}" ]; then
+    # Last resort: if orchestrator appended literal prompt tokens, use them.
+    # In practice orchestrator _launch_spawn/_append sets the prompt via env for wrappers.
+    INITIAL_PROMPT="Follow the system prompt in /app/system-prompt.md and briefing if present. Begin task work."
+fi
+
+# 4. Build grok invocation. Grok Build supports:
+#   grok -p "..." --output-format streaming-json --verbose -m model
+#   --mcp-config , instructions etc (best effort; grok will ignore unknown safely).
+GROK_CMD=(grok -p "${INITIAL_PROMPT}" --output-format streaming-json --verbose)
+
+# Model (orchestrator puts resolved in CLAUDE_CODE_SUBAGENT_MODEL or we use config)
+if [ -n "${CLAUDE_CODE_SUBAGENT_MODEL:-}" ]; then
+    GROK_CMD+=(-m "${CLAUDE_CODE_SUBAGENT_MODEL}")
+elif [ -n "${ROBOCO_AGENT_MODEL:-}" ]; then
+    GROK_CMD+=(-m "${ROBOCO_AGENT_MODEL}")
+fi
+
+# System prompt / instructions
+if [ -f /app/system-prompt.md ]; then
+    # Grok supports --instructions or reads project config; pass as text.
+    SYS_PROMPT="$(cat /app/system-prompt.md | head -c 12000 || true)"
+    if [ -n "$SYS_PROMPT" ]; then
+        GROK_CMD+=(--instructions "$SYS_PROMPT")
+    fi
+fi
+
+# MCP config (for flow/do/optimal/git). Grok Build supports MCP servers.
+if [ -f /app/mcp-config.json ]; then
+    GROK_CMD+=(--mcp-config /app/mcp-config.json || true)
+fi
+
+# 5. Exec grok (replaces shell; grok will source hooks from user-settings.json).
+echo "[grok-entrypoint] exec: ${GROK_CMD[*]}"
+exec "${GROK_CMD[@]}"

--- a/docker/scripts/grok-cli-agent-entrypoint.sh
+++ b/docker/scripts/grok-cli-agent-entrypoint.sh
@@ -1,75 +1,69 @@
 #!/bin/bash
-# Grok CLI agent entrypoint wrapper.
+# Grok CLI agent entrypoint wrapper (one-shot delivery agents).
 #
 # Responsibilities for full runtime hooks parity:
-# - Start the SDK server (and emit briefing) via sdk-startup-hook.sh BEFORE grok -p.
-#   This satisfies SessionStart equivalent + A2A/budget/usage counters.
-# - Grok discovers and activates the other hooks (PreToolUse, PostToolUse, Stop,
-#   UserPromptSubmit, PreCompact, SessionEnd) from the mounted
-#   /home/agent/.grok/user-settings.json (populated by orchestrator with identical
-#   command registrations as Claude).
-# - Exec the real `grok` CLI in headless mode with streaming-json, MCP, prompt.
+# - Invoke grok_cli_config (writes config.toml, ~/.grok/AGENTS.md role blueprint,
+#   per-role --disallow/--deny, and FULL set of hook JSONs via write_grok_hooks).
+# - Grok discovers/activates all hooks (SessionStart/sdk-startup, PreToolUse
+#   bash-guard + others, PostToolUse a2a/budget/usage, Stop, UserPromptSubmit,
+#   PreCompact, SessionEnd) from ~/.grok/hooks/*.json and/or user-settings.json .
+# - Exec grok -p headless (streaming-json) using MCP + role flags.
 #
-# The scripts are CLI-agnostic (read JSON events from stdin, POST to localhost:9000).
-# This entrypoint + generated user-settings gives the "full set".
-#
-# Orchestrator sets ROBOCO_INITIAL_PROMPT (and CLAUDE_CODE_SUBAGENT_MODEL etc)
-# via -e; entrypoint builds the clean grok argv and execs (no forwarded flags).
+# grok_cli_config on container start is the source of hook JSONs (AC2).
+# Scripts are CLI-agnostic (stdin JSON -> POST localhost:9000).
 set -euo pipefail
 
-# Match the robust uv env pinning used by Claude hooks + mcp-config.
 export UV_PROJECT_ENVIRONMENT=/app/.venv
 export PYTHONUNBUFFERED=1
 
 AGENT_ID="${ROBOCO_AGENT_ID:-unknown}"
-echo "[grok-entrypoint] agent=${AGENT_ID} starting full instrumentation..."
+echo "[grok-entrypoint] agent=${AGENT_ID} starting full instrumentation via grok_cli_config..."
 
-# 1. SDK startup + briefing (SessionStart hook equivalent). Idempotent.
-if [ -x /app/scripts/sdk-startup-hook.sh ]; then
-    # Run in subshell so set -e doesn't kill us on non-fatal inside hook
-    (/app/scripts/sdk-startup-hook.sh || echo "[grok-entrypoint] sdk-startup-hook completed with notes") 2>&1 | cat
-else
-    echo "[grok-entrypoint] WARNING: sdk-startup-hook.sh missing"
-fi
+# 1. Write config.toml + AGENTS.md (role blueprint) + FULL hooks JSONs + args.
+# This satisfies "Hook JSONs written by grok_cli_config on container start".
+# Run from /app so python -m finds installed package.
+(cd /app && python -m roboco.llm.providers.grok_cli_config) || echo "[grok-entrypoint] grok_cli_config completed (non-fatal notes ok)"
 
-# 2. Ensure grok can find its user-settings (hooks) and home.
 mkdir -p /home/agent/.grok /tmp/grok-logs
-# (the settings file is bind-mounted ro by orchestrator when provider=xai)
 
-# 3. Reconstruct the prompt. Prefer env injected by orchestrator; fall back.
+# 2. Reconstruct prompt (orchestrator injects via ROBOCO_INITIAL_PROMPT).
 INITIAL_PROMPT="${ROBOCO_INITIAL_PROMPT:-${PROMPT:-}}"
 if [ -z "${INITIAL_PROMPT}" ]; then
-    # Last resort: if orchestrator appended literal prompt tokens, use them.
-    # In practice orchestrator _launch_spawn/_append sets the prompt via env for wrappers.
     INITIAL_PROMPT="Follow the system prompt in /app/system-prompt.md and briefing if present. Begin task work."
 fi
 
-# 4. Build grok invocation. Grok Build supports:
-#   grok -p "..." --output-format streaming-json --verbose -m model
-#   --mcp-config , instructions etc (best effort; grok will ignore unknown safely).
-GROK_CMD=(grok -p "${INITIAL_PROMPT}" --output-format streaming-json --verbose)
-
-# Model (orchestrator puts resolved in CLAUDE_CODE_SUBAGENT_MODEL or we use config)
-if [ -n "${CLAUDE_CODE_SUBAGENT_MODEL:-}" ]; then
-    GROK_CMD+=(-m "${CLAUDE_CODE_SUBAGENT_MODEL}")
-elif [ -n "${ROBOCO_AGENT_MODEL:-}" ]; then
-    GROK_CMD+=(-m "${ROBOCO_AGENT_MODEL}")
+# Load any per-role args rendered by grok_cli_config (includes --always-approve,
+# --disallowed-tools, --deny rules, --max-turns, --disable-web-search).
+GROK_ARGS_FILE="${ROBOCO_GROK_ARGS_FILE:-/tmp/roboco-grok-args}"
+GROK_ARGS=()
+if [ -f "$GROK_ARGS_FILE" ]; then
+    mapfile -t GROK_ARGS < "$GROK_ARGS_FILE"
 fi
 
-# System prompt / instructions
-if [ -f /app/system-prompt.md ]; then
-    # Grok supports --instructions or reads project config; pass as text.
-    SYS_PROMPT="$(cat /app/system-prompt.md | head -c 12000 || true)"
-    if [ -n "$SYS_PROMPT" ]; then
-        GROK_CMD+=(--instructions "$SYS_PROMPT")
-    fi
+# 3. Exec grok. Hooks (including SessionStart for sdk) are active from the
+# files written above. Use --cwd for workspace.
+WORKSPACE="${ROBOCO_WORKSPACE:-$PWD}"
+RUN_LOG="/tmp/grok-run.json"
+ERR_LOG="/tmp/grok-run.err"
+
+set +e
+grok -p "${INITIAL_PROMPT}" \
+    -m "${CLAUDE_CODE_SUBAGENT_MODEL:-${ROBOCO_AGENT_MODEL:-grok-build}}" \
+    --cwd "$WORKSPACE" \
+    --output-format json \
+    "${GROK_ARGS[@]}" \
+    < /dev/null > "$RUN_LOG" 2> "$ERR_LOG"
+run_rc=$?
+set -e
+
+cat "$RUN_LOG"
+[ -s "$ERR_LOG" ] && cat "$ERR_LOG" >&2
+
+# Rate limit exit 75 for orchestrator parking (parity with canonical).
+if grep -qiE '(\b429\b|rate.?limit|too many requests|quota|insufficient_quota)' \
+    "$RUN_LOG" "$ERR_LOG" 2>/dev/null; then
+    echo "[grok-entrypoint] rate-limited — exit 75"
+    exit 75
 fi
 
-# MCP config (for flow/do/optimal/git). Grok Build supports MCP servers.
-if [ -f /app/mcp-config.json ]; then
-    GROK_CMD+=(--mcp-config /app/mcp-config.json || true)
-fi
-
-# 5. Exec grok (replaces shell; grok will source hooks from user-settings.json).
-echo "[grok-entrypoint] exec: ${GROK_CMD[*]}"
-exec "${GROK_CMD[@]}"
+exit "$run_rc"

--- a/roboco/llm/providers/grok_cli_config.py
+++ b/roboco/llm/providers/grok_cli_config.py
@@ -1,0 +1,279 @@
+"""Render a Grok CLI agent's runtime config + per-role flags at container start.
+
+Extended for full runtime hooks: in addition to config.toml / AGENTS.md / per-role
+args, grok_cli_config now writes the complete set of hook JSONs (SessionStart for
+sdk-startup, PreToolUse bash-guard, all PostToolUse, Stop, UserPromptSubmit,
+PreCompact, SessionEnd) so AC2 is met by this module on container start.
+
+The hooks use the exact same CLI-agnostic scripts as the Claude path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import tomli_w
+
+from roboco.agents_config import get_agent_role
+from roboco.services.gateway.role_config import get_role_config
+
+# grok reads its global config from ``$HOME/.grok/config.toml`` ...
+GROK_CONFIG_PATH = Path.home() / ".grok" / "config.toml"
+GROK_AGENTS_PATH = Path.home() / ".grok" / "AGENTS.md"
+SYSTEM_PROMPT_PATH = Path(
+    os.environ.get("ROBOCO_SYSTEM_PROMPT", "/app/system-prompt.md")
+)
+GROK_HOOKS_DIR = Path.home() / ".grok" / "hooks"
+BASH_GUARD_HOOK = os.environ.get(
+    "ROBOCO_BASH_GUARD_HOOK", "/app/scripts/bash-guard-hook.sh"
+)
+GROK_ARGS_PATH = Path(os.environ.get("ROBOCO_GROK_ARGS_FILE", "/tmp/roboco-grok-args"))
+
+# Also write user-settings.json for full hooks parity (grok discovers hooks here).
+GROK_USER_SETTINGS_PATH = Path.home() / ".grok" / "user-settings.json"
+
+_DEFAULT_MAX_TURNS = 200
+_FULL_REASONING_OVERRIDES = frozenset({"default", "full", "none", ""})
+_BASH_ROLES = frozenset({"developer", "documenter", "cell_pm", "main_pm"})
+_SUBAGENT_ALLOWED_ROLES = frozenset({"prompter"})
+_TOOL_SHELL = "run_terminal_cmd"
+_TOOL_EDIT = "search_replace"
+_TOOL_SUBAGENT = "Agent"
+
+_GIT_MUTATE_DENY = (
+    "Bash(git push*)",
+    "Bash(git fetch*)",
+    "Bash(git pull*)",
+    "Bash(git clone*)",
+    "Bash(git commit*)",
+    "Bash(git remote*)",
+    "Bash(git reset*)",
+    "Bash(git ls-remote*)",
+    "Bash(git checkout*)",
+    "Bash(git merge*)",
+    "Bash(git rebase*)",
+    "Bash(git cherry-pick*)",
+    "Bash(git revert*)",
+    "Bash(git update-ref*)",
+    "Bash(git tag -d*)",
+    "Bash(git reflog delete*)",
+)
+_DESTRUCTIVE_DENY = ("Bash(rm -rf*)",)
+
+
+def render_config_toml(mcp_config: dict[str, Any]) -> str:
+    servers: dict[str, dict[str, Any]] = {}
+    for name, spec in (mcp_config.get("mcpServers") or {}).items():
+        block: dict[str, Any] = {
+            "command": str(spec.get("command", "")),
+            "args": [str(a) for a in (spec.get("args") or [])],
+        }
+        env = spec.get("env") or {}
+        if env:
+            block["env"] = {str(k): str(v) for k, v in env.items()}
+        servers[str(name)] = block
+    return tomli_w.dumps({"mcp_servers": servers}) if servers else ""
+
+
+def _allows_write(role: str) -> bool:
+    try:
+        return bool(get_role_config(role).allows_write)
+    except KeyError:
+        return False
+
+
+def _disallowed_tools(role: str) -> str:
+    tools: list[str] = []
+    if role not in _SUBAGENT_ALLOWED_ROLES:
+        tools.append(_TOOL_SUBAGENT)
+    if role not in _BASH_ROLES:
+        tools.append(_TOOL_SHELL)
+    if not _allows_write(role):
+        tools.append(_TOOL_EDIT)
+    return ",".join(tools)
+
+
+def _deny_rules(role: str) -> list[str]:
+    if role not in _BASH_ROLES:
+        return []
+    return [*_DESTRUCTIVE_DENY, *_GIT_MUTATE_DENY]
+
+
+def _effort() -> str | None:
+    override = os.environ.get("ROBOCO_GROK_REASONING_EFFORT", "").strip()
+    if override and override.lower() not in _FULL_REASONING_OVERRIDES:
+        return override.lower()
+    return None
+
+
+def grok_cli_args_for_role(
+    role: str, *, max_turns: int = _DEFAULT_MAX_TURNS
+) -> list[str]:
+    args: list[str] = ["--always-approve"]
+    args += ["--disallowed-tools", _disallowed_tools(role)]
+    args += ["--disable-web-search"]
+    args += ["--max-turns", str(max_turns)]
+    for rule in _deny_rules(role):
+        args += ["--deny", rule]
+    effort = _effort()
+    if effort:
+        args += ["--effort", effort]
+    return args
+
+
+def grok_cli_args(agent_id: str, *, max_turns: int = _DEFAULT_MAX_TURNS) -> list[str]:
+    return grok_cli_args_for_role(get_agent_role(agent_id) or "", max_turns=max_turns)
+
+
+def _load_mcp_config(path: str) -> dict[str, Any]:
+    try:
+        with Path(path).open(encoding="utf-8") as fh:
+            loaded = json.load(fh)
+            return loaded if isinstance(loaded, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def write_agents_md() -> bool:
+    """Write AGENTS.md blueprint using current (possibly monkeypatched) globals."""
+    source = SYSTEM_PROMPT_PATH
+    dest = GROK_AGENTS_PATH
+    try:
+        blueprint = source.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(blueprint, encoding="utf-8")
+    return True
+
+
+def bash_guard_hook_config(hook_path: str = BASH_GUARD_HOOK) -> dict[str, Any]:
+    return {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": hook_path,
+                            "env": {"ROBOCO_GUARD_SKIP_GIT": "1"},
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+
+def _full_hooks_section() -> dict[str, Any]:
+    """Return the complete hooks dict matching orchestrator / Claude parity.
+
+    All scripts are the ones baked by agent-base; they are defensive (exit 0 on
+    missing/no stdin or non-matching Grok payloads).
+    """
+    sdk = "/app/scripts/sdk-startup-hook.sh"
+    a2a = "/app/scripts/a2a-check-hook.sh"
+    budget = "/app/scripts/post-tool-budget-hook.sh"
+    usage = "/app/scripts/usage-report-hook.sh"
+    stop = "/app/scripts/stop-hook.sh"
+    prompt = "/app/scripts/user-prompt-hook.sh"
+    compact = "/app/scripts/pre-compact-hook.sh"
+    end = "/app/scripts/session-end-hook.sh"
+    guard = BASH_GUARD_HOOK
+
+    return {
+        "SessionStart": [{"hooks": [{"type": "command", "command": sdk}]}],
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": guard,
+                        "env": {"ROBOCO_GUARD_SKIP_GIT": "1"},
+                    }
+                ],
+            },
+        ],
+        "PostToolUse": [
+            {"matcher": "*", "hooks": [{"type": "command", "command": a2a}]},
+            {"matcher": "*", "hooks": [{"type": "command", "command": budget}]},
+            {"matcher": "*", "hooks": [{"type": "command", "command": usage}]},
+        ],
+        "Stop": [
+            {
+                "hooks": [
+                    {"type": "command", "command": stop},
+                    {"type": "command", "command": usage},
+                ]
+            }
+        ],
+        "UserPromptSubmit": [{"hooks": [{"type": "command", "command": prompt}]}],
+        "PreCompact": [{"hooks": [{"type": "command", "command": compact}]}],
+        "SessionEnd": [{"hooks": [{"type": "command", "command": end}]}],
+    }
+
+
+def write_grok_hooks(
+    *, hooks_dir: Path = GROK_HOOKS_DIR, hook_path: str = BASH_GUARD_HOOK
+) -> bool:
+    """Install FULL set of runtime hook JSONs (for all event types).
+
+    Writes one json per lifecycle event under ~/.grok/hooks/ (and also a
+    consolidated user-settings.json) so grok_cli_config is the writer for AC2.
+    Always includes bash-guard + all others.
+    """
+    if not Path(hook_path).is_file():
+        # still proceed to write other hooks; guard optional
+        pass
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    full = _full_hooks_section()
+
+    # Write individual event json files (grok merges *.json from hooks dir)
+    for event, entries in full.items():
+        (hooks_dir / f"roboco-{event.lower()}.json").write_text(
+            json.dumps({"hooks": {event: entries}}, indent=2), encoding="utf-8"
+        )
+
+    # Also write the bash-guard specific for backward compat with old name
+    (hooks_dir / "roboco-bash-guard.json").write_text(
+        json.dumps(bash_guard_hook_config(hook_path), indent=2), encoding="utf-8"
+    )
+
+    # Write full user-settings.json (the mechanism used by the orchestrator grok path)
+    GROK_USER_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    GROK_USER_SETTINGS_PATH.write_text(
+        json.dumps({"hooks": full}, indent=2), encoding="utf-8"
+    )
+    return True
+
+
+def main() -> int:
+    """Entrypoint: write config.toml + AGENTS.md + FULL hooks + per-role args."""
+    agent_id = os.environ.get("ROBOCO_AGENT_ID", "")
+    mcp_path = os.environ.get("ROBOCO_MCP_CONFIG", "/app/mcp-config.json")
+    try:
+        max_turns = int(
+            os.environ.get("ROBOCO_GROK_MAX_TURNS", str(_DEFAULT_MAX_TURNS))
+        )
+    except ValueError:
+        max_turns = _DEFAULT_MAX_TURNS
+
+    GROK_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    GROK_CONFIG_PATH.write_text(
+        render_config_toml(_load_mcp_config(mcp_path)), encoding="utf-8"
+    )
+    write_agents_md()
+    write_grok_hooks()
+    GROK_ARGS_PATH.write_text(
+        "\n".join(grok_cli_args(agent_id, max_turns=max_turns)) + "\n", encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -1528,13 +1528,20 @@ class AgentOrchestrator:
         workspace_path = _agent_workspace_path(project_slug, team, agent_id)
         cell_workspace_path = _cell_workspace_path(project_slug, team)
 
-        agent_settings_path = self._generate_agent_settings(
-            agent_id,
-            canonical_role,
-            workspace_path,
-            cell_workspace_path,
-            provider_type=route.provider_type.value,
-        )
+        # For xai/grok the hooks + AGENTS + config.toml + role args are written
+        # inside the container by grok_cli_config.main (called from entrypoint
+        # at container start). Skip pre-generation of settings for xai so that
+        # path owns the "hook JSONs written by grok_cli_config" contract.
+        if route.provider_type.value == "xai":
+            agent_settings_path = None
+        else:
+            agent_settings_path = self._generate_agent_settings(
+                agent_id,
+                canonical_role,
+                workspace_path,
+                cell_workspace_path,
+                provider_type=route.provider_type.value,
+            )
 
         briefing_path = await self._write_agent_briefing(
             agent_id, task_id, workspace_path
@@ -1786,19 +1793,16 @@ class AgentOrchestrator:
     def _append_optional_host_mounts(
         cmd: list[str], hosts: dict[str, str | None], provider_type: str = "anthropic"
     ) -> None:
-        """Mount agent settings (claude or grok) + briefing when hosts exist."""
+        """Mount agent settings (claude) + briefing when hosts exist.
+
+        For xai/grok the grok_cli_config module (invoked by entrypoint on
+        container start) writes ~/.grok/config.toml, AGENTS.md, full hook JSONs
+        and per-role args. We deliberately do NOT ro-mount a pre-generated
+        settings for xai so the inside write (AC2) can succeed.
+        """
         settings_host = hosts.get("settings")
-        if settings_host:
-            if provider_type == "xai":
-                # Grok discovers hooks/ config from ~/.grok/user-settings.json
-                # (matches research on opencode/grok cli user-settings shape)
-                cmd.extend(
-                    ["-v", f"{settings_host}:/home/agent/.grok/user-settings.json:ro"]
-                )
-            else:
-                cmd.extend(
-                    ["-v", f"{settings_host}:/home/agent/.claude/settings.json:ro"]
-                )
+        if settings_host and provider_type != "xai":
+            cmd.extend(["-v", f"{settings_host}:/home/agent/.claude/settings.json:ro"])
         briefing_host = hosts.get("briefing")
         if briefing_host:
             cmd.extend(["-v", f"{briefing_host}:/app/briefing.md:ro"])

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -787,7 +787,10 @@ class AgentOrchestrator:
 
         # Ensure the role-specialized image if this agent uses one
         if agent_id:
-            bare = AGENT_IMAGES.get(agent_id, AGENT_BASE_IMAGE)
+            if agent_id == "grok":
+                bare = "roboco-agent-grok"
+            else:
+                bare = AGENT_IMAGES.get(agent_id, AGENT_BASE_IMAGE)
             if bare != AGENT_BASE_IMAGE:
                 # Map the bare image name to its dockerfile
                 dockerfile_map = {
@@ -801,6 +804,7 @@ class AgentOrchestrator:
                     "roboco-agent-prompter": "agent-prompter.Dockerfile",
                     "roboco-agent-secretary": "agent-secretary.Dockerfile",
                     "roboco-agent-pr-reviewer": "agent-pr-reviewer.Dockerfile",
+                    "roboco-agent-grok": "agent-grok.Dockerfile",
                 }
                 dockerfile = dockerfile_map.get(bare)
                 if dockerfile:
@@ -1000,20 +1004,19 @@ class AgentOrchestrator:
         role: str,
         workspace_path: str,
         cell_workspace_path: str,
+        provider_type: str = "anthropic",
     ) -> Path:
-        """Generate per-agent Claude Code settings file with role-specific permissions.
+        """Generate per-agent settings (Claude or Grok) with full hooks.
 
-        This replaces the shared settings approach. Each agent gets their own
-        settings.json with:
-        - Base MCP tools allowed for all agents
-        - Role-specific tool permissions
-        - Explicit deny list blocking native git/file operations
+        'xai' provider writes grok user-settings.json (hooks); else claude
+        settings. Hooks give guard parity for bash/a2a/budget/usage/stop/etc.
 
         Args:
             agent_id: Agent identifier (e.g., "be-dev-1")
             role: Agent role (e.g., "developer")
             workspace_path: Path to agent's own workspace directory
             cell_workspace_path: Path to cell's workspace root (for QA/Docs)
+            provider_type: 'anthropic' | 'ollama_cloud' | 'xai' | ...
 
         Returns:
             Path to the generated settings file
@@ -1072,143 +1075,152 @@ class AgentOrchestrator:
             "Bash(printenv:*)",
         ]
 
-        # Get role-specific permissions
-        role_config = self._get_role_permissions(
-            role, workspace_path, cell_workspace_path
-        )
-
         # Combine base + role-specific.
         # defaultMode=bypassPermissions lets unlisted operations proceed
         # without an interactive prompt (which would hang a non-TTY agent
         # container). Explicit deny rules still apply.
-        settings: dict[str, Any] = {
-            "permissions": {
-                "defaultMode": "bypassPermissions",
-                "allow": base_allow + role_config["allow"],
-                "deny": base_deny + role_config["deny"],
-            },
-            "hooks": {
-                # Start SDK server on session start (for A2A communication)
-                "SessionStart": [
-                    {
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/sdk-startup-hook.sh",
-                            }
-                        ]
-                    }
-                ],
-                # Guard Bash: block shell-level git/curl/wget/env patterns
-                # that the matcher-based `permissions.deny` can't catch
-                # (e.g. `cd X && git fetch`). Redirects agents to the MCP
-                # equivalents instead of bloating prompts with rules.
-                "PreToolUse": [
-                    {
-                        "matcher": "Bash",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/bash-guard-hook.sh",
-                            }
-                        ],
-                    },
-                ],
-                "PostToolUse": [
-                    # Check for incoming A2A messages after each tool use
-                    {
-                        "matcher": "*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/a2a-check-hook.sh",
-                            }
-                        ],
-                    },
-                    # Per-session budget counter + loop detector. Shared SDK
-                    # state lets this hook emit [Budget]/[Loop]/[Halt]
-                    # reminders that the orchestrator's kill-switch corroborates.
-                    {
-                        "matcher": "*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/post-tool-budget-hook.sh",
-                            }
-                        ],
-                    },
-                    # Sync token usage from the transcript so /usage/status
-                    # (and the cost dashboard) reflect real spend. Idempotent
-                    # absolute set — running it per tool keeps mid-run
-                    # snapshots and reaped-agent sessions accurate.
-                    {
-                        "matcher": "*",
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/usage-report-hook.sh",
-                            }
-                        ],
-                    },
-                ],
-                # Stop guard: refuse silent exits unless a terminal tool was
-                # just called (idle/substitute/escalate/pause/...). Second
-                # attempt auto-substitutes via SDK so the task doesn't rot.
-                "Stop": [
-                    {
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/stop-hook.sh",
-                            },
-                            # Final token-usage sync at turn end — guarantees
-                            # the session total is captured before the agent
-                            # idles and the orchestrator finalizes the row.
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/usage-report-hook.sh",
-                            },
-                        ]
-                    }
-                ],
-                # Prompt-injection guard — rejects turns that look like
-                # another agent's content trying to override our rules.
-                "UserPromptSubmit": [
-                    {
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/user-prompt-hook.sh",
-                            }
-                        ]
-                    }
-                ],
-                # Snapshot budget / terminal state before compact so the
-                # next session resumes with continuity.
-                "PreCompact": [
-                    {
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/pre-compact-hook.sh",
-                            }
-                        ]
-                    }
-                ],
-                # Post-mortem: write a reflect-journal entry summarising the
-                # session (tools called, halt/loop triggered, last tool).
-                "SessionEnd": [
-                    {
-                        "hooks": [
-                            {
-                                "type": "command",
-                                "command": "/app/scripts/session-end-hook.sh",
-                            }
-                        ]
-                    }
-                ],
-            },
+        hooks_section = {
+            # Start SDK server on session start (for A2A communication)
+            "SessionStart": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/sdk-startup-hook.sh",
+                        }
+                    ]
+                }
+            ],
+            # Guard Bash: block shell-level git/curl/wget/env patterns
+            # that the matcher-based `permissions.deny` can't catch
+            # (e.g. `cd X && git fetch`). Redirects agents to the MCP
+            # equivalents instead of bloating prompts with rules.
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/bash-guard-hook.sh",
+                        }
+                    ],
+                },
+            ],
+            "PostToolUse": [
+                # Check for incoming A2A messages after each tool use
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/a2a-check-hook.sh",
+                        }
+                    ],
+                },
+                # Per-session budget counter + loop detector. Shared SDK
+                # state lets this hook emit [Budget]/[Loop]/[Halt]
+                # reminders that the orchestrator's kill-switch corroborates.
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/post-tool-budget-hook.sh",
+                        }
+                    ],
+                },
+                # Sync token usage from the transcript so /usage/status
+                # (and the cost dashboard) reflect real spend. Idempotent
+                # absolute set — running it per tool keeps mid-run
+                # snapshots and reaped-agent sessions accurate.
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/usage-report-hook.sh",
+                        }
+                    ],
+                },
+            ],
+            # Stop guard: refuse silent exits unless a terminal tool was
+            # just called (idle/substitute/escalate/pause/...). Second
+            # attempt auto-substitutes via SDK so the task doesn't rot.
+            "Stop": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/stop-hook.sh",
+                        },
+                        # Final token-usage sync at turn end — guarantees
+                        # the session total is captured before the agent
+                        # idles and the orchestrator finalizes the row.
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/usage-report-hook.sh",
+                        },
+                    ]
+                }
+            ],
+            # Prompt-injection guard — rejects turns that look like
+            # another agent's content trying to override our rules.
+            "UserPromptSubmit": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/user-prompt-hook.sh",
+                        }
+                    ]
+                }
+            ],
+            # Snapshot budget / terminal state before compact so the
+            # next session resumes with continuity.
+            "PreCompact": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/pre-compact-hook.sh",
+                        }
+                    ]
+                }
+            ],
+            # Post-mortem: write a reflect-journal entry summarising the
+            # session (tools called, halt/loop triggered, last tool).
+            "SessionEnd": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "/app/scripts/session-end-hook.sh",
+                        }
+                    ]
+                }
+            ],
         }
+
+        settings: dict[str, Any]
+        if provider_type == "xai":
+            # Grok uses ~/.grok/user-settings.json with at minimum the hooks
+            # section. Reuse the exact same hook registrations (CLI-agnostic
+            # scripts). Grok CLI will invoke them at the matching lifecycle
+            # events, giving full parity on guards/instrumentation.
+            settings = {"hooks": hooks_section}
+        else:
+            # Claude (ollama_cloud proxy too): full permissions + hooks
+            role_config = self._get_role_permissions(
+                role, workspace_path, cell_workspace_path
+            )
+            settings = {
+                "permissions": {
+                    "defaultMode": "bypassPermissions",
+                    "allow": base_allow + role_config["allow"],
+                    "deny": base_deny + role_config["deny"],
+                },
+                "hooks": hooks_section,
+            }
 
         # Write to per-agent settings file
         # When running in container: write to /app/agent-settings (mounted to host)
@@ -1219,7 +1231,8 @@ class AgentOrchestrator:
             settings_dir = Path(tempfile.gettempdir()) / "roboco-agent-settings"
 
         settings_dir.mkdir(parents=True, exist_ok=True)
-        settings_path = settings_dir / f"{agent_id}-settings.json"
+        suffix = "grok-settings.json" if provider_type == "xai" else "settings.json"
+        settings_path = settings_dir / f"{agent_id}-{suffix}"
 
         # Handle case where Docker auto-created a directory instead of a file
         if settings_path.is_dir():
@@ -1227,14 +1240,23 @@ class AgentOrchestrator:
 
         settings_path.write_text(json.dumps(settings, indent=2))
 
-        logger.debug(
-            "Generated per-agent settings",
-            agent_id=agent_id,
-            role=role,
-            settings_path=str(settings_path),
-            allow_count=len(settings["permissions"]["allow"]),
-            deny_count=len(settings["permissions"]["deny"]),
-        )
+        if provider_type == "xai":
+            logger.debug(
+                "Generated per-agent Grok settings",
+                agent_id=agent_id,
+                role=role,
+                settings_path=str(settings_path),
+                hooks_count=len(settings.get("hooks", {})),
+            )
+        else:
+            logger.debug(
+                "Generated per-agent settings",
+                agent_id=agent_id,
+                role=role,
+                settings_path=str(settings_path),
+                allow_count=len(settings.get("permissions", {}).get("allow", [])),
+                deny_count=len(settings.get("permissions", {}).get("deny", [])),
+            )
 
         return settings_path
 
@@ -1507,7 +1529,11 @@ class AgentOrchestrator:
         cell_workspace_path = _cell_workspace_path(project_slug, team)
 
         agent_settings_path = self._generate_agent_settings(
-            agent_id, canonical_role, workspace_path, cell_workspace_path
+            agent_id,
+            canonical_role,
+            workspace_path,
+            cell_workspace_path,
+            provider_type=route.provider_type.value,
         )
 
         briefing_path = await self._write_agent_briefing(
@@ -1515,6 +1541,10 @@ class AgentOrchestrator:
         )
 
         await self._ensure_agent_image(agent_id)
+        if route.provider_type.value == "xai":
+            await self._ensure_agent_image(
+                "grok"
+            )  # triggers grok image via map extension below
         mcp_config_path = await self._generate_mcp_config(agent_id, git_context)
 
         from uuid import uuid4
@@ -1676,6 +1706,15 @@ class AgentOrchestrator:
         """Compute host mount paths for both containerized and host runtime."""
         mcp_name = config.mcp_config_path.name if config.mcp_config_path else ""
         if PROJECT_HOST_PATH:
+            settings_host_path = None
+            if agent_settings_path:
+                # Use the actual filename returned by _generate (claude or grok variant)
+                fname = (
+                    agent_settings_path.name
+                    if hasattr(agent_settings_path, "name")
+                    else Path(str(agent_settings_path)).name
+                )
+                settings_host_path = f"{DATA_HOST_PATH}/agent-settings/{fname}"
             return {
                 "docs": f"{PROJECT_HOST_PATH}/docs",
                 "workspaces": f"{DATA_HOST_PATH}/workspaces",
@@ -1684,11 +1723,7 @@ class AgentOrchestrator:
                 "prompt": (
                     f"{DATA_HOST_PATH}/prompts-generated/{config.agent_id}-prompt.md"
                 ),
-                "settings": (
-                    f"{DATA_HOST_PATH}/agent-settings/{config.agent_id}-settings.json"
-                    if agent_settings_path
-                    else None
-                ),
+                "settings": settings_host_path,
                 "briefing": (
                     f"{DATA_HOST_PATH}/briefings/{config.agent_id}.md"
                     if config.briefing_path
@@ -1727,7 +1762,7 @@ class AgentOrchestrator:
             f"{hosts['claude']}:/home/agent/.claude",
         ]
         AgentOrchestrator._append_claude_json_mount(cmd, hosts)
-        AgentOrchestrator._append_optional_host_mounts(cmd, hosts)
+        AgentOrchestrator._append_optional_host_mounts(cmd, hosts, config.provider_type)
         role = get_agent_role(config.agent_id) or "developer"
         cmd.extend(AgentOrchestrator._core_volume_and_env_args(config, hosts, role))
         AgentOrchestrator._append_provider_env(cmd, config)
@@ -1749,12 +1784,21 @@ class AgentOrchestrator:
 
     @staticmethod
     def _append_optional_host_mounts(
-        cmd: list[str], hosts: dict[str, str | None]
+        cmd: list[str], hosts: dict[str, str | None], provider_type: str = "anthropic"
     ) -> None:
-        """Mount agent settings.json and briefing.md when their hosts exist."""
+        """Mount agent settings (claude or grok) + briefing when hosts exist."""
         settings_host = hosts.get("settings")
         if settings_host:
-            cmd.extend(["-v", f"{settings_host}:/home/agent/.claude/settings.json:ro"])
+            if provider_type == "xai":
+                # Grok discovers hooks/ config from ~/.grok/user-settings.json
+                # (matches research on opencode/grok cli user-settings shape)
+                cmd.extend(
+                    ["-v", f"{settings_host}:/home/agent/.grok/user-settings.json:ro"]
+                )
+            else:
+                cmd.extend(
+                    ["-v", f"{settings_host}:/home/agent/.claude/settings.json:ro"]
+                )
         briefing_host = hosts.get("briefing")
         if briefing_host:
             cmd.extend(["-v", f"{briefing_host}:/app/briefing.md:ro"])
@@ -1798,7 +1842,7 @@ class AgentOrchestrator:
 
     @staticmethod
     def _append_provider_env(cmd: list[str], config: AgentConfig) -> None:
-        """Inject ANTHROPIC_* env only on non-Anthropic providers."""
+        """Inject provider-specific env (ANTHROPIC_* for ollama etc, XAI_* for grok)."""
         # Provider routing: only inject ANTHROPIC_* env vars when the
         # resolved provider is non-Anthropic (i.e. Ollama Cloud). For the
         # Anthropic default path both fields are None and Claude Code
@@ -1808,6 +1852,10 @@ class AgentOrchestrator:
             cmd.extend(["-e", f"ANTHROPIC_BASE_URL={config.provider_base_url}"])
         if config.provider_auth_token:
             cmd.extend(["-e", f"ANTHROPIC_AUTH_TOKEN={config.provider_auth_token}"])
+
+        # xAI / Grok path: the grok CLI and its SDK use XAI_API_KEY.
+        if config.provider_type == "xai" and config.provider_auth_token:
+            cmd.extend(["-e", f"XAI_API_KEY={config.provider_auth_token}"])
 
     @staticmethod
     def _append_manifest_args(
@@ -1907,25 +1955,27 @@ class AgentOrchestrator:
         )
 
     @classmethod
-    def _append_image_and_claude_args(
+    def _append_image_and_cli_args(
         cls, cmd: list[str], config: AgentConfig, initial_prompt: str | None
     ) -> None:
-        """Append the image + Claude Code CLI args to the docker run cmd.
+        """Append the image + CLI (claude or grok) args to the docker run cmd.
 
-        `--tools` explicitly enumerates the built-in tools loaded at session
-        start. Without it, Claude CLI's default behavior leaves Edit/Write
-        in the deferred pool, so an agent that doesn't reliably call
-        ToolSearch (e.g. weaker non-Anthropic models routed via
-        Ollama-cloud) ends up unable to modify any file. The set below is
-        the minimum every agent role needs:
-          - Read/Write/Edit  : file IO inside the workspace
-          - Bash             : shell commands (gated by bash-guard hook)
-          - Grep/Glob        : code navigation
-          - TodoWrite        : per-session planning
-        Permissions still gate *which* paths Edit/Write can touch (see
-        `_get_role_permissions`), so this is purely about loading vs
-        denying.
+        For provider_type=='xai' we use the grok image (with its entrypoint wrapper
+        that starts SDK + full hooks via user-settings.json). We pass the prompt
+        via ROBOCO_INITIAL_PROMPT env so the wrapper builds a clean `grok` argv
+        (no duplicated flags). Other providers keep the Claude Code invocation.
         """
+        if config.provider_type == "xai":
+            image = _qualify_agent_image("roboco-agent-grok")
+            # Pass prompt via env (entrypoint uses it for -p); just the image
+            # (its ENTRYPOINT script will run full hooks bootstrap then exec grok).
+            # Model is already injected as CLAUDE_CODE_SUBAGENT_MODEL by caller.
+            prompt = initial_prompt or cls._default_spawn_prompt()
+            cmd.extend(["-e", f"ROBOCO_INITIAL_PROMPT={prompt}"])
+            cmd.extend([image])
+            return
+
+        # Claude (or proxy) path
         claude_args = [
             get_agent_image(config.agent_id),
             "--model",
@@ -1963,9 +2013,9 @@ class AgentOrchestrator:
         """Spawn a Docker container for the agent.
 
         Args:
-            config: Agent configuration
+            config: Agent configuration (provider_type selects claude/grok + mount)
             initial_prompt: Optional initial prompt for the agent
-            agent_settings_path: Path to per-agent Claude settings file
+            agent_settings_path: Path to per-agent settings (claude or grok)
         """
         container_name = f"roboco-agent-{config.agent_id}"
         await self._remove_container(container_name)
@@ -1977,7 +2027,7 @@ class AgentOrchestrator:
         cmd = self._build_mount_args(container_name, config, hosts)
         self._append_agent_auth_env(cmd, config)
         self._append_git_context_env(cmd, config)
-        self._append_image_and_claude_args(cmd, config, initial_prompt)
+        self._append_image_and_cli_args(cmd, config, initial_prompt)
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,

--- a/tests/unit/runtime/test_agent_write_permissions.py
+++ b/tests/unit/runtime/test_agent_write_permissions.py
@@ -25,9 +25,13 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from roboco.runtime.orchestrator import AgentOrchestrator
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _orch() -> AgentOrchestrator:
@@ -160,7 +164,7 @@ def test_grok_xai_settings_has_full_hooks_only() -> None:
 # New coverage for AC2/AC4: grok_cli_config (not just orchestrator) writes the
 # full set of hook JSONs when invoked on container start.
 def test_grok_cli_config_writes_full_hooks_and_artifacts(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """grok_cli_config.write_grok_hooks (and main) emit hook JSONs for every
     required event (AC2) + AGENTS.md + config.toml (MCP) + role args (denies).

--- a/tests/unit/runtime/test_agent_write_permissions.py
+++ b/tests/unit/runtime/test_agent_write_permissions.py
@@ -155,3 +155,98 @@ def test_grok_xai_settings_has_full_hooks_only() -> None:
         "session-end-hook.sh",
     ]:
         assert script in flat, f"full set requires {script} registered for Grok"
+
+
+# New coverage for AC2/AC4: grok_cli_config (not just orchestrator) writes the
+# full set of hook JSONs when invoked on container start.
+def test_grok_cli_config_writes_full_hooks_and_artifacts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """grok_cli_config.write_grok_hooks (and main) emit hook JSONs for every
+    required event (AC2) + AGENTS.md + config.toml (MCP) + role args (denies).
+    """
+    # Import inside after Path.home patch: module level constants eval Path.home
+    import roboco.llm.providers.grok_cli_config as gcc  # noqa: PLC0415
+
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: fake_home, raising=False)
+    # Override module globals used by writers
+    monkeypatch.setattr(gcc, "GROK_HOOKS_DIR", fake_home / ".grok" / "hooks")
+    monkeypatch.setattr(gcc, "GROK_AGENTS_PATH", fake_home / ".grok" / "AGENTS.md")
+    monkeypatch.setattr(
+        gcc, "GROK_USER_SETTINGS_PATH", fake_home / ".grok" / "user-settings.json"
+    )
+    monkeypatch.setattr(gcc, "GROK_CONFIG_PATH", fake_home / ".grok" / "config.toml")
+    monkeypatch.setattr(gcc, "GROK_ARGS_PATH", tmp_path / "grok-args")
+
+    # Provide minimal system prompt and mcp for writers
+    (tmp_path / "system.md").write_text(
+        "# test blueprint for grok\nYou are a test agent."
+    )
+    monkeypatch.setattr(gcc, "SYSTEM_PROMPT_PATH", tmp_path / "system.md")
+    mcp = tmp_path / "mcp.json"
+    mcp.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "flow": {
+                        "command": "uv",
+                        "args": [
+                            "run",
+                            "--no-sync",
+                            "python",
+                            "-m",
+                            "roboco.mcp.flow_server",
+                        ],
+                    }
+                }
+            }
+        )
+    )
+
+    monkeypatch.setenv("ROBOCO_MCP_CONFIG", str(mcp))
+    monkeypatch.setenv("ROBOCO_AGENT_ID", "be-dev-1")
+
+    # Call writer directly (what grok entrypoint invokes on start)
+    hooks_dir = gcc.GROK_HOOKS_DIR
+    gcc.write_grok_hooks(hooks_dir=hooks_dir, hook_path="/nonexistent/guard.sh")
+    # guard file absent is tolerated (write_grok_hooks proceeds)
+
+    # Verify full event JSONs exist (written by grok_cli_config = AC2)
+    assert hooks_dir.exists()
+    event_map = {
+        "sessionstart": "SessionStart",
+        "pretooluse": "PreToolUse",
+        "posttooluse": "PostToolUse",
+        "stop": "Stop",
+        "userpromptsubmit": "UserPromptSubmit",
+        "precompact": "PreCompact",
+        "sessionend": "SessionEnd",
+    }
+    for event, cap in event_map.items():
+        p = hooks_dir / f"roboco-{event}.json"
+        assert p.exists(), f"missing hook json for {event}"
+        data = json.loads(p.read_text())
+        assert "hooks" in data, "hook json must contain hooks root"
+        hooksec = data.get("hooks", {})
+        assert cap in hooksec or cap in str(data), f"missing event {cap}"
+
+    # user-settings also has full hooks
+    us = gcc.GROK_USER_SETTINGS_PATH
+    assert us.exists()
+    usdata = json.loads(us.read_text())
+    assert "hooks" in usdata
+    for key in ["SessionStart", "PreToolUse", "Stop", "SessionEnd"]:
+        assert key in usdata["hooks"]
+
+    # AGENTS + config + role args (with --deny) written by main()
+    gcc.main()
+    assert gcc.GROK_AGENTS_PATH.exists()
+    assert "test blueprint" in gcc.GROK_AGENTS_PATH.read_text()
+    cfg = gcc.GROK_CONFIG_PATH
+    assert cfg.exists()
+    assert "mcp_servers" in cfg.read_text() or "flow" in cfg.read_text()
+    assert gcc.GROK_ARGS_PATH.exists()
+    args = gcc.GROK_ARGS_PATH.read_text()
+    assert "--always-approve" in args
+    assert "--disallowed-tools" in args or "--deny" in args

--- a/tests/unit/runtime/test_agent_write_permissions.py
+++ b/tests/unit/runtime/test_agent_write_permissions.py
@@ -108,3 +108,50 @@ def test_non_writer_generated_settings_block_write() -> None:
     deny = json.loads(Path(path).read_text())["permissions"]["deny"]
     assert "Write(*)" in deny, deny
     assert "Edit(*)" in deny, deny
+
+
+def test_grok_xai_settings_has_full_hooks_only() -> None:
+    """Grok (xai provider) must receive the *full* set of runtime hooks via
+    top-level 'hooks' in its user-settings.json equivalent. No permissions
+    block (grok uses different mechanism); all 9 hook scripts registered
+    under the Claude-compatible event names for parity.
+    """
+    orch = _orch()
+    path = orch._generate_agent_settings(
+        agent_id="be-dev-1",
+        role="developer",
+        workspace_path=_WS,
+        cell_workspace_path=_CELL,
+        provider_type="xai",
+    )
+    data = json.loads(Path(path).read_text())
+    assert "hooks" in data, "grok settings must have hooks"
+    assert "permissions" not in data, (
+        "grok settings must omit permissions (claude-only)"
+    )
+    hooks = data["hooks"]
+    # Full set of lifecycle hooks
+    for key in [
+        "SessionStart",
+        "PreToolUse",
+        "PostToolUse",
+        "Stop",
+        "UserPromptSubmit",
+        "PreCompact",
+        "SessionEnd",
+    ]:
+        assert key in hooks, f"missing hook event for full set: {key}"
+    # Verify concrete scripts are wired (all hook scripts)
+    flat = str(hooks)
+    for script in [
+        "sdk-startup-hook.sh",
+        "bash-guard-hook.sh",
+        "a2a-check-hook.sh",
+        "post-tool-budget-hook.sh",
+        "usage-report-hook.sh",
+        "stop-hook.sh",
+        "user-prompt-hook.sh",
+        "pre-compact-hook.sh",
+        "session-end-hook.sh",
+    ]:
+        assert script in flat, f"full set requires {script} registered for Grok"

--- a/tests/unit/runtime/test_spawn_strict_mcp.py
+++ b/tests/unit/runtime/test_spawn_strict_mcp.py
@@ -35,13 +35,13 @@ def _make_dev_config() -> OrchestratorAgentConfig:
 
 
 def _build_image_args(config: OrchestratorAgentConfig) -> list[str]:
-    """Invoke _append_image_and_claude_args against an empty cmd."""
+    """Invoke _append_image_and_cli_args against an empty cmd."""
     cmd: list[str] = []
     with patch(
         "roboco.runtime.orchestrator._resolve_agent_cli_model",
         return_value="claude-sonnet-4-6",
     ):
-        AgentOrchestrator._append_image_and_claude_args(cmd, config, None)
+        AgentOrchestrator._append_image_and_cli_args(cmd, config, None)
     return cmd
 
 


### PR DESCRIPTION
In roboco/llm/providers/grok_cli_config.py, generalize write_grok_hooks (and bash_guard_hook_config) to also write hook definitions for PostToolUse (to invoke a2a-check-hook, post-tool-budget-hook, usage-report-hook), UserPromptSubmit (user-prompt-hook), Stop (stop-hook + usage-report), PreCompact (pre-compact-hook), and SessionEnd (session-end-hook). Place definitions under ~/.grok/hooks/ (one or more .json files). Update main(), write_agents_md callsite, and the grok_*_main drivers. Ensure bash-guard continues to work exactly as before (with ROBOCO_GUARD_SKIP_GIT). This makes the Grok runtime actually invoke the hook scripts during an agent session.