### PR TITLE
[13b6c723] Task detail: inline timestamps + breadcrumb + prev/next navigation

### DIFF
--- a/docs/guide/task-detail-navigation.md
+++ b/docs/guide/task-detail-navigation.md
@@ -1,0 +1,182 @@
+# Task Detail Navigation & Timestamps
+
+This guide documents three related UI features added to the task-detail page: inline absolute timestamps, parent-task breadcrumbs, and list-context-aware prev/next navigation.
+
+## Inline Absolute Timestamps
+
+**Location:** `panel/src/lib/utils.ts`, `formatAbsoluteTimestamp()`
+
+All progress updates and checkpoints now display a standardized absolute timestamp (e.g., "Jul 10, 2026, 3:45 PM") **in addition to** the existing relative time text (e.g., "2m ago"). The absolute format is consistent across the panel, achieved via a shared helper that was extracted from the earlier `checkpoint-card.tsx` local implementation.
+
+### Implementation
+
+```typescript
+// lib/utils.ts
+export function formatAbsoluteTimestamp(timestamp: string): string {
+  return new Date(timestamp).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+```
+
+### Usage in Components
+
+- **`tab-progress.tsx` ProgressUpdatesSection:** Each progress entry now shows relative time + `·` + absolute time on the same line, with the absolute time also in the `title` tooltip for hover clarity.
+- **`tab-progress.tsx` CheckpointsSection:** Same treatment as progress updates.
+- **`progress-timeline.tsx`:** In the timeline view, relative time + absolute time on the same line.
+- **`checkpoint-card.tsx`:** The checkpoint component now uses the shared helper instead of its own format.
+
+The relative time remains the primary visual — it's glanceable. The absolute time is the secondary, precise reference, useful when comparing timestamps across different time zones or when exact dates matter (e.g., "was this before or after June 30?").
+
+## Parent Task Breadcrumb
+
+**Location:** `panel/src/components/tasks/task-detail/task-breadcrumb.tsx`
+
+When a task has a parent, a breadcrumb renders above the task title: `Parent Title > Child Title`. The breadcrumb is absent for root tasks (those with `parent_task_id = null`), keeping the UI clean for single-level work.
+
+### Implementation Details
+
+- Renders only if `task.parent_task_id` is set; otherwise returns `null`.
+- Uses `useTask(parentId)` to fetch the parent task data (title + styling).
+- While loading, a skeleton placeholder avoids layout shift.
+- The parent title is a clickable link to `/tasks/{parent.id}`.
+- Long titles are truncated with a `title` attribute tooltip.
+- Only the immediate parent is shown — deeper ancestry is reachable by following the chain one hop at a time, matching how the rest of the panel represents task hierarchy.
+
+### Example
+
+If Task B is a child of Task A:
+- Viewing Task B shows: `Task A > Task B`
+- Clicking "Task A" navigates to that parent
+- If Task A also has a parent, viewing Task A shows that grandparent, not Task B
+
+This recursive, one-level-at-a-time model prevents breadcrumbs from becoming unwieldy and mirrors the panel's task-tree representation elsewhere.
+
+## Prev/Next Task Navigation
+
+**Location:** `panel/src/components/tasks/task-detail/task-list-nav.tsx`
+
+Two chevron buttons (← →) on the task-detail page move to the adjacent task **within the current Tasks list filter/sort context**. This preserves the user's list view experience: if they filtered by status, sorted by priority, or searched for a term, those same filters apply when they navigate prev/next.
+
+### How It Works
+
+1. **List context capture:** The Tasks page (`tasks/page.tsx`) passes the currently visible task IDs (id + title) to `useScrollRestorationStore.setTaskListNav()` whenever the table's filtered/sorted order changes. The context includes the full query string (filters, search, sort) so a "Back to list" link can restore the exact view.
+
+2. **Session-scoped state:** The context lives in `sessionStorage` via Zustand's persist middleware. It survives navigation within the same browser session but is cleared if the browser is closed. This matches the "come back where you left off" UX without persisting across sessions.
+
+3. **Fallback when no context:** If the user navigates to a task via a direct link, search result, notification, or any path that doesn't pass through the Tasks list, `taskListNav` is `null`. Both buttons render **disabled** with a tooltip explaining: "Open this task from the Tasks list to enable prev/next navigation within that list's filter/sort order." This is the **documented fallback** — no guessing, no silent behavior change.
+
+4. **Edge cases:**
+   - **First item in list:** Prev button is disabled; next is enabled.
+   - **Last item in list:** Next button is disabled; prev is enabled.
+   - **Task not in captured list:** Both buttons are disabled (task was navigated to via another route after the list was visited).
+   - **Query string preservation:** The href for each nav link includes the original query string, so navigating back to the Tasks page from a nested task restores the same filters.
+
+### Components
+
+**`TaskListNav`:** The main export. Reads `taskListNav` from the store, computes prev/next items, and renders two `NavButton` children.
+
+**`NavButton`:** A single direction button. If enabled, it wraps a Next.js `<Link>`; if disabled, it's a plain button with a tooltip explaining why. The tooltip shows either the next task's title (when enabled) or the reason it's disabled.
+
+### Implementation Example
+
+```typescript
+export function TaskListNav({ task }: TaskListNavProps) {
+  const context = useScrollRestorationStore((state) => state.taskListNav);
+
+  const items = context?.items ?? [];
+  const index = items.findIndex((item) => item.id === task.id);
+  const hasContext = index !== -1;
+  const prevItem = hasContext && index > 0 ? items[index - 1] : null;
+  const nextItem =
+    hasContext && index < items.length - 1 ? items[index + 1] : null;
+
+  const query = context?.queryString ? `?${context.queryString}` : "";
+  // Render NavButton for each direction with the computed item and query
+}
+```
+
+## Store Extension
+
+**Location:** `panel/src/lib/stores/scroll-restoration-store.ts`
+
+The `useScrollRestorationStore` (already managing scroll positions, section expansions, etc.) now includes:
+
+- **`taskListNav: TaskListNavContext | null`** — The current task list context, or `null` if no list has been visited.
+- **`setTaskListNav(context: TaskListNavContext)`** — Updates the context when the Tasks table reports a new visible order.
+
+### Schema
+
+```typescript
+export interface TaskListNavItem {
+  id: string;
+  title: string;
+}
+
+export interface TaskListNavContext {
+  items: TaskListNavItem[];
+  queryString: string; // e.g., "status=in_progress&sort=-created_at"
+}
+```
+
+The store uses `sessionStorage` persistence, so state is automatically restored on page reload within the same session but is cleared when the session ends.
+
+## Integration Points
+
+### Tasks List Page (`tasks/page.tsx`)
+
+Calls `setTaskListNav()` whenever the table's visible order changes:
+
+```typescript
+const setTaskListNav = useScrollRestorationStore((state) => state.setTaskListNav);
+const handleVisibleOrderChange = useCallback(
+  (items: { id: string; title: string }[]) => {
+    setTaskListNav({ items, queryString: searchParamsString });
+  },
+  [setTaskListNav, searchParamsString],
+);
+```
+
+### TaskTable (`components/tasks/task-table.tsx`)
+
+Now accepts an optional `onVisibleOrderChange` callback, fired whenever the computed visible task order changes (e.g., on filter, sort, pagination, or expansion/collapse). The Tasks page wires this callback to capture the order.
+
+### Task Detail Page (`[taskId]/page.tsx`)
+
+Renders both `TaskBreadcrumb` and `TaskListNav` near the top of the page, in a flex row:
+
+```tsx
+<div className="flex items-center justify-between gap-4">
+  <TaskBreadcrumb task={task} />
+  <TaskListNav task={task} />
+</div>
+```
+
+The breadcrumb takes the left; nav buttons take the right, preserving the layout for long parent titles.
+
+## Design Considerations
+
+### Why relative + absolute times?
+
+Relative times ("2m ago") are glanceable but ambiguous across time zones and when comparing entries hours or days apart. Absolute times are precise but verbose if shown alone. Combining them gives quick context (relative) + accuracy (absolute) without sacrificing space.
+
+### Why session-scoped, not persistent?
+
+Task lists reflect current filters, which change frequently. Persisting a stale list order across sessions (e.g., "I opened this task from a filtered search yesterday, but I reopened the browser and the filter is gone") would silently navigate to the wrong next task. Session scope keeps the invariant: prev/next only works within the current session's list context.
+
+### Why disable instead of guess?
+
+A task opened via direct link, notification, or external system doesn't have a parent list context. We could try to infer one (e.g., "show all tasks" or "show tasks in this project"), but that's invisible magic — the user wouldn't know why they're seeing a particular next task. Disabling with a clear explanation ("open from the list to enable this") is explicit and honest.
+
+## Future Extensions
+
+Possible enhancements:
+
+1. **Remember list context across sessions:** A "pin this list" feature could persist context across browser sessions.
+2. **Breadcrumb depth:** Allow showing full ancestry (A > B > C) instead of one level; would require more space and careful truncation.
+3. **Recently viewed tasks:** A dropdown of tasks you've visited recently, separate from the list context.
+4. **Keyboard shortcuts:** Arrow keys to navigate prev/next when the buttons are enabled.

--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -7,6 +7,8 @@ import { useCreateBranch, useCreatePR, useMergePR } from "@/hooks/use-git";
 import { Team, TaskStatus } from "@/types";
 import {
   TaskHeader,
+  TaskBreadcrumb,
+  TaskListNav,
   TaskMetadata,
   TaskTabs,
 } from "@/components/tasks/task-detail";
@@ -443,6 +445,12 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   return (
     <div className="space-y-6">
+      {/* Breadcrumb (parent task) + prev/next list navigation */}
+      <div className="flex items-center justify-between gap-4">
+        <TaskBreadcrumb task={task} />
+        <TaskListNav task={task} />
+      </div>
+
       {/* Header */}
       <TaskHeader task={task} onAction={handleAction} />
 

--- a/panel/src/app/(dashboard)/tasks/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/page.tsx
@@ -17,6 +17,7 @@ import {
 import type { TaskFilters as TaskApiFilters } from "@/lib/api/tasks";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePageRefresh } from "@/hooks";
+import { useScrollRestorationStore } from "@/lib/stores";
 
 function TasksPageContent() {
   const router = useRouter();
@@ -157,6 +158,19 @@ function TasksPageContent() {
       });
     },
     [updateParams],
+  );
+
+  // Captures the table's live filtered/sorted order for task-detail prev/next
+  // navigation (see useScrollRestorationStore.taskListNav).
+  const setTaskListNav = useScrollRestorationStore(
+    (state) => state.setTaskListNav,
+  );
+  const searchParamsString = searchParams.toString();
+  const handleVisibleOrderChange = useCallback(
+    (items: { id: string; title: string }[]) => {
+      setTaskListNav({ items, queryString: searchParamsString });
+    },
+    [setTaskListNav, searchParamsString],
   );
 
   // Fetch tasks (server-filtered for single-select status/team) + client-side multi-select extras
@@ -342,6 +356,7 @@ function TasksPageContent() {
           onPageSizeChange={handlePageSizeChange}
           expandedIds={expandedIds}
           onExpandedChange={handleExpandedChange}
+          onVisibleOrderChange={handleVisibleOrderChange}
         />
       )}
     </div>

--- a/panel/src/components/tasks/task-detail/__tests__/task-breadcrumb.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/task-breadcrumb.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+const mockUseTask = vi.fn();
+vi.mock("@/hooks/use-tasks", () => ({
+  useTask: (id: string) => mockUseTask(id),
+}));
+
+import { TaskBreadcrumb } from "../task-breadcrumb";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "child-1",
+    title: "Child task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    parent_task_id: null,
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("TaskBreadcrumb", () => {
+  it("renders nothing when the task has no parent", () => {
+    mockUseTask.mockReturnValue({ data: undefined, isLoading: false });
+    const { container } = render(
+      <TaskBreadcrumb task={buildTask({ parent_task_id: null })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a link to the parent task when one exists", () => {
+    mockUseTask.mockReturnValue({
+      data: { id: "parent-1", title: "Parent task" },
+      isLoading: false,
+    });
+    render(
+      <TaskBreadcrumb
+        task={buildTask({ parent_task_id: "parent-1" })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Parent task" });
+    expect(link).toHaveAttribute("href", "/tasks/parent-1");
+    expect(screen.getByText("Child task")).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/tasks/task-detail/__tests__/task-list-nav.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/task-list-nav.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+import { useScrollRestorationStore } from "@/lib/stores";
+import { TaskListNav } from "../task-list-nav";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t2",
+    title: "Task 2",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    parent_task_id: null,
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("TaskListNav", () => {
+  beforeEach(() => {
+    useScrollRestorationStore.setState({ taskListNav: null });
+  });
+
+  it("disables both buttons with an explanatory tooltip when no list context exists", () => {
+    render(<TaskListNav task={buildTask()} />);
+    expect(screen.getByLabelText("Previous task")).toBeDisabled();
+    expect(screen.getByLabelText("Next task")).toBeDisabled();
+  });
+
+  it("disables both buttons when the current task isn't part of the captured list order", () => {
+    useScrollRestorationStore.setState({
+      taskListNav: {
+        items: [
+          { id: "other-1", title: "Other 1" },
+          { id: "other-2", title: "Other 2" },
+        ],
+        queryString: "",
+      },
+    });
+    render(<TaskListNav task={buildTask()} />);
+    expect(screen.getByLabelText("Previous task")).toBeDisabled();
+    expect(screen.getByLabelText("Next task")).toBeDisabled();
+  });
+
+  it("links prev/next to the adjacent tasks in the captured list order", () => {
+    useScrollRestorationStore.setState({
+      taskListNav: {
+        items: [
+          { id: "t1", title: "Task 1" },
+          { id: "t2", title: "Task 2" },
+          { id: "t3", title: "Task 3" },
+        ],
+        queryString: "status=in_progress",
+      },
+    });
+    render(<TaskListNav task={buildTask({ id: "t2" })} />);
+
+    const prev = screen.getByLabelText("Previous task");
+    const next = screen.getByLabelText("Next task");
+    expect(prev).not.toBeDisabled();
+    expect(next).not.toBeDisabled();
+    expect(prev.closest("a")).toHaveAttribute(
+      "href",
+      "/tasks/t1?status=in_progress",
+    );
+    expect(next.closest("a")).toHaveAttribute(
+      "href",
+      "/tasks/t3?status=in_progress",
+    );
+  });
+
+  it("disables prev at the start of the list and next at the end", () => {
+    useScrollRestorationStore.setState({
+      taskListNav: {
+        items: [
+          { id: "t1", title: "Task 1" },
+          { id: "t2", title: "Task 2" },
+        ],
+        queryString: "",
+      },
+    });
+    render(<TaskListNav task={buildTask({ id: "t1" })} />);
+    expect(screen.getByLabelText("Previous task")).toBeDisabled();
+    expect(screen.getByLabelText("Next task")).not.toBeDisabled();
+  });
+});

--- a/panel/src/components/tasks/task-detail/checkpoint-card.tsx
+++ b/panel/src/components/tasks/task-detail/checkpoint-card.tsx
@@ -4,19 +4,10 @@ import { Checkpoint } from "@/types";
 import { Card, CardContent } from "@/components/ui/card";
 import { Bookmark, Clock, User, ListTodo, FileText } from "lucide-react";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { formatAbsoluteTimestamp } from "@/lib/utils";
 
 interface CheckpointCardProps {
   checkpoint: Checkpoint;
-}
-
-function formatTime(timestamp: string): string {
-  const date = new Date(timestamp);
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 export function CheckpointCard({ checkpoint }: CheckpointCardProps) {
@@ -29,7 +20,7 @@ export function CheckpointCard({ checkpoint }: CheckpointCardProps) {
         </div>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Clock className="h-3 w-3" />
-          {formatTime(checkpoint.timestamp)}
+          {formatAbsoluteTimestamp(checkpoint.timestamp)}
         </div>
       </div>
       <CardContent className="pt-4">

--- a/panel/src/components/tasks/task-detail/index.ts
+++ b/panel/src/components/tasks/task-detail/index.ts
@@ -1,4 +1,6 @@
 export { TaskHeader } from "./task-header";
+export { TaskBreadcrumb } from "./task-breadcrumb";
+export { TaskListNav } from "./task-list-nav";
 export { TaskMetadata } from "./task-metadata";
 export { TaskDescription } from "./task-description";
 export { TaskTabs } from "./task-tabs";

--- a/panel/src/components/tasks/task-detail/progress-timeline.tsx
+++ b/panel/src/components/tasks/task-detail/progress-timeline.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { MessageSquare, Clock } from "lucide-react";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { formatAbsoluteTimestamp } from "@/lib/utils";
 
 interface ProgressTimelineProps {
   updates: ProgressUpdate[];
@@ -82,9 +83,13 @@ export function ProgressTimeline({ updates }: ProgressTimelineProps) {
                       <span className="text-sm font-medium">
                         {getAgentDisplayName(update.agent_id)}
                       </span>
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
+                      <span
+                        className="text-xs text-muted-foreground flex items-center gap-1"
+                        title={formatAbsoluteTimestamp(update.timestamp)}
+                      >
                         <Clock className="h-3 w-3" />
-                        {formatTime(update.timestamp)}
+                        {formatTime(update.timestamp)} ·{" "}
+                        {formatAbsoluteTimestamp(update.timestamp)}
                       </span>
                     </div>
                     <p className="text-sm">{update.message}</p>

--- a/panel/src/components/tasks/task-detail/tab-progress.tsx
+++ b/panel/src/components/tasks/task-detail/tab-progress.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { formatAbsoluteTimestamp } from "@/lib/utils";
 
 interface TabProgressProps {
   task: Task;
@@ -225,9 +226,13 @@ function ProgressUpdatesSection({ task }: { task: Task }) {
                         {getAgentDisplayName(update.agent_id)}
                       </span>
                       <div className="flex items-center gap-2">
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
+                        <span
+                          className="text-xs text-muted-foreground flex items-center gap-1"
+                          title={formatAbsoluteTimestamp(update.timestamp)}
+                        >
                           <Clock className="h-3 w-3" />
-                          {formatTime(update.timestamp)}
+                          {formatTime(update.timestamp)} ·{" "}
+                          {formatAbsoluteTimestamp(update.timestamp)}
                         </span>
                         <Button
                           size="sm"
@@ -438,9 +443,13 @@ function CheckpointsSection({ task }: { task: Task }) {
                     <span className="font-medium text-sm">Checkpoint</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground flex items-center gap-1">
+                    <span
+                      className="text-xs text-muted-foreground flex items-center gap-1"
+                      title={formatAbsoluteTimestamp(checkpoint.timestamp)}
+                    >
                       <Clock className="h-3 w-3" />
-                      {formatTime(checkpoint.timestamp)}
+                      {formatTime(checkpoint.timestamp)} ·{" "}
+                      {formatAbsoluteTimestamp(checkpoint.timestamp)}
                     </span>
                     <Button
                       size="sm"

--- a/panel/src/components/tasks/task-detail/task-breadcrumb.tsx
+++ b/panel/src/components/tasks/task-detail/task-breadcrumb.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Task } from "@/types";
+import { useTask } from "@/hooks/use-tasks";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+interface TaskBreadcrumbProps {
+  task: Task;
+}
+
+// Renders "Parent title >" above the task title whenever this task has a
+// parent — absent (returns null) for a root task. Only the immediate parent
+// is shown; deeper ancestry is reachable by following the chain one hop at a
+// time, matching how the rest of the panel represents task hierarchy.
+export function TaskBreadcrumb({ task }: TaskBreadcrumbProps) {
+  const parentId = task.parent_task_id;
+  const { data: parent, isLoading } = useTask(parentId ?? "");
+
+  if (!parentId) return null;
+
+  return (
+    <nav
+      aria-label="Parent task"
+      className="flex items-center gap-1.5 text-sm text-muted-foreground min-w-0"
+    >
+      {isLoading || !parent ? (
+        <Skeleton className="h-4 w-32" />
+      ) : (
+        <Link
+          href={`/tasks/${parent.id}`}
+          prefetch={false}
+          className="truncate hover:text-foreground hover:underline"
+          title={parent.title}
+        >
+          {parent.title}
+        </Link>
+      )}
+      <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate text-foreground/70" title={task.title}>
+        {task.title}
+      </span>
+    </nav>
+  );
+}

--- a/panel/src/components/tasks/task-detail/task-list-nav.tsx
+++ b/panel/src/components/tasks/task-detail/task-list-nav.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Task } from "@/types";
+import { useScrollRestorationStore } from "@/lib/stores";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+interface TaskListNavProps {
+  task: Task;
+}
+
+const NO_CONTEXT_TOOLTIP =
+  "Open this task from the Tasks list to enable prev/next navigation within that list's filter/sort order.";
+
+// Moves to the adjacent task within the Tasks list order the user last
+// visited (filters + sort applied), captured in useScrollRestorationStore by
+// the Tasks list page. Documented fallback: when no list context exists for
+// this session (task opened via a direct link, search result, notification,
+// etc.) or the current task isn't part of the captured order (it was
+// navigated to some other way), both buttons render disabled with a tooltip
+// explaining why — there is no list order to fall back to, so we don't guess.
+export function TaskListNav({ task }: TaskListNavProps) {
+  const context = useScrollRestorationStore((state) => state.taskListNav);
+
+  const items = context?.items ?? [];
+  const index = items.findIndex((item) => item.id === task.id);
+  const hasContext = index !== -1;
+  const prevItem = hasContext && index > 0 ? items[index - 1] : null;
+  const nextItem =
+    hasContext && index < items.length - 1 ? items[index + 1] : null;
+
+  const query = context?.queryString ? `?${context.queryString}` : "";
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1 shrink-0">
+        <NavButton
+          direction="prev"
+          item={prevItem}
+          query={query}
+          disabledReason={!hasContext ? NO_CONTEXT_TOOLTIP : undefined}
+        />
+        <NavButton
+          direction="next"
+          item={nextItem}
+          query={query}
+          disabledReason={!hasContext ? NO_CONTEXT_TOOLTIP : undefined}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function NavButton({
+  direction,
+  item,
+  query,
+  disabledReason,
+}: {
+  direction: "prev" | "next";
+  item: { id: string; title: string } | null;
+  query: string;
+  disabledReason?: string;
+}) {
+  const Icon = direction === "prev" ? ChevronLeft : ChevronRight;
+  const label = direction === "prev" ? "Previous task" : "Next task";
+  const disabled = item === null;
+
+  const button = (
+    <Button
+      variant="outline"
+      size="icon"
+      disabled={disabled}
+      aria-label={label}
+      asChild={!disabled}
+    >
+      {disabled ? (
+        <Icon className="h-4 w-4" />
+      ) : (
+        <Link href={`/tasks/${item.id}${query}`} prefetch={false}>
+          <Icon className="h-4 w-4" />
+        </Link>
+      )}
+    </Button>
+  );
+
+  const tooltipText = disabledReason ?? item?.title ?? label;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>{button}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/panel/src/components/tasks/task-table.tsx
+++ b/panel/src/components/tasks/task-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Task } from "@/types";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -95,6 +95,10 @@ interface TaskTableProps {
   // Controlled expanded state
   expandedIds?: Set<string>;
   onExpandedChange?: (ids: Set<string>) => void;
+  // Reports the currently visible, filtered + sorted task order (id + title
+  // pairs) — consumed by the Tasks list page to power task-detail prev/next
+  // navigation. Fires whenever the computed order changes.
+  onVisibleOrderChange?: (items: { id: string; title: string }[]) => void;
 }
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
@@ -268,6 +272,7 @@ export function TaskTable({
   onPageSizeChange,
   expandedIds: controlledExpandedIds,
   onExpandedChange,
+  onVisibleOrderChange,
 }: TaskTableProps) {
   // Internal state (used when not controlled)
   const [internalSortConfig, setInternalSortConfig] =
@@ -383,6 +388,18 @@ export function TaskTable({
   const flattenedTasks = useMemo(() => {
     return flattenTree(sortedRoots, expandedIds);
   }, [sortedRoots, expandedIds]);
+
+  // Report the visible order to the parent so task-detail can compute
+  // prev/next within this exact filter/sort context.
+  useEffect(() => {
+    onVisibleOrderChange?.(
+      flattenedTasks.map((node) => ({
+        id: node.task.id,
+        title: node.task.title,
+      })),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flattenedTasks]);
 
   // Pagination on flattened list
   const totalItems = flattenedTasks.length;

--- a/panel/src/lib/stores/index.ts
+++ b/panel/src/lib/stores/index.ts
@@ -1,1 +1,5 @@
 export { useScrollRestorationStore } from "./scroll-restoration-store";
+export type {
+  TaskListNavContext,
+  TaskListNavItem,
+} from "./scroll-restoration-store";

--- a/panel/src/lib/stores/scroll-restoration-store.ts
+++ b/panel/src/lib/stores/scroll-restoration-store.ts
@@ -15,6 +15,21 @@ interface ScrollPosition {
   y: number;
 }
 
+// A single entry in the current Tasks list order (filter + sort applied),
+// captured by the Tasks list page so the task-detail page can compute
+// prev/next without re-implementing the list's filter/sort logic.
+export interface TaskListNavItem {
+  id: string;
+  title: string;
+}
+
+export interface TaskListNavContext {
+  items: TaskListNavItem[];
+  // The Tasks list's current query string (filters/sort/search), so a "Back
+  // to list" link can restore the exact context the user navigated from.
+  queryString: string;
+}
+
 interface ScrollRestorationState {
   // Scroll positions per route
   scrollPositions: Record<string, ScrollPosition>;
@@ -27,6 +42,11 @@ interface ScrollRestorationState {
 
   // Last visited routes per section (for "back" behavior)
   lastVisited: Record<string, string>;
+
+  // Current Tasks list order (filter/sort context) for task-detail prev/next
+  // navigation. Null when no list has been visited this session — the
+  // documented fallback for task-detail is to disable prev/next then.
+  taskListNav: TaskListNavContext | null;
 
   // Actions
   setScrollPosition: (route: string, position: ScrollPosition) => void;
@@ -42,6 +62,8 @@ interface ScrollRestorationState {
 
   setLastVisited: (section: string, route: string) => void;
   getLastVisited: (section: string) => string | undefined;
+
+  setTaskListNav: (context: TaskListNavContext) => void;
 }
 
 export const useScrollRestorationStore = create<ScrollRestorationState>()(
@@ -51,6 +73,7 @@ export const useScrollRestorationStore = create<ScrollRestorationState>()(
       expandedSections: {},
       selectedItems: {},
       lastVisited: {},
+      taskListNav: null,
 
       // Scroll position management
       setScrollPosition: (route, position) =>
@@ -102,6 +125,8 @@ export const useScrollRestorationStore = create<ScrollRestorationState>()(
         })),
 
       getLastVisited: (section) => get().lastVisited[section],
+
+      setTaskListNav: (context) => set({ taskListNav: context }),
     }),
     {
       name: "roboco-ui-state",
@@ -111,6 +136,7 @@ export const useScrollRestorationStore = create<ScrollRestorationState>()(
         scrollPositions: state.scrollPositions,
         expandedSections: state.expandedSections,
         lastVisited: state.lastVisited,
+        taskListNav: state.taskListNav,
         // Don't persist selectedItems - they're temporary
       }),
     },

--- a/panel/src/lib/utils.ts
+++ b/panel/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Absolute inline timestamp shown alongside relative "Xm ago" text — e.g.
+// "Jul 10, 2026, 3:45 PM". Shared so progress updates and checkpoints render
+// the same format instead of each screen inventing its own.
+export function formatAbsoluteTimestamp(timestamp: string): string {
+  return new Date(timestamp).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}


### PR DESCRIPTION
Progress updates and checkpoints on the task-detail page already carry a `timestamp` field (ProgressUpdate.timestamp, Checkpoint.timestamp in types/index.ts) but progress-timeline.tsx and tab-progress.tsx only render a relative "Xm ago"/"Xh ago" string via their local formatTime() helpers. Add an absolute, human-readable timestamp shown inline alongside (or on hover/tooltip of) every progress update and checkpoint entry, so a user always has an exact time available, not just a relative estimate.

Also add navigation that doesn't exist today: (1) a breadcrumb on the task-detail page linking back to the parent task when one exists (Task.parent_task_id or similar — check types/index.ts), and (2) prev/next buttons that step to the adjacent task within whatever filter/sort the user arrived from (e.g. via the task list's current query params, or fall back to an unfiltered ordering if no filter context is available on a direct deep link — note any such fallback in dev_notes rather than blocking on a larger filter-persistence redesign). Check panel/src/components/ui for an existing Breadcrumb primitive before building a bespoke one.