### PR TITLE
[11e82f2e] Frontend: sidebar reorder, A2A rename, Notifications removal, 2-col objectives

### DIFF
--- a/docs/frontend/components/sidebar-navigation.md
+++ b/docs/frontend/components/sidebar-navigation.md
@@ -1,0 +1,93 @@
+# Sidebar Navigation
+
+## Overview
+
+The sidebar navigation in `panel/src/components/layout/sidebar.tsx` organizes the RoboCo panel's main navigation links into six logical groups, with a visual divider (`Separator`) between each group. This structure appears in both the desktop sidebar (with optional collapse to icon-only rail) and the mobile Sheet drawer.
+
+## Navigation Groups
+
+The six groups organize work by domain:
+
+### 1. Dashboard
+- **Overview** (`/overview`) – Command center, high-level status
+- **Business** (`/business`) – Business metrics and planning
+- **Social** (`/social`) – Social media tracking and insights
+
+### 2. Work Management
+- **Tasks** (`/tasks`) – Task list and detail view
+- **Kanban** (`/kanban`) – Kanban board view
+- **Task Assistant** (`/prompter`) – AI-assisted task creation/coaching
+
+### 3. Development
+- **Projects** (`/projects`) – Repository and project management
+- **Products** (`/products`) – Product configuration
+- **Git** (`/git`) – Git/CI/CD integration view
+
+### 4. Team & Reference
+- **Agents** (`/agents`) – AI agent roster and status
+- **Knowledge Base** (`/knowledge-base`) – Organizational RAG/learnings
+- **Auditor** (`/auditor`) – Quality gate dashboard
+
+### 5. History
+- **A2A** (`/a2a`) – Agent-to-agent live messaging (renamed from "A2A Live")
+- **Journals** (`/journals`) – Agent journal entries and reflections
+
+### 6. System
+- **Metrics** (`/metrics`) – System performance and delivery metrics
+- (Notifications no longer appear here; see below)
+
+## Key Changes
+
+### A2A Entry Rename
+The `/a2a` entry label changed from **"A2A Live"** to **"A2A"** for brevity. The route, icon (Radio), and functionality remain unchanged.
+
+### Notifications Removed from Sidebar
+The **Notifications** entry (previously `/notifications` in System) no longer appears in the sidebar or mobile drawer. Notifications remain accessible via:
+- The **NotificationBell** icon in the header (`panel/src/components/header/notification-bell.tsx`)
+- The **"View All Notifications"** link within the notification popover
+- The `/notifications` route is still available and untouched
+
+## Visual Behavior
+
+### Dividers
+A `Separator` component renders between each consecutive group (not before the first group). The dividers respect the collapsed state:
+- **Expanded sidebar:** Divider appears with normal width (`my-2` margin)
+- **Collapsed sidebar (icon-only rail):** Divider still renders, preserving visual grouping
+
+### Collapsed State
+When the sidebar is collapsed (icon-only mode):
+- Group structure is preserved (dividers still render)
+- Link labels are hidden
+- Icon titles appear as tooltips (`title` attribute)
+- Link layout uses `justify-center px-2` for icon centering
+
+### Mobile
+The mobile Sheet drawer reuses the same `SidebarNav` component, so grouping and dividers appear identically on both surfaces.
+
+## Data Structure
+
+Navigation items are organized as `navGroups` (array of arrays), then flattened into `navItems` for any code needing a flat list:
+
+```typescript
+const navGroups = [
+  [/* Dashboard group */],
+  [/* Work Management group */],
+  // ... etc
+];
+
+export const navItems = navGroups.flat();
+```
+
+This dual structure:
+- Keeps the grouping stable and self-documenting (comment-labeled sections)
+- Avoids couples UI concern (dividers) to individual items
+- Maintains item order as part of the acceptance criteria
+
+## Testing
+
+Sidebar behavior is tested in `panel/src/components/layout/__tests__/sidebar.test.tsx`:
+- Divider count (5 dividers for 6 groups)
+- A2A label ("A2A", not "A2A Live")
+- Notifications absence
+- Item order preservation
+- Collapsed state layout correctness

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -44,6 +44,20 @@ function formatTs(ts: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 // Objectives field — one text field per key derived from the first item.
 // Falls back to a single "value" field when array is empty.
+//
+// Renders a responsive grid of objective cards with the following layout:
+// - Mobile (< md): 1 column (grid-cols-1)
+// - Desktop (md+): 2 columns (md:grid-cols-2)
+// - The '+ Add objective' button sits below the grid as a full-width sibling
+//   (not as a grid item), maintaining consistent width across all breakpoints.
+//
+// Layout structure:
+//   <div className="space-y-3">
+//     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+//       {objective cards as grid items}
+//     </div>
+//     <Button className="w-full">{+ Add objective}</Button>
+//   </div>
 // ---------------------------------------------------------------------------
 
 interface ObjectivesEditorProps {
@@ -80,48 +94,51 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      {items.map((item, rowIdx) => (
-        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
-              Objective #{rowIdx + 1}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={disabled}
-              onClick={() => removeRow(rowIdx)}
-              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-            >
-              Remove
-            </Button>
-          </div>
-          {keys.map((key) => (
-            <div key={key} className="space-y-1">
-              <Label
-                htmlFor={`obj-${rowIdx}-${key}`}
-                className="text-xs capitalize"
-              >
-                {key.replace(/_/g, " ")}
-              </Label>
-              <Input
-                id={`obj-${rowIdx}-${key}`}
-                value={String(item[key] ?? "")}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {items.map((item, rowIdx) => (
+          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                Objective #{rowIdx + 1}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
                 disabled={disabled}
-                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                className="h-8 text-sm"
-              />
+                onClick={() => removeRow(rowIdx)}
+                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+              >
+                Remove
+              </Button>
             </div>
-          ))}
-        </div>
-      ))}
+            {keys.map((key) => (
+              <div key={key} className="space-y-1">
+                <Label
+                  htmlFor={`obj-${rowIdx}-${key}`}
+                  className="text-xs capitalize"
+                >
+                  {key.replace(/_/g, " ")}
+                </Label>
+                <Input
+                  id={`obj-${rowIdx}-${key}`}
+                  value={String(item[key] ?? "")}
+                  disabled={disabled}
+                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
       <Button
         type="button"
         variant="outline"
         size="sm"
         disabled={disabled}
         onClick={addRow}
+        className="w-full"
       >
         + Add objective
       </Button>

--- a/panel/src/components/layout/__tests__/sidebar.test.tsx
+++ b/panel/src/components/layout/__tests__/sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SidebarNav, navItems } from "../sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/overview",
+}));
+
+describe("SidebarNav", () => {
+  it("renders a divider between each of the six nav groups", () => {
+    const { container } = render(<SidebarNav />);
+    // One less divider than the number of groups (none before the first group).
+    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
+      5,
+    );
+  });
+
+  it("renders the /a2a entry labeled 'A2A', not 'A2A Live'", () => {
+    render(<SidebarNav />);
+    const link = screen.getByRole("link", { name: "A2A" });
+    expect(link).toHaveAttribute("href", "/a2a");
+    expect(screen.queryByText("A2A Live")).not.toBeInTheDocument();
+  });
+
+  it("no longer renders a Notifications entry", () => {
+    render(<SidebarNav />);
+    expect(screen.queryByRole("link", { name: /notifications/i })).toBeNull();
+    expect(navItems.some((item) => item.href === "/notifications")).toBe(
+      false,
+    );
+  });
+
+  it("keeps the same relative item order as before", () => {
+    expect(navItems.map((item) => item.href)).toEqual([
+      "/overview",
+      "/business",
+      "/social",
+      "/tasks",
+      "/kanban",
+      "/prompter",
+      "/projects",
+      "/products",
+      "/git",
+      "/agents",
+      "/knowledge-base",
+      "/auditor",
+      "/a2a",
+      "/journals",
+      "/metrics",
+    ]);
+  });
+
+  it("renders correctly when collapsed (icon-only, no layout break)", () => {
+    const { container } = render(<SidebarNav collapsed />);
+    expect(
+      container.querySelectorAll('[data-slot="separator"]'),
+    ).toHaveLength(5);
+    // Labels are hidden, but the links/icons still render.
+    expect(screen.getAllByRole("link")).toHaveLength(navItems.length);
+    expect(screen.queryByText("A2A")).not.toBeInTheDocument();
+  });
+});

--- a/panel/src/components/layout/sidebar.tsx
+++ b/panel/src/components/layout/sidebar.tsx
@@ -8,7 +8,6 @@ import {
   LayoutDashboard,
   ListTodo,
   Kanban,
-  Bell,
   Activity,
   ChevronLeft,
   Settings,
@@ -27,37 +26,48 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
 import { useUIStore } from "@/store";
 
-export const navItems = [
-  // Dashboard
-  { title: "Overview", href: "/overview", icon: LayoutDashboard },
-  { title: "Business", href: "/business", icon: Building2 },
-  { title: "Social", href: "/social", icon: Share2 },
-
-  // Work Management
-  { title: "Tasks", href: "/tasks", icon: ListTodo },
-  { title: "Kanban", href: "/kanban", icon: Kanban },
-  { title: "Task Assistant", href: "/prompter", icon: Sparkles },
-
-  // Development
-  { title: "Projects", href: "/projects", icon: FolderGit2 },
-  { title: "Products", href: "/products", icon: Boxes },
-  { title: "Git", href: "/git", icon: GitBranch },
-
-  // Team & Reference
-  { title: "Agents", href: "/agents", icon: Bot },
-  { title: "Knowledge Base", href: "/knowledge-base", icon: Database },
-  { title: "Auditor", href: "/auditor", icon: Shield },
-
-  // History
-  { title: "A2A Live", href: "/a2a", icon: Radio },
-  { title: "Journals", href: "/journals", icon: BookOpen },
-
-  // System
-  { title: "Notifications", href: "/notifications", icon: Bell },
-  { title: "Metrics", href: "/metrics", icon: Activity },
+// Grouped by section — a divider renders between each group in SidebarNav.
+// Keep item order within/across groups stable; it's part of the AC.
+const navGroups = [
+  [
+    // Dashboard
+    { title: "Overview", href: "/overview", icon: LayoutDashboard },
+    { title: "Business", href: "/business", icon: Building2 },
+    { title: "Social", href: "/social", icon: Share2 },
+  ],
+  [
+    // Work Management
+    { title: "Tasks", href: "/tasks", icon: ListTodo },
+    { title: "Kanban", href: "/kanban", icon: Kanban },
+    { title: "Task Assistant", href: "/prompter", icon: Sparkles },
+  ],
+  [
+    // Development
+    { title: "Projects", href: "/projects", icon: FolderGit2 },
+    { title: "Products", href: "/products", icon: Boxes },
+    { title: "Git", href: "/git", icon: GitBranch },
+  ],
+  [
+    // Team & Reference
+    { title: "Agents", href: "/agents", icon: Bot },
+    { title: "Knowledge Base", href: "/knowledge-base", icon: Database },
+    { title: "Auditor", href: "/auditor", icon: Shield },
+  ],
+  [
+    // History
+    { title: "A2A", href: "/a2a", icon: Radio },
+    { title: "Journals", href: "/journals", icon: BookOpen },
+  ],
+  [
+    // System (Notifications lives only in the header's NotificationBell now)
+    { title: "Metrics", href: "/metrics", icon: Activity },
+  ],
 ];
+
+export const navItems = navGroups.flat();
 
 const footerItems = [
   { title: "AI Providers", href: "/settings/ai-providers", icon: Cpu },
@@ -79,28 +89,33 @@ export function SidebarNav({
   const pathname = usePathname();
   return (
     <nav className="space-y-1 px-2">
-      {navItems.map((item) => {
-        const isActive = pathname.startsWith(item.href);
-        return (
-          <Link
-            prefetch={false}
-            key={item.href}
-            href={item.href}
-            onClick={onNavigate}
-            className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-              isActive
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              collapsed && "justify-center px-2",
-            )}
-            title={collapsed ? item.title : undefined}
-          >
-            <item.icon className="h-5 w-5 shrink-0" />
-            {!collapsed && <span>{item.title}</span>}
-          </Link>
-        );
-      })}
+      {navGroups.map((group, groupIndex) => (
+        <div key={group[0]!.href} className="space-y-1">
+          {groupIndex > 0 && <Separator className="my-2" />}
+          {group.map((item) => {
+            const isActive = pathname.startsWith(item.href);
+            return (
+              <Link
+                prefetch={false}
+                key={item.href}
+                href={item.href}
+                onClick={onNavigate}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  collapsed && "justify-center px-2",
+                )}
+                title={collapsed ? item.title : undefined}
+              >
+                <item.icon className="h-5 w-5 shrink-0" />
+                {!collapsed && <span>{item.title}</span>}
+              </Link>
+            );
+          })}
+        </div>
+      ))}
     </nav>
   );
 }


### PR DESCRIPTION
Reorder the panel sidebar entries per spec (including divider placement), rename the A2A sidebar entry, remove the Notifications sidebar entry (while keeping /notifications reachable via the navbar bell — no dead route), and switch the objectives display to a 2-column grid at desktop widths that collapses to single-column on mobile. Pure housekeeping, no design brief needed — HoM flagged this as not needing extra UX polish.