### PR TITLE
fix(release): publish via GitHub REST — gh CLI is not installed in any image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release manager publish no longer depends on a `gh` binary that was never installed.** `ReleaseExecutor.publish_release` shelled out to `gh release create`, but no image ships the gh CLI — with `ROBOCO_RELEASE_MANAGER_ENABLED` armed, every publish would have died on a missing binary after the release commit was already pushed (verified against the live 0.19.0 orchestrator container). The publish is now a GitHub REST `POST /repos/{owner}/{repo}/releases` authenticated with the project's decrypted token — the same auth + httpx pattern as PR creation — with the same fail-closed semantics (non-201 → structured `publish_failed`, CEO retries; the 300s deadline is now the HTTP client timeout).
+
 ## [0.19.0] - 2026-07-08
 
 ### Added

--- a/roboco/services/release_executor.py
+++ b/roboco/services/release_executor.py
@@ -6,7 +6,8 @@ before any publish. Idempotent: re-running an already-published version is a
 no-op. The bump/gate/commit/publish steps live behind a ``ReleaseOps`` seam so
 the fail-closed ORDERING (the correctness this feature exists to guarantee) is
 unit-tested deterministically; the production ``_GitReleaseOps`` performs the
-real git / ``make quality`` / ``gh`` work on a writable clone.
+real git / ``make quality`` work on a writable clone and publishes the GitHub
+release over REST (the orchestrator image ships no ``gh`` binary).
 """
 
 from __future__ import annotations
@@ -155,10 +156,10 @@ class ReleaseExecutor:
                 version, report.drafted_changelog
             )
         except RuntimeError as exc:
-            # ``gh release create`` failed (auth/quota/network). The commit is
-            # already pushed and CI is green, so the release is half-landed —
-            # surface it as a structured outcome (not a 500) so the CEO can
-            # retry ``gh release create`` for the same version.
+            # The GitHub release POST failed (auth/quota/network). The commit
+            # is already pushed and CI is green, so the release is half-landed
+            # — surface it as a structured outcome (not a 500) so the CEO can
+            # retry the publish for the same version.
             logger.error("release publish failed", error=str(exc)[:300])
             return ReleaseResult(
                 status="publish_failed",
@@ -166,7 +167,7 @@ class ReleaseExecutor:
                 files_changed=files,
                 commit_sha=commit_sha,
                 release_url=None,
-                detail=f"gh release create failed — not published (fail-closed): {exc}",
+                detail=f"release publish failed — not published (fail-closed): {exc}",
             )
         logger.info(
             "release published",
@@ -185,24 +186,27 @@ class ReleaseExecutor:
 
 
 # --------------------------------------------------------------------------- #
-# Production ops — real git / make / gh on a writable clone.
+# Production ops — real git / make on a writable clone; publish via REST.
 # --------------------------------------------------------------------------- #
 
 _CI_POLL_INTERVAL_SECONDS = 30
 _CI_MAX_POLLS = 80  # ~40 min ceiling
 
-# Subprocess deadlines. A hung git / make / gh would otherwise block the
+# Subprocess deadlines. A hung git / make would otherwise block the
 # CEO-gated release loop indefinitely. Each is generous enough that a
 # legitimate, slow operation is never wrongly aborted — only a true hang fails
 # closed. Mirrors the quality-gate ``_run_one`` kill-on-timeout idiom.
 _GIT_OP_TIMEOUT_SECONDS = 300  # git add/commit/rev-parse/ls-remote/push
 _RELEASE_GATE_TIMEOUT_SECONDS = 1800  # make quality — full ruff/mypy/pytest suite
-_PUBLISH_TIMEOUT_SECONDS = 300  # gh release create
+_PUBLISH_TIMEOUT_SECONDS = 300  # GitHub release POST (httpx client timeout)
 _CLONE_TIMEOUT_SECONDS = 600  # git clone / rm -rf the release clone
 
 # The conventional non-zero rc a timed-out subprocess reports so every caller's
 # fail-closed branch (rc != 0) fires instead of hanging the release loop.
 _TIMEOUT_RC = 124
+
+# GitHub REST "created" — the only success status for the release POST.
+_HTTP_CREATED = 201
 
 
 async def _await_proc(
@@ -384,32 +388,49 @@ class _GitReleaseOps:
         return False
 
     async def publish_release(self, version: str, notes: str) -> str:
+        # REST, not `gh release create` — the orchestrator image ships no gh
+        # binary, so the CLI path fails at publish time with a missing binary.
+        import httpx
+
+        from roboco.config import settings
+        from roboco.services.git import GitService
+        from roboco.services.project import ProjectService
+
         tag = f"v{version}"
-        proc = await asyncio.create_subprocess_exec(
-            "gh",
-            "release",
-            "create",
-            tag,
-            "--title",
-            tag,
-            "--notes",
-            notes,
-            "--target",
-            self._default_branch,
-            cwd=str(self._root),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+        token = await ProjectService(self._session).get_decrypted_token_by_slug(
+            self._slug
         )
-        rc, out = await _await_proc(proc, _PUBLISH_TIMEOUT_SECONDS)
-        text = out.strip()
-        if rc != 0:
-            logger.error("gh release create failed", error=text[:300])
-            raise RuntimeError(f"gh release create failed: {text[:200]}")
-        url = next(
-            (line.strip() for line in text.splitlines() if line.startswith("http")),
-            "",
-        )
-        return url
+        if not token:
+            raise RuntimeError(f"release publish failed: no git token for {self._slug}")
+        owner, repo = GitService._parse_git_url(self._git_url)
+        api_base = settings.github_api_base_url.rstrip("/")
+        try:
+            async with httpx.AsyncClient(timeout=_PUBLISH_TIMEOUT_SECONDS) as client:
+                resp = await client.post(
+                    f"{api_base}/repos/{owner}/{repo}/releases",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                    json={
+                        "tag_name": tag,
+                        "name": tag,
+                        "body": notes,
+                        "target_commitish": self._default_branch,
+                    },
+                )
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"release publish failed: {e}") from e
+        if resp.status_code != _HTTP_CREATED:
+            detail = resp.text[:200]
+            logger.error(
+                "release publish failed", status=resp.status_code, error=detail
+            )
+            raise RuntimeError(
+                f"release publish failed: HTTP {resp.status_code}: {detail}"
+            )
+        return str(resp.json().get("html_url") or "")
 
 
 def _bump_uv_lock(text: str, old: str, new: str) -> str:

--- a/tests/unit/services/test_release_executor.py
+++ b/tests/unit/services/test_release_executor.py
@@ -190,17 +190,17 @@ async def test_commit_push_failure_returns_structured_commit_failed() -> None:
 
 @pytest.mark.asyncio
 async def test_publish_failure_returns_structured_publish_failed() -> None:
-    """#88: a RuntimeError from ``gh release create`` (auth/quota/network) becomes
+    """#88: a RuntimeError from the GitHub release POST (auth/quota/network) becomes
     a structured ``publish_failed`` result. The commit is already pushed and CI
-    is green, so the release is half-landed — the CEO can retry ``gh release
+    is green, so the release is half-landed — the CEO can retry the publish
     create`` for the same version (the executor is idempotent on the commit
     side). No 500."""
-    ops = _FakeOps(publish_raises="gh release create failed: forbidden")
+    ops = _FakeOps(publish_raises="release publish failed: HTTP 403: forbidden")
     result = await ReleaseExecutor(ops).execute(_report())
     assert result.status == "publish_failed"
     assert result.commit_sha == "deadbeef"
     assert result.release_url is None
-    assert "gh release create failed" in result.detail
+    assert "release publish failed" in result.detail
     assert ops.calls.count("publish") == _ONE
 
 

--- a/tests/unit/services/test_release_executor_subprocess_timeout.py
+++ b/tests/unit/services/test_release_executor_subprocess_timeout.py
@@ -1,5 +1,5 @@
-"""``_GitReleaseOps`` subprocesses (git, ``make quality``, ``gh release create``,
-the release-clone ``git clone``) are wrapped in ``asyncio.wait_for`` with a
+"""``_GitReleaseOps`` subprocesses (git, ``make quality``, the release-clone
+``git clone``) are wrapped in ``asyncio.wait_for`` with a
 kill-on-timeout fail-close so a hung child cannot block the release loop.
 
 These tests hang the subprocess (a never-resolving ``communicate``) and patch
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
+import httpx
 import pytest
+from roboco.services.project import ProjectService
 from roboco.services.release_executor import (
     _CLONE_TIMEOUT_SECONDS,
     _GIT_OP_TIMEOUT_SECONDS,
@@ -23,12 +26,15 @@ from roboco.services.release_executor import (
     _run,
 )
 
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
 # Floors encoding the logical-regression guard: a deadline below these would
 # silently abort a legitimate slow release. Named (not magic) for ruff PLR2004.
 _MIN_GATE_TIMEOUT = 1800  # full make quality suite — ruff/mypy/pytest
 _MIN_GIT_OP_TIMEOUT = 300  # network push / ls-remote
 _MIN_CLONE_TIMEOUT = 600  # full clone on a slow link
-_MIN_PUBLISH_TIMEOUT = 120  # gh release create
+_MIN_PUBLISH_TIMEOUT = 120  # GitHub release POST (httpx client timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +105,9 @@ def _ops() -> _GitReleaseOps:
     ops._git_url = "https://github.com/o/roboco"
     ops._git_prefix = []
     ops._ci_workflow = None
+    # publish_release resolves the token via a (monkeypatched) ProjectService;
+    # the session itself is never touched in these tests.
+    ops._session = cast("AsyncSession", None)
     return ops
 
 
@@ -199,24 +208,110 @@ async def test_run_gate_times_out_returns_false(
     assert proc.killed
 
 
+class _FakeResponse:
+    def __init__(
+        self, status_code: int, body: dict[str, str] | None = None, text: str = ""
+    ) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+        self.text = text
+
+    def json(self) -> dict[str, str]:
+        return self._body
+
+
+class _FakeAsyncClient:
+    """Stands in for ``httpx.AsyncClient`` — canned response or raised error."""
+
+    response: _FakeResponse | None = None
+    raises: Exception | None = None
+    last_url: str = ""
+    last_json: dict[str, str] | None = None
+
+    def __init__(self, *args: object, **kwargs: object) -> None: ...
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+    async def post(self, url: str, **kwargs: object) -> _FakeResponse:
+        type(self).last_url = url
+        json_payload = kwargs.get("json")
+        assert json_payload is None or isinstance(json_payload, dict)
+        type(self).last_json = json_payload
+        err = type(self).raises
+        if err is not None:
+            raise err
+        resp = type(self).response
+        assert resp is not None
+        return resp
+
+
+def _patch_publish_deps(
+    monkeypatch: pytest.MonkeyPatch, token: str | None = "tok"
+) -> None:
+    async def _token(_self: ProjectService, _slug: str) -> str | None:
+        return token
+
+    monkeypatch.setattr(ProjectService, "get_decrypted_token_by_slug", _token)
+    monkeypatch.setattr("httpx.AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.response = None
+    _FakeAsyncClient.raises = None
+
+
 @pytest.mark.asyncio
-async def test_publish_release_times_out_raises(
+async def test_publish_release_posts_rest_and_returns_url(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A hung ``gh release create`` raises RuntimeError (fail-closed — never
-    reports a bogus published URL) and kills the child."""
-    monkeypatch.setattr(
-        "roboco.services.release_executor._PUBLISH_TIMEOUT_SECONDS", 0.05
-    )
-    proc = _HangingProc()
-    monkeypatch.setattr(
-        "roboco.services.release_executor.asyncio.create_subprocess_exec",
-        _exec_returning(proc),
+    """The publish is a GitHub REST POST (no ``gh`` binary in the orchestrator
+    image) hitting /repos/{owner}/{repo}/releases with the tag payload."""
+    _patch_publish_deps(monkeypatch)
+    _FakeAsyncClient.response = _FakeResponse(
+        201, body={"html_url": "https://github.com/o/roboco/releases/tag/v1.0.0"}
     )
     ops = _ops()
-    with pytest.raises(RuntimeError, match="timed out"):
-        await asyncio.wait_for(ops.publish_release("1.0.0", "notes"), timeout=2.0)
-    assert proc.killed
+    url = await ops.publish_release("1.0.0", "notes")
+    assert url.endswith("/releases/tag/v1.0.0")
+    assert _FakeAsyncClient.last_url.endswith("/repos/o/roboco/releases")
+    assert _FakeAsyncClient.last_json is not None
+    assert _FakeAsyncClient.last_json["tag_name"] == "v1.0.0"
+    assert _FakeAsyncClient.last_json["target_commitish"] == "master"
+
+
+@pytest.mark.asyncio
+async def test_publish_release_non_201_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_publish_deps(monkeypatch)
+    _FakeAsyncClient.response = _FakeResponse(422, text="already_exists")
+    ops = _ops()
+    with pytest.raises(RuntimeError, match="HTTP 422"):
+        await ops.publish_release("1.0.0", "notes")
+
+
+@pytest.mark.asyncio
+async def test_publish_release_network_error_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport error (incl. the httpx client-timeout on a hung POST) fails
+    closed as RuntimeError — never a bogus published URL."""
+    _patch_publish_deps(monkeypatch)
+    _FakeAsyncClient.raises = httpx.ReadTimeout("hung POST")
+    ops = _ops()
+    with pytest.raises(RuntimeError, match="release publish failed"):
+        await ops.publish_release("1.0.0", "notes")
+
+
+@pytest.mark.asyncio
+async def test_publish_release_no_token_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_publish_deps(monkeypatch, token=None)
+    ops = _ops()
+    with pytest.raises(RuntimeError, match="no git token"):
+        await ops.publish_release("1.0.0", "notes")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The 2026-07-08 image audit flagged, and the live 0.19.0 orchestrator container confirmed (`which gh` → nothing), that `ReleaseExecutor.publish_release` shells out to `gh release create` while **no image installs the gh CLI**. With `ROBOCO_RELEASE_MANAGER_ENABLED` armed, every publish would fail on a missing binary — *after* the release commit was already pushed, stranding the release half-landed every time (the existing `publish_failed` retry would then fail identically forever).

## Fix
`publish_release` now POSTs `/repos/{owner}/{repo}/releases` over REST, authenticated with the project's decrypted git token — the exact auth + httpx pattern `GitService._post_pr` already uses for PR creation. Owner/repo parse reuses `GitService._parse_git_url`. Fail-closed semantics preserved: non-201 or transport error → `RuntimeError` → structured `publish_failed` outcome the CEO can retry; `_PUBLISH_TIMEOUT_SECONDS` (300s) becomes the httpx client timeout. Choosing REST over installing gh keeps the orchestrator image lean (consistent with #330) and removes the binary dependency class entirely.

## Verification
- New REST-path tests replace the old subprocess-hang publish test: 201 → URL returned + correct endpoint/payload asserted; non-201 → `HTTP 422` error; transport error (incl. client timeout) → fail-closed `RuntimeError`; missing token → clear error.
- Full release suite green: **98 passed** across all 11 `test_release_*` files; `mypy roboco/ tests/` → no issues in 1081 files; ruff clean.
- The executor-seam tests (fail-closed ordering, half-landed retry) are mechanism-agnostic and pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)