### PR TITLE
[e799b5fb] Self-heal: fix the CI regression on roboco-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Mypy [unreachable] error in test_pr_gate_records_verdict resolved.** A test assigned `t.notes_structured = None` in the function body, causing mypy to narrow the attribute type to `None`. Since the test's helper function took the object as `Any`, mypy did not reset its narrowing after the call, treating `assert t.notes_structured is not None` as statically always-False and marking the next line as `[unreachable]`, failing the quality gate. Fixed by introducing `_TaskWithNoNotes` — a helper class that declares `notes_structured: dict[str, Any] | None = None` in `__init__` — so mypy uses the declared union type rather than a narrowed literal. All tests pass with no suppressions. This pattern is documented in the testing standards for future reference.
+
 ## [0.11.1] - 2026-06-25
 
 ### Fixed

--- a/docs/rag/standards/testing.md
+++ b/docs/rag/standards/testing.md
@@ -73,6 +73,38 @@ pnpm lint
 pnpm typecheck
 ```
 
+## Type Narrowing and mypy
+
+When you assign `None` to an attribute inside a test function, mypy narrows that attribute's type to `None`, and does **not** invalidate this narrowing after a function call — even when the called function takes the object as `Any` or modifies it.
+
+**Problem:** This causes mypy to treat subsequent assertions as unreachable, failing the quality gate.
+
+```python
+# ❌ BAD: mypy narrows notes to None and treats the assertion as unreachable
+def test_example() -> None:
+    t = _Task()
+    t.notes = None  # mypy narrows type to None
+    process(t)      # Even though process may write to t.notes
+    assert t.notes is not None  # [unreachable] — mypy sees this as always False
+```
+
+**Solution:** Use a helper class whose `__init__` declares the attribute with its full union type, so mypy uses the declared type (not a narrowed literal) when accessed in your test:
+
+```python
+# ✅ GOOD: Annotation-typed class preserves union type
+class _TaskWithNoNotes:
+    """Variant where notes starts as None (no prior state)."""
+    
+    def __init__(self) -> None:
+        self.id = uuid4()
+        self.notes: dict[str, Any] | None = None  # Declared as union, not narrowed
+        
+def test_example() -> None:
+    t = _TaskWithNoNotes()  # Use the helper instead
+    process(t)
+    assert t.notes is not None  # ✅ Reachable — mypy sees the union type
+```
+
 ## Quality Gates
 
 All tests MUST pass before:

--- a/tests/unit/gateway/test_pr_gate_records_verdict.py
+++ b/tests/unit/gateway/test_pr_gate_records_verdict.py
@@ -45,6 +45,15 @@ class _Task:
         self.pr_reviewer_notes = "stale"
 
 
+class _TaskWithNoNotes:
+    """Variant where notes_structured starts as None (no prior verdict history)."""
+
+    def __init__(self) -> None:
+        self.id = uuid4()
+        self.notes_structured: dict[str, Any] | None = None
+        self.pr_reviewer_notes: str = ""
+
+
 def test_pr_fail_overwrites_stale_passed_verdict() -> None:
     c = _make_choreographer()
     t = _Task()
@@ -60,8 +69,10 @@ def test_pr_fail_overwrites_stale_passed_verdict() -> None:
 
 def test_pr_pass_records_passed_verdict() -> None:
     c = _make_choreographer()
-    t = _Task()
-    t.notes_structured = None
+    # Use the None-initial variant so mypy sees the broader declared type
+    # (dict[str, Any] | None) rather than a narrowed None from an in-body
+    # assignment, which would make the post-call assertions look unreachable.
+    t = _TaskWithNoNotes()
     c._record_gate_verdict(
         t, "pr_pass", "Assembled root scope is clean; every criterion is covered."
     )


### PR DESCRIPTION
RoboCo's own CI regressed.

CI on roboco-api@master concluded 'failure' (CI)

Evidence: https://github.com/rennf93/roboco/actions/runs/28159574548

Investigate and fix the regression at its root so CI returns to green. This task was opened automatically by the self-heal loop and is READY TO START NOW — no approval needed; pick it up and coordinate the fix. It still ships through the normal gates (QA, PR review, and the CEO's merge).

## Constraints
- Convention (block): no routes in lib
- Convention (block): no components in lib
- Convention (block): no models in components
- Convention (block): no routes in components
- Convention (block): no components in hooks
- Convention (block): no models in hooks
- Convention (block): no routes in hooks
- Convention (block): no components in store
- Convention (block): no routes in store
- Convention (block): no models in api
- Convention (block): no components in stores
- Convention (block): no routes in stores
- Convention (block): no routes in models
- Convention (block): no routes in services
- Convention (block): no routes in utils
- Convention (block): no components in utils
- Convention (block): no models in routes
- Convention (block): no routes in schemas
- Convention (block): modular cohesion
- Place code per the map — panel/lib is for shared helpers / utilities (no route, component here)
- Place code per the map — panel/src/components is for presentational UI components (no model, route here)
- Place code per the map — panel/src/hooks is for React hooks — data fetching + state, no JSX (no component, model, route here)
- Place code per the map — panel/src/lib is for shared frontend helpers / utilities (no route, component here)
- Place code per the map — panel/src/store is for client-side state management (no component, route here)
- Place code per the map — panel/src/lib/api is for typed API client (no model here)
- Place code per the map — panel/src/lib/stores is for state management (no component, route here)
- Place code per the map — roboco/api is for API package wiring — app, deps, middleware, websocket (no model here)
- Place code per the map — roboco/models is for SQLAlchemy + Pydantic data models (no route here)
- Place code per the map — roboco/services is for business logic, DB writes, side effects — the only layer that owns them (no route here)
- Place code per the map — roboco/utils is for shared, side-effect-free helpers (no route, component here)
- Place code per the map — roboco/api/routes is for HTTP routes — thin handlers that delegate to services (no model, helper here)
- Place code per the map — roboco/api/schemas is for API request / response schemas (no route here)
- Place code per the map — roboco/api/utils is for shared helpers / utilities (no route, component here)
- Place code per the map — roboco/mcp/schemas is for MCP tool input / output schemas (no route here)