### PR TITLE
[868a3fb6] Replace inline status list with ACTIVE_STATUSES in get_team_metrics

### DIFF
--- a/roboco/services/metrics.py
+++ b/roboco/services/metrics.py
@@ -207,14 +207,7 @@ class MetricsService(BaseService):
             select(func.count(TaskTable.id)).where(
                 and_(
                     TaskTable.team == team,
-                    TaskTable.status.in_(
-                        [
-                            TaskStatus.CLAIMED,
-                            TaskStatus.IN_PROGRESS,
-                            TaskStatus.VERIFYING,
-                            TaskStatus.AWAITING_QA,
-                        ]
-                    ),
+                    TaskTable.status.in_(ACTIVE_STATUSES),
                 )
             )
         )


### PR DESCRIPTION
In roboco/services/metrics.py, the get_team_metrics() method builds an active-tasks query using an inline list literal: [TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS, TaskStatus.VERIFYING, TaskStatus.AWAITING_QA]. A module-level constant ACTIVE_STATUSES = frozenset({...}) already exists at the top of that file with exactly those same four statuses. Your job is to replace the inline list with ACTIVE_STATUSES (a frozenset is accepted by SQLAlchemy's .in_()). Only the get_team_metrics() method should be changed — get_health_status() has a DIFFERENT list that intentionally includes TaskStatus.BLOCKED; do NOT touch it. After the edit, run pytest tests/integration/test_metrics_service.py (and the full test suite with `uv run pytest`) to confirm all existing tests still pass. Format and lint with `uv run ruff format . && uv run ruff check .` before committing.