### PR TITLE
[55376b8a] Create page-scoped refresh provider and context

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -10,6 +10,7 @@ Documentation for the Frontend Cell team.
 ## Contents
 
 - `/components/` - Component documentation
+  - [Page-scoped refresh provider](./components/page-refresh-provider.md) — `PageRefreshProvider` and `PageRefreshContext` for route-scoped refresh actions.
 - `/qa/` - QA-related docs
 
 ## Contributing

--- a/docs/frontend/components/page-refresh-provider.md
+++ b/docs/frontend/components/page-refresh-provider.md
@@ -1,0 +1,117 @@
+# Page-scoped refresh provider
+
+A React Context + provider that lets global UI trigger a refresh action that is scoped to whichever page the user is currently viewing.
+
+## Purpose
+
+The panel has several pages that each fetch their own data. A global refresh button in the navbar needs to re-fetch data for the *current* page without invalidating every other page's React Query cache. `PageRefreshProvider` maintains a registry of scope-keyed refresh callbacks and an "active scope", so the refresh button can call the right handler for the current page.
+
+## Files
+
+| File | Role |
+|------|------|
+| `panel/src/store/page-refresh-context.ts` | Context value type (`PageRefreshContextValue`), callback type (`RefreshCallback`), and the raw React context object (`PageRefreshContext`). |
+| `panel/src/components/page-refresh-provider.tsx` | Provider component that manages scope registration, active scope, and dispatch. |
+| `panel/src/components/providers.tsx` | Root provider stack; wraps the app in `PageRefreshProvider`. |
+| `panel/src/components/__tests__/page-refresh-provider.test.tsx` | Unit tests for registration, active scope, explicit scope, unregister, and multi-scope isolation. |
+
+## API
+
+### `PageRefreshContextValue`
+
+```ts
+interface PageRefreshContextValue {
+  activeScope: string | null;
+  setActiveScope: (scope: string | null) => void;
+  register: (scope: string, callback: RefreshCallback) => void;
+  unregister: (scope: string) => void;
+  refresh: (scope?: string) => Promise<void>;
+}
+```
+
+- `activeScope` — the scope currently considered active, or `null` if none.
+- `setActiveScope` — mark a scope as active (e.g. on page mount) or clear it.
+- `register(scope, callback)` — associate a refresh callback with a scope.
+- `unregister(scope)` — remove a previously registered callback.
+- `refresh(scope?)` — invoke the callback for the given scope, or the active scope if none is provided. Does nothing when there is no target scope.
+
+### `RefreshCallback`
+
+```ts
+type RefreshCallback = () => void | Promise<void>;
+```
+
+May be sync or async; `refresh` always returns a Promise and awaits async callbacks.
+
+## How to consume
+
+> **Note:** the public `usePageRefresh` hook that wraps this context is being added in a sibling task. Until that lands, import the context directly only in the hook or in tests.
+
+Pages that want to expose a refresh action should:
+
+1. Pick a stable scope string, usually matching the route or feature (e.g. `"dashboard"`, `"tasks"`).
+2. Register a callback that performs the refresh (typically invalidating/re-fetching React Query cache keys for that page).
+3. Set that scope as active while the page is mounted.
+4. Unregister and clear the active scope on unmount.
+
+Example pattern using the raw context (to be replaced by the sibling `usePageRefresh` hook):
+
+```tsx
+"use client";
+
+import { useContext, useEffect } from "react";
+import { PageRefreshContext } from "@/store/page-refresh-context";
+
+export default function TasksPage() {
+  const ctx = useContext(PageRefreshContext);
+
+  useEffect(() => {
+    if (!ctx) return;
+    ctx.register("tasks", async () => {
+      // trigger the page-specific refetch
+    });
+    ctx.setActiveScope("tasks");
+    return () => {
+      ctx.unregister("tasks");
+      ctx.setActiveScope(null);
+    };
+  }, [ctx]);
+
+  return <div>{/* page content */}</div>;
+}
+```
+
+## Design decisions
+
+- **Split between `store/` and `components/`**: the context value type lives in `src/store/` (state-management layer) and the JSX provider lives in `src/components/`, matching the panel's architectural boundary that keeps state primitives out of component folders and JSX out of the store layer.
+- **React Context over Zustand**: the state is transient and tightly coupled to the React tree (mount/unmount lifecycle), so Context is the lighter, clearer fit.
+- **Scope registry keyed by string**: allows multiple pages to register independently. Only the active scope's callback is invoked by default, so unrelated pages are not refreshed.
+- **No React Query invalidation inside the provider**: the provider is deliberately dumb about *how* a page refreshes. Each page owns its refresh logic, keeping concerns separated.
+
+## Testing
+
+Run the provider tests with the panel test suite:
+
+```bash
+cd panel
+pnpm test page-refresh-provider
+```
+
+Covered behaviors:
+
+- Default active scope is `null`.
+- Registering a callback and setting the active scope makes `refresh()` invoke it.
+- `refresh("explicit-scope")` invokes the callback for that scope regardless of the active scope.
+- Unregistering prevents the callback from being called.
+- `refresh()` is a no-op when no active scope is set and no explicit scope is passed.
+- `setActiveScope` updates and clears the active scope.
+- Multiple scopes can be registered independently; only the active scope is refreshed by default.
+
+## Related work
+
+- Sibling task: **Add public `usePageRefresh` hook** — wraps this context in a friendly hook with cleanup.
+- Sibling task: **Add navbar refresh button and remove inline dashboard refresh buttons** — the consumer of this provider.
+
+## Migration / rollout
+
+No migration needed. The provider is added at the root of the provider stack in `panel/src/components/providers.tsx` and does not change existing data fetching behavior until a page registers its own refresh callback.

--- a/panel/src/components/__tests__/page-refresh-provider.test.tsx
+++ b/panel/src/components/__tests__/page-refresh-provider.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useContext, type ReactNode } from "react";
+import { PageRefreshProvider } from "@/components/page-refresh-provider";
+import {
+  PageRefreshContext,
+  type PageRefreshContextValue,
+} from "@/store/page-refresh-context";
+
+function usePageRefreshContextValue(): PageRefreshContextValue {
+  const context = useContext(PageRefreshContext);
+  if (!context) {
+    throw new Error("PageRefreshContext not provided");
+  }
+  return context;
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <PageRefreshProvider>{children}</PageRefreshProvider>;
+}
+
+describe("PageRefreshProvider", () => {
+  it("exposes null active scope by default", () => {
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    expect(result.current.activeScope).toBeNull();
+  });
+
+  it("registers and triggers a refresh callback for the active scope", async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.register("dashboard", callback);
+      result.current.setActiveScope("dashboard");
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers the callback for an explicit scope", async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.register("tasks", callback);
+    });
+
+    await act(async () => {
+      await result.current.refresh("tasks");
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call a callback after it is unregistered", async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.register("agents", callback);
+      result.current.setActiveScope("agents");
+      result.current.unregister("agents");
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when no active scope is set and no explicit scope is passed", async () => {
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.activeScope).toBeNull();
+  });
+
+  it("updates active scope through setActiveScope", () => {
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.setActiveScope("insights");
+    });
+
+    expect(result.current.activeScope).toBe("insights");
+
+    act(() => {
+      result.current.setActiveScope(null);
+    });
+
+    expect(result.current.activeScope).toBeNull();
+  });
+
+  it("allows multiple scopes to be registered independently", async () => {
+    const dashboardCallback = vi.fn();
+    const tasksCallback = vi.fn();
+    const { result } = renderHook(() => usePageRefreshContextValue(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.register("dashboard", dashboardCallback);
+      result.current.register("tasks", tasksCallback);
+      result.current.setActiveScope("dashboard");
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(dashboardCallback).toHaveBeenCalledTimes(1);
+    expect(tasksCallback).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.setActiveScope("tasks");
+    });
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(dashboardCallback).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(tasksCallback).toHaveBeenCalledTimes(1));
+  });
+});

--- a/panel/src/components/page-refresh-provider.tsx
+++ b/panel/src/components/page-refresh-provider.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import {
+  PageRefreshContext,
+  type RefreshCallback,
+} from "@/store/page-refresh-context";
+
+/**
+ * Provides page-scoped refresh state to the application.
+ *
+ * Pages or page-level components register a refresh callback keyed by scope.
+ * The active scope is tracked independently so that global UI (e.g. a navbar
+ * refresh button) can trigger the refresh handler for whatever page the user is
+ * currently viewing.
+ */
+export function PageRefreshProvider({ children }: { children: ReactNode }) {
+  const [activeScope, setActiveScope] = useState<string | null>(null);
+  const [callbacks, setCallbacks] = useState<Map<string, RefreshCallback>>(
+    () => new Map(),
+  );
+
+  const register = useCallback((scope: string, callback: RefreshCallback) => {
+    setCallbacks((prev) => {
+      const next = new Map(prev);
+      next.set(scope, callback);
+      return next;
+    });
+  }, []);
+
+  const unregister = useCallback((scope: string) => {
+    setCallbacks((prev) => {
+      const next = new Map(prev);
+      next.delete(scope);
+      return next;
+    });
+  }, []);
+
+  const refresh = useCallback(
+    async (scope?: string) => {
+      const target = scope ?? activeScope;
+      if (!target) return;
+
+      const callback = callbacks.get(target);
+      if (callback) {
+        await callback();
+      }
+    },
+    [callbacks, activeScope],
+  );
+
+  const value = useMemo(
+    () => ({
+      activeScope,
+      setActiveScope,
+      register,
+      unregister,
+      refresh,
+    }),
+    [activeScope, register, unregister, refresh],
+  );
+
+  return (
+    <PageRefreshContext.Provider value={value}>
+      {children}
+    </PageRefreshContext.Provider>
+  );
+}

--- a/panel/src/components/providers.tsx
+++ b/panel/src/components/providers.tsx
@@ -5,6 +5,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ThemeProvider } from "next-themes";
 import { useState } from "react";
 import { Toaster } from "@/components/ui/sonner";
+import { PageRefreshProvider } from "@/components/page-refresh-provider";
 import { useAgentRosterSync } from "@/hooks/use-agents";
 
 // Keeps the agent display-name resolver (agent-utils) in sync with the live
@@ -36,20 +37,22 @@ export function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-    >
-      <QueryClientProvider client={queryClient}>
-        <AgentRosterSync />
-        {children}
-        <Toaster position="top-right" />
-        {process.env.NODE_ENV === "development" && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )}
-      </QueryClientProvider>
-    </ThemeProvider>
+    <PageRefreshProvider>
+      <ThemeProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+      >
+        <QueryClientProvider client={queryClient}>
+          <AgentRosterSync />
+          {children}
+          <Toaster position="top-right" />
+          {process.env.NODE_ENV === "development" && (
+            <ReactQueryDevtools initialIsOpen={false} />
+          )}
+        </QueryClientProvider>
+      </ThemeProvider>
+    </PageRefreshProvider>
   );
 }

--- a/panel/src/store/page-refresh-context.ts
+++ b/panel/src/store/page-refresh-context.ts
@@ -1,0 +1,41 @@
+import { createContext } from "react";
+
+/**
+ * Callback invoked when the user requests a refresh for a registered page scope.
+ * May be synchronous or asynchronous.
+ */
+export type RefreshCallback = () => void | Promise<void>;
+
+/**
+ * Value exposed by PageRefreshProvider. Pages register their scope-specific
+ * refresh handler; callers such as the navbar refresh button trigger the
+ * active scope's handler.
+ */
+export interface PageRefreshContextValue {
+  /** The scope currently considered active, or null if none. */
+  activeScope: string | null;
+
+  /** Mark a scope as active (e.g. on page mount) or clear it. */
+  setActiveScope: (scope: string | null) => void;
+
+  /** Register a refresh callback for the given scope. */
+  register: (scope: string, callback: RefreshCallback) => void;
+
+  /** Remove a previously registered refresh callback. */
+  unregister: (scope: string) => void;
+
+  /**
+   * Trigger the refresh callback for a specific scope.
+   * If no scope is provided, the active scope is refreshed.
+   */
+  refresh: (scope?: string) => Promise<void>;
+}
+
+/**
+ * React context for page-scoped refresh state. Consumers should use the public
+ * `usePageRefresh` hook (added in a sibling task) rather than reading this
+ * context directly.
+ */
+export const PageRefreshContext = createContext<PageRefreshContextValue | null>(
+  null,
+);


### PR DESCRIPTION
fe-dev-1 adds a React Context provider under the state-management layer that owns a page-scoped refresh registry. The provider tracks which page component is currently active, exposes a trigger that dispatches only to the active page's registered callback, and never invalidates React Query caches or performs a browser reload. It exports PageRefreshProvider and an internal context hook.

## Constraints
- Convention (block): modular cohesion
- Convention (block): no models in api
- Convention (block): no routes in lib
- Convention (block): no models in hooks
- Convention (block): no routes in hooks
- Convention (block): no routes in store
- Convention (block): no routes in utils
- Convention (block): no models in routes
- Convention (block): no routes in models
- Convention (block): no routes in stores
- Convention (block): no components in lib
- Convention (block): no routes in schemas
- Convention (block): no routes in services
- Convention (block): no components in hooks
- Convention (block): no components in store
- Convention (block): no components in utils
- Convention (block): no components in stores
- Convention (block): no models in components
- Convention (block): no routes in components
- Place code per the map — docs-redirects/api is for HTTP routes / endpoint definitions (no model, helper here)
- Place code per the map — docs-redirects/models is for data models / schemas (no route here)
- Place code per the map — panel/lib is for shared helpers / utilities (no route, component here)
- Place code per the map — panel/src/components is for presentational UI components (no model, route here)
- Place code per the map — panel/src/hooks is for React hooks — data fetching + state, no JSX (no component, model, route here)
- Place code per the map — panel/src/lib is for shared frontend helpers / utilities (no route, component here)
- Place code per the map — panel/src/store is for client-side state management (no component, route here)
- Place code per the map — panel/src/lib/api is for typed API client (no model here)
- Place code per the map — panel/src/lib/stores is for state management (no component, route here)
- Place code per the map — roboco/api is for API package wiring — app, deps, middleware, websocket (no model here)
- Place code per the map — roboco/models is for SQLAlchemy + Pydantic data models (no route here)
- Place code per the map — roboco/services is for business logic, DB writes, side effects — the only layer that owns them (no route here)
- Place code per the map — roboco/utils is for shared, side-effect-free helpers (no route, component here)
- Place code per the map — roboco/api/routes is for HTTP routes — thin handlers that delegate to services (no model, helper here)
- Place code per the map — roboco/api/schemas is for API request / response schemas (no route here)
- Place code per the map — roboco/api/utils is for shared helpers / utilities (no route, component here)
- Place code per the map — roboco/mcp/schemas is for MCP tool input / output schemas (no route here)