### PR TITLE
fix(megatask): guardrail the wave sequence at the claim chokepoint

### DIFF
--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -2576,6 +2576,30 @@ class TaskService(BaseService):
         TaskStatus.AWAITING_PM_REVIEW,
     }
 
+    async def _claim_blocked_by_dependencies(self, task: TaskTable) -> bool:
+        """True when a PENDING task can't be claimed yet — a ``depends_on`` task
+        is still non-terminal (the sequence guardrail).
+
+        The gateway claim verbs enforce this, but the orchestrator's dispatcher
+        system-claims via the raw ``/tasks/{id}/claim`` route (which skips the
+        gateway guards), so a MegaTask root-subtask in a later wave was claimed
+        out of order (the Main PM held every wave at once). Enforcing it at the
+        claim chokepoint guardrails every path. Scoped to a PENDING start-of-work
+        claim — a mid-lifecycle claim (QA/doc on an ``awaiting_*`` task) already
+        cleared its dependencies at the original claim.
+        """
+        if task.status != TaskStatus.PENDING or not task.dependency_ids:
+            return False
+        unmet = await self.unmet_dependency_ids(list(task.dependency_ids))
+        if not unmet:
+            return False
+        self.log.warning(
+            "Cannot claim task - unmet dependencies",
+            task_id=str(task.id),
+            unmet=[str(dep_id) for dep_id in unmet],
+        )
+        return True
+
     async def _validate_claim_preconditions(
         self,
         task: TaskTable,
@@ -2588,6 +2612,9 @@ class TaskService(BaseService):
 
         if error := self._validate_claim_status(task, agent, valid_statuses):
             self.log.warning(f"Cannot claim task - {error}", task_id=str(task.id))
+            return False
+
+        if await self._claim_blocked_by_dependencies(task):
             return False
 
         if error := self._validate_claim_team(task, agent):

--- a/tests/integration/test_task_service_basics.py
+++ b/tests/integration/test_task_service_basics.py
@@ -1330,6 +1330,30 @@ async def test_claim_pending_task_with_existing_branch(
 
 
 @pytest.mark.asyncio
+async def test_claim_pending_with_unmet_dependency_returns_none(
+    task_setup: dict, db_session: AsyncSession
+) -> None:
+    """Sequence guardrail: a PENDING task with a non-terminal dependency cannot
+    be claimed — even via the raw claim path the orchestrator dispatcher uses.
+    Regression for the MegaTask "Main PM claimed every wave at once" bug."""
+    svc = task_setup["svc"]
+    dep = await svc.create(_req(task_setup, title="wave-0 dependency"))
+    task = await svc.create(_req(task_setup, title="wave-1 dependent"))
+    task.branch_name = "feature/backend/abcd1234"
+    await db_session.flush()
+    await svc.add_dependency(task.id, dep.id)  # task depends_on dep (still PENDING)
+
+    assert await svc.claim(task.id, task_setup["agent_id"]) is None
+
+    # Once the dependency reaches a terminal state, the claim goes through.
+    dep.status = TaskStatus.COMPLETED
+    await db_session.flush()
+    claimed = await svc.claim(task.id, task_setup["agent_id"])
+    assert claimed is not None
+    assert claimed.status == TaskStatus.CLAIMED
+
+
+@pytest.mark.asyncio
 async def test_claim_already_claimed_by_other_returns_none(
     task_setup: dict, db_session: AsyncSession
 ) -> None:


### PR DESCRIPTION
Fixes a MegaTask sequencing bug: the Main PM claimed **every wave at once**, ignoring the collision-ordered dependencies (live: the 9-root Panel & Org UX MegaTask — wave-1/2/3 root-subtasks were all `claimed` while their wave-0 dependencies were still in progress).

## Root cause (proven against the live batch)

The sequencing data was correct — the analyzer wired proper waves and the intended order (e.g. the tooltip task depends on the sidebar/task-detail/A2A/video tasks; docs-divergence is last). The failure was in *enforcement*, on two layers that both bypass the dependency gate:

1. The dependency guard (`unmet_dependency_guard`) lives only on the **agent-facing gateway claim verbs** (`i_will_plan` / `i_will_work_on` → `_run_claim_guards`). It refuses a claim while any `depends_on` task is non-terminal.
2. But the orchestrator dispatches coordination roots itself: `_dispatch_pm_work` fetches the pending list **without the dependency filter** (`_fetch_tasks(client, "pending")`), and `_route_unassigned_pm_task` system-claims each via `_claim_task_for_agent` → the **raw `POST /tasks/{id}/claim` route → `TaskService.claim`**, which had **no dependency check** at all. So the orchestrator claimed every pending root-subtask for the Main PM regardless of wave.

Net: sequence was "guardrailed" for agents claiming their own work, but not for the orchestrator dispatching MegaTask root-subtasks — which is the whole MegaTask case.

## Fix

Enforce the sequence at the claim **chokepoint**: `TaskService._validate_claim_preconditions` now refuses to claim a `PENDING` task while any of its `depends_on` tasks is non-terminal. This guardrails **every** claim path — the gateway verbs (redundant, already guarded) and the orchestrator's raw dispatch claim (the hole). Scoped to a PENDING start-of-work claim, so a mid-lifecycle claim (QA/doc on an `awaiting_*` task, whose dependencies were already cleared at the original claim) is unaffected. Dependencies are monotonic (unmet → met only), so once a wave completes the next dispatch tick claims the newly-ready wave normally.

## Verification

- New test `test_claim_pending_with_unmet_dependency_returns_none`: a PENDING task with a non-terminal dependency can't be claimed via the raw `claim()` path; once the dependency completes, the claim succeeds (no over-blocking).
- Full **DB-backed** `make quality` (with the test DB — the config that actually runs the ~2549 integration/DB tests CI runs).

## Follow-up (not in this PR)

`_dispatch_pm_work` will still *attempt* (and now correctly fail) to claim held later-wave tasks each dispatch tick — harmless but noisy. Filtering the dispatcher's pending fetch by dependency-readiness would remove that churn; deferred to keep this PR to the single correctness chokepoint.
