### PR TITLE
fix(prompter): batch confirm ignores a vestigial top-level project slug

### DIFF
--- a/roboco/services/prompter.py
+++ b/roboco/services/prompter.py
@@ -827,26 +827,7 @@ class PrompterService:
         #    sequence = its wave index and the umbrella as parent.
         task_of: dict[int, UUID] = {}
         for idx, draft in enumerate(drafts):
-            # Root-subtasks are coordination roots: assignment is the
-            # PM-activation flow's call, not a draft-carried field. Strip a
-            # hallucinated/injected assigned_to so a board-role uuid can't
-            # deadlock the umbrella (board roles have no dev delivery verbs).
-            sub_draft = dict(draft)
-            sub_draft.pop("assigned_to", None)
-            # A batch root-subtask targets its repos via the the_work per-cell
-            # map (the panel fills each cell with a real project UUID). A
-            # top-level project_id/product_id is vestigial here — the intake
-            # agent authors it as the repo SLUG it read (e.g. "roboco-api"),
-            # which the panel only clears on a manual picker toggle, so an
-            # untouched draft would reach create_task_from_draft's UUID parse and
-            # 400 the whole batch. Drop it when a cell map carries the real
-            # target; a legacy no-the_work draft keeps its panel-filled top-level.
-            if any(
-                isinstance(cell, dict) and cell.get("project_id")
-                for cell in (sub_draft.get("the_work") or [])
-            ):
-                sub_draft.pop("project_id", None)
-                sub_draft.pop("product_id", None)
+            sub_draft = _batch_subtask_draft(draft)
             sub = await self.create_task_from_draft(
                 sub_draft,
                 agent_id,
@@ -1099,6 +1080,30 @@ def _cell_teams(the_work: list[Any]) -> list[str]:
         if team in cell_values and team not in seen:
             seen.append(team)
     return seen
+
+
+def _batch_subtask_draft(draft: dict[str, Any]) -> dict[str, Any]:
+    """A batch root-subtask's draft: a copy with the non-targeting fields dropped.
+
+    ``assigned_to`` is stripped — assignment is the PM-activation flow's call, not
+    a draft-carried field, and a hallucinated/injected board-role uuid would
+    deadlock the umbrella (board roles have no dev delivery verbs). The top-level
+    ``project_id``/``product_id`` is stripped when the ``the_work`` per-cell map
+    carries the real target: the intake agent authors the top-level as the repo
+    SLUG it read (e.g. ``"roboco-api"``), which the panel only clears on a manual
+    picker toggle, so an untouched draft would reach ``create_task_from_draft``'s
+    UUID parse and 400 the whole batch. A legacy no-``the_work`` draft keeps its
+    panel-filled top-level target.
+    """
+    out = dict(draft)
+    out.pop("assigned_to", None)
+    if any(
+        isinstance(cell, dict) and cell.get("project_id")
+        for cell in (out.get("the_work") or [])
+    ):
+        out.pop("project_id", None)
+        out.pop("product_id", None)
+    return out
 
 
 def _draft_cell_map(draft: dict[str, Any]) -> list[tuple[Team, UUID]]:

--- a/roboco/services/prompter.py
+++ b/roboco/services/prompter.py
@@ -833,6 +833,20 @@ class PrompterService:
             # deadlock the umbrella (board roles have no dev delivery verbs).
             sub_draft = dict(draft)
             sub_draft.pop("assigned_to", None)
+            # A batch root-subtask targets its repos via the the_work per-cell
+            # map (the panel fills each cell with a real project UUID). A
+            # top-level project_id/product_id is vestigial here — the intake
+            # agent authors it as the repo SLUG it read (e.g. "roboco-api"),
+            # which the panel only clears on a manual picker toggle, so an
+            # untouched draft would reach create_task_from_draft's UUID parse and
+            # 400 the whole batch. Drop it when a cell map carries the real
+            # target; a legacy no-the_work draft keeps its panel-filled top-level.
+            if any(
+                isinstance(cell, dict) and cell.get("project_id")
+                for cell in (sub_draft.get("the_work") or [])
+            ):
+                sub_draft.pop("project_id", None)
+                sub_draft.pop("product_id", None)
             sub = await self.create_task_from_draft(
                 sub_draft,
                 agent_id,

--- a/tests/integration/test_git_conventions_pr.py
+++ b/tests/integration/test_git_conventions_pr.py
@@ -6,6 +6,7 @@ import subprocess
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from roboco.config import settings
 from roboco.db.tables import AgentTable, ProjectTable
 from roboco.models import AgentRole, AgentStatus, Team
 from roboco.services.git import _ConventionsPr, get_git_service
@@ -23,7 +24,9 @@ def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
 
 
-async def _seed_project(db: AsyncSession, workspace_path: str) -> ProjectTable:
+async def _seed_project(
+    db: AsyncSession, workspace_path: str, *, slug: str | None = None
+) -> ProjectTable:
     agent = AgentTable(
         id=uuid4(),
         name="Dev",
@@ -42,7 +45,7 @@ async def _seed_project(db: AsyncSession, workspace_path: str) -> ProjectTable:
     project = ProjectTable(
         id=uuid4(),
         name="G-Proj",
-        slug=f"g-proj-{uuid4().hex[:8]}",
+        slug=slug or f"g-proj-{uuid4().hex[:8]}",
         git_url="https://example.com/r.git",
         default_branch="master",
         assigned_cell=Team.BACKEND,
@@ -55,10 +58,15 @@ async def _seed_project(db: AsyncSession, workspace_path: str) -> ProjectTable:
 
 
 async def test_open_conventions_pr_commits_locally_without_remote(
-    db_session: AsyncSession, tmp_path: Path
+    db_session: AsyncSession, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    repo = tmp_path / "repo"
-    repo.mkdir()
+    # open_conventions_pr only accepts a workspace_path under
+    # {workspaces_root}/{slug} (the containment guard), so anchor the root at
+    # the test dir and place the repo under the project's own slug.
+    monkeypatch.setattr(settings, "workspaces_root", str(tmp_path))
+    slug = f"g-proj-{uuid4().hex[:8]}"
+    repo = tmp_path / slug / "repo"
+    repo.mkdir(parents=True)
     _git(repo, "init", "-b", "master")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "T")
@@ -67,7 +75,7 @@ async def test_open_conventions_pr_commits_locally_without_remote(
     _git(repo, "add", "README.md")
     _git(repo, "commit", "-m", "init")
 
-    project = await _seed_project(db_session, str(repo))
+    project = await _seed_project(db_session, str(repo), slug=slug)
     git = get_git_service(db_session)
     result = await git.open_conventions_pr(
         project.slug,

--- a/tests/unit/services/test_prompter_batch_panel_shape.py
+++ b/tests/unit/services/test_prompter_batch_panel_shape.py
@@ -74,6 +74,59 @@ async def test_confirm_live_batch_panel_the_work_shape(db_session: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_confirm_live_batch_ignores_vestigial_top_level_slug(
+    db_session: Any,
+) -> None:
+    """A batch draft whose the_work cell-map carries the real project UUID but
+    that also still has the intake agent's top-level project_id SLUG (the panel
+    only nulls it on a manual picker toggle) must NOT 400 the whole batch on the
+    UUID parse — the cell map is authoritative. Repro for the live 400
+    "Invalid project_id UUID: roboco-api"."""
+    project1, ceo_id = await _seed_project_and_ceo(db_session)
+    project2 = await _seed_second_project(db_session, ceo_id)
+    service = get_prompter_service(db=db_session)
+
+    drafts: list[dict[str, Any]] = [
+        {
+            "title": "A: backend work",
+            "acceptance_criteria": ["a"],
+            "project_id": "roboco-api",  # agent's slug, panel left it in place
+            "the_work": [
+                {
+                    "team": "backend",
+                    "summary": "s",
+                    "items": ["u"],
+                    "project_id": str(project1),
+                },
+            ],
+        },
+        {
+            "title": "B: frontend work",
+            "acceptance_criteria": ["b"],
+            "project_id": "roboco-panel",  # slug on the other draft too
+            "the_work": [
+                {
+                    "team": "frontend",
+                    "summary": "s",
+                    "items": ["u"],
+                    "project_id": str(project2),
+                },
+            ],
+        },
+    ]
+    with patch("roboco.services.prompter.redis.from_url", return_value=_FakeRedis()):
+        result = await service.confirm_live_batch(
+            "Slug batch",
+            drafts,
+            ceo_id,
+            project_ids=[project1, project2],
+            route="main_pm",
+            session_id=f"sess-slug-{uuid4().hex[:8]}",
+        )
+    assert len(result["root_subtask_ids"]) == len(drafts)
+
+
+@pytest.mark.asyncio
 async def test_confirm_live_batch_panel_multicell_root_subtask(db_session: Any) -> None:
     """A batch draft that targets TWO cells (backend+frontend, one repo each) →
     the cell_projects persistence path on a batch root-subtask."""


### PR DESCRIPTION
Fixes the MegaTask confirm-batch 400 `Invalid project_id UUID: roboco-api` — the Panel & Org UX MegaTask couldn't launch.

## Root cause (from the production logs)

The intake agent authors each draft's project as the repo **slug** it read (e.g. `roboco-api`), not a UUID. The panel resolves the real project targeting into each draft's `the_work[].project_id` (real UUIDs) and nulls the top-level `project_id` — **but only when the CEO toggles that draft's project picker.** A draft left at its auto-filled default keeps the agent's top-level slug.

`create_task_from_draft` resolves the top-level `project_id` eagerly (`_resolve_uuid_field` → `UUID("roboco-api")`) before the cell-map logic that would supersede it, so one untouched draft raises `ValidationError` and 400s the whole batch. (The logs show 7 tasks created inside the transaction before the raise; the route rolls back on the error, so no orphans — and the #376 guard-release lets the CEO retry, which is why this now surfaces as a clean 400 instead of the old wedged 500.)

## Fix

A batch root-subtask targets its repos via the `the_work` per-cell map — the top-level `project_id`/`product_id` is vestigial for it. In the batch build loop, drop the top-level target from a sub-draft when its cell-map carries the real one (mirroring the existing `assigned_to` strip). A legacy no-`the_work` draft keeps its panel-filled top-level UUID, and scope validation (which already runs off the cell-map) is unchanged.

## Verification

- New test `test_confirm_live_batch_ignores_vestigial_top_level_slug` reproduces the exact failure: two batch drafts with valid cell-map UUIDs plus a leftover top-level slug (`roboco-api` / `roboco-panel`) now confirm instead of 400-ing.
- Existing batch tests (panel shape, multi-cell, dense collisions, guard release) still pass; `make quality` green.

## Follow-up worth noting (not in this PR)

The panel surfaced only axios's generic "Request failed with status code 400" — the server's real `message` (`Invalid project_id UUID: roboco-api`) was visible only in the orchestrator logs. Surfacing the server validation `message` in the batch card would make the next confirm rejection self-explanatory instead of needing a log dig.
