### PR TITLE
[e56e6543] Reorder sidebar, rename A2A, remove Notifications entry, 2-col objectives

### DIFF
--- a/docs/frontend/components/sidebar-navigation.md
+++ b/docs/frontend/components/sidebar-navigation.md
@@ -1,0 +1,93 @@
+# Sidebar Navigation
+
+## Overview
+
+The sidebar navigation in `panel/src/components/layout/sidebar.tsx` organizes the RoboCo panel's main navigation links into six logical groups, with a visual divider (`Separator`) between each group. This structure appears in both the desktop sidebar (with optional collapse to icon-only rail) and the mobile Sheet drawer.
+
+## Navigation Groups
+
+The six groups organize work by domain:
+
+### 1. Dashboard
+- **Overview** (`/overview`) – Command center, high-level status
+- **Business** (`/business`) – Business metrics and planning
+- **Social** (`/social`) – Social media tracking and insights
+
+### 2. Work Management
+- **Tasks** (`/tasks`) – Task list and detail view
+- **Kanban** (`/kanban`) – Kanban board view
+- **Task Assistant** (`/prompter`) – AI-assisted task creation/coaching
+
+### 3. Development
+- **Projects** (`/projects`) – Repository and project management
+- **Products** (`/products`) – Product configuration
+- **Git** (`/git`) – Git/CI/CD integration view
+
+### 4. Team & Reference
+- **Agents** (`/agents`) – AI agent roster and status
+- **Knowledge Base** (`/knowledge-base`) – Organizational RAG/learnings
+- **Auditor** (`/auditor`) – Quality gate dashboard
+
+### 5. History
+- **A2A** (`/a2a`) – Agent-to-agent live messaging (renamed from "A2A Live")
+- **Journals** (`/journals`) – Agent journal entries and reflections
+
+### 6. System
+- **Metrics** (`/metrics`) – System performance and delivery metrics
+- (Notifications no longer appear here; see below)
+
+## Key Changes
+
+### A2A Entry Rename
+The `/a2a` entry label changed from **"A2A Live"** to **"A2A"** for brevity. The route, icon (Radio), and functionality remain unchanged.
+
+### Notifications Removed from Sidebar
+The **Notifications** entry (previously `/notifications` in System) no longer appears in the sidebar or mobile drawer. Notifications remain accessible via:
+- The **NotificationBell** icon in the header (`panel/src/components/header/notification-bell.tsx`)
+- The **"View All Notifications"** link within the notification popover
+- The `/notifications` route is still available and untouched
+
+## Visual Behavior
+
+### Dividers
+A `Separator` component renders between each consecutive group (not before the first group). The dividers respect the collapsed state:
+- **Expanded sidebar:** Divider appears with normal width (`my-2` margin)
+- **Collapsed sidebar (icon-only rail):** Divider still renders, preserving visual grouping
+
+### Collapsed State
+When the sidebar is collapsed (icon-only mode):
+- Group structure is preserved (dividers still render)
+- Link labels are hidden
+- Icon titles appear as tooltips (`title` attribute)
+- Link layout uses `justify-center px-2` for icon centering
+
+### Mobile
+The mobile Sheet drawer reuses the same `SidebarNav` component, so grouping and dividers appear identically on both surfaces.
+
+## Data Structure
+
+Navigation items are organized as `navGroups` (array of arrays), then flattened into `navItems` for any code needing a flat list:
+
+```typescript
+const navGroups = [
+  [/* Dashboard group */],
+  [/* Work Management group */],
+  // ... etc
+];
+
+export const navItems = navGroups.flat();
+```
+
+This dual structure:
+- Keeps the grouping stable and self-documenting (comment-labeled sections)
+- Avoids couples UI concern (dividers) to individual items
+- Maintains item order as part of the acceptance criteria
+
+## Testing
+
+Sidebar behavior is tested in `panel/src/components/layout/__tests__/sidebar.test.tsx`:
+- Divider count (5 dividers for 6 groups)
+- A2A label ("A2A", not "A2A Live")
+- Notifications absence
+- Item order preservation
+- Collapsed state layout correctness

--- a/docs/frontend/components/sidebar-navigation.md
+++ b/docs/frontend/components/sidebar-navigation.md
@@ -2,92 +2,116 @@
 
 ## Overview
 
-The sidebar navigation in `panel/src/components/layout/sidebar.tsx` organizes the RoboCo panel's main navigation links into six logical groups, with a visual divider (`Separator`) between each group. This structure appears in both the desktop sidebar (with optional collapse to icon-only rail) and the mobile Sheet drawer.
+The sidebar navigation in `panel/src/components/layout/sidebar.tsx` is a single flat list of navigation links. A visual `Separator` divider appears once, between the main navigation list and the footer group (Business + settings). This structure appears in both the desktop sidebar (with optional collapse to icon-only rail) and the mobile Sheet drawer.
 
-## Navigation Groups
+## Navigation Items
 
-The six groups organize work by domain:
+The navigation list contains 14 items in this exact order:
 
-### 1. Dashboard
-- **Overview** (`/overview`) – Command center, high-level status
+1. **Overview** (`/overview`) – Command center, high-level status
+2. **Task Assistant** (`/prompter`) – AI-assisted task creation/coaching
+3. **Tasks** (`/tasks`) – Task list and detail view
+4. **Kanban** (`/kanban`) – Kanban board view
+5. **Git** (`/git`) – Git/CI/CD integration view
+6. **Projects** (`/projects`) – Repository and project management
+7. **Products** (`/products`) – Product configuration
+8. **Social** (`/social`) – Social media tracking and insights
+9. **Knowledge Base** (`/knowledge-base`) – Organizational RAG/learnings
+10. **A2A** (`/a2a`) – Agent-to-agent live messaging
+11. **Agents** (`/agents`) – AI agent roster and status
+12. **Journals** (`/journals`) – Agent journal entries and reflections
+13. **Auditor** (`/auditor`) – Quality gate dashboard
+14. **Metrics** (`/metrics`) – System performance and delivery metrics
+
+## Footer Items
+
+After a single `Separator` divider, the footer contains three links:
+
 - **Business** (`/business`) – Business metrics and planning
-- **Social** (`/social`) – Social media tracking and insights
+- **AI Providers** (`/settings/ai-providers`) – LLM provider configuration
+- **Settings** (`/settings`) – General application settings
 
-### 2. Work Management
-- **Tasks** (`/tasks`) – Task list and detail view
-- **Kanban** (`/kanban`) – Kanban board view
-- **Task Assistant** (`/prompter`) – AI-assisted task creation/coaching
+## Key Structural Changes
 
-### 3. Development
-- **Projects** (`/projects`) – Repository and project management
-- **Products** (`/products`) – Product configuration
-- **Git** (`/git`) – Git/CI/CD integration view
+### Navigation Flattened to Single List
+Navigation previously organized into six logical groups (Dashboard, Work Management, Development, Team & Reference, History, System) with a `Separator` after each group. All items now appear in a single flat `navItems` array without per-item grouping dividers.
 
-### 4. Team & Reference
-- **Agents** (`/agents`) – AI agent roster and status
-- **Knowledge Base** (`/knowledge-base`) – Organizational RAG/learnings
-- **Auditor** (`/auditor`) – Quality gate dashboard
+### Business Moved to Footer
+The **Business** entry moved from the Dashboard group (first group) to the footer items, positioned immediately before AI Providers. This visually separates business/administrative concerns from the core workflow links.
 
-### 5. History
-- **A2A** (`/a2a`) – Agent-to-agent live messaging (renamed from "A2A Live")
-- **Journals** (`/journals`) – Agent journal entries and reflections
-
-### 6. System
-- **Metrics** (`/metrics`) – System performance and delivery metrics
-- (Notifications no longer appear here; see below)
-
-## Key Changes
+### Single Separator Between Nav and Footer
+A single `Separator` now renders once, between the main navigation list and the footer group. In the old structure, there were five dividers (one after each of the first five groups). The new structure places this divider at a clear boundary between primary workflow and secondary/settings links.
 
 ### A2A Entry Rename
 The `/a2a` entry label changed from **"A2A Live"** to **"A2A"** for brevity. The route, icon (Radio), and functionality remain unchanged.
 
 ### Notifications Removed from Sidebar
-The **Notifications** entry (previously `/notifications` in System) no longer appears in the sidebar or mobile drawer. Notifications remain accessible via:
+The **Notifications** entry (previously in the System group) no longer appears in the sidebar or mobile drawer. Notifications remain accessible via:
 - The **NotificationBell** icon in the header (`panel/src/components/header/notification-bell.tsx`)
 - The **"View All Notifications"** link within the notification popover
 - The `/notifications` route is still available and untouched
 
 ## Visual Behavior
 
-### Dividers
-A `Separator` component renders between each consecutive group (not before the first group). The dividers respect the collapsed state:
+### The Separator Divider
+A single `Separator` component renders between the main navigation list (`SidebarNav`) and the footer links (`SidebarFooter`). The separator appears identically in both expanded and collapsed states:
 - **Expanded sidebar:** Divider appears with normal width (`my-2` margin)
-- **Collapsed sidebar (icon-only rail):** Divider still renders, preserving visual grouping
+- **Collapsed sidebar (icon-only rail):** Divider still renders in the same position
+- No additional dividers appear within the navigation list or within the footer group
 
 ### Collapsed State
 When the sidebar is collapsed (icon-only mode):
-- Group structure is preserved (dividers still render)
+- The separator continues to render between nav and footer
 - Link labels are hidden
 - Icon titles appear as tooltips (`title` attribute)
 - Link layout uses `justify-center px-2` for icon centering
 
 ### Mobile
-The mobile Sheet drawer reuses the same `SidebarNav` component, so grouping and dividers appear identically on both surfaces.
+The mobile Sheet drawer reuses the same `SidebarNav` and `SidebarFooter` components with the separator between them, so appearance and behavior match the desktop sidebar in both expanded and collapsed states.
 
 ## Data Structure
 
-Navigation items are organized as `navGroups` (array of arrays), then flattened into `navItems` for any code needing a flat list:
+Navigation items are exported as a single flat `navItems` array:
 
 ```typescript
-const navGroups = [
-  [/* Dashboard group */],
-  [/* Work Management group */],
-  // ... etc
+export const navItems = [
+  { title: "Overview", href: "/overview", icon: LayoutDashboard },
+  { title: "Task Assistant", href: "/prompter", icon: Sparkles },
+  // ... 12 more items in exact order ...
+  { title: "Metrics", href: "/metrics", icon: Activity },
 ];
-
-export const navItems = navGroups.flat();
 ```
 
-This dual structure:
-- Keeps the grouping stable and self-documenting (comment-labeled sections)
-- Avoids couples UI concern (dividers) to individual items
-- Maintains item order as part of the acceptance criteria
+Footer items are defined separately:
+
+```typescript
+const footerItems = [
+  { title: "Business", href: "/business", icon: Building2 },
+  { title: "AI Providers", href: "/settings/ai-providers", icon: Cpu },
+  { title: "Settings", href: "/settings", icon: Settings },
+];
+```
+
+**Key points:**
+- `navItems` order is stable and part of the acceptance criteria — changing the order requires updating tests and design specs
+- `footerItems` are rendered after a `Separator` divider by the `SidebarFooter` component
+- Each item includes `title` (display label), `href` (route), and `icon` (Lucide icon component)
+- No internal grouping or comments in the structure — the flat order is the source of truth for navigation organization
 
 ## Testing
 
-Sidebar behavior is tested in `panel/src/components/layout/__tests__/sidebar.test.tsx`:
-- Divider count (5 dividers for 6 groups)
-- A2A label ("A2A", not "A2A Live")
-- Notifications absence
-- Item order preservation
-- Collapsed state layout correctness
+Sidebar behavior is tested in `panel/src/components/layout/__tests__/sidebar.test.tsx`. The test suite covers:
+
+**Navigation (`navItems`) tests:**
+- `navItems` is a single flat array in the exact expected order (Overview → Metrics)
+- Business is not in `navItems`
+
+**SidebarNav component tests:**
+- No dividers within the nav list (zero separators)
+- All nav items render as links in the correct order
+- Collapsed mode hides labels while preserving layout
+
+**SidebarFooter component tests:**
+- Footer items render in order: Business → AI Providers → Settings
+- Exactly one `Separator` divides nav from footer (in both expanded and collapsed states)
+- Collapsed mode hides labels while preserving layout

--- a/panel/src/components/business/__tests__/goals-tab.test.tsx
+++ b/panel/src/components/business/__tests__/goals-tab.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { CompanyGoals } from "@/lib/api/company-goals";
+
+// ---------------------------------------------------------------------------
+// Mock @tanstack/react-query so we can control useQuery/useMutation return
+// values without a real QueryClientProvider.
+// ---------------------------------------------------------------------------
+
+const { mockUseQuery, mockUseMutation, mockMutate } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+  mockUseMutation: vi.fn(),
+  mockMutate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+    useMutation: mockUseMutation,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+vi.mock("@/lib/api/company-goals", () => ({
+  companyGoalsApi: {
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks are set up
+// ---------------------------------------------------------------------------
+
+import { GoalsTab } from "../goals-tab";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildGoals(overrides: Partial<CompanyGoals> = {}): CompanyGoals {
+  return {
+    north_star: "Ship things",
+    objectives: [
+      { metric: "Lead time", target: "< 24h", status: "Active" },
+      { metric: "Escaped defects", target: "0", status: "Active" },
+    ],
+    constraints: [],
+    operating_policy: {},
+    brand_voice: "",
+    updated_at: null,
+    updated_by: null,
+    ...overrides,
+  };
+}
+
+function setup(goals: CompanyGoals) {
+  mockUseQuery.mockReturnValue({
+    data: goals,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  mockUseMutation.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  });
+}
+
+describe("GoalsTab — ObjectivesEditor grid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the objectives container as a 2-column grid that collapses to 1 column on mobile", () => {
+    setup(buildGoals());
+
+    render(<GoalsTab />);
+
+    const objectiveOne = screen.getByText("Objective #1");
+    // The grid wrapper is the parent of each objective card.
+    const gridContainer = objectiveOne.closest("div.rounded-lg")
+      ?.parentElement as HTMLElement;
+
+    expect(gridContainer).toHaveClass("grid");
+    expect(gridContainer).toHaveClass("grid-cols-1");
+    expect(gridContainer).toHaveClass("md:grid-cols-2");
+  });
+
+  it("keeps add/remove/edit objective behavior working", () => {
+    setup(buildGoals());
+
+    render(<GoalsTab />);
+
+    // Two seeded objectives render as separate cards.
+    expect(screen.getByText("Objective #1")).toBeInTheDocument();
+    expect(screen.getByText("Objective #2")).toBeInTheDocument();
+
+    // Edit a field on the first objective (both rows share the "metric" label,
+    // so grab the first one — it belongs to Objective #1's input group).
+    const metricInput = screen.getAllByLabelText(
+      "metric",
+    )[0] as HTMLInputElement;
+    fireEvent.change(metricInput, { target: { value: "Updated metric" } });
+    expect(metricInput.value).toBe("Updated metric");
+
+    // Add a new objective row.
+    fireEvent.click(screen.getByText("+ Add objective"));
+    expect(screen.getByText("Objective #3")).toBeInTheDocument();
+
+    // Remove the second objective row; remaining rows renumber to #1/#2.
+    const removeButtons = screen.getAllByText("Remove");
+    fireEvent.click(removeButtons[1]);
+    expect(screen.getAllByText(/^Objective #/)).toHaveLength(2);
+    expect(screen.queryByText("Objective #3")).not.toBeInTheDocument();
+  });
+});

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -52,6 +52,19 @@ interface ObjectivesEditorProps {
   disabled: boolean;
 }
 
+/**
+ * ObjectivesEditor renders a responsive 2-column grid of objective cards.
+ *
+ * Layout:
+ * - Desktop (md+): 2-column grid with 3px gap
+ * - Mobile: 1-column stack (full width)
+ *
+ * Each card shows a set of editable fields derived from the first objective
+ * (metric, target, status, etc.) with add/remove controls. The outer container
+ * maintains space-y-3 gap to separate the grid from the "Add objective" button.
+ *
+ * Tests: `goals-tab.test.tsx` asserts the grid classes and add/remove/edit behavior.
+ */
 function ObjectivesEditor({
   items,
   onChange,
@@ -80,42 +93,44 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      {items.map((item, rowIdx) => (
-        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
-              Objective #{rowIdx + 1}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={disabled}
-              onClick={() => removeRow(rowIdx)}
-              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-            >
-              Remove
-            </Button>
-          </div>
-          {keys.map((key) => (
-            <div key={key} className="space-y-1">
-              <Label
-                htmlFor={`obj-${rowIdx}-${key}`}
-                className="text-xs capitalize"
-              >
-                {key.replace(/_/g, " ")}
-              </Label>
-              <Input
-                id={`obj-${rowIdx}-${key}`}
-                value={String(item[key] ?? "")}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {items.map((item, rowIdx) => (
+          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                Objective #{rowIdx + 1}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
                 disabled={disabled}
-                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                className="h-8 text-sm"
-              />
+                onClick={() => removeRow(rowIdx)}
+                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+              >
+                Remove
+              </Button>
             </div>
-          ))}
-        </div>
-      ))}
+            {keys.map((key) => (
+              <div key={key} className="space-y-1">
+                <Label
+                  htmlFor={`obj-${rowIdx}-${key}`}
+                  className="text-xs capitalize"
+                >
+                  {key.replace(/_/g, " ")}
+                </Label>
+                <Input
+                  id={`obj-${rowIdx}-${key}`}
+                  value={String(item[key] ?? "")}
+                  disabled={disabled}
+                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
       <Button
         type="button"
         variant="outline"

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -44,20 +44,6 @@ function formatTs(ts: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 // Objectives field — one text field per key derived from the first item.
 // Falls back to a single "value" field when array is empty.
-//
-// Renders a responsive grid of objective cards with the following layout:
-// - Mobile (< md): 1 column (grid-cols-1)
-// - Desktop (md+): 2 columns (md:grid-cols-2)
-// - The '+ Add objective' button sits below the grid as a full-width sibling
-//   (not as a grid item), maintaining consistent width across all breakpoints.
-//
-// Layout structure:
-//   <div className="space-y-3">
-//     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-//       {objective cards as grid items}
-//     </div>
-//     <Button className="w-full">{+ Add objective}</Button>
-//   </div>
 // ---------------------------------------------------------------------------
 
 interface ObjectivesEditorProps {
@@ -94,51 +80,48 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        {items.map((item, rowIdx) => (
-          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-muted-foreground">
-                Objective #{rowIdx + 1}
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={disabled}
-                onClick={() => removeRow(rowIdx)}
-                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-              >
-                Remove
-              </Button>
-            </div>
-            {keys.map((key) => (
-              <div key={key} className="space-y-1">
-                <Label
-                  htmlFor={`obj-${rowIdx}-${key}`}
-                  className="text-xs capitalize"
-                >
-                  {key.replace(/_/g, " ")}
-                </Label>
-                <Input
-                  id={`obj-${rowIdx}-${key}`}
-                  value={String(item[key] ?? "")}
-                  disabled={disabled}
-                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                  className="h-8 text-sm"
-                />
-              </div>
-            ))}
+      {items.map((item, rowIdx) => (
+        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground">
+              Objective #{rowIdx + 1}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              onClick={() => removeRow(rowIdx)}
+              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+            >
+              Remove
+            </Button>
           </div>
-        ))}
-      </div>
+          {keys.map((key) => (
+            <div key={key} className="space-y-1">
+              <Label
+                htmlFor={`obj-${rowIdx}-${key}`}
+                className="text-xs capitalize"
+              >
+                {key.replace(/_/g, " ")}
+              </Label>
+              <Input
+                id={`obj-${rowIdx}-${key}`}
+                value={String(item[key] ?? "")}
+                disabled={disabled}
+                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+          ))}
+        </div>
+      ))}
       <Button
         type="button"
         variant="outline"
         size="sm"
         disabled={disabled}
         onClick={addRow}
-        className="w-full"
       >
         + Add objective
       </Button>

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -44,6 +44,20 @@ function formatTs(ts: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 // Objectives field — one text field per key derived from the first item.
 // Falls back to a single "value" field when array is empty.
+//
+// Renders a responsive grid of objective cards with the following layout:
+// - Mobile (< md): 1 column (grid-cols-1)
+// - Desktop (md+): 2 columns (md:grid-cols-2)
+// - The '+ Add objective' button sits below the grid as a full-width sibling
+//   (not as a grid item), maintaining consistent width across all breakpoints.
+//
+// Layout structure:
+//   <div className="space-y-3">
+//     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+//       {objective cards as grid items}
+//     </div>
+//     <Button className="w-full">{+ Add objective}</Button>
+//   </div>
 // ---------------------------------------------------------------------------
 
 interface ObjectivesEditorProps {
@@ -80,48 +94,51 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      {items.map((item, rowIdx) => (
-        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
-              Objective #{rowIdx + 1}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={disabled}
-              onClick={() => removeRow(rowIdx)}
-              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-            >
-              Remove
-            </Button>
-          </div>
-          {keys.map((key) => (
-            <div key={key} className="space-y-1">
-              <Label
-                htmlFor={`obj-${rowIdx}-${key}`}
-                className="text-xs capitalize"
-              >
-                {key.replace(/_/g, " ")}
-              </Label>
-              <Input
-                id={`obj-${rowIdx}-${key}`}
-                value={String(item[key] ?? "")}
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {items.map((item, rowIdx) => (
+          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                Objective #{rowIdx + 1}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
                 disabled={disabled}
-                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                className="h-8 text-sm"
-              />
+                onClick={() => removeRow(rowIdx)}
+                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+              >
+                Remove
+              </Button>
             </div>
-          ))}
-        </div>
-      ))}
+            {keys.map((key) => (
+              <div key={key} className="space-y-1">
+                <Label
+                  htmlFor={`obj-${rowIdx}-${key}`}
+                  className="text-xs capitalize"
+                >
+                  {key.replace(/_/g, " ")}
+                </Label>
+                <Input
+                  id={`obj-${rowIdx}-${key}`}
+                  value={String(item[key] ?? "")}
+                  disabled={disabled}
+                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
       <Button
         type="button"
         variant="outline"
         size="sm"
         disabled={disabled}
         onClick={addRow}
+        className="w-full"
       >
         + Add objective
       </Button>

--- a/panel/src/components/layout/__tests__/sidebar.test.tsx
+++ b/panel/src/components/layout/__tests__/sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SidebarNav, navItems } from "../sidebar";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/overview",
+}));
+
+describe("SidebarNav", () => {
+  it("renders a divider between each of the six nav groups", () => {
+    const { container } = render(<SidebarNav />);
+    // One less divider than the number of groups (none before the first group).
+    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
+      5,
+    );
+  });
+
+  it("renders the /a2a entry labeled 'A2A', not 'A2A Live'", () => {
+    render(<SidebarNav />);
+    const link = screen.getByRole("link", { name: "A2A" });
+    expect(link).toHaveAttribute("href", "/a2a");
+    expect(screen.queryByText("A2A Live")).not.toBeInTheDocument();
+  });
+
+  it("no longer renders a Notifications entry", () => {
+    render(<SidebarNav />);
+    expect(screen.queryByRole("link", { name: /notifications/i })).toBeNull();
+    expect(navItems.some((item) => item.href === "/notifications")).toBe(
+      false,
+    );
+  });
+
+  it("keeps the same relative item order as before", () => {
+    expect(navItems.map((item) => item.href)).toEqual([
+      "/overview",
+      "/business",
+      "/social",
+      "/tasks",
+      "/kanban",
+      "/prompter",
+      "/projects",
+      "/products",
+      "/git",
+      "/agents",
+      "/knowledge-base",
+      "/auditor",
+      "/a2a",
+      "/journals",
+      "/metrics",
+    ]);
+  });
+
+  it("renders correctly when collapsed (icon-only, no layout break)", () => {
+    const { container } = render(<SidebarNav collapsed />);
+    expect(
+      container.querySelectorAll('[data-slot="separator"]'),
+    ).toHaveLength(5);
+    // Labels are hidden, but the links/icons still render.
+    expect(screen.getAllByRole("link")).toHaveLength(navItems.length);
+    expect(screen.queryByText("A2A")).not.toBeInTheDocument();
+  });
+});

--- a/panel/src/components/layout/__tests__/sidebar.test.tsx
+++ b/panel/src/components/layout/__tests__/sidebar.test.tsx
@@ -1,62 +1,88 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { SidebarNav, navItems } from "../sidebar";
+import { SidebarNav, SidebarFooter, navItems } from "../sidebar";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/overview",
 }));
 
+const EXPECTED_ORDER = [
+  "/overview",
+  "/prompter",
+  "/tasks",
+  "/kanban",
+  "/git",
+  "/projects",
+  "/products",
+  "/social",
+  "/knowledge-base",
+  "/a2a",
+  "/agents",
+  "/journals",
+  "/auditor",
+  "/metrics",
+];
+
+describe("navItems", () => {
+  it("is a single flat array in the exact expected order", () => {
+    expect(navItems.map((item) => item.href)).toEqual(EXPECTED_ORDER);
+  });
+
+  it("does not include Business", () => {
+    expect(navItems.some((item) => item.href === "/business")).toBe(false);
+  });
+});
+
 describe("SidebarNav", () => {
-  it("renders a divider between each of the six nav groups", () => {
+  it("renders no dividers — the nav list itself has no group separators", () => {
     const { container } = render(<SidebarNav />);
-    // One less divider than the number of groups (none before the first group).
-    expect(container.querySelectorAll('[data-slot="separator"]')).toHaveLength(
-      5,
-    );
+    expect(
+      container.querySelectorAll('[data-slot="separator"]'),
+    ).toHaveLength(0);
   });
 
-  it("renders the /a2a entry labeled 'A2A', not 'A2A Live'", () => {
+  it("renders every nav item as a link, in order", () => {
     render(<SidebarNav />);
-    const link = screen.getByRole("link", { name: "A2A" });
-    expect(link).toHaveAttribute("href", "/a2a");
-    expect(screen.queryByText("A2A Live")).not.toBeInTheDocument();
-  });
-
-  it("no longer renders a Notifications entry", () => {
-    render(<SidebarNav />);
-    expect(screen.queryByRole("link", { name: /notifications/i })).toBeNull();
-    expect(navItems.some((item) => item.href === "/notifications")).toBe(
-      false,
+    const links = screen.getAllByRole("link");
+    expect(links.map((link) => link.getAttribute("href"))).toEqual(
+      EXPECTED_ORDER,
     );
-  });
-
-  it("keeps the same relative item order as before", () => {
-    expect(navItems.map((item) => item.href)).toEqual([
-      "/overview",
-      "/business",
-      "/social",
-      "/tasks",
-      "/kanban",
-      "/prompter",
-      "/projects",
-      "/products",
-      "/git",
-      "/agents",
-      "/knowledge-base",
-      "/auditor",
-      "/a2a",
-      "/journals",
-      "/metrics",
-    ]);
   });
 
   it("renders correctly when collapsed (icon-only, no layout break)", () => {
-    const { container } = render(<SidebarNav collapsed />);
-    expect(
-      container.querySelectorAll('[data-slot="separator"]'),
-    ).toHaveLength(5);
-    // Labels are hidden, but the links/icons still render.
+    render(<SidebarNav collapsed />);
     expect(screen.getAllByRole("link")).toHaveLength(navItems.length);
-    expect(screen.queryByText("A2A")).not.toBeInTheDocument();
+    expect(screen.queryByText("Overview")).not.toBeInTheDocument();
+  });
+});
+
+describe("SidebarFooter", () => {
+  it("renders Business immediately before AI Providers, with Settings last", () => {
+    render(<SidebarFooter />);
+    const links = screen.getAllByRole("link");
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "/business",
+      "/settings/ai-providers",
+      "/settings",
+    ]);
+  });
+
+  it("renders exactly one Separator between the nav list and the footer, expanded and collapsed", () => {
+    const expanded = render(<SidebarFooter />);
+    expect(
+      expanded.container.querySelectorAll('[data-slot="separator"]'),
+    ).toHaveLength(1);
+    expanded.unmount();
+
+    const collapsed = render(<SidebarFooter collapsed />);
+    expect(
+      collapsed.container.querySelectorAll('[data-slot="separator"]'),
+    ).toHaveLength(1);
+  });
+
+  it("renders correctly when collapsed (icon-only)", () => {
+    render(<SidebarFooter collapsed />);
+    expect(screen.getAllByRole("link")).toHaveLength(3);
+    expect(screen.queryByText("Business")).not.toBeInTheDocument();
   });
 });

--- a/panel/src/components/layout/sidebar.tsx
+++ b/panel/src/components/layout/sidebar.tsx
@@ -8,7 +8,6 @@ import {
   LayoutDashboard,
   ListTodo,
   Kanban,
-  Bell,
   Activity,
   ChevronLeft,
   Settings,
@@ -27,37 +26,48 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
 import { useUIStore } from "@/store";
 
-export const navItems = [
-  // Dashboard
-  { title: "Overview", href: "/overview", icon: LayoutDashboard },
-  { title: "Business", href: "/business", icon: Building2 },
-  { title: "Social", href: "/social", icon: Share2 },
-
-  // Work Management
-  { title: "Tasks", href: "/tasks", icon: ListTodo },
-  { title: "Kanban", href: "/kanban", icon: Kanban },
-  { title: "Task Assistant", href: "/prompter", icon: Sparkles },
-
-  // Development
-  { title: "Projects", href: "/projects", icon: FolderGit2 },
-  { title: "Products", href: "/products", icon: Boxes },
-  { title: "Git", href: "/git", icon: GitBranch },
-
-  // Team & Reference
-  { title: "Agents", href: "/agents", icon: Bot },
-  { title: "Knowledge Base", href: "/knowledge-base", icon: Database },
-  { title: "Auditor", href: "/auditor", icon: Shield },
-
-  // History
-  { title: "A2A Live", href: "/a2a", icon: Radio },
-  { title: "Journals", href: "/journals", icon: BookOpen },
-
-  // System
-  { title: "Notifications", href: "/notifications", icon: Bell },
-  { title: "Metrics", href: "/metrics", icon: Activity },
+// Grouped by section — a divider renders between each group in SidebarNav.
+// Keep item order within/across groups stable; it's part of the AC.
+const navGroups = [
+  [
+    // Dashboard
+    { title: "Overview", href: "/overview", icon: LayoutDashboard },
+    { title: "Business", href: "/business", icon: Building2 },
+    { title: "Social", href: "/social", icon: Share2 },
+  ],
+  [
+    // Work Management
+    { title: "Tasks", href: "/tasks", icon: ListTodo },
+    { title: "Kanban", href: "/kanban", icon: Kanban },
+    { title: "Task Assistant", href: "/prompter", icon: Sparkles },
+  ],
+  [
+    // Development
+    { title: "Projects", href: "/projects", icon: FolderGit2 },
+    { title: "Products", href: "/products", icon: Boxes },
+    { title: "Git", href: "/git", icon: GitBranch },
+  ],
+  [
+    // Team & Reference
+    { title: "Agents", href: "/agents", icon: Bot },
+    { title: "Knowledge Base", href: "/knowledge-base", icon: Database },
+    { title: "Auditor", href: "/auditor", icon: Shield },
+  ],
+  [
+    // History
+    { title: "A2A", href: "/a2a", icon: Radio },
+    { title: "Journals", href: "/journals", icon: BookOpen },
+  ],
+  [
+    // System (Notifications lives only in the header's NotificationBell now)
+    { title: "Metrics", href: "/metrics", icon: Activity },
+  ],
 ];
+
+export const navItems = navGroups.flat();
 
 const footerItems = [
   { title: "AI Providers", href: "/settings/ai-providers", icon: Cpu },
@@ -79,28 +89,33 @@ export function SidebarNav({
   const pathname = usePathname();
   return (
     <nav className="space-y-1 px-2">
-      {navItems.map((item) => {
-        const isActive = pathname.startsWith(item.href);
-        return (
-          <Link
-            prefetch={false}
-            key={item.href}
-            href={item.href}
-            onClick={onNavigate}
-            className={cn(
-              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-              isActive
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              collapsed && "justify-center px-2",
-            )}
-            title={collapsed ? item.title : undefined}
-          >
-            <item.icon className="h-5 w-5 shrink-0" />
-            {!collapsed && <span>{item.title}</span>}
-          </Link>
-        );
-      })}
+      {navGroups.map((group, groupIndex) => (
+        <div key={group[0]!.href} className="space-y-1">
+          {groupIndex > 0 && <Separator className="my-2" />}
+          {group.map((item) => {
+            const isActive = pathname.startsWith(item.href);
+            return (
+              <Link
+                prefetch={false}
+                key={item.href}
+                href={item.href}
+                onClick={onNavigate}
+                className={cn(
+                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                  isActive
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  collapsed && "justify-center px-2",
+                )}
+                title={collapsed ? item.title : undefined}
+              >
+                <item.icon className="h-5 w-5 shrink-0" />
+                {!collapsed && <span>{item.title}</span>}
+              </Link>
+            );
+          })}
+        </div>
+      ))}
     </nav>
   );
 }

--- a/panel/src/components/layout/sidebar.tsx
+++ b/panel/src/components/layout/sidebar.tsx
@@ -29,47 +29,29 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useUIStore } from "@/store";
 
-// Grouped by section — a divider renders between each group in SidebarNav.
-// Keep item order within/across groups stable; it's part of the AC.
-const navGroups = [
-  [
-    // Dashboard
-    { title: "Overview", href: "/overview", icon: LayoutDashboard },
-    { title: "Business", href: "/business", icon: Building2 },
-    { title: "Social", href: "/social", icon: Share2 },
-  ],
-  [
-    // Work Management
-    { title: "Tasks", href: "/tasks", icon: ListTodo },
-    { title: "Kanban", href: "/kanban", icon: Kanban },
-    { title: "Task Assistant", href: "/prompter", icon: Sparkles },
-  ],
-  [
-    // Development
-    { title: "Projects", href: "/projects", icon: FolderGit2 },
-    { title: "Products", href: "/products", icon: Boxes },
-    { title: "Git", href: "/git", icon: GitBranch },
-  ],
-  [
-    // Team & Reference
-    { title: "Agents", href: "/agents", icon: Bot },
-    { title: "Knowledge Base", href: "/knowledge-base", icon: Database },
-    { title: "Auditor", href: "/auditor", icon: Shield },
-  ],
-  [
-    // History
-    { title: "A2A", href: "/a2a", icon: Radio },
-    { title: "Journals", href: "/journals", icon: BookOpen },
-  ],
-  [
-    // System (Notifications lives only in the header's NotificationBell now)
-    { title: "Metrics", href: "/metrics", icon: Activity },
-  ],
+// Flat list, in the exact order product wants the sidebar to read top to
+// bottom. Notifications lives only in the header's NotificationBell now.
+export const navItems = [
+  { title: "Overview", href: "/overview", icon: LayoutDashboard },
+  { title: "Task Assistant", href: "/prompter", icon: Sparkles },
+  { title: "Tasks", href: "/tasks", icon: ListTodo },
+  { title: "Kanban", href: "/kanban", icon: Kanban },
+  { title: "Git", href: "/git", icon: GitBranch },
+  { title: "Projects", href: "/projects", icon: FolderGit2 },
+  { title: "Products", href: "/products", icon: Boxes },
+  { title: "Social", href: "/social", icon: Share2 },
+  { title: "Knowledge Base", href: "/knowledge-base", icon: Database },
+  { title: "A2A", href: "/a2a", icon: Radio },
+  { title: "Agents", href: "/agents", icon: Bot },
+  { title: "Journals", href: "/journals", icon: BookOpen },
+  { title: "Auditor", href: "/auditor", icon: Shield },
+  { title: "Metrics", href: "/metrics", icon: Activity },
 ];
 
-export const navItems = navGroups.flat();
-
+// Business moved out of the main nav — it lives with the settings-adjacent
+// links, separated from navItems by a single Separator (see SidebarFooter).
 const footerItems = [
+  { title: "Business", href: "/business", icon: Building2 },
   { title: "AI Providers", href: "/settings/ai-providers", icon: Cpu },
   { title: "Settings", href: "/settings", icon: Settings },
 ];
@@ -89,33 +71,28 @@ export function SidebarNav({
   const pathname = usePathname();
   return (
     <nav className="space-y-1 px-2">
-      {navGroups.map((group, groupIndex) => (
-        <div key={group[0]!.href} className="space-y-1">
-          {groupIndex > 0 && <Separator className="my-2" />}
-          {group.map((item) => {
-            const isActive = pathname.startsWith(item.href);
-            return (
-              <Link
-                prefetch={false}
-                key={item.href}
-                href={item.href}
-                onClick={onNavigate}
-                className={cn(
-                  "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
-                  isActive
-                    ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                  collapsed && "justify-center px-2",
-                )}
-                title={collapsed ? item.title : undefined}
-              >
-                <item.icon className="h-5 w-5 shrink-0" />
-                {!collapsed && <span>{item.title}</span>}
-              </Link>
-            );
-          })}
-        </div>
-      ))}
+      {navItems.map((item) => {
+        const isActive = pathname.startsWith(item.href);
+        return (
+          <Link
+            prefetch={false}
+            key={item.href}
+            href={item.href}
+            onClick={onNavigate}
+            className={cn(
+              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+              collapsed && "justify-center px-2",
+            )}
+            title={collapsed ? item.title : undefined}
+          >
+            <item.icon className="h-5 w-5 shrink-0" />
+            {!collapsed && <span>{item.title}</span>}
+          </Link>
+        );
+      })}
     </nav>
   );
 }
@@ -129,23 +106,26 @@ export function SidebarFooter({
   onNavigate?: () => void;
 }) {
   return (
-    <div className="space-y-1">
-      {footerItems.map((item) => (
-        <Link
-          prefetch={false}
-          key={item.href}
-          href={item.href}
-          onClick={onNavigate}
-          className={cn(
-            "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors",
-            collapsed && "justify-center px-2",
-          )}
-          title={collapsed ? item.title : undefined}
-        >
-          <item.icon className="h-5 w-5" />
-          {!collapsed && <span>{item.title}</span>}
-        </Link>
-      ))}
+    <div className="space-y-2">
+      <Separator />
+      <div className="space-y-1">
+        {footerItems.map((item) => (
+          <Link
+            prefetch={false}
+            key={item.href}
+            href={item.href}
+            onClick={onNavigate}
+            className={cn(
+              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors",
+              collapsed && "justify-center px-2",
+            )}
+            title={collapsed ? item.title : undefined}
+          >
+            <item.icon className="h-5 w-5" />
+            {!collapsed && <span>{item.title}</span>}
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Objective

Align the panel sidebar navigation to the CEO's specified hierarchy and convert the Goals/Objectives tab to a scannable 2-column layout.

## What This Builds

- Reordered sidebar matching the spec verbatim
- A2A Live renamed to A2A
- Notifications entry removed from sidebar (navbar bell remains the entry point)
- 2-column responsive objectives layout on the Goals tab

## The Work

**Frontend** — Sidebar array reorder + rename + removal, and Goals tab 2-column layout
- Reorder navItems to: Overview, Task Assistant, Tasks, Kanban, Git, Projects, Products, Knowledge Base, A2A, Agents, Journals, Auditor, Metrics; move Business to footerItems before AI Providers; rename A2A Live → A2A; remove Notifications entry — route stays, navbar bell is the entry point
- Convert GoalsTab ObjectivesEditor to a responsive 2-column grid (2-col at md+ desktop widths, single-col on mobile) — independent of the sidebar change

## Notes

- The Notifications route (/notifications) must remain functional — only the sidebar link is removed
- The mobile bottom-tab-bar and mobile-sidebar both consume the exported navItems array, so the reorder propagates automatically

## Success Criteria

- Sidebar reorder delegated to frontend cell and merged — order matches spec verbatim including the divider placement
- No dead route after Notifications sidebar entry removal; /notifications still reachable via navbar bell
- Objectives render in a 2-column grid at desktop widths and collapse to single-column on mobile
- All cell subtasks terminal and root PR merged to master