### PR TITLE
chore(docker): lean images — drop unused playwright, dedupe grok layer, cache-stable layering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,6 +46,11 @@ data/
 logs/
 *.log
 
+# Gitignored working notes — leak into the orchestrator's COPY docs layer from
+# a CEO working tree that has them checked out locally, causing env-dependent
+# cache keys (docs/rag/ + docs/map/ are NOT ignored — the agent-facing corpus).
+docs/internal/
+
 # VCS and editor cruft
 .idea
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **Leaner agent/orchestrator images (~1.65GB less, cache-stable deploys).** Playwright + its Chromium and system libs are gone from `agent-dev-fe`/`agent-qa-fe` (~770MB each — verified unused repo-wide: panel tests are vitest, the e2e harness is scripted Python; browser-based FE QA is a designed follow-up, and the re-add is two lines scoped to `chromium-headless-shell` in the QA image only). The `agent-grok` image drops a redundant `chown -R` that duplicated the entire 149MB CLI tree into a second layer. The runner-stage `/app` COPY in `agent-base` and `orchestrator` is split `.venv`-first/source-last, so a source-only deploy re-layers ~13MB instead of ~380MB per image, and `agent-base`'s single 813MB apt+node+claude-code RUN is split so a CLI version bump no longer re-downloads the OS/node layer. Hygiene: gitignored `docs/internal/` no longer leaks into the orchestrator image from a working-tree build, and the `uv` helper image is pinned (`0.11`) instead of `:latest`. All four rebuilt images pass runtime probes (claude/git/jq/node/uv/pnpm/grok binaries, `import roboco`, docs/alembic/agents trees present); cache-stability proven by rebuild log (`.venv` layer CACHED across a source-only change).
+
 ## [0.19.0] - 2026-07-08
 
 ### Added

--- a/docker/agent-base.Dockerfile
+++ b/docker/agent-base.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -45,10 +45,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates git gnupg jq build-essential \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
-    && npm install -g @anthropic-ai/claude-code \
-    && npm cache clean --force \
     && apt-get purge -y --auto-remove gnupg \
-    && rm -rf /var/lib/apt/lists/* /root/.npm /tmp/*
+    && rm -rf /var/lib/apt/lists/*
+
+# Split from the apt layer above: this churns with every claude-code CLI
+# release, while the OS/node layer above stays stable across those bumps.
+RUN npm install -g @anthropic-ai/claude-code \
+    && npm cache clean --force \
+    && rm -rf /root/.npm /tmp/*
 
 RUN useradd -m -s /bin/bash agent
 
@@ -56,12 +60,17 @@ RUN useradd -m -s /bin/bash agent
 # `uv run python -m roboco.mcp.<server>`. Without it, all 10 roboco MCP
 # servers fail to start and the agent falls back to raw HTTP, losing every
 # guardrail and inline schema the MCP layer provides.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
-# Copy the pre-built venv + source from builder, owned by agent user
-COPY --from=builder --chown=agent:agent /app /app
+# Copy the pre-built venv + source from builder, owned by agent user.
+# .venv first (invalidated only by pyproject.toml/uv.lock changes via the
+# builder's own dep-then-project split), source dirs last so an app-code-only
+# change doesn't bust the much larger .venv layer's cache.
+COPY --from=builder --chown=agent:agent /app/.venv /app/.venv
+COPY --from=builder --chown=agent:agent /app/pyproject.toml /app/uv.lock /app/README.md /app/
+COPY --from=builder --chown=agent:agent /app/roboco /app/roboco
 
 # Hook scripts: 0755 so the `agent` user (not root) can read+execute them.
 # SessionStart hook runs these as agent; stricter perms break the hook with

--- a/docker/agent-dev-fe.Dockerfile
+++ b/docker/agent-dev-fe.Dockerfile
@@ -1,36 +1,14 @@
 # Frontend Developer Agent
-# React/TypeScript development with browser automation
+# React/TypeScript development
 
 FROM roboco-agent-base
 
 USER root
-
-# Playwright system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libnspr4 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libdrm2 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxrandr2 \
-    libgbm1 \
-    libasound2 \
-    libpango-1.0-0 \
-    libcairo2 \
-    && rm -rf /var/lib/apt/lists/*
 
 # Install pnpm globally
 RUN npm install -g pnpm
 
 USER agent
 
-# Install Playwright (browsers will be installed on first run or can be cached)
-RUN npx playwright install chromium
-
 LABEL role="frontend-developer"
-LABEL description="Frontend developer agent - React, TypeScript, Playwright"
+LABEL description="Frontend developer agent - React, TypeScript"

--- a/docker/agent-grok.Dockerfile
+++ b/docker/agent-grok.Dockerfile
@@ -30,10 +30,10 @@ RUN su agent -s /bin/bash -c "set -euo pipefail; export HOME=/home/agent; \
     && rm -rf /tmp/*
 
 # Entrypoint: render ~/.grok/config.toml + the per-role flags, then run grok
-# headless (overrides the base image's `claude` entrypoint).
+# headless (overrides the base image's `claude` entrypoint). ~/.grok is already
+# agent:agent-owned (installed above via `su agent`), so no chown needed here.
 COPY docker/scripts/grok-cli-agent-entrypoint.sh /app/scripts/grok-cli-agent-entrypoint.sh
-RUN chmod 0755 /app/scripts/grok-cli-agent-entrypoint.sh \
-    && chown -R agent:agent /home/agent/.grok
+RUN chmod 0755 /app/scripts/grok-cli-agent-entrypoint.sh
 
 USER agent
 

--- a/docker/agent-qa-fe.Dockerfile
+++ b/docker/agent-qa-fe.Dockerfile
@@ -1,35 +1,13 @@
 # Frontend QA Agent
-# Browser testing and accessibility tools
+# Accessibility and code-level testing tools
 
 FROM roboco-agent-base
 
 USER root
 
-# Playwright system dependencies (same as fe-dev)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libnss3 \
-    libnspr4 \
-    libatk1.0-0 \
-    libatk-bridge2.0-0 \
-    libcups2 \
-    libdrm2 \
-    libxkbcommon0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxrandr2 \
-    libgbm1 \
-    libasound2 \
-    libpango-1.0-0 \
-    libcairo2 \
-    && rm -rf /var/lib/apt/lists/*
-
 RUN npm install -g pnpm
 
 USER agent
 
-# Playwright for browser testing
-RUN npx playwright install chromium
-
 LABEL role="frontend-qa"
-LABEL description="Frontend QA agent - browser testing, accessibility, visual regression"
+LABEL description="Frontend QA agent - accessibility, code review, testing"

--- a/docker/orchestrator.Dockerfile
+++ b/docker/orchestrator.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /usr/local/bin/uv
 
 WORKDIR /app
 
@@ -71,8 +71,17 @@ RUN npm install -g pnpm
 
 WORKDIR /app
 
-# Copy the already-built venv + app tree from builder
-COPY --from=builder /app /app
+# Copy the already-built venv + app tree from builder.
+# .venv first (invalidated only by pyproject.toml/uv.lock changes via the
+# builder's own dep-then-project split), source dirs last so an app-code-only
+# change doesn't bust the much larger .venv layer's cache.
+COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/pyproject.toml /app/uv.lock /app/README.md /app/
+COPY --from=builder /app/roboco /app/roboco
+COPY --from=builder /app/agents /app/agents
+COPY --from=builder /app/docs /app/docs
+COPY --from=builder /app/alembic.ini /app/
+COPY --from=builder /app/alembic /app/alembic
 
 # uv is needed at runtime: WorkspaceService runs `uv sync` to pre-install
 # Python cell deps, and CI commands shell out to `uv run`. The builder stage


### PR DESCRIPTION
## Summary

Cuts ~1.65GB of image weight and makes routine deploys cache-stable, per the measured NAS layer audit (fleet was ~24GB, 20-min cold builds).

- **agent-dev-fe / agent-qa-fe:** remove `npx playwright install chromium` + its 17-package system-lib block (~770MB each). Verified unused repo-wide: panel tests are vitest, the e2e harness is scripted Python, no spec files, no prompt/workflow references. Browser-based FE QA is a worthwhile *future* capability — the scoped re-add (two lines, `chromium-headless-shell`, qa-fe image only) is noted in the changelog for when it's actually wired.
- **agent-grok:** the CLI install runs as the `agent` user, so the follow-up `chown -R` was a no-op that still rewrote the entire 149MB tree into a duplicate layer. Dropped.
- **agent-base + orchestrator:** runner-stage `COPY /app /app` split into `.venv`-first / source-last, so a source-only change re-layers ~13MB instead of ~380MB per image. Proven by rebuild log: `.venv` COPY reports `CACHED` across a source-only edit.
- **agent-base:** the 813MB apt+NodeSource+claude-code RUN split in two, so a Claude CLI version bump stops re-downloading node + build-essential. Every package kept (build-essential is load-bearing for the armed toolchain-match flag).
- **Hygiene:** gitignored `docs/internal/` excluded from the build context (env-dependent cache keys on the orchestrator's docs layer); uv helper image pinned `0.11` (was `:latest`).

## Verification
All four affected images rebuilt locally and runtime-probed: `claude`/`git`/`jq`/`node`/`uv`/`pnpm`/`grok` binaries, `import roboco` (0.19.0, editable venv intact), grok tree ownership, orchestrator's `/app/docs` `/app/alembic` `/app/agents` present, `docs/internal` correctly absent. Final image content for the COPY-split is byte-identical — layer boundaries only.

Deliberately untouched: `build-essential` (armed `ROBOCO_TOOLCHAIN_MATCH_ENABLED` needs it), orchestrator node/pnpm (WorkspaceService shells out to pnpm), static-ffmpeg for video-renderer (supply-chain tradeoff — parked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)