### PR TITLE
[3d608631] Replace inline status list with ACTIVE_STATUSES in get_team_metrics

### DIFF
--- a/roboco/services/metrics.py
+++ b/roboco/services/metrics.py
@@ -29,7 +29,9 @@ DEFAULT_COMM_HOURS = 24
 HOURS_PER_DAY = 24
 SECONDS_PER_HOUR = 3600
 
-# Active task statuses for queries
+# Active task statuses for get_team_metrics and related queries.
+# Note: BLOCKED is intentionally excluded here; get_health_status() uses its
+# own local list that includes BLOCKED to compute the blocked-task ratio.
 ACTIVE_STATUSES = frozenset(
     {
         TaskStatus.CLAIMED,


### PR DESCRIPTION
In roboco/services/metrics.py, the get_team_metrics() method contains an inline list at lines 210-216 inside a TaskTable.status.in_([...]) call. That list — [TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS, TaskStatus.VERIFYING, TaskStatus.AWAITING_QA] — duplicates the module-level ACTIVE_STATUSES frozenset already defined at lines 33-40 of the same file.

Change: replace that inline list with a reference to ACTIVE_STATUSES. No import is needed; ACTIVE_STATUSES is already in scope. The result should be: TaskTable.status.in_(ACTIVE_STATUSES).

Constraint: do NOT touch get_health_status() (line 466+). That method has its own distinct local list that intentionally includes BLOCKED — it must remain unchanged.

After the edit, run the two team-metrics tests to confirm they pass:
  uv run pytest tests/integration/test_metrics_service.py -k "test_get_team_metrics_empty or test_get_team_metrics_with_data" -v

The change is confined to a single call site in a single method. No other files should be modified.