### PR TITLE
[1fb5b5cb] Project picker, re-render button, and composition preview panel

### DIFF
--- a/panel/docs/video-post-queue.md
+++ b/panel/docs/video-post-queue.md
@@ -1,0 +1,215 @@
+# Video Post Queue: Project Picker, Re-render, and Composition Preview
+
+The video posting flow consists of three major components: project selection for on-demand video requests, a re-render retry control for failed drafts, and a live composition preview panel. All three integrate into the VideoPostRow and RequestVideoDialog components in `panel/src/components/dashboard/video-post-queue.tsx`.
+
+## Project Picker in RequestVideoDialog
+
+The "Request a video" dialog now requires a project selection before the CEO can submit. The picker is built on the existing `ProjectSelector` component (from `panel/src/components/projects/project-selector.tsx`) that provides a combobox populated via `projectsApi.list()`.
+
+### Implementation
+
+- **Location**: RequestVideoDialog component, first form field
+- **State**: `projectId` (string | null), initialized to `null`
+- **Binding**: The `ProjectSelector` renders with `value={projectId}` and `onChange={setProjectId}`, and the Request button is disabled until `projectId` is truthy
+- **Payload**: The `project_id` is passed as a string to `videoApi.requestVideo()` in the mutation body
+
+### Usage in RequestVideoDialog
+
+```typescript
+const [projectId, setProjectId] = useState<string | null>(null);
+
+// Inside the form:
+<div className="space-y-2">
+  <Label>Project</Label>
+  <ProjectSelector
+    value={projectId}
+    onChange={setProjectId}
+    placeholder="Select the project this video is about..."
+    allowClear={false}
+  />
+</div>
+
+// Submit guard:
+const canSubmit =
+  !!projectId &&
+  occasion.trim().length > 0 &&
+  brief.trim().length > 0 &&
+  platforms.length > 0;
+```
+
+The picker prevents submission of the video request until a project is explicitly selected, ensuring every on-demand video is scoped to a specific project.
+
+## Re-render Control for Stale Drafts
+
+The `RerenderControl` component appears only on drafts whose render has failed (`render_status === "failed"`), giving the CEO a way to retry a failed render without creating a new request.
+
+### When It Appears
+
+- Only rendered in `VideoPostRow` when both conditions hold:
+  - `post.render_status === "failed"`
+  - `post.source_task_id` is truthy (the authoring task exists)
+- Positioned in the draft header row, right-aligned after the occasion badge
+
+### Visual States
+
+1. **Idle** ("Re-render" button) — ready to click
+2. **Loading** ("Re-rendering...") — mutation in flight, button disabled, spinner animating
+3. **Error** ("Retry re-render") — the retry itself failed, button text and border turn red (`text-destructive` / `border-destructive`), button re-enables so the CEO can try again
+
+### API Interaction
+
+- Calls `videoApi.rerender(authoringTaskId)` where `authoringTaskId` is the draft's `source_task_id` (the video-authoring task, NOT the draft's own task_id)
+- The backend endpoint is `POST /video/pipeline/{task_id}/rerender` and clears the render idempotency keys so the render loop picks up the task on its next cycle
+- On success, invalidates the `["video", "pipeline"]` query key and shows a success toast: "Re-render queued — it will re-pick up on the next cycle."
+- On error, shows an error toast with the backend message
+
+### Implementation Detail
+
+The component uses `useMutation` from @tanstack/react-query and mirrors the pattern in the "Reject draft" dialog's mutation (error state re-enables the button, allowing the CEO to retry).
+
+## Composition Preview Panel
+
+The `CompositionPreviewPanel` displays a live, read-only preview of the video composition (the actual HyperFrames HTML render) alongside the platform captions so the CEO can see exactly what will post before approving.
+
+### When It Appears
+
+- Rendered in `VideoPostRow` immediately above the MP4 player
+- Only shows when BOTH of these are true:
+  - `post.composition_id` is truthy
+  - `post.source_task_id` is truthy
+
+This degrades gracefully: older drafts or drafts from versions before the backend exposed these fields simply render no preview panel (not a crash).
+
+### Layout
+
+The panel is a two-column grid on desktop (`sm:grid-cols-2`) that stacks on mobile:
+
+1. **Left column (desktop) / Top (mobile)**:
+   - An `<iframe>` element embedding the composition HTML directly
+   - The iframe uses a sandboxed environment (`sandbox="allow-scripts"`)
+   - Lazy-loads for performance (`loading="lazy"`)
+   - Applies aspect-video sizing and a black background
+
+2. **Right column (desktop) / Bottom (mobile)**:
+   - A "Captions as they will post" header
+   - Per-platform caption display:
+     - "X:" followed by the `x_caption` (if present)
+     - "TikTok:" followed by the `tiktok_caption` (if present)
+
+### Composition Preview URL
+
+The iframe `src` is built using the `compositionPreviewUrl()` helper:
+
+```typescript
+compositionPreviewUrl(
+  post.source_task_id,        // authoring task ID
+  post.composition_id,         // composition ID from the draft
+  cut,                         // current cut selection (vertical or square)
+)
+// → `/api/video/preview/{source_task_id}/motion/compositions/{composition_id}/{cut}.html`
+```
+
+The backend's `GET /video/preview/{task_id}/{file_path:path}` route serves the composition HTML + sibling assets from the project's merged read-clone with iframe-permitting headers (no auth-header workaround needed like the MP4 route).
+
+### Caption Display
+
+Captions are displayed as read-only text. The component only renders a caption section if at least one platform has a caption defined. This mirrors the structure the CEO will see when editing captions below (the "Edit X caption" / "Edit TikTok caption" checkboxes), giving visual parity between the live preview and the editable form.
+
+## API Updates
+
+### VideoPost Interface
+
+Two new optional fields were added to mirror the backend's `video_draft` marker's render idempotency tracking:
+
+```typescript
+composition_id?: string | null;  // The composition this draft rendered from
+render_status?: string | null;   // null | "rendered" | "failed"
+```
+
+Both are optional because drafts created before the backend exposed these fields will not have them. The UI gracefully handles their absence (re-render button doesn't appear, composition preview doesn't render).
+
+### New API Functions
+
+#### `compositionPreviewUrl()`
+
+Builds the URL for the composition preview iframe:
+
+```typescript
+export function compositionPreviewUrl(
+  authoringTaskId: string,
+  compositionId: string,
+  cut: VideoCut,
+): string
+```
+
+- **Parameters**:
+  - `authoringTaskId`: The video-authoring task ID (VideoPost.source_task_id)
+  - `compositionId`: The composition ID (VideoPost.composition_id)
+  - `cut`: "vertical" or "square"
+- **Returns**: The URL to pass to `<iframe src>`
+
+#### `videoApi.rerender()`
+
+Triggers a re-render of a failed composition:
+
+```typescript
+rerender: async (authoringTaskId: string): Promise<void>
+```
+
+- **Parameter**: The authoring task ID (VideoPost.source_task_id), NOT the draft's task_id
+- **Backend**: POSTs to `/video/pipeline/{task_id}/rerender`
+- **Effect**: Clears the render idempotency keys so the render loop picks the task up again on the next cycle
+
+### Updated: `videoApi.requestVideo()`
+
+The request signature now includes `project_id`:
+
+```typescript
+requestVideo: async (body: {
+  occasion: string;
+  brief: string;
+  platforms: string[];
+  project_id: string;  // ← NEW
+}): Promise<VideoRequestResult>
+```
+
+## Integration with VideoPostRow
+
+All three features integrate into `VideoPostRow` via:
+
+1. **Re-render button** appears in the header row (between the occasion badge and the edge):
+   ```typescript
+   {isStale && post.source_task_id && (
+     <div className="ml-auto">
+       <RerenderControl authoringTaskId={post.source_task_id} />
+     </div>
+   )}
+   ```
+
+2. **Composition preview panel** renders immediately above the MP4 player/cut switcher:
+   ```typescript
+   <CompositionPreviewPanel post={post} cut={cut} />
+   ```
+
+This placement gives the CEO a visual hierarchy: draft metadata → live composition preview → MP4 cuts → caption editors → approve/reject actions.
+
+## Design Notes
+
+- **Stale detection**: The `isStale` computation (`render_status === "failed" && !!source_task_id`) mirrors the pipeline strip's render-failure logic in `video-pipeline-utils.ts`, keeping both UI surfaces consistent.
+- **Composition preview sizing**: Uses `aspect-video` to maintain the standard 16:9 ratio for the iframe, with `w-full` for responsive scaling.
+- **Lazy loading**: The iframe uses `loading="lazy"` so it only fetches when scrolled into view, reducing initial page load on the queue.
+- **Sandbox isolation**: The iframe runs with `sandbox="allow-scripts"` to execute the composition's interactive elements while preventing navigation or form submission from escaping the preview.
+- **Graceful degradation**: All three features degrade safely — missing `composition_id` or `render_status` fields simply hide the corresponding UI, never crash.
+
+## Testing
+
+Six new tests cover the three features:
+
+1. **Project picker** — Submit disabled until a project is selected
+2. **Re-render button** — Hidden on healthy renders, shown only on stale drafts
+3. **Re-render action** — Clicking queues the backend re-render action
+4. **Composition preview** — Rendered only when `composition_id` is present, with correct iframe src and caption display
+5. **Preview visibility** — No preview when `composition_id` is absent
+6. **Request payload** — The `project_id` is sent in the POST /video/request body
+
+All tests pass; the full suite (380 tests) is green on the panel, and typecheck/lint/prettier are clean.

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -15,6 +15,7 @@ const {
   reject,
   requestVideo,
   getMediaBlob,
+  rerender,
 } = vi.hoisted(() => ({
   listPosts: vi.fn(
     async () =>
@@ -53,6 +54,7 @@ const {
   getMediaBlob: vi.fn(
     async () => new Blob(["fake-mp4-bytes"], { type: "video/mp4" }),
   ),
+  rerender: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -63,7 +65,17 @@ vi.mock("@/lib/api", () => ({
     reject,
     requestVideo,
     getMediaBlob,
+    rerender,
   },
+}));
+// ProjectSelector: a button that sets the project, mirroring
+// create-task-dialog.test.tsx — bypasses the data-fetching combobox.
+vi.mock("@/components/projects/project-selector", () => ({
+  ProjectSelector: ({ onChange }: { onChange: (v: string | null) => void }) => (
+    <button type="button" onClick={() => onChange("p-1")}>
+      Set Project
+    </button>
+  ),
 }));
 
 import { VideoPostQueue } from "../video-post-queue";
@@ -277,11 +289,12 @@ describe("VideoPostQueue", () => {
     );
   });
 
-  it("requests an on-demand video with the chosen occasion, brief, and platforms", async () => {
+  it("requests an on-demand video with the chosen project, occasion, brief, and platforms", async () => {
     render(withQueryClient(<VideoPostQueue />));
     await screen.findByText("release");
 
     fireEvent.click(screen.getByRole("button", { name: /Request a video/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Set Project" }));
     fireEvent.change(screen.getByLabelText("Occasion"), {
       target: { value: "Founder's Day" },
     });
@@ -296,8 +309,26 @@ describe("VideoPostQueue", () => {
         occasion: "Founder's Day",
         brief: "Celebrate the founding.",
         platforms: ["x", "tiktok"],
+        project_id: "p-1",
       }),
     );
+  });
+
+  it("keeps Request disabled until a project is picked", async () => {
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    fireEvent.click(screen.getByRole("button", { name: /Request a video/ }));
+    fireEvent.change(screen.getByLabelText("Occasion"), {
+      target: { value: "Founder's Day" },
+    });
+    fireEvent.change(screen.getByLabelText("Brief"), {
+      target: { value: "Celebrate the founding." },
+    });
+    expect(screen.getByRole("button", { name: "Request" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Set Project" }));
+    expect(screen.getByRole("button", { name: "Request" })).not.toBeDisabled();
   });
 
   it("shows the keys/engine empty copy when nothing is in the pipeline either", async () => {
@@ -331,5 +362,73 @@ describe("VideoPostQueue", () => {
       await screen.findByText(/1 video in flight — nothing rendered yet/),
     ).toBeInTheDocument();
     expect(screen.queryByText(/No drafts yet/)).not.toBeInTheDocument();
+  });
+
+  it("does not show a re-render button when the draft's render is healthy", async () => {
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+    expect(
+      screen.queryByRole("button", { name: /Re-render/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a re-render button only on a stale draft and triggers the backend re-render action", async () => {
+    listPosts.mockResolvedValueOnce([
+      {
+        task_id: "v-1",
+        source: "video_post",
+        title: "Video: release v0.19.0",
+        status: "pending",
+        occasion: "release",
+        script: "RoboCo v0.19.0 just shipped!",
+        platforms: ["x", "tiktok"],
+        x_caption: "RoboCo v0.19.0 is here!",
+        tiktok_caption: "New RoboCo drop!",
+        mp4_paths: { vertical: "/fake/vertical.mp4" },
+        source_task_id: "auth-1",
+        render_status: "failed",
+      },
+    ] as VideoPost[]);
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    const rerenderButton = screen.getByRole("button", { name: /Re-render/ });
+    fireEvent.click(rerenderButton);
+
+    await waitFor(() => expect(rerender).toHaveBeenCalledWith("auth-1"));
+  });
+
+  it("shows the live composition preview iframe with captions when composition_id is present", async () => {
+    listPosts.mockResolvedValueOnce([
+      {
+        task_id: "v-1",
+        source: "video_post",
+        title: "Video: release v0.19.0",
+        status: "pending",
+        occasion: "release",
+        script: "RoboCo v0.19.0 just shipped!",
+        platforms: ["x", "tiktok"],
+        x_caption: "RoboCo v0.19.0 is here!",
+        tiktok_caption: "New RoboCo drop!",
+        mp4_paths: { vertical: "/fake/vertical.mp4" },
+        source_task_id: "auth-1",
+        composition_id: "release-recap",
+      },
+    ] as VideoPost[]);
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    const iframe = document.querySelector("iframe");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe?.getAttribute("src")).toContain(
+      "/video/preview/auth-1/motion/compositions/release-recap/vertical.html",
+    );
+    expect(screen.getByText("Captions as they will post")).toBeInTheDocument();
+  });
+
+  it("hides the composition preview panel when the draft carries no composition_id", async () => {
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+    expect(document.querySelector("iframe")).not.toBeInTheDocument();
   });
 });

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { videoApi } from "@/lib/api";
+import { compositionPreviewUrl } from "@/lib/api/video";
 import type {
   VideoCut,
   VideoPost,
@@ -30,7 +31,8 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { CheckCircle2, Film, Sparkles, XCircle } from "lucide-react";
+import { ProjectSelector } from "@/components/projects/project-selector";
+import { CheckCircle2, Film, RefreshCw, Sparkles, XCircle } from "lucide-react";
 import { toast } from "sonner";
 
 const MAX_X_CAPTION_CHARS = 280;
@@ -62,6 +64,98 @@ function describeExecuteResult(result: VideoPostExecuteResult): string {
   if (result.status === "redis_unavailable")
     return "Redis is unavailable — can't acquire the post lock.";
   return `${result.status}: ${result.detail}`;
+}
+
+// Re-render retry control — only rendered by the caller when the draft's
+// render is stale (render_status === "failed"; see VideoPostRow). Three
+// visual states: idle (button, ready to click), loading (mutation
+// in-flight), error (the retry itself failed — button re-enables so the CEO
+// can try again). Mirrors the pipeline strip's render_failed derivation in
+// video-pipeline-utils.ts.
+function RerenderControl({ authoringTaskId }: { authoringTaskId: string }) {
+  const queryClient = useQueryClient();
+  const rerenderMutation = useMutation({
+    mutationFn: () => videoApi.rerender(authoringTaskId),
+    onSuccess: () => {
+      toast.success("Re-render queued — it will re-pick up on the next cycle.");
+      queryClient.invalidateQueries({ queryKey: ["video", "pipeline"] });
+    },
+    onError: (e) =>
+      toast.error(
+        `Re-render failed: ${e instanceof Error ? e.message : "error"}`,
+      ),
+  });
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={rerenderMutation.isPending}
+      onClick={() => rerenderMutation.mutate()}
+      className={
+        rerenderMutation.isError
+          ? "border-destructive text-destructive"
+          : undefined
+      }
+    >
+      <RefreshCw
+        className={`mr-1 h-4 w-4 ${rerenderMutation.isPending ? "animate-spin" : ""}`}
+      />
+      {rerenderMutation.isPending
+        ? "Re-rendering..."
+        : rerenderMutation.isError
+          ? "Retry re-render"
+          : "Re-render"}
+    </Button>
+  );
+}
+
+// Live composition preview: the authoring task's actual HyperFrames HTML for
+// the currently-selected cut, embedded via the backend's composition-HTML
+// proxy (iframe-permitting headers, so a direct <iframe src> works — no
+// blob-fetch workaround needed, unlike the MP4 player below). Read-only
+// captions sit alongside so the CEO can compare the live composition against
+// what will actually post, before approving. Renders nothing when the draft
+// carries no composition_id (older drafts / backend not yet exposing it).
+function CompositionPreviewPanel({
+  post,
+  cut,
+}: {
+  post: VideoPost;
+  cut: VideoCut;
+}) {
+  if (!post.composition_id || !post.source_task_id) return null;
+  return (
+    <div className="mb-3 grid gap-3 rounded-md border p-3 sm:grid-cols-2">
+      <iframe
+        src={compositionPreviewUrl(
+          post.source_task_id,
+          post.composition_id,
+          cut,
+        )}
+        title={`${post.title} — live composition preview`}
+        sandbox="allow-scripts"
+        loading="lazy"
+        className="aspect-video w-full rounded-md border bg-black"
+      />
+      <div className="space-y-2 text-sm">
+        <p className="font-medium text-muted-foreground">
+          Captions as they will post
+        </p>
+        {post.x_caption && (
+          <p>
+            <span className="font-medium">X:</span> {post.x_caption}
+          </p>
+        )}
+        {post.tiktok_caption && (
+          <p>
+            <span className="font-medium">TikTok:</span> {post.tiktok_caption}
+          </p>
+        )}
+      </div>
+    </div>
+  );
 }
 
 // One row of the queue: an MP4 preview (9:16 / 1:1 cut switcher) + per-
@@ -134,6 +228,11 @@ function VideoPostRow({
   const tiktokOverLimit =
     editTiktok && tiktokCaption.length > MAX_TIKTOK_CAPTION_CHARS;
   const overLimit = xOverLimit || tiktokOverLimit;
+  // The re-render (CEO retry) endpoint's use case is retrying a render that
+  // hit a terminal failed state — mirrors video-pipeline-utils.ts's
+  // render_failed derivation. Undefined render_status (backend not yet
+  // exposing it on this response, or a healthy render) never shows the button.
+  const isStale = post.render_status === "failed" && !!post.source_task_id;
 
   const handleApprove = () => {
     onApprove(post.task_id, {
@@ -148,6 +247,11 @@ function VideoPostRow({
         <meta.icon className="h-4 w-4 text-muted-foreground" />
         <span className="font-medium">{meta.label}</span>
         {post.occasion && <Badge variant="outline">{post.occasion}</Badge>}
+        {isStale && post.source_task_id && (
+          <div className="ml-auto">
+            <RerenderControl authoringTaskId={post.source_task_id} />
+          </div>
+        )}
       </div>
 
       <p className="mb-1 text-sm font-medium">{post.title}</p>
@@ -156,6 +260,8 @@ function VideoPostRow({
           {post.script}
         </p>
       )}
+
+      <CompositionPreviewPanel post={post} cut={cut} />
 
       <div className="mb-3 space-y-2">
         <div className="flex gap-2">
@@ -176,7 +282,9 @@ function VideoPostRow({
             size="sm"
             variant={cut === "square" ? "default" : "outline"}
             disabled={!post.mp4_paths?.square}
-            title={post.mp4_paths?.square ? undefined : "1:1 hasn't rendered yet"}
+            title={
+              post.mp4_paths?.square ? undefined : "1:1 hasn't rendered yet"
+            }
             onClick={() => setCut("square")}
           >
             1:1{!post.mp4_paths?.square && " (missing)"}
@@ -294,6 +402,7 @@ function RequestVideoDialog({
   const [occasion, setOccasion] = useState("");
   const [brief, setBrief] = useState("");
   const [platforms, setPlatforms] = useState<string[]>(["x", "tiktok"]);
+  const [projectId, setProjectId] = useState<string | null>(null);
 
   const requestMutation = useMutation({
     mutationFn: () =>
@@ -301,6 +410,7 @@ function RequestVideoDialog({
         occasion: occasion.trim(),
         brief: brief.trim(),
         platforms,
+        project_id: projectId as string,
       }),
     onSuccess: (result) => {
       if (result.status === "opened") {
@@ -309,6 +419,7 @@ function RequestVideoDialog({
         setOccasion("");
         setBrief("");
         setPlatforms(["x", "tiktok"]);
+        setProjectId(null);
       } else {
         toast.warning(result.detail);
       }
@@ -328,6 +439,7 @@ function RequestVideoDialog({
   };
 
   const canSubmit =
+    !!projectId &&
     occasion.trim().length > 0 &&
     brief.trim().length > 0 &&
     platforms.length > 0;
@@ -344,6 +456,15 @@ function RequestVideoDialog({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Project</Label>
+            <ProjectSelector
+              value={projectId}
+              onChange={setProjectId}
+              placeholder="Select the project this video is about..."
+              allowClear={false}
+            />
+          </div>
           <div className="space-y-2">
             <Label htmlFor="video-request-occasion">Occasion</Label>
             <Input

--- a/panel/src/lib/api/video.ts
+++ b/panel/src/lib/api/video.ts
@@ -23,6 +23,12 @@ export interface VideoPost {
   reject_reason?: string | null;
   mp4_paths?: Record<string, string>;
   source_task_id?: string | null; // the authoring task this draft rendered from
+  // The following mirror the shared `video_draft` marker's render idempotency
+  // keys (same fields as VideoPipelineItem) — optional because a draft may
+  // predate the backend exposing them on this response. Undefined reads as
+  // "not stale" everywhere below, so the re-render control degrades safely.
+  composition_id?: string | null;
+  render_status?: string | null; // null | "rendered" | "failed"
 }
 
 // One in-flight source=video authoring task — GET /video/pipeline
@@ -86,6 +92,20 @@ export function videoMediaUrl(taskId: string, cut: VideoCut): string {
   return `${API_URL}/video/posts/${taskId}/media?cut=${cut}`;
 }
 
+// GET /video/preview/{task_id}/{file_path:path} (roboco/api/routes/video.py)
+// serves a video-authoring task's composition HTML + sibling assets directly
+// from the project's merged read-clone, with iframe-permitting headers — the
+// panel's live composition preview embeds this URL as an <iframe src>
+// directly (unlike the MP4 media route, no auth-header workaround needed).
+export function compositionPreviewUrl(
+  authoringTaskId: string,
+  compositionId: string,
+  cut: VideoCut,
+): string {
+  const filePath = `motion/compositions/${compositionId}/${cut}.html`;
+  return `${API_URL}/video/preview/${authoringTaskId}/${filePath}`;
+}
+
 export const videoApi = {
   listPosts: async (): Promise<VideoPost[]> => {
     const { data } = await api.get<VideoPost[]>("/video/posts");
@@ -136,9 +156,17 @@ export const videoApi = {
     occasion: string;
     brief: string;
     platforms: string[];
+    project_id: string;
   }): Promise<VideoRequestResult> => {
     const { data } = await api.post<VideoRequestResult>("/video/request", body);
     return data;
+  },
+  // POST /video/pipeline/{task_id}/rerender (roboco/api/routes/video.py) —
+  // clears the authoring task's render idempotency keys so the render loop
+  // re-picks it up. taskId is the *authoring* task (VideoPost.source_task_id),
+  // not the held draft's own task_id.
+  rerender: async (authoringTaskId: string): Promise<void> => {
+    await api.post(`/video/pipeline/${authoringTaskId}/rerender`);
   },
   getCredentialsStatus: async (): Promise<TikTokCredentialsStatus> => {
     const { data } = await api.get<TikTokCredentialsStatus>(


### PR DESCRIPTION
Extend panel/src/components/dashboard/video-post-queue.tsx (and panel/src/lib/api/video.ts as needed) with three additions:

1. Add a project picker to RequestVideoDialog, backed by the existing projectsApi.list() (panel/src/lib/api/projects.ts), that submits `project_id` in the POST /video/request body per the backend's VideoRequestBody schema. Verify the backend has (or is landing) the project_id field before wiring — if it's genuinely missing, raise a dependency block rather than inventing the contract.

2. Add a re-render button to VideoPostRow, visible only when a draft's render is stale (a failed/stale render_status), that calls the backend's re-render action for that draft.

3. Add a pre-approval composition preview panel that embeds the backend's composition-HTML proxy route in an iframe, with the platform captions (x_caption/tiktok_caption) shown alongside it, for reviewing the composition before approval. Note: a plain <iframe src> won't carry axios auth headers the same way a bare <video src> doesn't (see the existing getMediaBlob/object-URL pattern in this file) — check whether the proxy route needs the same blob-URL workaround or supports a different auth mechanism (e.g. a scoped/signed URL) before assuming a bare src works.

Match the frontend cell's design bar (dense product UI defaults: variance 2-3, motion 2-3, density 7-8) and the existing Card/Dialog/Button component patterns already used in this file. Run pnpm format/lint/typecheck/test before submitting.