### PR TITLE
[bc36c380] Replace inline status list in get_team_metrics with ACTIVE_STATUSES

### DIFF
--- a/roboco/services/metrics.py
+++ b/roboco/services/metrics.py
@@ -207,14 +207,7 @@ class MetricsService(BaseService):
             select(func.count(TaskTable.id)).where(
                 and_(
                     TaskTable.team == team,
-                    TaskTable.status.in_(
-                        [
-                            TaskStatus.CLAIMED,
-                            TaskStatus.IN_PROGRESS,
-                            TaskStatus.VERIFYING,
-                            TaskStatus.AWAITING_QA,
-                        ]
-                    ),
+                    TaskTable.status.in_(ACTIVE_STATUSES),
                 )
             )
         )


### PR DESCRIPTION
In roboco/services/metrics.py, the get_team_metrics() method (lines 210-216) hardcodes an inline list of four TaskStatus values that duplicates the ACTIVE_STATUSES frozenset already defined at line 33 of the same file. Replace the inline list with a reference to ACTIVE_STATUSES. This is a one-line refactor with no behavioral change — SQLAlchemy's .in_() accepts frozenset directly.

Constraints:
- Do NOT modify get_health_status() or any other call site — only get_team_metrics() changes.
- Existing metrics tests must continue to pass unchanged.
- The change is confined to roboco/services/metrics.py only.