### PR TITLE
[68d7f3ce] Fix: navbar refresh button must actually disable when no page has registered a refresh callback

### DIFF
--- a/docs/frontend/components/page-refresh-provider.md
+++ b/docs/frontend/components/page-refresh-provider.md
@@ -32,11 +32,11 @@ interface PageRefreshState {
 }
 ```
 
-- `disabled` — whether refresh actions are currently disabled (controlled by the provider prop).
+- `disabled` — whether there are no refresh callbacks currently registered (the registry is empty). When true, clicking refresh is a no-op.
 - `loading` — whether a refresh cycle is currently running.
 - `register(callback)` — add a callback to invoke on the next refresh.
 - `unregister(callback)` — remove a previously registered callback.
-- `refresh()` — invoke every registered callback concurrently and update `loading` until they settle.
+- `refresh()` — invoke every registered callback concurrently and update `loading` until they settle. Does nothing if the registry is empty.
 
 ### `RefreshCallback`
 
@@ -51,12 +51,12 @@ May be sync or async; `refresh` always returns a `Promise` and awaits async call
 ```ts
 interface PageRefreshProviderProps {
   children: React.ReactNode;
-  disabled?: boolean;
 }
 ```
 
 - `children` — React tree that can consume the context.
-- `disabled` — when `true`, `refresh()` is ignored and `disabled` is exposed as `true`.
+
+The provider does not expose a `disabled` prop; instead, `disabled` is derived from whether any refresh callbacks are currently registered (the registry size).
 
 ## How to consume
 
@@ -98,13 +98,13 @@ export default function ProductsPage() {
 `panel/src/components/layout/header.tsx` consumes the same context:
 
 ```tsx
-const { refresh, loading } = usePageRefresh();
+const { refresh, loading, disabled } = usePageRefresh();
 
 <Button
   variant="ghost"
   size="icon"
   onClick={() => void refresh()}
-  disabled={loading}
+  disabled={disabled || loading}
   aria-label="Refresh only the current page"
   title="Refresh only the current page"
 >
@@ -112,7 +112,11 @@ const { refresh, loading } = usePageRefresh();
 </Button>
 ```
 
-The button sits between the connection-status badge and the theme toggle. It is disabled and shows a spinner while any registered refresh callback is still running. Concurrent clicks are coalesced: a second click while a cycle is in progress does nothing.
+The button sits between the connection-status badge and the theme toggle. It is disabled when:
+- No page has registered a refresh callback (the registry is empty)
+- A refresh cycle is currently running
+
+When disabled, the button is grayed out and clicking has no effect. While loading, the icon shows a spinner. Concurrent clicks are coalesced: a second click while a cycle is in progress does nothing.
 
 ## Pages wired to the navbar refresh
 
@@ -162,13 +166,14 @@ pnpm test page-refresh
 Covered behaviors:
 
 - `usePageRefresh` throws when called outside a `PageRefreshProvider`.
-- Registering callbacks makes `refresh()` invoke them.
+- The hook returns `disabled: true` when nothing is registered, and `disabled: false` once a callback is registered.
+- Registering callbacks makes `refresh()` invoke them and sets `disabled: false`.
+- Unregistering callbacks prevents the callback from being called and returns `disabled: true` when the registry is empty.
 - `refresh()` returns a promise and awaits async callbacks.
-- Unregistering prevents the callback from being called.
-- `refresh()` is a no-op when `disabled` is `true`.
+- `refresh()` is a no-op when the registry is empty (disabled).
 - The navbar button renders between the connection-status badge and the theme toggle.
 - The navbar button exposes an accessible page-scoped label.
-- The navbar button is disabled and shows a spinner while a refresh callback is running.
+- The navbar button is disabled when no callbacks are registered and shows a spinner while a refresh callback is running.
 - Concurrent clicks do not start a second refresh cycle.
 
 ## Related work

--- a/panel/README.md
+++ b/panel/README.md
@@ -59,13 +59,17 @@ The panel exposes public hooks under `@/hooks`. See [Frontend hooks](../docs/fro
 
 ### `usePageRefresh`
 
-Page-scoped refresh coordinator. Pages register data-refetch callbacks; the navbar refresh button in `src/components/layout/header.tsx` calls `refresh()` and reflects the combined `loading`/`disabled` state.
+Page-scoped refresh coordinator. Pages register data-refetch callbacks; the navbar refresh button in `src/components/layout/header.tsx` calls `refresh()` and reflects the combined `loading`/`disabled` state. The button is disabled when no callbacks are registered (the registry is empty) and while a refresh is in progress.
 
 ```tsx
 import { usePageRefresh } from "@/hooks";
 
 const { register, unregister, refresh, loading, disabled } = usePageRefresh();
 ```
+
+- `disabled` is `true` when no callbacks are registered (there is nothing to refresh)
+- `disabled` becomes `false` once a callback is registered
+- `disabled` returns to `true` when all callbacks are unregistered
 
 Wrap your page or layout in `PageRefreshProvider` from `@/components/providers` before consuming the hook. Dashboard pages should register their refetch callbacks and avoid adding inline "Refresh" buttons; see [`docs/frontend/components/page-refresh-provider.md`](../docs/frontend/components/page-refresh-provider.md) for the full wiring list and examples.
 

--- a/panel/src/components/layout/__tests__/header.test.tsx
+++ b/panel/src/components/layout/__tests__/header.test.tsx
@@ -97,6 +97,16 @@ describe("Header — navbar refresh button", () => {
     );
   });
 
+  it("disables the refresh button when no page has registered a refresh callback", () => {
+    render(withPageRefresh(<Header />));
+
+    const refreshButton = screen.getByRole("button", {
+      name: /refresh only the current page/i,
+    });
+
+    expect(refreshButton).toBeDisabled();
+  });
+
   it("shows a spinner while the registered refresh callback is running and disables the button", async () => {
     let resolveRefresh: (() => void) | undefined;
     const deferred = new Promise<void>((resolve) => {

--- a/panel/src/components/layout/header.tsx
+++ b/panel/src/components/layout/header.tsx
@@ -24,7 +24,7 @@ import { usePageRefresh } from "@/hooks";
 
 export function Header() {
   const { setTheme } = useTheme();
-  const { refresh, loading } = usePageRefresh();
+  const { refresh, loading, disabled } = usePageRefresh();
 
   return (
     <header className="flex h-16 items-center justify-between border-b bg-background px-6">
@@ -60,7 +60,7 @@ export function Header() {
           variant="ghost"
           size="icon"
           onClick={() => void refresh()}
-          disabled={loading}
+          disabled={disabled || loading}
           aria-label="Refresh only the current page"
           title="Refresh only the current page"
         >

--- a/panel/src/components/providers/__tests__/test-utils.tsx
+++ b/panel/src/components/providers/__tests__/test-utils.tsx
@@ -1,14 +1,10 @@
 import type { ReactNode } from "react";
 import { PageRefreshProvider } from "../page-refresh-provider";
 
+/**
+ * A `PageRefreshProvider` with nothing registered — `disabled` starts `true`
+ * since it is derived from the registry, not a prop.
+ */
 export function PageRefreshWrapper({ children }: { children: ReactNode }) {
   return <PageRefreshProvider>{children}</PageRefreshProvider>;
-}
-
-export function DisabledPageRefreshWrapper({
-  children,
-}: {
-  children: ReactNode;
-}) {
-  return <PageRefreshProvider disabled>{children}</PageRefreshProvider>;
 }

--- a/panel/src/components/providers/page-refresh-provider.tsx
+++ b/panel/src/components/providers/page-refresh-provider.tsx
@@ -26,8 +26,6 @@ export interface PageRefreshState {
 
 export interface PageRefreshProviderProps {
   children: React.ReactNode;
-  /** When true, refresh requests are ignored. */
-  disabled?: boolean;
 }
 
 export const PageRefreshContext = React.createContext<PageRefreshState | null>(
@@ -38,22 +36,25 @@ export const PageRefreshContext = React.createContext<PageRefreshState | null>(
  * Provides a scoped page-refresh registry for child components.
  *
  * Pages and panels can register callbacks that refetch data; UI chrome can call
- * `refresh()` and reflect the combined loading/disabled state.
+ * `refresh()` and reflect the combined loading/disabled state. `disabled` reflects
+ * whether any callback is currently registered — there's nothing to refresh when
+ * the registry is empty.
  */
-export function PageRefreshProvider({
-  children,
-  disabled = false,
-}: PageRefreshProviderProps) {
+export function PageRefreshProvider({ children }: PageRefreshProviderProps) {
   const [loading, setLoading] = React.useState(false);
+  const [registeredCount, setRegisteredCount] = React.useState(0);
   const callbacksRef = React.useRef(new Set<RefreshCallback>());
   const refreshingRef = React.useRef(false);
+  const disabled = registeredCount === 0;
 
   const register = React.useCallback((callback: RefreshCallback) => {
     callbacksRef.current.add(callback);
+    setRegisteredCount(callbacksRef.current.size);
   }, []);
 
   const unregister = React.useCallback((callback: RefreshCallback) => {
     callbacksRef.current.delete(callback);
+    setRegisteredCount(callbacksRef.current.size);
   }, []);
 
   const refresh = React.useCallback(async () => {

--- a/panel/src/hooks/__tests__/use-page-refresh.test.tsx
+++ b/panel/src/hooks/__tests__/use-page-refresh.test.tsx
@@ -2,10 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { usePageRefresh } from "../use-page-refresh";
 import { usePageRefresh as usePageRefreshPublic } from "@/hooks";
-import {
-  PageRefreshWrapper,
-  DisabledPageRefreshWrapper,
-} from "@/components/providers/__tests__/test-utils";
+import { PageRefreshWrapper } from "@/components/providers/__tests__/test-utils";
 
 describe("usePageRefresh", () => {
   it("throws when used outside a PageRefreshProvider", () => {
@@ -14,18 +11,24 @@ describe("usePageRefresh", () => {
     );
   });
 
-  it("returns disabled=false and loading=false by default", () => {
+  it("returns disabled=true and loading=false when nothing is registered", () => {
     const { result } = renderHook(() => usePageRefresh(), {
       wrapper: PageRefreshWrapper,
     });
-    expect(result.current.disabled).toBe(false);
+    expect(result.current.disabled).toBe(true);
     expect(result.current.loading).toBe(false);
   });
 
-  it("reflects the provider disabled prop", () => {
+  it("becomes enabled once a callback is registered, and disabled again once unregistered", () => {
+    const cb = vi.fn();
     const { result } = renderHook(() => usePageRefresh(), {
-      wrapper: DisabledPageRefreshWrapper,
+      wrapper: PageRefreshWrapper,
     });
+
+    act(() => result.current.register(cb));
+    expect(result.current.disabled).toBe(false);
+
+    act(() => result.current.unregister(cb));
     expect(result.current.disabled).toBe(true);
   });
 
@@ -92,13 +95,13 @@ describe("usePageRefresh", () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
-  it("does not run callbacks while disabled", async () => {
+  it("does not run any callback when refresh is called with nothing registered", async () => {
     const cb = vi.fn();
     const { result } = renderHook(() => usePageRefresh(), {
-      wrapper: DisabledPageRefreshWrapper,
+      wrapper: PageRefreshWrapper,
     });
 
-    act(() => result.current.register(cb));
+    expect(result.current.disabled).toBe(true);
 
     await act(async () => {
       await result.current.refresh();


### PR DESCRIPTION
The master PR (#351) for this root failed PR review on one concrete gap. Goal: the navbar refresh button must be genuinely disabled on pages with nothing to refresh (e.g. Settings, or Git before a project is selected), not just visually inert during loading.

Two concrete gaps to close, both inside code the frontend cell already shipped:
1. `panel/src/components/providers/page-refresh-provider.tsx` currently exposes `disabled` as a pass-through of a static `disabled` prop that nothing ever sets (the provider is mounted once at the root in `panel/src/components/app-providers.tsx` with no `disabled` prop, so the flag is permanently `false`). The provider needs to derive a real "no callbacks registered" signal from its own callback registry (e.g. track callback count and treat zero registered callbacks as disabled) so it reflects whether the current page actually has anything to refresh.
2. `panel/src/components/layout/header.tsx` currently destructures only `{ refresh, loading }` from `usePageRefresh()` and sets `disabled={loading}` on the button — it never reads the context's `disabled` flag at all. It needs to destructure `disabled` too and set `disabled={disabled || loading}`, matching the pattern already documented in `docs/frontend/hooks.md`.

This is a scoped fix to existing files, not new scope — do not touch the rest of the feature (navbar placement, tooltip/aria-label, refresh semantics, loading spinner, or the already-removed inline buttons), all of which passed review already. Add a regression test asserting the button is disabled when the provider has zero registered callbacks (e.g. render `Header` inside `PageRefreshProvider` with nothing registered and assert the button is disabled).