### PR TITLE
Fix god-mode status override (panel sends force:true)

### DIFF
--- a/panel/src/components/tasks/task-detail/__tests__/task-header-godmode.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/task-header-godmode.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+// God-mode status override: forcing a task into a hatch/terminal state via the
+// header Select must send `force: true`, else the backend refuses the PATCH
+// with 400 (the lifecycle-bypass acknowledgement added by the gap sweep).
+
+const { mutateAsync } = vi.hoisted(() => ({
+  mutateAsync: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useUpdateTask: () => ({ mutateAsync, isPending: false }),
+  useDeleteTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  // Empty valid-transitions => every other status is a god-mode override.
+  useTaskValidTransitions: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Make the Select testable without Radix's portal/pointer machinery: each
+// SelectItem renders a button carrying its value; clicking it invokes the
+// nearest Select's onValueChange (scoped via context so the status Select and
+// the team Select don't cross-fire).
+vi.mock("@/components/ui/select", () => {
+  const Ctx = React.createContext<(v: string) => void>(() => {});
+  return {
+    Select: ({
+      onValueChange,
+      children,
+    }: {
+      onValueChange?: (v: string) => void;
+      children: React.ReactNode;
+    }) => (
+      <Ctx.Provider value={onValueChange ?? (() => {})}>{children}</Ctx.Provider>
+    ),
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectValue: () => null,
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectItem: ({
+      value,
+      children,
+    }: {
+      value: string;
+      children: React.ReactNode;
+    }) => {
+      const onValueChange = React.useContext(Ctx);
+      return (
+        <button data-value={value} onClick={() => onValueChange(value)}>
+          {children}
+        </button>
+      );
+    },
+  };
+});
+
+import { TaskHeader } from "../task-header";
+
+function buildTask(): Task {
+  return {
+    id: "t1",
+    title: "Wedged task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+  } as unknown as Task;
+}
+
+describe("TaskHeader god-mode status override", () => {
+  it("sends force: true when forcing a hatch/terminal status", async () => {
+    const { container } = render(<TaskHeader task={buildTask()} />);
+    const btn = container.querySelector<HTMLButtonElement>(
+      `[data-value="${TaskStatus.COMPLETED}"]`,
+    );
+    expect(btn).not.toBeNull();
+    btn?.click();
+    await vi.waitFor(() =>
+      expect(mutateAsync).toHaveBeenCalledWith({
+        taskId: "t1",
+        updates: { status: TaskStatus.COMPLETED, force: true },
+      }),
+    );
+  });
+});

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -236,10 +236,13 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
     // reopening a `cancelled` task). Audited via PATCH /tasks/{id} {status} ->
     // admin_set_status. No PR merge / lifecycle side effects fire — this is a
     // pure, operator-driven state correction the CEO is entitled to make.
+    // `force: true` is the explicit acknowledgement the backend requires to
+    // override into a hatch state (awaiting_*, completed, cancelled) or to
+    // resurrect a terminal task; without it the PATCH is refused with 400.
     try {
       await updateTask.mutateAsync({
         taskId: task.id,
-        updates: { status: newStatus },
+        updates: { status: newStatus, force: true },
       });
       toast.success(`Status forced to ${statusLabels[newStatus]}`);
     } catch {


### PR DESCRIPTION
## Live bug
Forcing a task's status from the task page (god-mode Select) fails with **400 Bad Request** — `PATCH /api/tasks/{id}`. God-mode is effectively gone.

## Root cause
The 230-gap sweep added a backend safety gate: overriding a task into a **hatch state** (`awaiting_qa` / `awaiting_documentation` / `awaiting_pr_review` / `awaiting_pm_review` / `awaiting_ceo_approval` / `completed` / `cancelled`) or **resurrecting a terminal task** now requires an explicit `"force": true` in the PATCH body (`_apply_forced_status_override`, `tasks.py` → 400 otherwise). The **kanban** bypass path was updated to send `force: true`; the **task-header status Select** was missed — it still sent `{ status }` alone.

## Fix
`task-header.tsx` `handleStatusChange` god-mode branch now sends `{ status, force: true }`. That branch only runs when the target is NOT a valid in-band transition (the true god-mode override), which is exactly when the acknowledgement is required. One-line payload change + a focused test locking the payload (mirrors the existing kanban-bypass contract test).

`page.tsx`'s `start-revision` path (needs_revision→in_progress) is unaffected — `in_progress` isn't a hatch state and `needs_revision` isn't a resurrect source, so it doesn't hit the gate.

## Verification
- New test `task-header-godmode.test.tsx` green; panel `tsc --noEmit` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)