### PR TITLE
fix(prompter): MegaTask review scrolls + confirm-batch guard releases on failure

### DIFF
--- a/panel/src/app/(dashboard)/prompter/page.tsx
+++ b/panel/src/app/(dashboard)/prompter/page.tsx
@@ -152,18 +152,13 @@ export default function PrompterPage() {
                 )}
               </div>
             </div>
-          ) : (
-            <ChatMessages
-              messages={messages}
-              onStart={launchTask}
-              onKeepChatting={keepChatting}
-              isLaunching={isLaunching}
-            />
-          )}
-
-          {/* MegaTask review — the agent proposed a batch; confirm them together */}
-          {state === "batch_preview" && batch && (
-            <div className="mx-4 mb-2">
+          ) : state === "batch_preview" && batch ? (
+            /* MegaTask review — the agent proposed a batch; confirm them
+               together. Owns the scroll area (min-h-0 + overflow-y-auto) so a
+               tall batch — many tasks, per-cell pickers, the wave plan — scrolls
+               instead of overflowing the clipped parent and stranding the launch
+               buttons off-screen. */
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
               <BatchReviewCard
                 batch={batch}
                 waves={batchWaves}
@@ -174,6 +169,13 @@ export default function PrompterPage() {
                 isLaunching={isLaunching}
               />
             </div>
+          ) : (
+            <ChatMessages
+              messages={messages}
+              onStart={launchTask}
+              onKeepChatting={keepChatting}
+              isLaunching={isLaunching}
+            />
           )}
 
           {/* Live activity indicator — "watch it work" (prominent) */}

--- a/roboco/services/prompter.py
+++ b/roboco/services/prompter.py
@@ -700,6 +700,25 @@ class PrompterService:
                 "MegaTask confirm result-sidecar write failed (redis): %s", exc
             )
 
+    async def _release_confirm_guard(self, session_id: str) -> None:
+        """Delete the confirm guard so a retry can re-attempt the build.
+
+        Called when the build raises before a result sidecar is written — the
+        transaction rolls back (nothing was created), so the 1h guard would
+        otherwise wedge the session into a permanent 500 ('already in progress')
+        for every retry. Best-effort: a failed delete only reinstates the old
+        wedge-until-TTL behaviour, never a double-build (the sidecar guards that).
+        """
+        guard_key = f"{_MEGATASK_CONFIRM_KEY_PREFIX}{session_id}"
+        try:
+            conn = redis.from_url(settings.redis_url)
+            try:
+                await conn.delete(guard_key)
+            finally:
+                await conn.aclose()
+        except Exception as exc:
+            self.log.warning("MegaTask confirm guard release failed (redis): %s", exc)
+
     async def confirm_live_batch(
         self,
         title: str,
@@ -729,9 +748,6 @@ class PrompterService:
         Returns ``{umbrella_task_id, root_subtask_ids, waves, warnings}`` for the
         panel's wave/DAG review.
         """
-        from roboco.seeds.initial_data import AGENT_UUIDS
-        from roboco.services.task import get_task_service
-
         if not drafts:
             raise ValidationError(
                 message="A MegaTask needs at least one task draft.", field="drafts"
@@ -745,6 +761,38 @@ class PrompterService:
         prior = await self._acquire_confirm_guard(session_id)
         if prior is not None:
             return prior
+
+        try:
+            return await self._build_confirm_batch(
+                title,
+                drafts,
+                agent_id,
+                route=route,
+                session_id=session_id,
+            )
+        except Exception:
+            # The build failed before a result sidecar was written — the txn
+            # rolls back (nothing created), so release the guard or the 1h key
+            # wedges every retry into a 500 ('already in progress').
+            await self._release_confirm_guard(session_id)
+            raise
+
+    async def _build_confirm_batch(
+        self,
+        title: str,
+        drafts: list[dict[str, Any]],
+        agent_id: UUID,
+        *,
+        route: Literal["board", "main_pm"],
+        session_id: str,
+    ) -> dict[str, Any]:
+        """Build the umbrella + sequenced root-subtasks (post-guard-acquire).
+
+        Split from :meth:`confirm_live_batch` so the guard-release-on-failure
+        wrapper stays a thin try/except and this keeps its own complexity budget.
+        """
+        from roboco.seeds.initial_data import AGENT_UUIDS
+        from roboco.services.task import get_task_service
 
         batch_id = uuid4()
         # 1. Sequence the drafts into conflict-free waves (same plan the panel

--- a/tests/unit/services/test_prompter_batch_panel_shape.py
+++ b/tests/unit/services/test_prompter_batch_panel_shape.py
@@ -1,0 +1,250 @@
+"""Reproduce the panel's confirm-batch payload shape.
+
+The panel's ``rebuildTheWork`` writes each task's project into
+``the_work[].project_id`` and sets the top-level ``project_id`` to ``null``
+(multi-cell model), whereas the existing MegaTask tests use the legacy
+top-level ``project_id``. This drives ``confirm_live_batch`` with the real
+panel shape to surface the live 500.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from roboco.services.prompter import get_prompter_service
+from tests.unit.services.test_prompter import (
+    _FakeRedis,
+    _seed_project_and_ceo,
+    _seed_second_project,
+)
+
+
+@pytest.mark.asyncio
+async def test_confirm_live_batch_panel_the_work_shape(db_session: Any) -> None:
+    project1, ceo_id = await _seed_project_and_ceo(db_session)
+    project2 = await _seed_second_project(db_session, ceo_id)
+    service = get_prompter_service(db=db_session)
+
+    # Panel shape: project lives in the_work[].project_id, top-level is null.
+    drafts: list[dict[str, Any]] = [
+        {
+            "title": "A: backend work",
+            "acceptance_criteria": ["a"],
+            "project_id": None,
+            "the_work": [
+                {
+                    "team": "backend",
+                    "summary": "do the thing",
+                    "items": ["unit 1"],
+                    "project_id": str(project1),
+                }
+            ],
+            "intends_to_touch": ["roboco/services/foo.py"],
+        },
+        {
+            "title": "B: frontend work",
+            "acceptance_criteria": ["b"],
+            "project_id": None,
+            "the_work": [
+                {
+                    "team": "frontend",
+                    "summary": "ui",
+                    "items": ["unit 1"],
+                    "project_id": str(project2),
+                }
+            ],
+            "intends_to_touch": ["panel/src/widget.tsx"],
+        },
+    ]
+    with patch("roboco.services.prompter.redis.from_url", return_value=_FakeRedis()):
+        result = await service.confirm_live_batch(
+            "Panel shape batch",
+            drafts,
+            ceo_id,
+            project_ids=[project1, project2],
+            route="main_pm",
+            session_id=f"sess-panel-{uuid4().hex[:8]}",
+        )
+
+    ids = result["root_subtask_ids"]
+    assert len(ids) == len(drafts)
+
+
+@pytest.mark.asyncio
+async def test_confirm_live_batch_panel_multicell_root_subtask(db_session: Any) -> None:
+    """A batch draft that targets TWO cells (backend+frontend, one repo each) →
+    the cell_projects persistence path on a batch root-subtask."""
+    project1, ceo_id = await _seed_project_and_ceo(db_session)
+    project2 = await _seed_second_project(db_session, ceo_id)
+    service = get_prompter_service(db=db_session)
+
+    drafts: list[dict[str, Any]] = [
+        {
+            "title": "A: cross-cell task",
+            "acceptance_criteria": ["a"],
+            "project_id": None,
+            "the_work": [
+                {
+                    "team": "backend",
+                    "summary": "api",
+                    "items": ["u1"],
+                    "project_id": str(project1),
+                },
+                {
+                    "team": "frontend",
+                    "summary": "ui",
+                    "items": ["u2"],
+                    "project_id": str(project2),
+                },
+            ],
+        },
+        {
+            "title": "B: backend only",
+            "acceptance_criteria": ["b"],
+            "project_id": None,
+            "the_work": [
+                {
+                    "team": "backend",
+                    "summary": "more api",
+                    "items": ["u1"],
+                    "project_id": str(project1),
+                },
+            ],
+        },
+    ]
+    with patch("roboco.services.prompter.redis.from_url", return_value=_FakeRedis()):
+        result = await service.confirm_live_batch(
+            "Cross-cell batch",
+            drafts,
+            ceo_id,
+            project_ids=[project1, project2],
+            route="main_pm",
+            session_id=f"sess-mc-{uuid4().hex[:8]}",
+        )
+    assert len(result["root_subtask_ids"]) == len(drafts)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("route", ["main_pm", "board"])
+async def test_confirm_live_batch_dense_same_repo_collisions(
+    db_session: Any, route: str
+) -> None:
+    """The real panel-MegaTask shape: MANY tasks in the SAME repo with heavy
+    file overlap → dense sequencing edges. Repro for the live confirm-batch 500."""
+    project1, ceo_id = await _seed_project_and_ceo(db_session)
+    project2 = await _seed_second_project(db_session, ceo_id)
+    service = get_prompter_service(db=db_session)
+
+    shared = "panel/src/app/layout.tsx"
+    drafts: list[dict[str, Any]] = []
+    # 6 backend/panel tasks in project1, overlapping on a shared file + migrations.
+    for i in range(6):
+        drafts.append(
+            {
+                "title": f"Panel task {i}",
+                "acceptance_criteria": [f"c{i}"],
+                "project_id": None,
+                "the_work": [
+                    {
+                        "team": "frontend",
+                        "summary": f"s{i}",
+                        "items": ["u"],
+                        "project_id": str(project1),
+                    },
+                ],
+                "intends_to_touch": [shared, f"panel/src/f{i}.tsx"],
+                "adds_migration": i % 2 == 0,
+                "touches_shared": True,
+            }
+        )
+    # 1 task in project2 so the batch spans ≥2 repos.
+    drafts.append(
+        {
+            "title": "Other repo",
+            "acceptance_criteria": ["c"],
+            "project_id": None,
+            "the_work": [
+                {
+                    "team": "frontend",
+                    "summary": "s",
+                    "items": ["u"],
+                    "project_id": str(project2),
+                },
+            ],
+            "intends_to_touch": ["src/other.ts"],
+        }
+    )
+    with patch("roboco.services.prompter.redis.from_url", return_value=_FakeRedis()):
+        result = await service.confirm_live_batch(
+            "Panel MegaTask",
+            drafts,
+            ceo_id,
+            project_ids=[project1, project2],
+            route=cast("Literal['board', 'main_pm']", route),
+            session_id=f"sess-dense-{route}-{uuid4().hex[:8]}",
+        )
+    assert len(result["root_subtask_ids"]) == len(drafts)
+
+
+class _DeleteFakeRedis(_FakeRedis):
+    """_FakeRedis + delete tracking, for the guard-release-on-failure test."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.deleted: list[str] = []
+
+    async def delete(self, name: str) -> int:
+        self.deleted.append(name)
+        return int(self._store.pop(name, None) is not None)
+
+
+@pytest.mark.asyncio
+async def test_confirm_live_batch_releases_guard_on_build_failure(
+    db_session: Any,
+) -> None:
+    """A build failure must DELETE the idempotency guard so a retry re-attempts,
+    instead of the 1h key wedging every retry into a 500 ('already in progress').
+    """
+    project1, ceo_id = await _seed_project_and_ceo(db_session)
+    project2 = await _seed_second_project(db_session, ceo_id)
+    service = get_prompter_service(db=db_session)
+    drafts: list[dict[str, Any]] = [
+        {
+            "title": "A",
+            "acceptance_criteria": ["a"],
+            "team": "backend",
+            "project_id": str(project1),
+        },
+        {
+            "title": "B",
+            "acceptance_criteria": ["b"],
+            "team": "frontend",
+            "project_id": str(project2),
+        },
+    ]
+    fake = _DeleteFakeRedis()
+    session_id = f"sess-fail-{uuid4().hex[:8]}"
+
+    async def _boom(*_a: Any, **_kw: Any) -> Any:
+        raise RuntimeError("build blew up")
+
+    with patch("roboco.services.prompter.redis.from_url", return_value=fake):
+        with (
+            patch.object(service, "_build_confirm_batch", _boom),
+            pytest.raises(RuntimeError, match="build blew up"),
+        ):
+            await service.confirm_live_batch(
+                "Batch",
+                drafts,
+                ceo_id,
+                project_ids=[project1, project2],
+                route="main_pm",
+                session_id=session_id,
+            )
+        # The guard was released, so the key no longer holds the session.
+        assert f"roboco:megatask_confirm:{session_id}" in fake.deleted
+        # A retry can now re-acquire the guard (not a permanent 'in progress').
+        assert await service._acquire_confirm_guard(session_id) is None


### PR DESCRIPTION
Fixes two proven bugs in the MegaTask review flow and hardens a third failure mode. Reported live: the review card fills the screen with no scrollbar (tasks/waves/buttons unreachable) and confirming the batch returns a 500.

## 1. Layout: MegaTask review card had no scroll region (proven)

The single-draft proposal card renders *inside* the scrollable `ChatMessages` list, but the `BatchReviewCard` was a static sibling block with no height bound — so a tall batch (many tasks × per-cell project pickers + the wave plan) overflowed the `overflow-hidden` chat container and clipped the launch buttons off-screen with no scrollbar.

Fix (`prompter/page.tsx`): during `batch_preview`, the batch card owns the scroll area — `min-h-0 flex-1 overflow-y-auto`, the same flex-scroll pattern `ChatMessages` already uses in that slot. The tall batch now scrolls; the buttons are always reachable.

## 2. Confirm-batch idempotency guard wedged the session for 1h (proven)

`confirm_live_batch` acquires a Redis SETNX guard (1h TTL) before building the umbrella + root-subtasks, and writes a result sidecar only on success. If the build fails *after* acquiring the guard but *before* the sidecar write, the guard key lingers for a full hour — and every retry then hits `ServiceError("already in progress")`, which the route maps to **HTTP 500**. So one first-attempt failure turns the MegaTask into a permanent 500 on every subsequent click for an hour. That matches the repeated identical 500s in the console.

Fix (`services/prompter.py`): the build is wrapped so any exception before the sidecar write **releases the guard** (`_release_confirm_guard`) before re-raising — the transaction has rolled back (nothing was created), so a retry can legitimately re-attempt instead of being locked out. Extracted the build into `_build_confirm_batch` to keep the try/except thin (xenon budget). Best-effort: a failed release only reinstates the old wedge-until-TTL behaviour, never a double-build (the sidecar still guards that).

## What this does NOT fix yet

The **root cause of the first-attempt failure** is still unproven. I reproduced the panel's exact confirm-batch payload shape against the test DB across four realistic cases — single-cell-per-draft, multi-cell root-subtasks (cell_projects path), and dense same-repo collisions on both routes — and **all pass**. So the first failure is data-specific or environmental, and I won't guess. The guard-release fix ensures a retry is no longer locked out; if the underlying failure is deterministic, the retry will surface the *real* error (a clean 400/500 with a message) instead of the masking "already in progress". To pin it I need the orchestrator's traceback or the 500 response body's `message` field for that session.

## Tests

`tests/unit/services/test_prompter_batch_panel_shape.py` (new, DB-backed): the panel `the_work[].project_id` shape, multi-cell root-subtasks, dense same-repo collisions (both routes), and the guard-release-on-build-failure behaviour.

Verified: `make quality` green; panel `build` / `typecheck` / `lint` / prompter hook tests green.
