### PR TITLE
[28853cee] Use ACTIVE_STATUSES constant in get_team_metrics

### DIFF
--- a/roboco/services/metrics.py
+++ b/roboco/services/metrics.py
@@ -207,14 +207,7 @@ class MetricsService(BaseService):
             select(func.count(TaskTable.id)).where(
                 and_(
                     TaskTable.team == team,
-                    TaskTable.status.in_(
-                        [
-                            TaskStatus.CLAIMED,
-                            TaskStatus.IN_PROGRESS,
-                            TaskStatus.VERIFYING,
-                            TaskStatus.AWAITING_QA,
-                        ]
-                    ),
+                    TaskTable.status.in_(ACTIVE_STATUSES),
                 )
             )
         )

--- a/roboco/services/metrics.py
+++ b/roboco/services/metrics.py
@@ -29,7 +29,9 @@ DEFAULT_COMM_HOURS = 24
 HOURS_PER_DAY = 24
 SECONDS_PER_HOUR = 3600
 
-# Active task statuses for queries
+# Active task statuses for get_team_metrics and related queries.
+# Note: BLOCKED is intentionally excluded here; get_health_status() uses its
+# own local list that includes BLOCKED to compute the blocked-task ratio.
 ACTIVE_STATUSES = frozenset(
     {
         TaskStatus.CLAIMED,


### PR DESCRIPTION
## Objective

Replace the hardcoded status list in MetricsService.get_team_metrics() with the existing ACTIVE_STATUSES constant, eliminating a duplication that could silently diverge if the constant is updated.

## What This Builds

- A one-line fix in roboco/services/metrics.py that swaps an inline list of four TaskStatus values for the ACTIVE_STATUSES frozenset already defined at the top of the same file

## The Work

**Backend** — Replace the inline status list in get_team_metrics() with the ACTIVE_STATUSES constant
- In roboco/services/metrics.py, replace the inline [TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS, TaskStatus.VERIFYING, TaskStatus.AWAITING_QA] list at line ~210 in get_team_metrics() with list(ACTIVE_STATUSES). Single commit, single PR.

## Notes

- ACTIVE_STATUSES frozenset (line 33 of metrics.py) already holds the identical four statuses — the inline list is a straight duplicate.
- A similar-looking list in get_health_status() (~line 476) intentionally includes TaskStatus.BLOCKED — that one is NOT in scope since it's a deliberately different set.
- No behavioral change, no migration, no API contract change.

## Success Criteria

- The inline status list in get_team_metrics() is replaced with a reference to ACTIVE_STATUSES
- Existing metrics tests continue to pass
- No other call sites are modified — the get_health_status() list is left as-is since it intentionally differs