### PR TITLE
[2b0d5fe8] Audit axios compatibility and open scoped PR

### DIFF
--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -14,6 +14,12 @@ declare module "axios" {
 const RATE_LIMIT_MAX_RETRIES = 3;
 
 // Create axios instance with default config
+// axios ^1.16.0 audit (2026-07-09): every call in panel/src rides this
+// browser instance (no proxy option, no maxRedirects/adapter override, no
+// manual form-data upload). axios's node-only transitives that changed with
+// this bump — follow-redirects, proxy-from-env, form-data — are exercised
+// only by axios's Node http adapter, which the panel never invokes; no
+// compatibility fix is needed here.
 const api: AxiosInstance = axios.create({
   baseURL: API_URL,
   headers: {


### PR DESCRIPTION
Building on the axios bump from the prior subtask (same branch), audit panel/src for any direct or indirect reliance on the proxy-from-env, follow-redirects, or form-data APIs that changed between axios 1.13.2 and 1.16.0 — grep for axios proxy config usage, custom adapter usage, and multipart/form-data upload calls. If a genuine incompatibility is found, apply the minimal compatibility fix required (no unrelated refactors). Then open a PR from our own branch (never the original contributor's fork that produced PR #344) with a diff scoped strictly to the dependency bump plus any minimal compatibility fixes — no unrelated changes.

Context: a prior review of the superseded PR #344 diff found the bump clean with no source changes required, so the audit is expected to confirm "no changes needed" rather than uncover a real break — but the audit itself, and the PR being opened from our branch, are still required deliverables of this task.