### PR TITLE
[54b94e44] A2A page: filter controls + agent identity consistency

### DIFF
--- a/docs/frontend/a2a-filtering.md
+++ b/docs/frontend/a2a-filtering.md
@@ -1,0 +1,303 @@
+# A2A Page Filtering & Agent Identity
+
+## Overview
+
+The A2A (Agent-to-Agent) page now features a unified filter bar and consistent agent identity rendering across both the switchboard (org-chart view) and classic conversation list. Both views respond identically to filtering and pulse animations, creating a cohesive experience regardless of the active view.
+
+## Filter Bar
+
+The `A2AFilterBar` component renders above the switchboard/list content and provides two independent filtering controls:
+
+### Component
+
+**File:** `panel/src/components/a2a/a2a-filter-bar.tsx`
+
+**Props:**
+
+- `status` (`A2AStatusFilter`): Current status filter, either `"active"` or `"all"`
+- `onStatusChange` (callback): Fires when the Active/All toggle changes
+- `search` (string): Current search query
+- `onSearchChange` (callback): Fires as the user types in the search input
+
+**Rendering:**
+
+- Search input with placeholder "Search agent or topic..." accepts free-text queries
+- Two toggle buttons: "Active" narrows to conversations with live activity; "All" shows everything
+- Compact styling (7px button height, 3px font size) to avoid crowding the view
+
+**Usage:**
+
+```tsx
+import { A2AFilterBar } from "@/components/a2a/a2a-filter-bar";
+
+<A2AFilterBar
+  status={statusFilter}
+  onStatusChange={setStatusFilter}
+  search={search}
+  onSearchChange={setSearch}
+/>
+```
+
+## Filter Utilities
+
+The `a2a-filter-utils.ts` module exports pure, testable filtering logic shared by both views.
+
+**File:** `panel/src/components/a2a/a2a-filter-utils.ts`
+
+### `A2AStatusFilter` Type
+
+```typescript
+type A2AStatusFilter = "active" | "all";
+```
+
+### `filterConversations()`
+
+Narrows the conversation list to the matching subset based on status and search query.
+
+**Parameters:**
+
+- `conversations`: `ReadonlyArray<AdminConversationSummary>`
+- `status`: `A2AStatusFilter` — `"active"` filters to `conversation.status === "active"`; `"all"` passes all
+- `search`: `string` — free-text query (case-insensitive)
+
+**Behavior:**
+
+- Searches across both agent slugs (raw IDs), their display names (via `getAgentDisplayName`), and the topic
+- Empty search passes all conversations
+- Status filter is applied first, then search
+
+**Example:**
+
+```typescript
+const filtered = filterConversations(
+  conversations,
+  "active",
+  "backend qa"
+);
+// Returns only active conversations where one agent is Backend QA or mentions "backend qa"
+```
+
+### `filterPairs()`
+
+Narrows the switchboard pairs to the matching subset based on status and search query.
+
+**Parameters:**
+
+- `pairs`: `ReadonlyArray<AdminPairSummary>`
+- `status`: `A2AStatusFilter` — `"active"` filters to pairs that have a `conversation_id` (have A2A'd); `"all"` passes all
+- `search`: `string` — free-text query (case-insensitive)
+
+**Behavior:**
+
+- Searches across both agent slugs (raw IDs) and their display names
+- Empty search passes all pairs
+- Status filter is applied first, then search
+- Note: `AdminPairSummary` has no backend `status` field, so "active" is interpreted as "has a conversation"
+
+**Example:**
+
+```typescript
+const filtered = filterPairs(pairs, "active", "auditor");
+// Returns only pairs where at least one agent matches "auditor" and the pair has an active conversation
+```
+
+## Conversation List Updates
+
+The conversation list now accepts a `pulses` prop and renders agent avatars.
+
+**File:** `panel/src/components/a2a/a2a-conversation-list.tsx`
+
+### `A2AConversationListProps`
+
+**New prop:**
+
+- `pulses` (`Record<string, number>`): Maps `pairKey(agent_a, agent_b)` to the epoch timestamp of the latest pulse frame. This is the same `pulses` map the switchboard uses, keyed identically, so a conversation row flashes in sync with its pair's card on the switchboard.
+
+**Example:**
+
+```tsx
+<A2AConversationList
+  conversations={filteredConversations}
+  selectedId={selectedId}
+  onSelect={handleSelect}
+  isLoading={loadingConversations}
+  pulses={pulses}  // New: from page state
+/>
+```
+
+### `ConversationRow` Subcomponent
+
+Each conversation renders as a `ConversationRow` that mirrors the switchboard's pair card styling:
+
+- **Avatars:** Two `PairAvatar` components (initials, colors) matching `A2APairCard`
+- **Pulse animation:** Uses `usePulseFlash()` to determine if the row should flash hot
+- **Styling:** Emerald background + shadow while pulsing, matches switchboard
+- **Selection state:** Bordered/highlighted when selected, same as switchboard selection
+
+### Breaking Change
+
+The `pulses` prop is **required**. If you're calling `A2AConversationList` from outside the A2A page, you must supply it:
+
+```typescript
+// Old code (will TypeScript error)
+<A2AConversationList conversations={data} ... />
+
+// New code
+const pulses = { "be-dev-1|be-qa": 1700000000000 };
+<A2AConversationList conversations={data} ... pulses={pulses} />
+```
+
+If you don't have a pulses map available, pass an empty object `{}` — rows won't flash, but selection/interaction will work normally.
+
+## Pulse-Flash Hook
+
+**File:** `panel/src/hooks/use-pulse-flash.ts`
+
+The `usePulseFlash()` hook extracts the pulse-flash animation logic from inline state in `A2APairCard`, making it reusable across the switchboard and conversation list.
+
+### `usePulseFlash(pulsedAt: number | null): boolean`
+
+Returns `true` for one paint frame after `pulsedAt` changes to a non-null value, then `false`. The consumer's CSS `transition-duration` does the actual fade-out.
+
+**How it works:**
+
+1. Seeded to `null` (not the initial `pulsedAt`), so a component that *mounts* already carrying a live pulse still flashes hot
+2. On render, if `pulsedAt !== lastSeenPulse`, updates `lastSeenPulse` and sets `isPulsing = true` if `pulsedAt !== null`
+3. On the next paint frame (via `requestAnimationFrame`), flips `isPulsing` back to `false`
+4. CSS transition handles the fade — `transition-duration: PAIR_PULSE_FADE_MS` applied to elements that conditionally render the hot styling
+
+**Example:**
+
+```tsx
+import { usePulseFlash } from "@/hooks/use-pulse-flash";
+import { PAIR_PULSE_FADE_MS } from "@/components/a2a/a2a-switchboard-utils";
+
+export function MyPulsedRow({ pulsedAt }: { pulsedAt: number | null }) {
+  const isPulsing = usePulseFlash(pulsedAt);
+
+  return (
+    <div
+      className={cn("p-2", isPulsing && "bg-emerald-500/15")}
+      style={{ transitionDuration: `${PAIR_PULSE_FADE_MS}ms` }}
+    >
+      {/* content */}
+    </div>
+  );
+}
+```
+
+## A2A Page Integration
+
+**File:** `panel/src/app/(dashboard)/a2a/page.tsx`
+
+The page composes these pieces:
+
+1. **Filter state:** Lifts `statusFilter` and `search` to page level
+2. **Derived state:** Computes `filteredPairs` and `filteredConversations` via `useMemo` on each render
+3. **Filter bar:** Mounts `A2AFilterBar` above the view content
+4. **Synchronized pulses:** Both `A2ASwitchboard` and `A2AConversationList` receive the same `pulses` map, keyed identically, so pulse animations sync across views
+
+**Code sketch:**
+
+```tsx
+const [statusFilter, setStatusFilter] = useState<A2AStatusFilter>("all");
+const [search, setSearch] = useState("");
+
+const filteredPairs = useMemo(
+  () => filterPairs(pairs, statusFilter, search),
+  [pairs, statusFilter, search]
+);
+
+const filteredConversations = useMemo(
+  () => filterConversations(conversations, statusFilter, search),
+  [conversations, statusFilter, search]
+);
+
+// Both views receive the same pulses map
+<A2AFilterBar
+  status={statusFilter}
+  onStatusChange={setStatusFilter}
+  search={search}
+  onSearchChange={setSearch}
+/>
+
+{view === "switchboard" ? (
+  <A2ASwitchboard pairs={filteredPairs} pulses={pulses} ... />
+) : (
+  <A2AConversationList conversations={filteredConversations} pulses={pulses} ... />
+)}
+```
+
+## Testing
+
+All filtering and pulse behavior is covered by tests:
+
+- **`a2a-filter-utils.test.ts`:** `filterConversations()` and `filterPairs()` with status/search combinations
+- **`a2a-filter-bar.test.tsx`:** Button pressed state, search input changes, status toggle callbacks
+- **`a2a-conversation-list.test.tsx`:** Avatar rendering, pulse flash detection (tests the `data-pulsing` attribute)
+- **`page.test.tsx`:** Filter bar renders, narrows switchboard independently, narrows classic list independently
+
+Run tests with:
+
+```bash
+cd panel
+pnpm test
+```
+
+## Design Notes
+
+### Status Filter Semantics
+
+The "active" filter has different semantics across views due to data availability:
+
+- **Conversations:** `active` filters to `conversation.status === "active"` (backend-provided status)
+- **Pairs:** `active` filters to pairs with a non-null `conversation_id` (have A2A'd at least once)
+
+This is intentional and documented in code comments. If the backend adds an explicit `AdminPairSummary.status` field in the future, update `filterPairs()` to use it instead of the `conversation_id` heuristic.
+
+### Pulse Animation Timing
+
+The pulse flash is a brief, high-contrast alert (emerald bg + shadow) that fades over `PAIR_PULSE_FADE_MS` (200ms by default, defined in `a2a-switchboard-utils.ts`). If you're experiencing chop or seeing the animation cut off, check:
+
+1. The `usePulseFlash()` hook is being called (not bypassed)
+2. The consumer element has `transition-[background-color,box-shadow]` or equivalent CSS
+3. The `transitionDuration` inline style matches the fade constant
+
+## Migration Guide
+
+### If you use `A2AConversationList` in another context:
+
+**Before:**
+
+```tsx
+<A2AConversationList
+  conversations={conversations}
+  selectedId={selectedId}
+  onSelect={handleSelect}
+  isLoading={false}
+/>
+```
+
+**After:**
+
+```tsx
+<A2AConversationList
+  conversations={conversations}
+  selectedId={selectedId}
+  onSelect={handleSelect}
+  isLoading={false}
+  pulses={{}} // Add this prop (empty object if no pulses available)
+/>
+```
+
+### If you extract pulse-flash logic into other components:
+
+Import and use the `usePulseFlash()` hook instead of rolling your own state management:
+
+```tsx
+import { usePulseFlash } from "@/hooks/use-pulse-flash";
+import { PAIR_PULSE_FADE_MS } from "@/components/a2a/a2a-switchboard-utils";
+
+const isPulsing = usePulseFlash(pulsedAt);
+// Now use isPulsing to conditionally render the hot styling
+```

--- a/panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx
+++ b/panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx
@@ -308,4 +308,78 @@ describe("A2APage", () => {
       queryKey: a2aLiveKeys.all,
     });
   });
+
+  it("renders the filter bar above the switchboard/list content", () => {
+    useA2AAdminPairs.mockReturnValue({
+      data: { items: [buildPair()], total: 1 },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    render(withPageRefresh(<A2APage />));
+    expect(
+      screen.getByPlaceholderText("Search agent or topic..."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Active" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+  });
+
+  it("narrows the switchboard's pairs by search", () => {
+    useA2AAdminPairs.mockReturnValue({
+      data: {
+        items: [
+          buildPair(),
+          buildPair({
+            agent_a: "auditor",
+            agent_b: "product-owner",
+            group_key: "board",
+            conversation_id: null,
+            last_message_at: null,
+            message_count: 0,
+          }),
+        ],
+        total: 2,
+      },
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+    render(withPageRefresh(<A2APage />));
+    expect(screen.getByText(/Backend Cell/)).toBeInTheDocument();
+    expect(screen.getByText(/^Board$/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search agent or topic..."), {
+      target: { value: "auditor" },
+    });
+    expect(screen.queryByText(/Backend Cell/)).not.toBeInTheDocument();
+    expect(screen.getByText(/^Board$/)).toBeInTheDocument();
+  });
+
+  it("narrows the classic list's conversations by search", () => {
+    useA2AConversations.mockReturnValue({
+      data: {
+        items: [
+          buildConversation(),
+          buildConversation({
+            id: "conv-2",
+            agent_a: "ux-dev-1",
+            agent_b: "ux-qa",
+            topic: "Design review",
+          }),
+        ],
+        total: 2,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    render(withPageRefresh(<A2APage />));
+    fireEvent.click(screen.getByTitle("Classic conversation list"));
+    expect(screen.getByText("QA handoff")).toBeInTheDocument();
+    expect(screen.getByText("Design review")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search agent or topic..."), {
+      target: { value: "design review" },
+    });
+    expect(screen.queryByText("QA handoff")).not.toBeInTheDocument();
+    expect(screen.getByText("Design review")).toBeInTheDocument();
+  });
 });

--- a/panel/src/app/(dashboard)/a2a/page.tsx
+++ b/panel/src/app/(dashboard)/a2a/page.tsx
@@ -22,7 +22,13 @@ import { A2AConversationList } from "@/components/a2a/a2a-conversation-list";
 import { A2ASwitchboard } from "@/components/a2a/a2a-switchboard";
 import { A2ATranscript } from "@/components/a2a/a2a-transcript";
 import { A2AReplyComposer } from "@/components/a2a/a2a-reply-composer";
+import { A2AFilterBar } from "@/components/a2a/a2a-filter-bar";
 import { latestPulseTimestamps } from "@/components/a2a/a2a-switchboard-utils";
+import {
+  filterConversations,
+  filterPairs,
+  type A2AStatusFilter,
+} from "@/components/a2a/a2a-filter-utils";
 import type { AdminPairSummary } from "@/lib/api/a2a";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -79,6 +85,11 @@ function A2APageContent() {
   // nothing to select via `?conversation=`, so it's tracked separately and
   // shown as an explicit "no A2A yet" state in the drill-in panel.
   const [peekedPair, setPeekedPair] = useState<PeekedPair | null>(null);
+
+  // Filter bar: status (active/all) + free-text search over agent name/topic
+  // — narrows both the switchboard's pairs and the list's conversations.
+  const [statusFilter, setStatusFilter] = useState<A2AStatusFilter>("all");
+  const [search, setSearch] = useState("");
 
   const {
     data: conversationData,
@@ -158,6 +169,10 @@ function A2APageContent() {
     () => latestPulseTimestamps(a2aMessages, pairs),
     [a2aMessages, pairs],
   );
+  const filteredPairs = useMemo(
+    () => filterPairs(pairs, statusFilter, search),
+    [pairs, statusFilter, search],
+  );
 
   const handleSelect = useCallback(
     (id: string) => {
@@ -186,7 +201,14 @@ function A2APageContent() {
     [handleSelect, router, searchParams],
   );
 
-  const conversations = conversationData?.items ?? [];
+  const conversations = useMemo(
+    () => conversationData?.items ?? [],
+    [conversationData],
+  );
+  const filteredConversations = useMemo(
+    () => filterConversations(conversations, statusFilter, search),
+    [conversations, statusFilter, search],
+  );
   const selected = conversations.find((c) => c.id === selectedId) ?? null;
   const messages = messagesData?.items ?? [];
   const lastSender = lastSenderOf(messages);
@@ -296,10 +318,16 @@ function A2APageContent() {
                     </Button>
                   </div>
                 </div>
+                <A2AFilterBar
+                  status={statusFilter}
+                  onStatusChange={setStatusFilter}
+                  search={search}
+                  onSearchChange={setSearch}
+                />
                 <div className="flex-1 overflow-hidden -mx-3">
                   {view === "switchboard" ? (
                     <A2ASwitchboard
-                      pairs={pairs}
+                      pairs={filteredPairs}
                       pulses={pulses}
                       selectedConversationId={selectedId}
                       isLoading={loadingPairs}
@@ -307,10 +335,11 @@ function A2APageContent() {
                     />
                   ) : (
                     <A2AConversationList
-                      conversations={conversations}
+                      conversations={filteredConversations}
                       selectedId={selectedId}
                       onSelect={handleSelect}
                       isLoading={loadingConversations}
+                      pulses={pulses}
                     />
                   )}
                 </div>

--- a/panel/src/components/a2a/__tests__/a2a-conversation-list.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-conversation-list.test.tsx
@@ -30,12 +30,16 @@ describe("A2AConversationList", () => {
         selectedId={null}
         onSelect={vi.fn()}
         isLoading={false}
+        pulses={{}}
       />,
     );
 
     // Participants via getAgentDisplayName ("{a} <-> {b}").
     expect(screen.getByText(/Backend Dev 1/)).toBeInTheDocument();
     expect(screen.getByText(/Backend QA/)).toBeInTheDocument();
+    // Both participants get an avatar, matching A2APairCard's PairAvatar.
+    expect(screen.getByTitle("Backend Dev 1")).toBeInTheDocument();
+    expect(screen.getByTitle("Backend QA")).toBeInTheDocument();
     // Topic, preview, message count, relative timestamp.
     expect(screen.getByText("QA handoff")).toBeInTheDocument();
     expect(
@@ -61,6 +65,7 @@ describe("A2AConversationList", () => {
         selectedId={null}
         onSelect={onSelect}
         isLoading={false}
+        pulses={{}}
       />,
     );
     fireEvent.click(screen.getByRole("button"));
@@ -75,6 +80,7 @@ describe("A2AConversationList", () => {
         selectedId={null}
         onSelect={onSelect}
         isLoading={false}
+        pulses={{}}
       />,
     );
     fireEvent.click(screen.getByRole("link", { name: /Task 11111111/ }));
@@ -88,8 +94,25 @@ describe("A2AConversationList", () => {
         selectedId={null}
         onSelect={vi.fn()}
         isLoading={false}
+        pulses={{}}
       />,
     );
     expect(screen.getByText(/No A2A conversations yet/)).toBeInTheDocument();
+  });
+
+  it("flashes a row hot when its pair's pulse key matches (same key as the switchboard)", () => {
+    render(
+      <A2AConversationList
+        conversations={[buildConversation()]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        isLoading={false}
+        pulses={{ "be-dev-1|be-qa": 1700000000000 }}
+      />,
+    );
+    expect(screen.getByTestId("conversation-row")).toHaveAttribute(
+      "data-pulsing",
+      "true",
+    );
   });
 });

--- a/panel/src/components/a2a/__tests__/a2a-filter-bar.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-filter-bar.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { A2AFilterBar } from "../a2a-filter-bar";
+
+describe("A2AFilterBar", () => {
+  it("renders the search input and both status toggle buttons", () => {
+    render(
+      <A2AFilterBar
+        status="all"
+        onStatusChange={vi.fn()}
+        search=""
+        onSearchChange={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByPlaceholderText("Search agent or topic..."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Active" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+  });
+
+  it("marks the current status button as pressed", () => {
+    render(
+      <A2AFilterBar
+        status="active"
+        onStatusChange={vi.fn()}
+        search=""
+        onSearchChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Active" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("fires onStatusChange when a status button is clicked", () => {
+    const onStatusChange = vi.fn();
+    render(
+      <A2AFilterBar
+        status="all"
+        onStatusChange={onStatusChange}
+        search=""
+        onSearchChange={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Active" }));
+    expect(onStatusChange).toHaveBeenCalledWith("active");
+  });
+
+  it("fires onSearchChange as the user types", () => {
+    const onSearchChange = vi.fn();
+    render(
+      <A2AFilterBar
+        status="all"
+        onStatusChange={vi.fn()}
+        search=""
+        onSearchChange={onSearchChange}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText("Search agent or topic..."), {
+      target: { value: "be-qa" },
+    });
+    expect(onSearchChange).toHaveBeenCalledWith("be-qa");
+  });
+});

--- a/panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts
+++ b/panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import type {
+  AdminConversationSummary,
+  AdminPairSummary,
+} from "@/lib/api/a2a";
+import { filterConversations, filterPairs } from "../a2a-filter-utils";
+
+function buildConversation(
+  overrides: Partial<AdminConversationSummary> = {},
+): AdminConversationSummary {
+  return {
+    id: "conv-1",
+    agent_a: "be-dev-1",
+    agent_b: "be-qa",
+    topic: "QA handoff",
+    task_id: null,
+    status: "active",
+    message_count: 3,
+    last_message_at: "2026-07-02T09:00:00Z",
+    last_message_preview: null,
+    created_at: "2026-07-01T08:00:00Z",
+    updated_at: "2026-07-02T09:00:00Z",
+    ...overrides,
+  };
+}
+
+function buildPair(
+  overrides: Partial<AdminPairSummary> = {},
+): AdminPairSummary {
+  return {
+    agent_a: "be-dev-1",
+    role_a: "developer",
+    team_a: "backend",
+    agent_b: "be-qa",
+    role_b: "qa",
+    team_b: "backend",
+    group_key: "cell-backend",
+    conversation_id: null,
+    last_message_at: null,
+    message_count: 0,
+    ...overrides,
+  };
+}
+
+describe("filterConversations", () => {
+  it("passes everything through with an empty search and status=all", () => {
+    const conversations = [
+      buildConversation({ status: "active" }),
+      buildConversation({ id: "conv-2", status: "closed" }),
+    ];
+    expect(filterConversations(conversations, "all", "")).toHaveLength(2);
+  });
+
+  it("narrows to active-status conversations when status=active", () => {
+    const conversations = [
+      buildConversation({ id: "conv-1", status: "active" }),
+      buildConversation({ id: "conv-2", status: "closed" }),
+    ];
+    const result = filterConversations(conversations, "active", "");
+    expect(result.map((c) => c.id)).toEqual(["conv-1"]);
+  });
+
+  it("matches search against agent display name (case-insensitive)", () => {
+    const conversations = [buildConversation()];
+    expect(filterConversations(conversations, "all", "backend qa")).toHaveLength(
+      1,
+    );
+    expect(filterConversations(conversations, "all", "nope")).toHaveLength(0);
+  });
+
+  it("matches search against the topic", () => {
+    const conversations = [buildConversation({ topic: "QA handoff" })];
+    expect(filterConversations(conversations, "all", "handoff")).toHaveLength(
+      1,
+    );
+  });
+
+  it("matches search against a raw agent slug", () => {
+    const conversations = [buildConversation({ agent_a: "be-dev-1" })];
+    expect(filterConversations(conversations, "all", "be-dev-1")).toHaveLength(
+      1,
+    );
+  });
+});
+
+describe("filterPairs", () => {
+  it("passes everything through with an empty search and status=all", () => {
+    const pairs = [
+      buildPair({ conversation_id: "conv-1" }),
+      buildPair({ agent_a: "auditor", agent_b: "product-owner" }),
+    ];
+    expect(filterPairs(pairs, "all", "")).toHaveLength(2);
+  });
+
+  it("narrows to pairs with a conversation when status=active", () => {
+    const pairs = [
+      buildPair({ conversation_id: "conv-1" }),
+      buildPair({ agent_a: "auditor", agent_b: "product-owner" }),
+    ];
+    const result = filterPairs(pairs, "active", "");
+    expect(result).toHaveLength(1);
+    expect(result[0].conversation_id).toBe("conv-1");
+  });
+
+  it("matches search against agent display name (case-insensitive)", () => {
+    const pairs = [buildPair()];
+    expect(filterPairs(pairs, "all", "backend dev 1")).toHaveLength(1);
+    expect(filterPairs(pairs, "all", "nope")).toHaveLength(0);
+  });
+});

--- a/panel/src/components/a2a/a2a-conversation-list.tsx
+++ b/panel/src/components/a2a/a2a-conversation-list.tsx
@@ -6,14 +6,123 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { getAgentDisplayName } from "@/lib/agent-utils";
 import type { AdminConversationSummary } from "@/lib/api/a2a";
+import { usePulseFlash } from "@/hooks/use-pulse-flash";
+import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import { ListTodo, MessagesSquare } from "lucide-react";
+import { PairAvatar } from "./a2a-pair-card";
+import { PAIR_PULSE_FADE_MS, pairKey } from "./a2a-switchboard-utils";
 
 interface A2AConversationListProps {
   conversations: AdminConversationSummary[];
   selectedId: string | null;
   onSelect: (id: string) => void;
   isLoading: boolean;
+  /** pairKey(agent_a, agent_b) -> epoch ms of the latest matching frame —
+   * the same map the switchboard uses, so a row flashes on the same live
+   * pulse as its pair's card. */
+  pulses: Record<string, number>;
+}
+
+interface ConversationRowProps {
+  conversation: AdminConversationSummary;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+  pulsedAt: number | null;
+}
+
+function ConversationRow({
+  conversation,
+  isSelected,
+  onSelect,
+  pulsedAt,
+}: ConversationRowProps) {
+  const isPulsing = usePulseFlash(pulsedAt);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid="conversation-row"
+      data-pulsing={isPulsing}
+      onClick={() => onSelect(conversation.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(conversation.id);
+        }
+      }}
+      className={cn(
+        "block w-full cursor-pointer p-3 rounded-lg border",
+        "transition-[background-color,box-shadow] ease-out",
+        isSelected ? "border-primary" : "border-border",
+        isPulsing
+          ? "bg-emerald-500/15 shadow-[0_0_0_1px_rgba(16,185,129,0.6)]"
+          : isSelected
+            ? "bg-primary/10"
+            : "bg-card hover:bg-muted/50 hover:border-primary/50",
+      )}
+      style={{ transitionDuration: `${PAIR_PULSE_FADE_MS}ms` }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-start gap-2 min-w-0 flex-1">
+          <div className="flex -space-x-2 shrink-0 pt-0.5">
+            <PairAvatar slug={conversation.agent_a} />
+            <PairAvatar slug={conversation.agent_b} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="font-medium text-sm truncate">
+              {getAgentDisplayName(conversation.agent_a)}
+              {" ↔ "}
+              {getAgentDisplayName(conversation.agent_b)}
+            </div>
+            {conversation.topic && (
+              <div className="text-xs text-muted-foreground truncate mt-0.5">
+                {conversation.topic}
+              </div>
+            )}
+            <div className="text-xs text-muted-foreground mt-1">
+              {formatDistanceToNow(
+                new Date(
+                  conversation.last_message_at ?? conversation.created_at,
+                ),
+              )}{" "}
+              ago
+            </div>
+            {conversation.last_message_preview && (
+              <p className="text-xs text-muted-foreground truncate mt-1">
+                {conversation.last_message_preview}
+              </p>
+            )}
+            {conversation.task_id && (
+              <Link
+                prefetch={false}
+                href={`/tasks/${conversation.task_id}`}
+                onClick={(e) => e.stopPropagation()}
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-1"
+              >
+                <ListTodo className="h-3 w-3" />
+                Task {conversation.task_id.slice(0, 8)}
+              </Link>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <Badge
+            variant={
+              conversation.status === "active" ? "default" : "secondary"
+            }
+            className="text-xs"
+          >
+            {conversation.status}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {conversation.message_count} msgs
+          </span>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function A2AConversationList({
@@ -21,6 +130,7 @@ export function A2AConversationList({
   selectedId,
   onSelect,
   isLoading,
+  pulses,
 }: A2AConversationListProps) {
   if (isLoading) {
     return (
@@ -47,76 +157,16 @@ export function A2AConversationList({
     <ScrollArea className="h-full">
       <div className="p-2 space-y-2">
         {conversations.map((conversation) => (
-          <div
+          <ConversationRow
             key={conversation.id}
-            role="button"
-            tabIndex={0}
-            onClick={() => onSelect(conversation.id)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onSelect(conversation.id);
-              }
-            }}
-            className={
-              "block w-full cursor-pointer p-3 rounded-lg border transition-all " +
-              (selectedId === conversation.id
-                ? "bg-primary/10 border-primary"
-                : "bg-card hover:bg-muted/50 hover:border-primary/50")
+            conversation={conversation}
+            isSelected={selectedId === conversation.id}
+            onSelect={onSelect}
+            pulsedAt={
+              pulses[pairKey(conversation.agent_a, conversation.agent_b)] ??
+              null
             }
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0 flex-1">
-                <div className="font-medium text-sm truncate">
-                  {getAgentDisplayName(conversation.agent_a)}
-                  {" ↔ "}
-                  {getAgentDisplayName(conversation.agent_b)}
-                </div>
-                {conversation.topic && (
-                  <div className="text-xs text-muted-foreground truncate mt-0.5">
-                    {conversation.topic}
-                  </div>
-                )}
-                <div className="text-xs text-muted-foreground mt-1">
-                  {formatDistanceToNow(
-                    new Date(
-                      conversation.last_message_at ?? conversation.created_at,
-                    ),
-                  )}{" "}
-                  ago
-                </div>
-                {conversation.last_message_preview && (
-                  <p className="text-xs text-muted-foreground truncate mt-1">
-                    {conversation.last_message_preview}
-                  </p>
-                )}
-                {conversation.task_id && (
-                  <Link
-                    prefetch={false}
-                    href={`/tasks/${conversation.task_id}`}
-                    onClick={(e) => e.stopPropagation()}
-                    className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-1"
-                  >
-                    <ListTodo className="h-3 w-3" />
-                    Task {conversation.task_id.slice(0, 8)}
-                  </Link>
-                )}
-              </div>
-              <div className="flex flex-col items-end gap-1 shrink-0">
-                <Badge
-                  variant={
-                    conversation.status === "active" ? "default" : "secondary"
-                  }
-                  className="text-xs"
-                >
-                  {conversation.status}
-                </Badge>
-                <span className="text-xs text-muted-foreground">
-                  {conversation.message_count} msgs
-                </span>
-              </div>
-            </div>
-          </div>
+          />
         ))}
       </div>
     </ScrollArea>

--- a/panel/src/components/a2a/a2a-filter-bar.tsx
+++ b/panel/src/components/a2a/a2a-filter-bar.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
+import type { A2AStatusFilter } from "./a2a-filter-utils";
+
+interface A2AFilterBarProps {
+  status: A2AStatusFilter;
+  onStatusChange: (status: A2AStatusFilter) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+}
+
+/**
+ * Filter bar above the switchboard/list content: free-text search (agent
+ * name or topic) plus an active/all status toggle. Both narrow the
+ * switchboard's pairs and the classic list's conversations identically —
+ * see a2a-filter-utils.ts.
+ */
+export function A2AFilterBar({
+  status,
+  onStatusChange,
+  search,
+  onSearchChange,
+}: A2AFilterBarProps) {
+  return (
+    <div className="flex items-center gap-2 mb-2 shrink-0">
+      <div className="relative flex-1 min-w-0">
+        <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search agent or topic..."
+          className="h-7 pl-7 text-xs"
+          aria-label="Search agent or topic"
+        />
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <Button
+          type="button"
+          variant={status === "active" ? "secondary" : "ghost"}
+          size="sm"
+          className="h-7 px-2 text-xs"
+          aria-pressed={status === "active"}
+          onClick={() => onStatusChange("active")}
+        >
+          Active
+        </Button>
+        <Button
+          type="button"
+          variant={status === "all" ? "secondary" : "ghost"}
+          size="sm"
+          className="h-7 px-2 text-xs"
+          aria-pressed={status === "all"}
+          onClick={() => onStatusChange("all")}
+        >
+          All
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/panel/src/components/a2a/a2a-filter-utils.ts
+++ b/panel/src/components/a2a/a2a-filter-utils.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure filter helpers for the A2A page's filter bar — shared by both the
+ * switchboard (pairs) and the classic list (conversations) so the same two
+ * inputs narrow both views to the matching subset.
+ */
+
+import type {
+  AdminConversationSummary,
+  AdminPairSummary,
+} from "@/lib/api/a2a";
+import { getAgentDisplayName } from "@/lib/agent-utils";
+
+/** "active" narrows to items with a live/talked conversation; "all" is no
+ * status narrowing. */
+export type A2AStatusFilter = "active" | "all";
+
+function matchesSearch(
+  query: string,
+  ...fields: Array<string | null | undefined>
+): boolean {
+  if (!query) return true;
+  const haystack = fields
+    .filter((field): field is string => !!field)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+/** Narrow conversations to the active/all status (conversation.status)
+ * and free-text search over both agents' slugs/display names and the
+ * topic. */
+export function filterConversations(
+  conversations: ReadonlyArray<AdminConversationSummary>,
+  status: A2AStatusFilter,
+  search: string,
+): AdminConversationSummary[] {
+  const query = search.trim().toLowerCase();
+  return conversations.filter((conversation) => {
+    if (status === "active" && conversation.status !== "active") return false;
+    return matchesSearch(
+      query,
+      conversation.agent_a,
+      conversation.agent_b,
+      getAgentDisplayName(conversation.agent_a),
+      getAgentDisplayName(conversation.agent_b),
+      conversation.topic,
+    );
+  });
+}
+
+/** Narrow switchboard pairs to the active/all status (active = the pair has
+ * a representative conversation, i.e. has actually A2A'd) and free-text
+ * search over both agents' slugs/display names. */
+export function filterPairs(
+  pairs: ReadonlyArray<AdminPairSummary>,
+  status: A2AStatusFilter,
+  search: string,
+): AdminPairSummary[] {
+  const query = search.trim().toLowerCase();
+  return pairs.filter((pair) => {
+    if (status === "active" && !pair.conversation_id) return false;
+    return matchesSearch(
+      query,
+      pair.agent_a,
+      pair.agent_b,
+      getAgentDisplayName(pair.agent_a),
+      getAgentDisplayName(pair.agent_b),
+    );
+  });
+}

--- a/panel/src/components/a2a/a2a-pair-card.tsx
+++ b/panel/src/components/a2a/a2a-pair-card.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { getAgentDisplayName, getAgentInitials } from "@/lib/agent-utils";
 import type { AdminPairSummary } from "@/lib/api/a2a";
 import { cn } from "@/lib/utils";
+import { usePulseFlash } from "@/hooks/use-pulse-flash";
 import { formatDistanceToNow } from "date-fns";
 import { PAIR_PULSE_FADE_MS } from "./a2a-switchboard-utils";
 
@@ -17,7 +17,10 @@ interface A2APairCardProps {
   onOpen: () => void;
 }
 
-function PairAvatar({ slug }: { slug: string }) {
+/** One agent's avatar (initials in a circle) — shared with
+ * A2AConversationList so a pair/conversation's two participants render
+ * identically across the switchboard and the classic list. */
+export function PairAvatar({ slug }: { slug: string }) {
   return (
     <div
       className="h-7 w-7 rounded-full bg-primary/10 border flex items-center justify-center shrink-0"
@@ -44,31 +47,7 @@ export function A2APairCard({
   onOpen,
 }: A2APairCardProps) {
   const hasHistory = pair.conversation_id !== null;
-  const [isPulsing, setIsPulsing] = useState(false);
-
-  // Render-phase derivation, not an Effect (react.dev/learn/you-might-not-
-  // need-an-effect#adjusting-some-state-when-a-prop-changes): flash hot in
-  // the very same render that receives a new pulsedAt, comparing against the
-  // last value we've seen. No cascading extra render from an Effect body.
-  // Seeded to null (not the initial pulsedAt) so a card that *mounts*
-  // already carrying a live pulse — e.g. switching into switchboard view
-  // right after a frame arrived — still flashes hot instead of looking cold.
-  const [lastSeenPulse, setLastSeenPulse] = useState<number | null>(null);
-  if (pulsedAt !== lastSeenPulse) {
-    setLastSeenPulse(pulsedAt);
-    if (pulsedAt !== null) setIsPulsing(true);
-  }
-
-  // Flip back on the next paint frame — the long CSS transition-duration
-  // below then animates the decay from "hot" to baseline over
-  // PAIR_PULSE_FADE_MS. The setState here is inside the (async) rAF
-  // callback, not the Effect body itself, so it's the intended "subscribe to
-  // an external clock" use of an Effect.
-  useEffect(() => {
-    if (!isPulsing) return;
-    const raf = requestAnimationFrame(() => setIsPulsing(false));
-    return () => cancelAnimationFrame(raf);
-  }, [isPulsing]);
+  const isPulsing = usePulseFlash(pulsedAt);
 
   return (
     <button

--- a/panel/src/hooks/use-pulse-flash.ts
+++ b/panel/src/hooks/use-pulse-flash.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * True for one paint frame after `pulsedAt` changes to a non-null value, then
+ * flips back to false — the consumer's own CSS `transition-duration` does the
+ * actual fade-out. Shared between A2APairCard (switchboard) and
+ * A2AConversationList (classic list) so both flash consistently off the same
+ * `pairKey -> epoch ms` pulse map.
+ *
+ * Render-phase derivation (react.dev/learn/you-might-not-need-an-effect
+ * #adjusting-some-state-when-a-prop-changes), not an Effect keyed on
+ * `pulsedAt`: flips hot in the very same render that receives a new
+ * `pulsedAt`, comparing against the last value seen. Seeded to `null` (not
+ * the initial `pulsedAt`) so a component that *mounts* already carrying a
+ * live pulse still flashes hot instead of looking cold.
+ */
+export function usePulseFlash(pulsedAt: number | null): boolean {
+  const [isPulsing, setIsPulsing] = useState(false);
+  const [lastSeenPulse, setLastSeenPulse] = useState<number | null>(null);
+  if (pulsedAt !== lastSeenPulse) {
+    setLastSeenPulse(pulsedAt);
+    if (pulsedAt !== null) setIsPulsing(true);
+  }
+
+  // Flip back on the next paint frame — the async rAF callback is the
+  // intended "subscribe to an external clock" use of an Effect.
+  useEffect(() => {
+    if (!isPulsing) return;
+    const raf = requestAnimationFrame(() => setIsPulsing(false));
+    return () => cancelAnimationFrame(raf);
+  }, [isPulsing]);
+
+  return isPulsing;
+}


### PR DESCRIPTION
The A2A page at panel/src/app/(dashboard)/a2a/page.tsx already implements much of a conversation-first redesign: a switchboard/list toggle (A2ASwitchboard groups allowed pairs into sections with avatar-carrying A2APairCard entries that pulse on live message arrival), and a connection-status dot wired to useA2ALiveStream in the header. What's missing to close out the redesign:

1. Filter controls: add a filter bar above the switchboard/list panel content (below the existing panel header with the view-toggle buttons) with a status filter (active / all) and a free-text search matching agent display name or conversation topic. Thread the filtered subset into both A2ASwitchboard (filter `pairs`) and A2AConversationList (filter `conversations`) so both views respect the same filter state. Use local `useState` in page.tsx — no new API params needed, filter client-side against the already-fetched arrays.

2. Agent identity consistency: A2AConversationList currently renders only text names (getAgentDisplayName) per row, while A2ASwitchboard's A2APairCard renders avatar circles with agent initials (getAgentInitials) plus the display name. Add the same avatar treatment to A2AConversationList rows so agent identity presentation is consistent between both views. Reuse the existing `getAgentInitials`/`getAgentDisplayName` helpers from `@/lib/agent-utils` — do not invent a new avatar component if `A2APairCard`'s `PairAvatar` pattern can be reused/extracted.

3. Live-stream affordance: verify the existing connection-status dot (isConnected) and pair-card pulse animation (on `a2a.message` frames) already satisfy this criterion end-to-end across both switchboard and list views; if the list view has no equivalent "new message" indication, add a minimal one (e.g. a small live-dot badge on rows matching a currently-pulsing pair) consistent with the existing pulse pattern in a2a-switchboard-utils.ts.

Follow the design bar in your team prompt (VISUAL_DENSITY should read as standard app density here — this is a dense monitoring surface, not a landing page). Match existing Tailwind/shadcn conventions already used across a2a-*.tsx files.