### PR TITLE
fix(agents): block subagent spawning at the Claude Code level (disallow Task)

### DIFF
--- a/roboco/agent_sdk/intake_driver.py
+++ b/roboco/agent_sdk/intake_driver.py
@@ -576,6 +576,13 @@ def build_intake_options(
             "mcp__intake__propose_batch",
             "mcp__intake__search_past_tasks",
         ],
+        # `Task` is a default-permitted Claude Code built-in — omitting it from
+        # allowed_tools does NOT remove it (an allowlist auto-approves; it does
+        # not restrict), and permission_mode="dontAsk" never gates a
+        # pre-permitted built-in, so can_use_tool below never fires for it. The
+        # ONLY claude-code-level block that removes the subagent tool is an
+        # explicit disallow → the fleet-wide subagent ban reaches intake here.
+        disallowed_tools=["Task"],
         model=model,
         include_partial_messages=True,  # live token streaming
         permission_mode="dontAsk",

--- a/roboco/agent_sdk/secretary_driver.py
+++ b/roboco/agent_sdk/secretary_driver.py
@@ -249,6 +249,11 @@ def build_secretary_options(
             "mcp__secretary__search_tasks",
             "mcp__secretary__submit_directive",
         ],
+        # Fleet-wide subagent ban: `Task` is a default-permitted built-in that an
+        # allowlist omission + permission_mode="dontAsk" do NOT remove, so an
+        # explicit disallow is the only claude-code-level block (see the intake
+        # driver for the full rationale).
+        disallowed_tools=["Task"],
         model=model,
         include_partial_messages=True,
         permission_mode="dontAsk",

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -1719,6 +1719,13 @@ class AgentOrchestrator:
         base_deny = [
             # Block ALL native git commands - must use roboco_git_* tools
             "Bash(git:*)",
+            # Fleet-wide subagent ban (CEO, 2026-07-09): no agent spawns Claude
+            # Code subagents. `Task` is a default-permitted built-in, so under
+            # defaultMode=bypassPermissions the manifest/allowlist omission does
+            # NOT remove it — only an explicit deny does. Mirrors the grok path's
+            # `--disallowed-tools Agent`. `allows_subagent` is False for every
+            # role, so this is unconditional.
+            "Task",
             # NOTE: Write/Edit are intentionally NOT globally denied here.
             # Claude Code evaluates rules deny -> ask -> allow and the first
             # match wins, so a deny ALWAYS beats a more-specific allow (the

--- a/tests/unit/agent_sdk/test_sdk_driver_subagent_ban.py
+++ b/tests/unit/agent_sdk/test_sdk_driver_subagent_ban.py
@@ -1,0 +1,28 @@
+"""The SDK-driver agents (intake, secretary) hard-disallow the `Task` tool.
+
+`Task` is a default-permitted Claude Code built-in: omitting it from
+`allowed_tools` only removes an auto-approve entry, it does not restrict, and
+`permission_mode="dontAsk"` never routes a pre-permitted built-in through the
+`can_use_tool` gate. So the ONLY claude-code-level block is an explicit
+`disallowed_tools=["Task"]` (→ CLI `--disallowedTools Task`). These pin that
+the intake interviewer and the Secretary cannot fan out subagents.
+"""
+
+from __future__ import annotations
+
+from roboco.agent_sdk.intake_driver import build_intake_options
+from roboco.agent_sdk.secretary_driver import build_secretary_options
+
+
+def test_intake_options_disallow_task() -> None:
+    opts = build_intake_options(
+        system_prompt="x", cwd="/tmp", session_id="s1", model="sonnet"
+    )
+    assert "Task" in opts.disallowed_tools
+    assert "Task" not in opts.allowed_tools
+
+
+def test_secretary_options_disallow_task() -> None:
+    opts = build_secretary_options(system_prompt="x", cwd="/tmp", model="sonnet")
+    assert "Task" in opts.disallowed_tools
+    assert "Task" not in opts.allowed_tools

--- a/tests/unit/runtime/test_cc_lockdown.py
+++ b/tests/unit/runtime/test_cc_lockdown.py
@@ -106,6 +106,41 @@ class TestSharedClaudeCredentialsDenied:
             assert inner.startswith("//"), f"must use // absolute form: {entry}"
 
 
+class TestSubagentBanned:
+    """Every role's settings.json denies the `Task` subagent tool.
+
+    `Task` is a default-permitted Claude Code built-in; under
+    defaultMode=bypassPermissions the manifest/allowlist omission does NOT
+    remove it — only an explicit `permissions.deny` entry does. Without this
+    the fleet-wide subagent ban (CEO, 2026-07-09) is unenforced on the Claude
+    path (the grok path already blocks it via `--disallowed-tools Agent`).
+    """
+
+    def test_developer_settings_deny_task(self) -> None:
+        orch = _orch()
+        path = orch._generate_agent_settings(
+            agent_id="be-dev-1",
+            role="developer",
+            workspace_path=_WS,
+            cell_workspace_path=_CELL,
+        )
+        deny = json.loads(Path(path).read_text())["permissions"]["deny"]
+        assert "Task" in deny, deny
+
+    def test_read_only_role_also_denies_task(self) -> None:
+        """A read-only role (pr_reviewer, the top prompt-injection target)
+        gets the same base_deny → no subagent escape hatch."""
+        orch = _orch()
+        path = orch._generate_agent_settings(
+            agent_id="be-pr-reviewer",
+            role="pr_reviewer",
+            workspace_path=_WS,
+            cell_workspace_path=_CELL,
+        )
+        deny = json.loads(Path(path).read_text())["permissions"]["deny"]
+        assert "Task" in deny, deny
+
+
 class TestSlashCommandsDisabled:
     """--disable-slash-commands accompanies every container agent spawn."""
 


### PR DESCRIPTION
Blocks agent subagent-spawning at the Claude Code level — the layer the CEO asked for — after the earlier allowlist-based ban (#375) proved insufficient.

## Root cause

The "fleet-wide subagent ban" was implemented as an **allowlist omission**: the `Task` tool was left out of `allowed_tools` (SDK) / the tool manifest (fleet). But `Task` is a **default-permitted Claude Code built-in**, and an allowlist auto-approves — it does not restrict. So omitting `Task` never removed it:

- **Intake / Secretary (SDK drivers):** `permission_mode="dontAsk"` means "deny if not pre-approved," but a default-permitted built-in *is* pre-approved, so `Task` runs and the `can_use_tool` gate is never even invoked for it (the SDK docstring: `can_use_tool` is "not invoked for tool calls already permitted by … `permission_mode`").
- **Fleet (container `claude` CLI):** the generated `settings.json` uses `"defaultMode": "bypassPermissions"`, under which — per the file's own comment — "unlisted operations proceed." No deny list contained `Task`, and the spawn passes no `--disallowedTools`. The tool manifest governs only gateway MCP tools, not built-ins.

Net: every Claude-path agent (intake, secretary, and the whole delivery fleet) could spawn subagents, despite `allows_subagent=False`. Only the **grok** path actually blocked it (`--disallowed-tools Agent`).

## Fix — explicit disallow, the only mechanism that removes a default-permitted built-in

- **Intake** (`agent_sdk/intake_driver.py`): `disallowed_tools=["Task"]` → CLI `--disallowedTools Task`.
- **Secretary** (`agent_sdk/secretary_driver.py`): same.
- **Fleet** (`runtime/orchestrator.py`): `"Task"` added to `base_deny`, so every role's `settings.json` denies it. Explicit deny rules apply even under `bypassPermissions` (stated in the surrounding comment).

The prior allowlist/gate/prompt changes from #375 stay as defense-in-depth.

## Verification

- `--disallowedTools` is a real CLI flag (`claude --help`) and the SDK maps `disallowed_tools` → `--disallowedTools` (verified in the installed `claude_agent_sdk` transport source). This is Anthropic's documented tool-removal mechanism, not an app-level gate.
- New pins: `tests/unit/agent_sdk/test_sdk_driver_subagent_ban.py` (intake + secretary options carry `disallowed_tools=["Task"]`) and a `TestSubagentBanned` class in `tests/unit/runtime/test_cc_lockdown.py` (fleet `settings.json` deny contains `Task`, for a writer and a read-only role).
- `make quality` green; touched-file ruff/mypy clean.
- Not run against a live intake container (that path is `# pragma: no cover — requires the live claude binary`); the mechanism is verified at the SDK/CLI level and the config is unit-pinned.

Note: this takes effect once the agent image is rebuilt and the orchestrator redeployed — the merged-but-not-deployed #375 is likely why the symptom persisted.
