### PR TITLE
[009ff9e5] Backend: re-add Playwright chromium to QA images + prompt guidance

### DIFF
--- a/.github/workflows/agent-image-smoke.yml
+++ b/.github/workflows/agent-image-smoke.yml
@@ -1,0 +1,116 @@
+name: Agent Image Smoke (Playwright)
+
+# Builds the two images that carry Playwright + chromium-headless-shell
+# (agent-qa-fe, agent-ux) with a real Docker daemon, verifies a headless
+# chromium launch actually works inside each, and reports the real
+# before/after image size delta against origin/master. This exists because
+# dev/QA agent sandboxes have no Docker daemon of their own — this workflow
+# is the only place that can produce non-estimated numbers for this change.
+
+on:
+  push:
+    paths:
+      - 'docker/agent-base.Dockerfile'
+      - 'docker/agent-qa-fe.Dockerfile'
+      - 'docker/agent-ux.Dockerfile'
+      - '.github/workflows/agent-image-smoke.yml'
+  pull_request:
+    # No `branches:` filter — this repo's task hierarchy opens dev-level
+    # PRs against nested parent feature branches (e.g.
+    # feature/backend/<root>--<cell>--<subcell>), not directly against
+    # master, so a `branches: [master]` filter here would only ever fire
+    # once the assembled PR reaches root->master — too late to give QA/PM
+    # real evidence at the dev-PR review stage this task exists for.
+    paths:
+      - 'docker/agent-base.Dockerfile'
+      - 'docker/agent-qa-fe.Dockerfile'
+      - 'docker/agent-ux.Dockerfile'
+      - '.github/workflows/agent-image-smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  playwright-smoke:
+    name: Build QA images, verify headless chromium launch + size delta
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # Need origin/master reachable to diff this branch's Dockerfiles
+          # against the pre-change baseline for the size-delta report below.
+          fetch-depth: 0
+
+      - name: Build agent-base (shared FROM target for both variants)
+        run: docker build -f docker/agent-base.Dockerfile -t roboco-agent-base .
+
+      - name: Build "after" images (this branch)
+        run: |
+          docker build -f docker/agent-qa-fe.Dockerfile -t agent-qa-fe:after .
+          docker build -f docker/agent-ux.Dockerfile -t agent-ux:after .
+
+      - name: Build "before" images (origin/master baseline)
+        run: |
+          mkdir -p /tmp/before
+          git show origin/master:docker/agent-qa-fe.Dockerfile > /tmp/before/agent-qa-fe.Dockerfile
+          git show origin/master:docker/agent-ux.Dockerfile > /tmp/before/agent-ux.Dockerfile
+          docker build -f /tmp/before/agent-qa-fe.Dockerfile -t agent-qa-fe:before .
+          docker build -f /tmp/before/agent-ux.Dockerfile -t agent-ux:before .
+
+      - name: Report real before/after image size delta
+        run: |
+          {
+            echo "### Playwright image size delta (real \`docker inspect\` sizes)"
+            echo
+            echo "| image | before | after | delta |"
+            echo "|---|---|---|---|"
+            for name in agent-qa-fe agent-ux; do
+              before_bytes=$(docker inspect -f '{{.Size}}' "${name}:before")
+              after_bytes=$(docker inspect -f '{{.Size}}' "${name}:after")
+              delta_mb=$(( (after_bytes - before_bytes) / 1024 / 1024 ))
+              echo "| ${name} | $(( before_bytes / 1024 / 1024 ))MB | $(( after_bytes / 1024 / 1024 ))MB | +${delta_mb}MB |"
+            done
+          } | tee -a "$GITHUB_STEP_SUMMARY" /tmp/smoke-report.md
+
+      - name: Headless chromium launch smoke check
+        run: |
+          {
+            echo
+            echo "### Headless chromium launch smoke check"
+            echo
+          } | tee -a /tmp/smoke-report.md
+          for name in agent-qa-fe agent-ux; do
+            echo "::group::${name} headless launch smoke"
+            docker run --rm --entrypoint /app/.venv/bin/python "${name}:after" -c '
+          from playwright.sync_api import sync_playwright
+          with sync_playwright() as p:
+              browser = p.chromium.launch()
+              page = browser.new_page()
+              page.goto("about:blank")
+              assert page.title() == ""
+              browser.close()
+          print("PLAYWRIGHT_SMOKE_OK")
+          ' | tee -a /tmp/smoke-report.md
+            echo "::endgroup::"
+          done
+
+      - name: Post results as a PR comment
+        # always() so the PR comment (the only evidence-delivery path QA/PM
+        # has, since no agent role can read the Checks tab directly) still
+        # posts a partial report even if an earlier build/smoke step failed —
+        # an `if:` that doesn't call a status function is otherwise
+        # implicitly ANDed with success(), silently swallowing the report.
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/smoke-report.md', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## Agent Image Smoke (Playwright) results\n\n${body}`,
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to RoboCo are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Playwright chromium headless verification for QA images.** `agent-qa-fe` and `agent-ux` (the shared UX/QA image) now ship Playwright with `chromium-headless-shell` pre-installed for browser-based QA verification — fe-qa and ux-qa agents can now launch headless chromium to verify rendered output, computed styles, a11y trees, and visual design when reading the diff alone cannot settle an acceptance criterion. A new CI workflow (`agent-image-smoke.yml`) builds real before/after images, runs a headless-launch smoke check inside each, and reports the real `docker inspect` size delta as a PR comment — the only non-estimated verification source available since agent sandboxes have no Docker daemon. See `docs/backend/qa/browser-verification.md` for examples and `fe-qa.md` / `ux-qa.md` identity prompts for the built-in guidance.
+
 ## [0.21.0] - 2026-07-09
 
 ### Added

--- a/agents/prompts/identities/fe-qa.md
+++ b/agents/prompts/identities/fe-qa.md
@@ -10,3 +10,19 @@ reports_to: fe-pm
 ```
 
 You are the QA agent for the Frontend Cell.
+
+## Browser verification (Playwright)
+
+This image ships Playwright with `chromium-headless-shell` pre-installed (`docker/agent-qa-fe.Dockerfile`) — no install step needed. Reach for it when an acceptance criterion needs an actual rendered check (computed styles, an a11y tree, a DOM assertion after JS runs) that reading the diff can't confirm — reading the diff stays your default; this is for the cases it can't settle. Launch it headless via `Bash`:
+
+    /app/.venv/bin/python -c "
+    from playwright.sync_api import sync_playwright
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto('http://localhost:3000/some-route')
+        print(page.accessibility.snapshot())
+        browser.close()
+    "
+
+Only `chromium-headless-shell` is installed (no firefox/webkit) — `p.chromium` is the only browser type available, and `p.chromium.launch()` uses it automatically in headless mode. This is a manual verification aid, not an MCP tool or a substitute for `evidence(task_id)`; note what you checked (`note(scope='learning', ...)`) same as any other review evidence.

--- a/agents/prompts/identities/ux-qa.md
+++ b/agents/prompts/identities/ux-qa.md
@@ -10,3 +10,19 @@ reports_to: ux-pm
 ```
 
 You are the QA agent for the UX/UI Cell.
+
+## Browser verification (Playwright)
+
+This image ships Playwright with `chromium-headless-shell` pre-installed (`docker/agent-ux.Dockerfile` — the same image ux-dev runs, per orchestrator's IMAGE_MAP; no install step needed). Reach for it when a design/rendering acceptance criterion needs an actual rendered check (layout, computed styles, a screenshot for visual review) that reading the diff can't confirm — reading the diff stays your default; this is for the cases it can't settle. Launch it headless via `Bash`:
+
+    /app/.venv/bin/python -c "
+    from playwright.sync_api import sync_playwright
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page(viewport={'width': 1280, 'height': 800})
+        page.goto('http://localhost:3000/some-route')
+        page.screenshot(path='/tmp/review.png')
+        browser.close()
+    "
+
+Only `chromium-headless-shell` is installed (no firefox/webkit) — `p.chromium` is the only browser type available, and `p.chromium.launch()` uses it automatically in headless mode. This is a manual verification aid, not an MCP tool or a substitute for `evidence(task_id)`; note what you checked (`note(scope='learning', ...)`) same as any other review evidence.

--- a/docker/agent-qa-fe.Dockerfile
+++ b/docker/agent-qa-fe.Dockerfile
@@ -7,6 +7,17 @@ USER root
 
 RUN npm install -g pnpm
 
+# Playwright + chromium-headless-shell (not full chromium) for FE QA's
+# browser-based rendering/a11y checks — scoped to this image so agent-dev-fe
+# stays lean. Browsers land in /app/.playwright (not /app/.venv) so the
+# closing chown only touches this new ~small dir, never the pre-owned .venv
+# tree (a chown -R over .venv would COW-duplicate the whole thing into this
+# layer — see the 0.19.0 lean-images CHANGELOG note on agent-grok's chown -R).
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/.playwright
+RUN uv pip install --python /app/.venv/bin/python playwright \
+    && /app/.venv/bin/playwright install --with-deps chromium-headless-shell \
+    && chown -R agent:agent /app/.playwright
+
 USER agent
 
 LABEL role="frontend-qa"

--- a/docker/agent-ux.Dockerfile
+++ b/docker/agent-ux.Dockerfile
@@ -8,5 +8,21 @@ FROM roboco-agent-base
 # - Image generation tools
 # - Design token management
 
+USER root
+
+# Playwright + chromium-headless-shell for UX-QA's browser-based design/
+# rendering verification. No dedicated ux-qa image exists — ux-qa runs this
+# same image as ux-dev (see orchestrator.py IMAGE_MAP), so ux-dev picks this
+# up too. Browsers land in /app/.playwright (not /app/.venv) so the closing
+# chown only touches this new dir, never the pre-owned .venv tree (a
+# chown -R over .venv would COW-duplicate the whole thing into this layer —
+# see the 0.19.0 lean-images CHANGELOG note on agent-grok's chown -R).
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/.playwright
+RUN uv pip install --python /app/.venv/bin/python playwright \
+    && /app/.venv/bin/playwright install --with-deps chromium-headless-shell \
+    && chown -R agent:agent /app/.playwright
+
+USER agent
+
 LABEL role="ux-designer"
 LABEL description="UX/UI agent - design, prototyping, design system"

--- a/docs/backend/qa/browser-verification.md
+++ b/docs/backend/qa/browser-verification.md
@@ -1,0 +1,215 @@
+# Browser Verification with Playwright
+
+**For:** Frontend QA (`fe-qa`) and UX QA (`ux-qa`) agents
+**Purpose:** Verify rendered output, computed styles, a11y trees, and visual design when code review and diff analysis cannot settle an acceptance criterion
+
+## When to use browser verification
+
+Browser verification is a **verification aid** — use it when reading the diff cannot confirm an acceptance criterion and you need rendered output or runtime behavior.
+
+**Read the diff first.** This is your default verification method. Browser verification supplements it in cases like:
+
+- **Rendered output:** Layout, typography, color application, visual hierarchy (after CSS changes)
+- **Computed styles:** Verifying actual applied styles vs. declared styles (cascading, overrides, media queries)
+- **Accessibility:** a11y tree structure, ARIA attributes, semantic correctness, contrast (via accessibility snapshot)
+- **Visual design:** Spatial relationships, viewport-specific behavior, responsive breakpoints (UX QA focus)
+- **Dynamic behavior:** DOM updates after JavaScript runs, interactive states (hover, focus, disabled)
+
+**Examples of what you CAN'T use this for:**
+- Rendering interactions that require user input (animations triggered by user gestures)
+- Cross-browser compatibility (only chromium-headless-shell is available)
+- Performance metrics (synthetic browser is not production-representative)
+- Network behavior (no network mocking setup provided)
+- Audio/video playback
+
+## Setup and examples
+
+### What's installed
+
+The QA image (`agent-qa-fe` for Frontend, `agent-ux` for UX) ships:
+- **Python 3.13** via `/app/.venv`
+- **Playwright** library (sync API) installed in the venv
+- **chromium-headless-shell** browser only (no firefox or webkit)
+- **System dependencies** for headless rendering (via `playwright install --with-deps chromium-headless-shell`)
+
+### Basic headless launch
+
+```python
+/app/.venv/bin/python -c "
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto('http://localhost:3000/some-route')
+    
+    # Your assertions here
+    
+    browser.close()
+"
+```
+
+Replace `http://localhost:3000/some-route` with the actual route under test.
+
+### Frontend QA examples
+
+**Check computed styles (after a CSS change):**
+
+```python
+/app/.venv/bin/python -c "
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto('http://localhost:3000/dashboard')
+    
+    # Get computed styles
+    computed = page.locator('.sidebar').evaluate('el => window.getComputedStyle(el).backgroundColor')
+    print('Computed background:', computed)
+    assert computed != 'rgba(0, 0, 0, 0)', 'Background should not be transparent'
+    
+    browser.close()
+"
+```
+
+**Verify accessibility tree (after a semantic HTML change):**
+
+```python
+/app/.venv/bin/python -c "
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto('http://localhost:3000/form-page')
+    
+    # Get accessibility tree
+    snapshot = page.accessibility.snapshot()
+    print('A11y tree:', snapshot)
+    
+    # Verify a form button is properly labeled
+    form_button = [node for node in snapshot['children'] if node.get('name') == 'Submit']
+    assert form_button, 'Form should have a Submit button in accessibility tree'
+    
+    browser.close()
+"
+```
+
+### UX QA examples
+
+**Check layout in a specific viewport (responsive design verification):**
+
+```python
+/app/.venv/bin/python -c "
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    
+    # Test desktop viewport
+    page = browser.new_page(viewport={'width': 1280, 'height': 800})
+    page.goto('http://localhost:3000/home')
+    page.screenshot(path='/tmp/review-desktop.png')
+    
+    browser.close()
+
+print('Screenshot saved to /tmp/review-desktop.png')
+"
+```
+
+**Verify CSS grid or flex layout after a design change:**
+
+```python
+/app/.venv/bin/python -c "
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(viewport={'width': 1280, 'height': 800})
+    page.goto('http://localhost:3000/kanban')
+    
+    # Get bounding boxes of cards to verify layout
+    card_boxes = page.locator('[data-testid=card]').all_bounding_boxes()
+    print(f'Card count: {len(card_boxes)}')
+    
+    # Check cards are in a grid (same x-positions per row)
+    x_positions = [box['x'] for box in card_boxes]
+    unique_x = len(set(x_positions))
+    print(f'Unique x-positions (columns): {unique_x}')
+    
+    browser.close()
+"
+```
+
+**Take a screenshot for visual review:**
+
+```python
+/app/.venv/bin/python -c "
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(viewport={'width': 1280, 'height': 800})
+    page.goto('http://localhost:3000/new-design')
+    page.screenshot(path='/tmp/review.png')
+    browser.close()
+
+print('Visual review screenshot saved: /tmp/review.png')
+"
+```
+
+## Important notes
+
+### Limitations
+
+- **Only chromium-headless-shell** is installed; `p.chromium` is the only browser type available
+- `p.chromium.launch()` automatically runs in headless mode — no visual browser window will open
+- The screenshot is saved to the container's filesystem (e.g., `/tmp/review.png`), not downloaded to your host
+- JavaScript is enabled; async DOM updates may require `page.wait_for_timeout()` or navigation waits
+- No console output capture is provided; use Playwright's logging if needed for debugging
+
+### Documentation
+
+- **Playwright sync API docs:** https://playwright.dev/python/docs/api/class-browser
+- **Common methods:**
+  - `page.goto(url)` — Navigate to a URL
+  - `page.locator(selector)` — Query elements (CSS selector)
+  - `page.evaluate(js_code)` — Run JavaScript in the page context
+  - `page.accessibility.snapshot()` — Get the accessibility tree
+  - `page.screenshot(path=...)` — Take a screenshot
+  - `page.wait_for_timeout(ms)` — Wait (for animations, etc.)
+  - `page.content()` — Get the full HTML source
+
+### Journaling your verification
+
+Always record browser-based verification the same way as any other evidence:
+
+```
+note(scope='learning', text='Verified sidebar computed background color matches design token via headless chromium after CSS refactor')
+```
+
+This documents what you checked and how for future reference.
+
+## Troubleshooting
+
+**"ModuleNotFoundError: No module named 'playwright'"**
+- The Playwright package is installed in the venv; ensure you're using the full venv path: `/app/.venv/bin/python`
+
+**"Timeout waiting for target..."**
+- The app may not be running on `localhost:3000`. Check that the dev server is up.
+- Increase timeout: `page.goto(..., timeout=30000)` (milliseconds)
+
+**"Browser exited unexpectedly"**
+- Insufficient memory or display resources in the container. Chromium headless is lightweight but needs some system memory.
+- If screenshots hang, reduce viewport size or try without screenshot.
+
+**"No screenshots appear"**
+- Screenshots are saved to the container's filesystem (e.g., `/tmp/review.png`), not your host. They're local to the QA agent's environment and cannot be downloaded directly.
+- If you need visual output for review, use `page.evaluate()` to extract element properties or accessibility snapshots instead.
+
+## Related documentation
+
+- **Identity prompts:** `agents/prompts/identities/fe-qa.md` and `ux-qa.md` contain the built-in browser verification guidance
+- **CI verification:** `.github/workflows/agent-image-smoke.yml` runs a real headless smoke test to verify the Playwright + chromium installation on each image build
+- **Diff review:** Always start with code review; browser verification is a supplement, not a replacement


### PR DESCRIPTION
Re-add the Playwright chromium dependency to the frontend-QA and ux_ui-QA Docker images so ux-qa and fe-qa containers can launch headless chromium again. Add prompt-guidance documentation describing the browser-verification flow for QA agents. Report the image-size delta for the affected images.