### PR TITLE
[ed9c5b59] Fix 3 mypy arg-type errors in test_conventions_resolve.py using typing.cast

### DIFF
--- a/tests/unit/services/test_conventions_resolve.py
+++ b/tests/unit/services/test_conventions_resolve.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import subprocess
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from roboco.services.conventions import ConventionsService
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from roboco.db.tables import ProjectTable
 
 
 def _git_repo(root: Path) -> str:
@@ -37,7 +39,7 @@ def _svc() -> ConventionsService:
 def test_resolve_reads_clone_head_and_backfills(tmp_path: Path) -> None:
     sha = _git_repo(tmp_path)
     project = SimpleNamespace(workspace_path=None, head_commit=None, slug="p")
-    root, head = _svc()._resolve(project, tmp_path)
+    root, head = _svc()._resolve(cast("ProjectTable", project), tmp_path)
     assert root == tmp_path
     assert head == sha
     # The backfill: the resolved path + real HEAD are persisted on the project.
@@ -49,7 +51,7 @@ def test_resolve_non_git_path_keeps_persisted_head(tmp_path: Path) -> None:
     project = SimpleNamespace(
         workspace_path=str(tmp_path), head_commit="deadbeef", slug="p"
     )
-    _root, head = _svc()._resolve(project, None)
+    _root, head = _svc()._resolve(cast("ProjectTable", project), None)
     # A non-git legacy path must not clobber the persisted head_commit.
     assert head == "deadbeef"
     assert project.head_commit == "deadbeef"
@@ -57,7 +59,7 @@ def test_resolve_non_git_path_keeps_persisted_head(tmp_path: Path) -> None:
 
 def test_resolve_no_workspace_returns_none_root() -> None:
     project = SimpleNamespace(workspace_path=None, head_commit=None, slug="p")
-    root, head = _svc()._resolve(project, None)
+    root, head = _svc()._resolve(cast("ProjectTable", project), None)
     assert root is None
     assert head == "HEAD"
 


### PR DESCRIPTION
Edit tests/unit/services/test_conventions_resolve.py to resolve the 3 mypy arg-type errors caused by passing a SimpleNamespace object where ConventionsService._resolve() expects a ProjectTable.

Steps:
1. Add `from typing import cast` to the imports (it may already be imported via TYPE_CHECKING — check first).
2. Add `from roboco.db.tables import ProjectTable` to the imports.
3. In test_resolve_reads_clone_head_and_backfills: change `_svc()._resolve(project, tmp_path)` to `_svc()._resolve(cast(ProjectTable, project), tmp_path)`.
4. In test_resolve_non_git_path_keeps_persisted_head: change `_svc()._resolve(project, None)` to `_svc()._resolve(cast(ProjectTable, project), None)`.
5. In test_resolve_no_workspace_returns_none_root: change `_svc()._resolve(project, None)` to `_svc()._resolve(cast(ProjectTable, project), None)`.
6. Run `uv run mypy roboco/ tests/` and confirm zero errors.
7. Run `make quality` and confirm no regressions.

Do NOT modify any other file. Do NOT add `# type: ignore` or `--ignore-missing-imports` or any mypy suppression.

## Constraints
- Convention (block): modular cohesion
- Convention (block): no models in api
- Convention (block): no routes in lib
- Convention (block): no models in hooks
- Convention (block): no routes in hooks
- Convention (block): no routes in store
- Convention (block): no routes in utils
- Convention (block): no models in routes
- Convention (block): no routes in models
- Convention (block): no routes in stores
- Convention (block): no components in lib
- Convention (block): no routes in schemas
- Convention (block): no routes in services
- Convention (block): no components in hooks
- Convention (block): no components in store
- Convention (block): no components in utils
- Convention (block): no components in stores
- Convention (block): no models in components
- Convention (block): no routes in components
- Place code per the map — panel/lib is for shared helpers / utilities (no route, component here)
- Place code per the map — panel/src/components is for presentational UI components (no model, route here)
- Place code per the map — panel/src/hooks is for React hooks — data fetching + state, no JSX (no component, model, route here)
- Place code per the map — panel/src/lib is for shared frontend helpers / utilities (no route, component here)
- Place code per the map — panel/src/store is for client-side state management (no component, route here)
- Place code per the map — panel/src/lib/api is for typed API client (no model here)
- Place code per the map — panel/src/lib/stores is for state management (no component, route here)
- Place code per the map — roboco/api is for API package wiring — app, deps, middleware, websocket (no model here)
- Place code per the map — roboco/models is for SQLAlchemy + Pydantic data models (no route here)
- Place code per the map — roboco/services is for business logic, DB writes, side effects — the only layer that owns them (no route here)
- Place code per the map — roboco/utils is for shared, side-effect-free helpers (no route, component here)
- Place code per the map — roboco/api/routes is for HTTP routes — thin handlers that delegate to services (no model, helper here)
- Place code per the map — roboco/api/schemas is for API request / response schemas (no route here)
- Place code per the map — roboco/api/utils is for shared helpers / utilities (no route, component here)
- Place code per the map — roboco/mcp/schemas is for MCP tool input / output schemas (no route here)