### PR TITLE
fix(prompter): keep a watched intake chat alive (idle-reap counted reading as idle)

### DIFF
--- a/roboco/services/prompter_live.py
+++ b/roboco/services/prompter_live.py
@@ -34,6 +34,13 @@ logger = structlog.get_logger()
 SDK_PORT = 9000
 # Sentinel pushed onto a session's queue to end its SSE stream.
 _CLOSE = object()
+# While the panel holds the SSE stream open, refresh ``last_activity`` on this
+# cadence even with no events — an open stream means the human is watching (e.g.
+# reading a proposed draft / MegaTask without typing), so the idle reaper must
+# not retire the chat out from under them. Well under
+# ``interactive_idle_reap_seconds`` (default 1800). When the tab closes the
+# generator is cancelled, the refresh stops, and the chat reaps normally.
+_STREAM_KEEPALIVE_SECONDS = 60.0
 
 
 @dataclass
@@ -182,16 +189,37 @@ class PrompterLiveRegistry:
             and now - s.last_activity > threshold_seconds
         ]
 
+    @staticmethod
+    async def _keepalive(session: LiveIntakeSession) -> None:
+        """Refresh ``last_activity`` while a stream is connected (see ``stream``)."""
+        while True:
+            await asyncio.sleep(_STREAM_KEEPALIVE_SECONDS)
+            session.last_activity = time.monotonic()
+
     async def stream(self, session_id: str) -> AsyncIterator[dict[str, Any]]:
-        """Yield queued agent events until the session is closed."""
+        """Yield queued agent events until the session is closed.
+
+        A connected stream keeps the session's ``last_activity`` fresh (a
+        ``_keepalive`` task ticks every ``_STREAM_KEEPALIVE_SECONDS`` even with
+        no events), so the idle reaper treats an open, actively-watched chat as
+        alive — a human reading a proposed draft without typing is not "idle".
+        The keepalive runs beside an un-cancelled ``queue.get()`` (so no live
+        token/``_CLOSE`` is lost) and is cancelled when the stream ends; on
+        client disconnect the refresh stops and an abandoned chat reaps normally.
+        """
         session = self._sessions.get(session_id)
         if session is None:
             return
-        while True:
-            item = await session.queue.get()
-            if item is _CLOSE:
-                return
-            yield item
+        keepalive = asyncio.create_task(self._keepalive(session))
+        try:
+            while True:
+                item = await session.queue.get()
+                if item is _CLOSE:
+                    return
+                session.last_activity = time.monotonic()
+                yield item
+        finally:
+            keepalive.cancel()
 
     # -- panel -> agent ----------------------------------------------------
 

--- a/tests/integration/test_git_conventions_pr.py
+++ b/tests/integration/test_git_conventions_pr.py
@@ -6,6 +6,7 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from roboco.config import settings
 from roboco.db.tables import AgentTable, ProjectTable
 from roboco.models import AgentRole, AgentStatus, Team
 from roboco.services.git import _ConventionsPr, get_git_service
@@ -23,7 +24,9 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
 
 
-async def _seed_project(db: AsyncSession, workspace_path: str) -> ProjectTable:
+async def _seed_project(
+    db: AsyncSession, workspace_path: str, *, slug: str | None = None
+) -> ProjectTable:
     agent = AgentTable(
         id=uuid4(),
         name="Dev",
@@ -42,7 +45,7 @@ async def _seed_project(db: AsyncSession, workspace_path: str) -> ProjectTable:
     project = ProjectTable(
         id=uuid4(),
         name="G-Proj",
-        slug=f"g-proj-{uuid4().hex[:8]}",
+        slug=slug or f"g-proj-{uuid4().hex[:8]}",
         git_url="https://example.com/r.git",
         default_branch="master",
         assigned_cell=Team.BACKEND,
@@ -55,10 +58,15 @@ async def _seed_project(db: AsyncSession, workspace_path: str) -> ProjectTable:
 
 
 async def test_open_conventions_pr_commits_locally_without_remote(
-    db_session: AsyncSession, tmp_path: Path
+    db_session: AsyncSession, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
+    # open_conventions_pr only accepts a workspace_path under
+    # {workspaces_root}/{slug} (the containment guard), so anchor the root at
+    # the test dir and place the repo under the project's own slug.
+    monkeypatch.setattr(settings, "workspaces_root", str(tmp_path))
+    slug = f"g-proj-{uuid4().hex[:8]}"
+    repo = tmp_path / slug / "repo"
+    repo.mkdir(parents=True)
     _git(repo, "init", "-b", "master")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "T")
@@ -67,7 +75,7 @@ async def test_open_conventions_pr_commits_locally_without_remote(
     _git(repo, "add", "README.md")
     _git(repo, "commit", "-m", "init")
 
-    project = await _seed_project(db_session, str(repo))
+    project = await _seed_project(db_session, str(repo), slug=slug)
     git = get_git_service(db_session)
     result = await git.open_conventions_pr(
         project.slug,

--- a/tests/unit/services/test_prompter_live.py
+++ b/tests/unit/services/test_prompter_live.py
@@ -8,6 +8,7 @@ import time
 
 import httpx
 import pytest
+import roboco.services.prompter_live as pl
 from roboco.services.prompter_live import (
     PrompterLiveRegistry,
     get_live_registry,
@@ -149,6 +150,35 @@ async def test_stream_yields_queued_events_then_ends_on_close() -> None:
         {"event": "text", "data": "hel"},
         {"event": "turn_end", "data": "{}"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_stream_keepalive_keeps_watched_chat_alive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An open SSE stream refreshes last_activity even with no events, so a
+    human reading a proposal (tab open, not typing) is not idle-reaped. Without
+    this the chat "drops after a while" mid-review."""
+    monkeypatch.setattr(pl, "_STREAM_KEEPALIVE_SECONDS", 0.01)
+    reg = PrompterLiveRegistry()
+    session = reg.open("s1", "intake-1")
+    session.last_activity = time.monotonic() - 4000  # silent for >1h
+
+    # Before anyone connects, the abandoned-looking chat IS idle-reapable.
+    assert ("s1", "intake-1") in reg.idle_session_ids(1800)
+
+    async def watch() -> None:
+        async for _ in reg.stream("s1"):
+            pass
+
+    task = asyncio.create_task(watch())
+    try:
+        await asyncio.sleep(0.05)  # let a keepalive tick fire on the open stream
+        # The connected stream refreshed activity → no longer idle.
+        assert reg.idle_session_ids(1800) == []
+    finally:
+        reg.close("s1")
+        await asyncio.wait_for(task, timeout=1.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes intake chats that "drop after a while" — the panel shows "Live connection lost — the chat session is no longer reachable."

## Root cause (proven from the code)

"Live connection lost" is a transport-level SSE drop — the session was torn down server-side, not a per-turn error (those render as red error bubbles). The teardown is the idle reaper: `_reap_idle_interactive_sessions` retires any intake/secretary session whose `last_activity` is older than `interactive_idle_reap_seconds` (default **1800s / 30 min**).

`last_activity` is bumped **only** by an agent event (`push`) or a human turn (`deliver`). An **open SSE stream does not bump it.** So when the agent finishes streaming and the human is *reading* — reviewing a proposed draft, or deciding on a MegaTask spec — with the tab open but not typing, nothing refreshes the timer. After 30 min of that, the reaper reaps the session, closes the stream, and the panel reports "Live connection lost." The reaper meant to clean up *abandoned* (tab-closed) chats, but it can't tell "tab closed" from "tab open, human reading," so it kills both.

Independent of my recent changes (the reaper predates them), which matches the report.

## Fix — treat an open SSE stream as liveness

While the panel holds the stream open, `stream()` now refreshes `last_activity` on a keepalive cadence (`_STREAM_KEEPALIVE_SECONDS = 60`, well under the 1800s threshold) even with no events. An open, actively-watched chat stays alive; when the tab closes the generator is cancelled, the refresh stops, and a genuinely-abandoned chat still reaps after the threshold. Server-only change (`prompter_live.py`) — no agent-image rebuild needed, just an orchestrator redeploy.

## Verification

- New test `test_stream_keepalive_keeps_watched_chat_alive`: a session that is idle-reapable before connect is no longer in the idle set once a stream is open and a keepalive tick fires.
- Existing stream/idle tests still pass; `make quality` green.

## Confirming this is your exact cause

The reaper logs `Reaped idle interactive session` (with `session_id` + `idle_threshold_s`) when it fires. If that line appears in the orchestrator log at the moment a chat drops, this is the cause and this fix resolves it. If a chat instead drops **quickly** (a minute or two) or **mid-agent-response**, that's a different failure (Claude OAuth/session-limit, or an orchestrator restart) and we should pull the intake container logs next:
`sudo docker logs --tail 200 roboco-agent-intake-1` and `sudo docker inspect roboco-agent-intake-1 --format '{{.State.OOMKilled}} {{.State.ExitCode}} {{.State.Error}}'`.
