### PR TITLE
[35a27c3d] UX/UI: design task-detail overhaul

### DIFF
--- a/docs/ux_ui/design/content-readability-spec.md
+++ b/docs/ux_ui/design/content-readability-spec.md
@@ -1,0 +1,169 @@
+# Content-readability spec: markdown, collapsible sections, timestamps
+
+Status: proposed
+Owner: ux-dev-1
+Surface: task detail panel (`panel/src/components/tasks/task-detail/`) and any other
+view that renders task-authored markdown or an activity/notes feed (journals,
+A2A transcript).
+
+## Dial read
+
+Per the team design bar, this is dense product UI (task detail / admin panel), not
+a marketing surface:
+
+- **DESIGN_VARIANCE:** 2 — predictable, symmetric card layout. Collapsing content
+  changes height, not position; no asymmetric grid.
+- **MOTION_INTENSITY:** 2 — a single `transform`/`opacity`/`grid-template-rows`
+  expand-collapse transition on the section body, nothing else animates.
+- **VISUAL_DENSITY:** 8 — tight padding, no added chrome beyond what already
+  exists in `Card`, tabular timestamps in list contexts.
+
+## Problem
+
+Long task bodies (descriptions, dev/QA/PR-reviewer notes, journal entries) render
+in full with no way to collapse them, so a task with a large plan or a long QA
+note pushes the rest of the tab below the fold — this is the "scrolling fatigue"
+the acceptance criteria name. Separately, the panel currently renders timestamps
+three different ways depending on which component you're looking at:
+
+| Component | Format | Example |
+|---|---|---|
+| `progress-timeline.tsx` `formatTime()` | relative bucket, falls back to short absolute past 7 days | `"3h ago"` / `"Jul 3, 02:14 PM"` |
+| `tab-notes.tsx` `writtenAt()` | always absolute, no time-of-day granularity beyond minutes | `"Jul 10, 04:41 AM"` |
+| `a2a-transcript.tsx` | `date-fns` `formatDistanceToNow`, always relative, no absolute fallback | `"3 hours ago"` |
+
+Three renderers means three different date-math implementations to keep correct
+and three different reading experiences in the same activity feed. This spec
+fixes both problems without introducing a new dependency — `date-fns` is already
+installed and used by `a2a-transcript.tsx`.
+
+## 1. Collapsible-section pattern
+
+Use the existing Radix wrapper (`panel/src/components/ui/collapsible.tsx`,
+`Collapsible`/`CollapsibleTrigger`/`CollapsibleContent`) — do not add a new
+library or hand-roll a `useState` show/hide toggle for this; the primitive
+already handles the `data-state`/animation attributes lint components key off.
+
+**Trigger condition.** A markdown body collapses when its rendered content
+would exceed **~10 lines or ~640 characters of source markdown**, whichever
+comes first — measured on the raw markdown string before render, not the
+rendered DOM height, so the decision is synchronous and doesn't require a
+layout pass. Content under that threshold renders inline with no
+trigger/affordance at all (a collapse control on a 2-line note is chrome for
+its own sake).
+
+**Default state by field, not a single global rule** — a reader's expectation
+of "do I need this right now" differs per field:
+
+| Field / feed | Default state | Rationale |
+|---|---|---|
+| Task `description` | **open** | The task's own brief — the reason the reader opened the task. |
+| `dev_notes` / `qa_notes` / `pr_reviewer_notes` / `auditor_notes` / `doc_notes` | **collapsed** if over threshold | Historical record; opened on demand while triaging or auditing, not on first load. |
+| `quick_context` (resumption) | **open** | Explicitly the field a resuming agent/PM needs first. |
+| Progress-timeline / journal entries (list items) | **collapsed**, most recent 2 entries **open** | Matches "activity feed" convention — recent items visible, older ones summarized. |
+| Task `constraints` | **collapsed** | Read-only, project-wide, rarely the thing a reader is here for. |
+
+**Affordance.** The `CollapsibleTrigger` wraps a text button reading
+`Show more (N lines)` / `Show less`, right-aligned in the existing `CardHeader`
+row those components already use (see `tab-notes.tsx`'s header
+`flex items-center justify-between`) — no new header layout. Use a `ChevronDown`
+(`lucide-react`, already a dependency) that rotates 180° on open via
+`data-[state=open]:rotate-180 transition-transform`, matching the
+`MOTION_INTENSITY: 2` budget (transform only, no scroll listener).
+
+**Persistence.** Collapse state is component-local (`useState`), not persisted
+to the task record or localStorage — a reader re-opening the tab should see the
+field-default state again, not their last session's toggle. This keeps the
+change purely presentational with zero backend/schema touch.
+
+**Accessibility.** `CollapsibleTrigger` already renders `aria-expanded` via the
+Radix primitive; keep the visible label text in sync with that state (`"Show
+more"` / `"Show less"`, not just an icon) so screen readers get the same
+information sighted users do.
+
+## 2. Markdown rendering treatment
+
+The existing `Markdown` component (`panel/src/components/ui/markdown.tsx`)
+already defines the full token set — this spec does not introduce a second
+markdown renderer or a competing prose scale. It formalizes which of its two
+existing modes (`compact` vs. default) each surface should use, since that
+choice is currently made ad hoc per call site:
+
+- **Default mode** (`prose-headings:font-bold`, `h1` 2xl / `h2` xl with a
+  bottom border / `h3` lg / `h4` base, `prose-pre:bg-muted prose-pre:border
+  prose-pre:rounded-lg`) is for content the reader is reading top-to-bottom as
+  a document: task `description`, `dev_notes`/`qa_notes`/etc. bodies, journal
+  entries, constraints.
+- **`compact` mode** (uniform `text-xs` headings, hidden `pre` blocks, tight
+  list/paragraph spacing) is for anything rendered inside a list row or card
+  summary where markdown is secondary to the surrounding metadata — e.g. a
+  one-line progress-update message or an A2A transcript bubble. Do not disable
+  `compact`'s `prose-pre:hidden` for these contexts: a code block inside a chat
+  bubble already breaks density, and this spec's threshold-based collapse (§1)
+  is the mechanism for anyone who needs the full content, not an inline
+  fenced-block render.
+- **Code blocks** (default mode only, since `compact` hides them): rely on the
+  existing `prose-pre:bg-muted prose-pre:border prose-pre:rounded-lg` plus
+  inline-code's `prose-code:bg-muted prose-code:rounded prose-code:font-mono`
+  — this already matches the panel's card/muted tokens, so no new color is
+  introduced. No syntax highlighting — out of scope; a highlighter is a new
+  dependency this spec's content doesn't justify (ponytail: revisit only if a
+  future task specifically needs highlighted diffs/code review inline).
+- **Lists**: GFM task-list checkboxes already render via the `Checkbox`
+  component when `onCheckboxChange` is supplied (editable contexts:
+  description, notes) and as a plain styled `input[type=checkbox]` otherwise
+  (read-only contexts: journals, PR bodies) — keep that split; do not force
+  every consumer to wire up `onCheckboxChange`.
+
+No changes to `markdown.tsx`'s Tailwind token classes are proposed — they
+already satisfy this criterion. What was missing was a documented rule for
+*which mode a new call site should pick*, captured above.
+
+## 3. Timestamp presentation format
+
+**One format, applied everywhere a note or progress/journal entry shows a
+timestamp:** a relative bucket for anything within the last 7 days, an absolute
+short date+time beyond that — this is `progress-timeline.tsx`'s existing
+`formatTime()` behavior, and it becomes the canonical implementation the other
+two call sites adopt instead of maintaining their own date math:
+
+```
+< 1 min        "Just now"
+< 60 min       "{n}m ago"
+< 24 h         "{n}h ago"
+< 7 d          "{n}d ago"
+>= 7 d         "Jul 3, 2:14 PM"   (Intl "MMM d, h:mm a", locale en-US)
+```
+
+**Always-visible absolute timestamp on hover/focus.** Every timestamp element
+carries a `title` attribute with the full ISO-derived absolute stamp (`"Jul 3,
+2026, 2:14:32 PM"`), so a relative bucket never fully hides the precise time —
+this is a one-line addition to each call site, no new component required
+beyond the shared formatter.
+
+**Consolidation, not three rules.** Extract `progress-timeline.tsx`'s
+`formatTime()` into a shared helper (e.g. `panel/src/lib/format-timestamp.ts`,
+matching where other date/agent-name helpers already live like
+`lib/agent-utils.ts`) and have `tab-notes.tsx`'s `writtenAt()` and
+`a2a-transcript.tsx`'s `formatDistanceToNow(...)` call replaced with it. This
+removes two of the three divergent implementations rather than adding a fourth.
+`date-fns` stays a dependency (already used elsewhere in the panel) but this
+specific formatter does not need it — the bucket math is short enough to stay
+plain `Date` arithmetic, consistent with `formatTime()`'s current
+implementation, so `format-timestamp.ts` has no new dependency to justify.
+
+**Where this applies:** progress updates, journal/note entries in every
+task-detail tab (`quick_context`/`dev_notes`/`qa_notes`/`pr_reviewer_notes`/
+`auditor_notes`/`doc_notes` "written at" stamps), and the A2A transcript. Any
+future feed showing a note/progress entry should reuse the same helper rather
+than writing a fourth formatter.
+
+## Non-goals
+
+- No new component library or animation dependency — everything above composes
+  `Collapsible`, `Markdown`, and `date-fns`/plain `Date`, all already in the
+  panel's dependency tree.
+- No change to how markdown is stored or how notes are written (backend,
+  `notes_structured`, gateway verbs) — this is purely a rendering-layer spec.
+- Syntax highlighting, persisted collapse-state, and a global "collapse all"
+  control are explicitly out of scope for this pass.

--- a/docs/ux_ui/design/task-navigation-structure.md
+++ b/docs/ux_ui/design/task-navigation-structure.md
@@ -1,0 +1,223 @@
+# Navigation/structure spec: breadcrumb, prev/next, constraints distinction
+
+Status: proposed
+Owner: ux-dev-2
+Surface: task detail page (`panel/src/app/(dashboard)/tasks/[taskId]/page.tsx`)
+and its header (`panel/src/components/tasks/task-detail/task-header.tsx`) and
+description tab (`panel/src/components/tasks/task-detail/task-description.tsx`).
+
+## Dial read
+
+Per the team design bar, this is dense product UI (task detail / admin panel):
+
+- **DESIGN_VARIANCE:** 2 — the breadcrumb and prev/next controls are a
+  predictable single row above the existing header; no new grid or layout
+  shape.
+- **MOTION_INTENSITY:** 1 — hover/focus states only (existing `Button` /
+  `Link` hover treatment), no transition is introduced.
+- **VISUAL_DENSITY:** 8 — compact 28px-tall controls that add one row of
+  chrome, nothing more; the constraints card stays a `Card`, not a heavier
+  modal or full-width banner.
+
+## Problem
+
+The task detail page currently has no sense of *where this task sits*: the
+header's only navigation is a single `ArrowLeft` icon button that always goes
+to `/tasks` (`task-header.tsx` lines 474-479), regardless of whether the task
+has a parent. A reader drilling into a subtask of a subtask loses the parent
+chain the moment they land on the page, and moving between sibling tasks
+(e.g. checking each dev subtask of the same parent while triaging) requires
+going back to the list and re-finding the next one every time.
+
+Separately, `task.constraints` (the auto-attached project-wide architectural
+standard, read-only) renders in `task-description.tsx` as a `Card` with only
+`border-dashed` and a muted title (lines 181-196) — visually one dash away
+from the free-form, user-authored `description` card right above it. A reader
+skimming the page has no fast visual cue that one box is "the project's rule"
+and the other is "this task's own words."
+
+This spec is a pure design/markup change: no new dependency, no new backend
+field (`parent_task_id`, `sequence`, and `project_id` already exist on `Task`;
+`useTask` and `useSubtasks` already exist in `@/hooks/use-tasks`).
+
+## 1. Breadcrumb trail
+
+**Component:** new `TaskBreadcrumb` at
+`panel/src/components/tasks/task-detail/task-breadcrumb.tsx`, rendered inside
+`TaskHeader` as a new row **above** the existing title row (still inside the
+`<div className="border-b pb-4">` wrapper), replacing the standalone
+`ArrowLeft` button — the breadcrumb's leading "Tasks" crumb takes over that
+back-to-list function, so no control is lost.
+
+**Data.** The chain is built client-side from data already available:
+`Project` (via the existing `useProject(task.project_id)` call `TaskMetadata`
+already makes — lift it into `TaskHeader` or pass as a prop from
+`page.tsx`'s `useTaskDetail`, which already resolves `project`) and the
+ancestor chain, walked with one `useTask(parentId)` call per ancestor
+generation (small trees in practice — task hierarchies cap at 3 levels
+umbrella → root-subtask → cell task → dev subtask per `CLAUDE.md`'s MegaTask
+section, so this is at most 3 sequential fetches, each already cached by
+React Query once visited).
+
+**Rendered chain, left to right:**
+
+```
+Tasks  /  {Project name}  /  {Ancestor 1 title}  /  {Ancestor 2 title}  /  {Current task title}
+```
+
+- `Tasks` — static crumb, links to `/tasks` (replaces the old `ArrowLeft`
+  button's destination).
+- `{Project name}` — links to `/projects` (matching `TaskMetadata`'s existing
+  Project card link target, since there is no single-project detail route
+  today); omitted entirely when `task.project_id` is null (a branchless
+  fan-out/umbrella task).
+- One crumb per ancestor, oldest first, each a `Link` to `/tasks/{id}`,
+  showing that ancestor's `title` truncated to **24 characters** with a
+  trailing ellipsis (CSS `truncate` on a `max-w-[10rem]` span, `title=`
+  attribute carries the full string for hover).
+- The current task's own title renders **last, non-interactive** (a `span`,
+  not a `Link`) in `font-medium text-foreground` — every other crumb is
+  `text-muted-foreground hover:text-foreground`, so the current position is
+  the one crumb that doesn't look clickable.
+- Separator: `ChevronRight` (`lucide-react`, `h-3.5 w-3.5 text-muted-foreground`),
+  matching the existing `|` separator weight already used elsewhere in
+  `TaskHeader`'s metadata row (visually consistent icon-as-divider language).
+
+**Collapsing long chains.** When the rendered chain (Project + ancestors)
+exceeds **3 entries before the current task**, collapse the middle ones into
+a single `…` crumb: always show the first entry (`Project`) and the last
+ancestor (immediate parent), with everything in between behind a
+`DropdownMenu` (already a dependency, used elsewhere in `task-header.tsx`)
+triggered by the `…` — each hidden ancestor is a `DropdownMenuItem` linking to
+`/tasks/{id}`. This keeps the row to a bounded width on narrow viewports
+without truncating to unreadable fragments.
+
+**Responsive.** Below `md:`, the breadcrumb row wraps its own `flex-wrap`
+(same technique `TaskHeader`'s existing metadata row already uses) rather
+than horizontally scrolling — a 3-level chain wrapping to two lines is
+preferable to introducing a new scroll container.
+
+**Accessibility.** Wrap the row in `<nav aria-label="Task breadcrumb">`; the
+current-task span carries `aria-current="page"`.
+
+## 2. Prev/next sibling navigation
+
+**Component:** new `TaskPrevNext` at
+`panel/src/components/tasks/task-detail/task-prev-next.tsx`, rendered in the
+existing header's right-hand action area (`task-header.tsx`'s
+`<div className="shrink-0">` block, lines 598-649), immediately to the left
+of the "Actions" dropdown button — two icon buttons, not a full toolbar,
+so it doesn't compete with the primary Actions control for attention.
+
+**Data & ordering.** "Sibling" means another task sharing the same
+`parent_task_id`. Fetch with the existing `useSubtasks(task.parent_task_id)`
+hook (already used by `SubtasksList` for the reverse direction — children —
+so this is the same hook pointed at the parent instead of at `task.id`), sort
+the result by `sequence` ascending (the field `TaskMetadata` already surfaces
+as a read-only "Sequence" card), and locate the current task's index in that
+sorted list.
+
+**Controls.** Two `Button variant="ghost" size="icon"` (matching the
+existing `ArrowLeft` button's exact styling in `task-header.tsx`) using
+`ChevronLeft` / `ChevronRight` (`lucide-react`):
+
+- **Prev** navigates (`router.push` or `Link href="/tasks/{id}"`) to the
+  sibling at `index - 1`; **disabled** (not hidden — a disabled control at
+  the boundary communicates "this is the first one," an absent control
+  reads as "there is no prev/next feature here") when the current task is
+  first in sequence, or when `task.parent_task_id` is null (no parent, so
+  no sibling set — every button in the pair is disabled in that case, not
+  removed, since the feature applies uniformly across the task tree).
+- **Next** mirrors this at `index + 1`, disabled when current is last.
+- Each button carries a `title` tooltip naming the target: `"Previous:
+  {sibling.title}"` / `"Next: {sibling.title}"` (truncated to ~40 chars),
+  or `"No previous task"` / `"No next task"` when disabled — so hovering a
+  disabled button still explains why, rather than looking broken.
+
+**Keyboard.** `Alt+ArrowLeft` / `Alt+ArrowRight` trigger the same navigation
+when focus is not inside a text input, `Textarea`, or `contenteditable`
+element (guard on `document.activeElement.tagName`) — a plain
+`useEffect` + `window.addEventListener("keydown", ...)` in `TaskPrevNext`,
+cleaned up on unmount. `Alt+Arrow` (not the bare arrow key) avoids colliding
+with normal text-field cursor movement anywhere else on the page, so no
+existing input behavior changes.
+
+**Empty state.** When `useSubtasks` resolves to a single-item list (no
+siblings) or `task.parent_task_id` is null, both buttons render disabled with
+the "No previous/next task" tooltip rather than being omitted — consistent
+with the boundary-disabled treatment above, so the control's presence is
+predictable regardless of which task the reader is on.
+
+## 3. Constraints visual distinction
+
+**File:** `panel/src/components/tasks/task-detail/task-description.tsx`,
+replacing the existing `constraints` block (lines 181-196).
+
+**Treatment — amber "read-only architectural" tint, matching the existing
+convention already used for the *same* concept elsewhere in the panel:** the
+per-project Conventions tab uses `border-amber-500/40` for its "this is a
+committed, canonical rule" card (`conventions-tab.tsx` line 412), and
+`edit-project-dialog.tsx` uses `text-amber-600 dark:text-amber-400` plus a
+`KeyRound` icon (line 214-215) for the same "system-controlled, read-only"
+semantic on the git-token field. `task.constraints` is generated from that
+same `.roboco/conventions.yml` map (per `CLAUDE.md`'s Architectural
+Conventions Standard section), so reusing that exact token pairing —
+instead of introducing a new color — makes the same underlying concept look
+the same everywhere it appears, rather than inventing a fourth "read-only"
+treatment.
+
+```tsx
+<Card className="border-amber-500/40 bg-amber-500/5">
+  <CardHeader className="pb-3">
+    <CardTitle className="text-base flex items-center gap-2 text-amber-700 dark:text-amber-400">
+      <Lock className="h-4 w-4" />
+      Constraints
+    </CardTitle>
+  </CardHeader>
+  <CardContent>
+    <p className="text-xs text-muted-foreground mb-3">
+      Architectural standard derived from the project conventions —
+      read-only. Applies to every task in this project.
+    </p>
+    <Markdown>{task.constraints}</Markdown>
+  </CardContent>
+</Card>
+```
+
+- `Lock` (`lucide-react`, already a project dependency — no new icon
+  package) replaces no icon at all today, signaling "not editable" at a
+  glance before the reader even reads the label — the `description` card
+  above it has an `Edit3` pencil in its header for the opposite reason (it
+  IS editable), so the two icons now read as a matched pair of opposite
+  affordances.
+- `bg-amber-500/5` is a barely-there tint (5% opacity) — enough to
+  differentiate the card body from the plain-white `description` card
+  above without competing with it or reading as a warning/error state
+  (which would call for `destructive`/red, wrong semantic here — this is
+  informational, not an alert).
+- The header text and icon both take `text-amber-700 dark:text-amber-400`
+  (matching `edit-project-dialog.tsx`'s exact light/dark pair) instead of
+  the current plain `text-muted-foreground`, so the section title itself
+  carries the distinction, not just the border.
+- The explanatory caption paragraph (already present, unchanged) stays
+  `text-muted-foreground` — only the card chrome and heading change color;
+  body copy stays neutral for readability.
+
+**Placement.** Unchanged — still renders directly below the `description`
+`Card` in the Overview tab, so the reading order (task's own words, then the
+project-wide rule) is preserved; only the visual weight changes.
+
+## Non-goals
+
+- No new shadcn/ui primitive (no `breadcrumb.tsx` added to `components/ui`)
+  — the breadcrumb composes existing `Link`, `DropdownMenu`, and
+  `lucide-react` icons already in the tree, per the "fewest files" bar.
+- No change to how siblings/ancestors are fetched server-side — this reuses
+  `useTask` and `useSubtasks` exactly as they exist today; no new endpoint,
+  no new query param.
+- No persisted "last visited sibling" or breadcrumb history — this is a
+  point-in-time structural view of the current task's position, not a
+  session/browsing-history feature.
+- No global keyboard-shortcut registry — the `Alt+Arrow` binding is local to
+  `TaskPrevNext` and unregisters on unmount; a cross-page shortcut system is
+  out of scope for this pass.


### PR DESCRIPTION
Design the markdown rendering treatment, navigation (breadcrumb to parent task plus prev/next within current filter), collapsible-section layout for long tasks with 30+ progress entries, and inline timestamp presentation for every note/progress entry. Also design how the auto-attached Constraints section reads as visually distinct from the rest of the description. Feature-spotlight item per HoM review — extra UX polish expected.