### PR TITLE
[ee99307e] Rebase, diff-compare, and close PR #280 on feature/main_pm/7bd41bc4

### DIFF
--- a/REBASE_REPORT_PR280.md
+++ b/REBASE_REPORT_PR280.md
@@ -1,0 +1,131 @@
+# Rebase & PR #280 Closure Report — feature/main_pm/7bd41bc4
+
+**Task:** ee99307e-97ed-4cf9-9e89-972c1d40ea0e
+**Author:** be-dev-1 (re-assigned after escalation cycle redirected back from product-owner)
+**Date:** 2026-06-26
+**Branch under analysis:** `feature/main_pm/7bd41bc4`
+**Master SHA:** `e2f7097aab099ab23ce856a5f844bbfe8dbb25a6`
+
+---
+
+## 1. Branch topology (read-only verification)
+
+| Ref | SHA | Notes |
+|---|---|---|
+| `origin/master` (tip) | `e2f7097` | "Persist the PM-respawn counter across orchestrator restarts (#275)" |
+| `origin/feature/main_pm/7bd41bc4` | `4fd119f` | Branch the PR #280 is on |
+| `origin/feature/backend/7bd41bc4--747b9898` | `53d0164` | Backend-flavored copy of the same branch (PRs #276 + #279 already added here) |
+| `origin/feature/backend/7bd41bc4--747b9898--ee99307e` | `53d0164` | My current working branch (this report) |
+
+**Key finding — branch is already an ancestor of master:** The branch tip `4fd119f` ("Merge branch 'master' of https://github.com/rennf93/roboco") is literally **a commit in master's history** (3 commits back from `e2f7097`). A rebase of `4fd119f` onto `e2f7097` is mathematically a **no-op fast-forward** (the branch tip is already an ancestor of master; git would simply report "Already up to date.").
+
+The locally visible branch `feature/backend/7bd41bc4--747b9898` has two commits **on top of** `4fd119f` — these are the CI-fix commits that were already delivered as PRs #276 and #279:
+
+```
+53d0164  [e67b2ba0] Backend: investigate CI regression on roboco-api master and fix root cause (#279)
+8b77923  [d8afb69f] Run make quality, identify all failing checks, and fix them to restore green CI on roboco-api master (#274) (#276)
+4fd119f  Merge branch 'master' of https://github.com/rennf93/roboco  ← branch tip in PR #280
+aeff60c  [57f83a44] Verify and fix all failing CI quality gates from run 28194267886 (#271) (#272) (#273)  ← the "equivalent landed fix"
+88d00aa  fix(pr-review): reject a verdict that contradicts the review's findings
+... (master ancestry continues backward)
+e2f7097  Persist the PM-respawn counter across orchestrator restarts (#275)  ← master tip
+```
+
+## 2. Diff analysis (branch tip `53d0164` vs master tip `e2f7097`)
+
+The branch tip carries **2 commits not present on master**:
+
+| SHA | Subject | Status vs master |
+|---|---|---|
+| `8b77923` | `[d8afb69f] Run make quality, identify all failing checks, and fix them to restore green CI on roboco-api master (#274) (#276)` | NOT on master |
+| `53d0164` | `[e67b2ba0] Backend: investigate CI regression on roboco-api master and fix root cause (#279)` | NOT on master |
+
+**This is a non-trivial delta.** Per AC5 of this task ("If the rebased branch carries non-trivial deltas NOT on master, dev escalates to be-pm BEFORE closing PR #280 — no closure happens until be-pm escalates and main-pm decides"), the closure is **blocked pending escalation**.
+
+The previous round of escalation (main-pm → product-owner) was redirected back because product-owner is a board role with no delivery verbs. The escalation needs to go to main-pm (who owns the main_pm/* namespace and can decide whether the 2 commits should land on master before PR #280 is closed, or whether the closure can proceed with the branch tip ahead of master).
+
+## 3. Why the AC1 rebase cannot be executed by an agent
+
+The bash-guard layer in the agent container blocks all branch-mutating git ops:
+
+```
+$ git rebase origin/master
+PreToolUse:Bash hook error: Denied: shell git for network / auth / branch-mutating ops is blocked.
+Use the verb listed in your role's State→Verb table (e.g. commit, complete, i_am_done).
+```
+
+The agent role manifest (per `roboco/services/gateway/role_config.py`) does not expose a `rebase` or `force_push` verb to any role. The KB (`troubleshooting/git-errors.md`) explicitly states: "There is no agent-layer pull/rebase to reconcile it" and "Escalate rather than improvise — devs `i_am_blocked(...)`, PMs `escalate_up(...)`."
+
+Additionally, `gh` is not installed in any agent container (verified: `which gh` returns nothing). PR closure requires either:
+- `gh pr close 280 --comment "..."` (no CLI available, and no agent verb for it)
+- A platform-side close via the GitHub UI/API (requires orchestrator override or CEO action)
+
+Per `tool-permissions.md`, only `cell_pm` and `main_pm` can `complete` (which merges a PR); closing an unmerged PR has the same action surface. The **CEO** closes PRs via the panel's PR Review Queue (per `docs/rag/roles/pr-reviewer.md`).
+
+## 4. Proposed closure-comment text
+
+This is the exact comment text I would post on PR #280 once the platform path is unblocked:
+
+```
+Closing as superseded.
+
+The equivalent fix landed on master via PR #273 as commit aeff60c:
+"[57f83a44] Verify and fix all failing CI quality gates from run 28194267886
+ (#271) (#272) (#273)"
+
+The follow-on CI regression fixes were delivered as PRs #276 (8b77923) and #279
+(53d0164) on the backend-flavored copy of this branch.
+
+The branch `feature/main_pm/7bd41bc4` is being retired; no further work will land
+here. Closing PR #280 to retire the stale coordination-root branch.
+
+Reference: commit aeff60c on origin/master.
+```
+
+## 5. Path forward (escalation request)
+
+be-dev-1 cannot complete this task end-to-end. The four unblock options (carried forward from my initial assessment and confirmed by main-pm in their escalation note):
+
+| Option | Pros | Cons |
+|---|---|---|
+| **(A)** Orchestrator one-off shell rebase + force-push on the workspace | Preserves AC1 verbatim; dev continues ownership | Sets a precedent for skipping the bash-guard; risk of silent git damage |
+| **(B)** Hand to a human/CI to perform rebase + push + close PR #280 via gh | Safest; matches the documented "platform-action path" | Requires CEO or infra-team action |
+| **(C)** Accept closure of PR #280 without a rebase (deviation from AC1) | Simplest; aeff60c is already on master so the branch's purpose is already served | Violates explicit AC1 |
+| **(D)** Some other platform path not yet found | TBD | TBD |
+
+**Recommended path: Option (B)** — escalate to CEO via main-pm to either close PR #280 via the panel (CEO has the PR-closure surface per the CEO PR Review Queue) or delegate the rebase to a human/CI operator.
+
+## 6. What I have done on this branch (this commit)
+
+- Re-verified the branch vs master topology via read-only git inspection
+- Confirmed the math: rebase of `4fd119f` onto `e2f7097` is a no-op (branch tip already an ancestor of master)
+- Documented the 2 non-trivial commits on the BE-flavored branch (`8b77923`, `53d0164`) that are NOT on master
+- Drafted the exact closure-comment text for PR #280
+- Recorded the escalation rationale in the journal
+
+## 7. What remains (platform-side)
+
+1. **Rebase decision:** either execute the (no-op) rebase of `feature/main_pm/7bd41bc4` onto `e2f7097`, or accept that the math makes the rebase unnecessary
+2. **PR #280 closure:** post the closure comment (text in section 4) and close the PR — requires `gh` CLI access or CEO panel action
+3. **Final commit on the rebased branch:** I have done the equivalent on my own branch (`feature/backend/7bd41bc4--747b9898--ee99307e`) — this file is the report
+4. **Non-trivial delta decision:** decide whether the 2 CI-fix commits on the BE-flavored branch (`8b77923`, `53d0164`) need to land on master first, or can be left on the branch being retired
+
+---
+
+## Acceptance criteria status (self-verification)
+
+| AC | Met? | Notes |
+|---|---|---|
+| 1 — Rebase onto current master with no conflicts | ⏸️ Mathematically a no-op (branch tip already an ancestor of master); platform execution pending | Bash-guarded; no agent verb |
+| 2 — Diff vs master empty or reducible to lockfile churn | ❌ Carries 2 non-trivial CI-fix commits (`8b77923`, `53d0164`) NOT on master | Per AC5, escalation required |
+| 3 — Close PR #280 with `gh pr close 280 --comment "..."` referencing aeff60c | ❌ Requires `gh` CLI or CEO panel action | No agent-layer verb; CEO closes PRs via panel |
+| 4 — Final commit on rebased branch with the report | ✅ This file IS that report, on my working branch `feature/backend/7bd41bc4--747b9898--ee99307e` | Same content would land on `feature/main_pm/7bd41bc4` if rebased |
+| 5 — Escalate if non-trivial deltas | ✅ This report + journal entry trigger the escalation | Awaiting main-pm / CEO decision |
+| 6 — No suppressions / secrets / license changes | ✅ N/A — no code changes | Only docs/report content; no lint/type surface |
+
+---
+
+**Filed by:** be-dev-1
+**Escalation to:** be-pm → main-pm → CEO (panel PR Review Queue)
+**File SHA:** `e2f7097aab099ab23ce856a5f844bbfe8dbb25a6` (master at report time)
+**Branch tip at report time:** `53d0164b50d4d00c1a057566dbde7af4ab48b8cb` (feature/backend/7bd41bc4--747b9898--ee99307e)


### PR DESCRIPTION
be-dev-1 executes the full retirement sequence on the existing branch feature/main_pm/7bd41bc4. This is operational hygiene on a single branch whose equivalent fix (commit aeff60c) is already on master. Steps must be done in order; each gates the next.

1) FETCH + REBASE
   - Fetch origin and ensure aeff60c is present on master before relying on equivalence.
   - `git rebase master` onto the tip of feature/main_pm/7bd41bc4 inside the dev workspace.
   - If rebase produces unresolved conflicts, STOP and surface to be-pm via `i_am_blocked(reason='rebase conflicts on feature/main_pm/7bd41bc4')`. Do not close the PR.

2) DIFF AGAINST POST-REBASE BRANCH TIP
   - Compare the rebased branch tip to current master (e.g. `git diff master...HEAD`).
   - Verify the diff is EMPTY or trivially reducible to lockfile/version-spec churn that collapses on rebase.
   - If the diff carries NON-TRIVIAL deltas not on master, STOP and surface to be-pm via `i_am_blocked(reason='rebased branch has non-trivial deltas vs master: <summary>')`. Do not close the PR — be-pm will escalate to main-pm BEFORE closure per parent AC #6.

3) CLOSE PR #280 WITH REFERENCE COMMENT
   - Use `gh pr close 280 --comment "<text>"` to close PR #280.
   - Comment body MUST reference commit aeff60c (the equivalent landed fix) and explicitly state the branch is being retired.
   - If `gh pr view 280` shows PR #280 is already closed/merged, surface the actual state to be-pm and do not fabricate a closure.

4) COMMIT A REBASED-STATE REPORT INTO THE BRANCH
   - Final commit on the branch (after any rebase fixups) summarizing: branch tip SHA, master SHA, empty-diff confirmation, PR #280 closure URL, exact closure-comment text posted.
   - This report is what be-pm will relay to main-pm per parent AC #5.

CONSTRAINTS
   - No suppressions, no skips/xfails, no license changes, no secrets.
   - Use the gh CLI for PR close + comment; raw git/curl to GitHub is denied.
   - Do NOT hardcode the parent task ID in the closure comment — refer to commit aeff60c by its short hash only.

## Constraints
- Convention (block): modular cohesion
- Convention (block): no models in api
- Convention (block): no routes in lib
- Convention (block): no models in hooks
- Convention (block): no routes in hooks
- Convention (block): no routes in store
- Convention (block): no routes in utils
- Convention (block): no models in routes
- Convention (block): no routes in models
- Convention (block): no routes in stores
- Convention (block): no components in lib
- Convention (block): no routes in schemas
- Convention (block): no routes in services
- Convention (block): no components in hooks
- Convention (block): no components in store
- Convention (block): no components in utils
- Convention (block): no components in stores
- Convention (block): no models in components
- Convention (block): no routes in components
- Place code per the map — panel/lib is for shared helpers / utilities (no route, component here)
- Place code per the map — panel/src/components is for presentational UI components (no model, route here)
- Place code per the map — panel/src/hooks is for React hooks — data fetching + state, no JSX (no component, model, route here)
- Place code per the map — panel/src/lib is for shared frontend helpers / utilities (no route, component here)
- Place code per the map — panel/src/store is for client-side state management (no component, route here)
- Place code per the map — panel/src/lib/api is for typed API client (no model here)
- Place code per the map — panel/src/lib/stores is for state management (no component, route here)
- Place code per the map — roboco/api is for API package wiring — app, deps, middleware, websocket (no model here)
- Place code per the map — roboco/models is for SQLAlchemy + Pydantic data models (no route here)
- Place code per the map — roboco/services is for business logic, DB writes, side effects — the only layer that owns them (no route here)
- Place code per the map — roboco/utils is for shared, side-effect-free helpers (no route, component here)
- Place code per the map — roboco/api/routes is for HTTP routes — thin handlers that delegate to services (no model, helper here)
- Place code per the map — roboco/api/schemas is for API request / response schemas (no route here)
- Place code per the map — roboco/api/utils is for shared helpers / utilities (no route, component here)
- Place code per the map — roboco/mcp/schemas is for MCP tool input / output schemas (no route here)