### PR TITLE
MinIO chunk 5: deployment note (RAG pointer)

### DIFF
--- a/docs/rag/architecture/minio-storage.md
+++ b/docs/rag/architecture/minio-storage.md
@@ -22,7 +22,7 @@ Config fields, the `minio` dependency, and the compose services (`minio` + `mini
 
 ## Planned end state (later chunks)
 
-- **Deployment note.** `docs/deploy/deployment.mdx` operator note: optional `mc cp --recursive` backfill of existing renders into MinIO, how to point a dev env at MinIO, and the default-off state. Deferred to chunk 5.
+- (none — the deployment note landed in chunk 5; see docs.roboco.tech/deploy/deployment)
 
 ## Why not presigned URLs
 


### PR DESCRIPTION
Final chunk of the MinIO stack. Docs-only: marks the deployment-note item in the RAG doc as landed (the note itself lives in docs.roboco.tech/deploy/deployment, extended in website PR #7). No code change.

Stack: #308 (chunk 1) → #309 (chunk 2) → #310 (chunk 3) → #311 (chunk 4) → this.