### PR TITLE
[be-dev-1] Investigate non-coverage make-quality gates on roboco-api master — all 14 already green, no fix needed

### DIFF
--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -16,4 +16,10 @@ RoboCo measures what the company spends and how it's performing, and shows both 
 
     The health and readiness probes, and the delivery-performance metrics — velocity, blockers, and team health.
 
+-   **[Non-coverage `make quality` investigation (2026-06-26)](quality-gates-investigation-2026-06-26.md)**
+
+    ---
+
+    Gate-by-gate result of an investigation into the non-coverage `make quality` gates on master HEAD at `e2f7097` — all 14 gates exit 0, no fix needed in this scope.
+
 </div>

--- a/docs/operations/quality-gates-investigation-2026-06-26.md
+++ b/docs/operations/quality-gates-investigation-2026-06-26.md
@@ -1,0 +1,40 @@
+# Non-coverage `make quality` gate investigation — 2026-06-26
+
+**Scope:** Every gate in `make quality` except the pytest/coverage step. **Master HEAD at time of investigation:** `e2f7097` (Persist the PM-respawn counter across orchestrator restarts). **Workspace:** `/data/workspaces/roboco-api/backend/be-dev-1`. **Outcome:** All non-coverage gates already exit `0`. **No code change required.**
+
+## Gate-by-gate result
+
+| # | Gate | Command (from `Makefile`) | Exit | Notes |
+|---|------|---------------------------|------|-------|
+| 1 | ruff format | `uv run ruff format --check .` | 0 | 854 files already formatted |
+| 2 | ruff check | `uv run ruff check .` | 0 | "All checks passed!" |
+| 3 | reflow_md | `uv run python scripts/reflow_md.py --check` | 0 | "OK: no hard-wrapped markdown prose in scope." |
+| 4 | mypy | `uv run mypy roboco/ tests/` | 0 | "Success: no issues found in 849 source files" |
+| 5 | xenon | `uv run xenon --max-absolute B --max-modules A --max-average A roboco/` | 0 | no output, exit 0 |
+| 6 | radon mi | `uv run radon mi roboco/ -nc -s` | 0 | 6 files listed at C-grade (see note); `-s` only displays MI values, does not fail |
+| 7 | radon cc | `uv run radon cc roboco -nc` | 0 | 4617 blocks, average A (2.92) |
+| 8 | vulture | `uv run vulture roboco/ tests/ vulture_whitelist.py --min-confidence 100` | 0 | no dead-code hits |
+| 9 | bandit | `uv run bandit -r roboco/ -ll` | 0 | 0 issues identified (1 nosec waiver, 55 low-severity display) |
+| 10 | pip-audit | `uv run pip-audit --ignore-vuln CVE-2025-3000` | 0 | no known vulnerabilities; documented torch JIT waiver applies |
+| 11 | deptry | `uv run deptry roboco/` | 0 | "Success! No dependency issues found." |
+| 12 | alembic --sql | `uv run alembic upgrade head --sql > /dev/null` | 0 | migrations parse successfully |
+| 13 | import-linter | `uv run lint-imports` | 0 | 2 contracts kept, 0 broken |
+| 14 | foundation-check | `make foundation-check` | 0 | lifecycle artifacts stable; postgres enum-parity skip-on-no-DB |
+
+## Note on `radon mi`
+
+The `-s` flag in `radon mi` is "show the actual MI value in results" (display), **not** "fail on low MI". With the default `-n A` (minimum A) and `-x C` (maximum C) display range, files at C-grade are listed for visibility but the gate does not fail. The 6 files at C-grade on master HEAD are:
+
+- `roboco/api/routes/tasks.py` (MI 7.65)
+- `roboco/runtime/orchestrator.py` (MI 0.00)
+- `roboco/services/git.py` (MI 0.00)
+- `roboco/services/optimal.py` (MI 0.00)
+- `roboco/services/task.py` (MI 0.00)
+- `roboco/services/gateway/choreographer/_impl.py` (MI 0.00)
+
+An MI of `0.00` is unusual; it indicates these files have either very high cyclomatic complexity, very low comment ratio, or both, contributing to the maintainability formula's saturation at the floor. They are pre-existing on master and are not a regression of this task; future refactors may raise them, but the gate as written does not require it.
+
+## Out of scope (intentionally not investigated here)
+
+- The pytest/coverage step in `make quality` (`uv run pytest -q --cov=roboco --cov-report=term-missing --cov-fail-under=80`) is the **coverage gate** and is owned by task `813521ad` ("Lift unit coverage on autonomous-maintenance modules to restore the 80% gate"). In this sandbox the step additionally fails for environment-specific reasons (missing `ROBOCO_ENCRYPTION_KEY` env, missing git tags) which CI resolves.
+- `panel-gate` / `panel-quality` (Next.js) is a separate gate owned by the frontend cell.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,7 @@ nav:
       - operations/index.md
       - Cost & usage: operations/cost-and-usage.md
       - Health & metrics: operations/health-and-metrics.md
+      - Quality gates investigation (2026-06-26): operations/quality-gates-investigation-2026-06-26.md
   - Optional Subsystems:
       - optional/index.md
       - Architectural Conventions: optional/conventions.md


### PR DESCRIPTION
## Summary

Investigation found all 14 non-coverage `make quality` gates already exit 0 on master HEAD (`e2f7097`). **No code fix was needed in this scope.** The only failure inside `make quality` is the pytest/coverage step, which is owned by a separate in-flight task (`813521ad` "Lift unit coverage on autonomous-maintenance modules to restore the 80% gate") and is out of scope for "non-coverage gates".

## Gates investigated (master HEAD `e2f7097`)

| # | Gate | Exit | Notes |
|---|------|------|-------|
| 1 | ruff format --check | 0 | 854 files already formatted |
| 2 | ruff check | 0 | All checks passed |
| 3 | reflow_md.py --check | 0 | No hard-wrapped markdown prose |
| 4 | mypy roboco/ tests/ | 0 | 849 source files, no issues |
| 5 | xenon | 0 | No output, exit 0 |
| 6 | radon mi | 0 | 6 files at C-grade (see investigation note); `-s` displays MI, does not fail |
| 7 | radon cc | 0 | 4617 blocks, average A (2.92) |
| 8 | vulture | 0 | No dead-code hits |
| 9 | bandit | 0 | No issues identified (1 documented nosec waiver, 55 low-severity display) |
| 10 | pip-audit | 0 | No known vulnerabilities; documented CVE-2025-3000 torch waiver applies |
| 11 | deptry | 0 | No dependency issues |
| 12 | alembic upgrade --sql | 0 | Migrations parse successfully |
| 13 | import-linter | 0 | 2 contracts kept, 0 broken |
| 14 | foundation-check | 0 | Lifecycle artifacts stable; postgres enum-parity skip-on-no-DB |

## What was red

**None.** No non-coverage gate was red on master HEAD.

## What changed

This PR only adds the investigation note itself — `docs/operations/quality-gates-investigation-2026-06-26.md` (new file) and an entry in `docs/operations/index.md` linking to it. No code, no tests, no Makefile, no pyproject, no uv.lock, no conventions file.

## No masking suppressions

- Zero new pytest.mark.skip / xfail
- Zero commented-out tests
- Zero `if False:` guards
- Zero new # noqa / # type: ignore
- Zero --cov-fail-under floor changes
- Zero widened test assertions
- Zero .roboco/conventions.yml modifications
- Zero dep version changes
- No lifecycle-artifact drift (foundation-check artifacts are stable on master)

## Out of scope (intentionally untouched)

- The pytest/coverage step in `make quality` is the **coverage gate** and is owned by task `813521ad` ("Lift unit coverage on autonomous-maintenance modules to restore the 80% gate"). In this sandbox it additionally fails for environment-specific reasons (missing `ROBOCO_ENCRYPTION_KEY`, missing git tags) which CI resolves.
- `panel-gate` / `panel-quality` (Next.js) is a separate gate owned by the frontend cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)