### PR TITLE
[1bc8195e] Add panel-gate + panel-quality Makefile targets and CI test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,6 @@ jobs:
 
       - name: Type-check
         run: pnpm exec tsc --noEmit
+
+      - name: Test (vitest + coverage)
+        run: pnpm test

--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,18 @@ gate:
 	@uv run mypy roboco/ tests/
 	@uv run xenon --max-absolute B --max-modules A --max-average A roboco/
 
+# Panel (Next.js) fast gate: lint + type-check + vitest.
+# Run locally before submitting panel changes; mirrors the CI panel job exactly.
+.PHONY: panel-gate
+panel-gate:
+	@cd panel && pnpm lint
+	@cd panel && pnpm exec tsc --noEmit
+	@cd panel && pnpm test
+
+# Full CI-equivalent panel gate (alias for panel-gate).
+.PHONY: panel-quality
+panel-quality: panel-gate
+
 # Run all analysis tools
 .PHONY: analysis
 analysis: deptry


### PR DESCRIPTION
Add two new Makefile targets to the root Makefile and add a test step to the panel job in .github/workflows/ci.yml so the build blocks on test failure and coverage output is visible.

**Root Makefile changes (`Makefile` at repo root):**

Add these two phony targets under the `# QUALITY GATES` section (or a new `# PANEL` section near the existing panel-token target):

```makefile
# Fast panel gate: lint + type-check + tests (runs from repo root)
.PHONY: panel-gate
panel-gate:
	cd panel && pnpm lint && pnpm exec tsc --noEmit && pnpm test

# Full CI-equivalent panel quality gate
.PHONY: panel-quality
panel-quality: panel-gate
	@echo "Panel quality gate passed."
```

Also add entries to the help target:
```
  make panel-gate               - Run panel lint + typecheck + tests
  make panel-quality            - Full CI-equivalent panel gate
```

Note: The panel directory has pnpm scripts defined in panel/package.json. The `pnpm test` script there runs `vitest run --coverage`. Using `cd panel && ...` is the correct way to invoke these from the root.

**CI workflow changes (`.github/workflows/ci.yml`):**

The panel job already has `defaults: run: working-directory: panel`. Add a new step after the existing "Type-check" step:

```yaml
      - name: Test (vitest + coverage)
        run: pnpm test
```

This runs `pnpm test` which maps to `vitest run --coverage` in panel/package.json. The vitest reporter is configured as ["text", "lcov", "json-summary"] in vitest.config.ts, so the text coverage summary is printed to stdout and visible in CI job output. The step blocks the build on failure (exit code non-zero from vitest).

**Verification:** After making changes, confirm the Makefile has both `panel-gate` and `panel-quality` phony targets, and that ci.yml has the test step between Type-check and end of the panel job steps. The pnpm test command must be identical to what runs locally.