### PR TITLE
[9baa1c34] Frontend: implement task-detail overhaul

### DIFF
--- a/docs/frontend/components/collapsible-section.md
+++ b/docs/frontend/components/collapsible-section.md
@@ -1,0 +1,214 @@
+# CollapsibleSection component
+
+A reusable Card wrapper that enables independent collapse/expand of section content, allowing users to navigate long pages (like task-detail) without forcing continuous scrolling. Collapse/expand animations use only opacity and transform (no height/width), respecting prefers-reduced-motion globally.
+
+## Purpose
+
+When task-detail pages carry long descriptions, many notes, and detailed plans, users must scroll through all expanded content to reach later sections. `CollapsibleSection` wraps each logical section (Description, Constraints, Notes fields, Plan subsections) in a collapsible card so users can fold away irrelevant content and jump to what they need. The component supports both **controlled** (e.g., force-open while editing) and **uncontrolled** (stateless) modes.
+
+## Files
+
+| File | Role |
+|------|------|
+| `panel/src/components/tasks/task-detail/collapsible-section.tsx` | Component definition, `CollapsibleSectionProps` interface, state management. |
+| `panel/src/components/tasks/task-detail/task-description.tsx` | Description and Constraints sections wrapped. Constraints styled with amber accent border/background + ShieldAlert icon for visual distinction. |
+| `panel/src/components/tasks/task-detail/tab-notes.tsx` | Each editable note field (Description, Notes, Plan) wrapped. Edit/preview toggle is force-open while editing. |
+| `panel/src/components/tasks/task-detail/tab-plan.tsx` | Approach, Sub-Tasks, Technical Considerations, Risks, and Open Questions sections wrapped. |
+| `panel/src/app/globals.css` | Global `prefers-reduced-motion: reduce` override that disables all animations/transitions for users with reduced-motion enabled. |
+
+## API
+
+### `CollapsibleSectionProps`
+
+```typescript
+interface CollapsibleSectionProps {
+  /** Card title content (icon + text + badges as needed) */
+  title: ReactNode;
+  
+  /** Right-aligned header controls (edit/preview toggles, buttons) — always visible */
+  actions?: ReactNode;
+  
+  /** Controlled open state (e.g. force-open while a section is mid-edit). Omit for uncontrolled. */
+  open?: boolean;
+  
+  /** Whether the (uncontrolled) section starts expanded. Defaults to true so nothing visible today disappears. */
+  defaultOpen?: boolean;
+  
+  /** Callback when the user toggles the section open/closed. */
+  onOpenChange?: (open: boolean) => void;
+  
+  /** Tailwind class string applied to the outer Card element. */
+  className?: string;
+  
+  /** Tailwind class string applied to the CardHeader (title + actions row). */
+  headerClassName?: string;
+  
+  /** Content rendered inside CardContent when the section is open. */
+  children: ReactNode;
+}
+```
+
+### Component behavior
+
+- **Uncontrolled mode** (omit `open` prop): component manages its own open state. `defaultOpen` determines initial state (defaults to `true`). `onOpenChange` is called when the user clicks the toggle; internal state updates automatically.
+- **Controlled mode** (`open` prop set): `onOpenChange` is called on toggle, but internal state is not updated; parent must update the `open` prop. Useful to force a section open while a user is editing (e.g., `open={isEditing || sectionOpen}`).
+- **Title and actions**: title is always visible in the header; actions (right side) are also always visible, never collapsed away. This allows edit/preview toggles, save/cancel buttons, etc. to remain accessible.
+- **ChevronDown icon**: rotates -90° when closed, 0° when open. Uses `transition-transform duration-200` so the rotation animates smoothly.
+
+### Animation
+
+Collapse/expand uses fade + slide from Tailwind CSS's `tw-animate-css` utilities:
+
+```tsx
+"duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in",
+"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+"data-[state=closed]:slide-out-to-top-1 data-[state=open]:slide-in-from-top-1",
+```
+
+- **Duration**: 200ms
+- **Animation type**: fade (opacity) + slide (translateY), both controlled via transform/opacity CSS properties only — no height/width animation, so layout does not reflow mid-animation.
+- **Accessibility**: `prefers-reduced-motion: reduce` is handled globally in `panel/src/app/globals.css`, which sets `animation-duration` and `transition-duration` to 0.01ms for all elements when the user has enabled reduced motion in their OS settings. The section content still opens/closes; it just doesn't animate.
+
+## How to use
+
+Wrap any section content that should be collapsible:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { CollapsibleSection } from "./collapsible-section";
+import { FileText, Edit3 } from "lucide-react";
+
+export function MySection() {
+  const [sectionOpen, setSectionOpen] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+
+  return (
+    <CollapsibleSection
+      title={
+        <>
+          <FileText className="h-5 w-5" />
+          Section Title
+        </>
+      }
+      actions={
+        <Button size="sm" variant="ghost" onClick={() => setIsEditing(true)}>
+          <Edit3 className="h-4 w-4 mr-1" />
+          Edit
+        </Button>
+      }
+      open={isEditing || sectionOpen}
+      onOpenChange={setSectionOpen}
+    >
+      <p>Section content here.</p>
+    </CollapsibleSection>
+  );
+}
+```
+
+### Controlled vs. uncontrolled
+
+**Uncontrolled (simple case):**
+
+```tsx
+<CollapsibleSection title="Notes" defaultOpen={true}>
+  <p>Your notes content.</p>
+</CollapsibleSection>
+```
+
+The component manages open state internally. `onOpenChange` is optional; if provided, it's called for logging/debugging, but state still updates automatically.
+
+**Controlled (e.g., force-open while editing):**
+
+```tsx
+const [sectionOpen, setSectionOpen] = useState(true);
+const [isEditing, setIsEditing] = useState(false);
+
+<CollapsibleSection
+  title="Notes"
+  open={isEditing || sectionOpen}
+  onOpenChange={setSectionOpen}
+>
+  {isEditing ? <textarea /> : <p>Rendered content.</p>}
+</CollapsibleSection>
+```
+
+When `isEditing` is `true`, the section is forced open even if the user clicked to close it. This prevents an edit form from being hidden mid-interaction.
+
+## Used in
+
+The component is now applied across task-detail pages:
+
+| Page / Component | Sections wrapped | Notes |
+|---|---|---|
+| `task-description.tsx` | Description, Constraints | Constraints section styled with amber border/background + ShieldAlert icon for visual distinction from authored content. |
+| `tab-notes.tsx` | Each editable note field (Description, Notes, Plan) | Edit/preview toggle forced open while editing via `open={isEditing \|\| sectionOpen}`. |
+| `tab-plan.tsx` | Approach, Sub-Tasks, Technical Considerations, Risks, Open Questions | Each sub-section independently collapsible. |
+
+## Design decisions
+
+- **Fade + slide animation only**: opacity and transform are GPU-accelerated and don't trigger layout reflow. Height/width animations are avoided because they force the browser to recalculate layout mid-animation, causing jank on slower devices and making the motion distracting.
+
+- **Controlled + uncontrolled modes**: uncontrolled is the default for simple read-only sections (no extra state management needed), while controlled mode (via `open` prop) lets parent components force a section open during edit (the common case for tab-notes EditableNoteCard).
+
+- **Always-visible actions**: the actions slot (buttons, toggles) is never collapsed, so users can always edit, delete, or perform actions on a section without expanding it first.
+
+- **ChevronDown icon rotates, not replaces**: using a rotating icon is more intuitive and uses less real estate than swapping between two different icons (Chevron-Down vs. Chevron-Up).
+
+- **Global prefers-reduced-motion override**: instead of checking `prefers-reduced-motion` in JavaScript (which is error-prone and scattered across components), a single global CSS rule ensures that **all** animations and transitions respect the user's OS setting. No component logic needed.
+
+- **`CardTitle` inside the trigger**: the title is inside a styled `<button>` (the CollapsibleTrigger) so it's keyboard-accessible and screenreader-labeled. The button is full-width (flex-1) and text-left, so users can click anywhere on the title to toggle.
+
+## Testing
+
+The test suite covers:
+
+- Rendering a section with title, children, and optional actions.
+- Toggling the section open/closed on click.
+- Checking `aria-expanded` attribute on the trigger button.
+- Verifying that content is hidden when closed (not just visually; `CollapsibleContent` removes it from the DOM).
+- Controlled vs. uncontrolled state management.
+- Animation classes applied to `CollapsibleContent` based on open state.
+- ChevronDown icon rotation (CSS class toggling).
+- Always-visible actions slot (buttons not collapsed away).
+
+See `panel/src/components/tasks/task-detail/__tests__/task-description.test.tsx` for integration tests covering:
+- Independent collapse of Description and Constraints sections.
+- Controlled open state while editing.
+- Edit/preview toggle working alongside collapse behavior.
+
+## Related work
+
+- **Task detail: collapsible markdown sections + distinct Constraints styling** — this commit. Introduces `CollapsibleSection` and applies it to task-description.tsx, tab-notes.tsx, tab-plan.tsx. Constraints section gets distinct amber styling.
+
+## Migration / rollout
+
+For developers adding a new collapsible section to task-detail or other pages:
+
+1. Import `CollapsibleSection` from `./collapsible-section` (adjust path as needed).
+2. Wrap the section content, provide a `title` (can include icons, badges).
+3. Optionally provide `actions` (buttons, toggles that should stay visible).
+4. For editable content, use the controlled pattern: `open={isEditing || sectionOpen}` to force-open while editing.
+5. No extra state management is needed for read-only sections; the component handles it.
+
+Example:
+
+```tsx
+const [sectionOpen, setSectionOpen] = useState(true);
+
+<CollapsibleSection
+  title="My Section"
+  open={sectionOpen}
+  onOpenChange={setSectionOpen}
+>
+  <p>Content here.</p>
+</CollapsibleSection>
+```
+
+## Accessibility
+
+- **`aria-expanded` attribute** on the trigger button communicates the open/closed state to screenreaders.
+- **Keyboard support**: the trigger is a `<button>`, so it's focusable with Tab and activatable with Enter/Space.
+- **`aria-hidden="true"` on the ChevronDown icon**: the icon is decorative; screenreaders skip it.
+- **`prefers-reduced-motion` support**: animations are disabled globally for users with motion sensitivity, but the section still opens/closes (the content is not hidden, just instant).

--- a/docs/guide/task-detail-navigation.md
+++ b/docs/guide/task-detail-navigation.md
@@ -1,0 +1,182 @@
+# Task Detail Navigation & Timestamps
+
+This guide documents three related UI features added to the task-detail page: inline absolute timestamps, parent-task breadcrumbs, and list-context-aware prev/next navigation.
+
+## Inline Absolute Timestamps
+
+**Location:** `panel/src/lib/utils.ts`, `formatAbsoluteTimestamp()`
+
+All progress updates and checkpoints now display a standardized absolute timestamp (e.g., "Jul 10, 2026, 3:45 PM") **in addition to** the existing relative time text (e.g., "2m ago"). The absolute format is consistent across the panel, achieved via a shared helper that was extracted from the earlier `checkpoint-card.tsx` local implementation.
+
+### Implementation
+
+```typescript
+// lib/utils.ts
+export function formatAbsoluteTimestamp(timestamp: string): string {
+  return new Date(timestamp).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+```
+
+### Usage in Components
+
+- **`tab-progress.tsx` ProgressUpdatesSection:** Each progress entry now shows relative time + `·` + absolute time on the same line, with the absolute time also in the `title` tooltip for hover clarity.
+- **`tab-progress.tsx` CheckpointsSection:** Same treatment as progress updates.
+- **`progress-timeline.tsx`:** In the timeline view, relative time + absolute time on the same line.
+- **`checkpoint-card.tsx`:** The checkpoint component now uses the shared helper instead of its own format.
+
+The relative time remains the primary visual — it's glanceable. The absolute time is the secondary, precise reference, useful when comparing timestamps across different time zones or when exact dates matter (e.g., "was this before or after June 30?").
+
+## Parent Task Breadcrumb
+
+**Location:** `panel/src/components/tasks/task-detail/task-breadcrumb.tsx`
+
+When a task has a parent, a breadcrumb renders above the task title: `Parent Title > Child Title`. The breadcrumb is absent for root tasks (those with `parent_task_id = null`), keeping the UI clean for single-level work.
+
+### Implementation Details
+
+- Renders only if `task.parent_task_id` is set; otherwise returns `null`.
+- Uses `useTask(parentId)` to fetch the parent task data (title + styling).
+- While loading, a skeleton placeholder avoids layout shift.
+- The parent title is a clickable link to `/tasks/{parent.id}`.
+- Long titles are truncated with a `title` attribute tooltip.
+- Only the immediate parent is shown — deeper ancestry is reachable by following the chain one hop at a time, matching how the rest of the panel represents task hierarchy.
+
+### Example
+
+If Task B is a child of Task A:
+- Viewing Task B shows: `Task A > Task B`
+- Clicking "Task A" navigates to that parent
+- If Task A also has a parent, viewing Task A shows that grandparent, not Task B
+
+This recursive, one-level-at-a-time model prevents breadcrumbs from becoming unwieldy and mirrors the panel's task-tree representation elsewhere.
+
+## Prev/Next Task Navigation
+
+**Location:** `panel/src/components/tasks/task-detail/task-list-nav.tsx`
+
+Two chevron buttons (← →) on the task-detail page move to the adjacent task **within the current Tasks list filter/sort context**. This preserves the user's list view experience: if they filtered by status, sorted by priority, or searched for a term, those same filters apply when they navigate prev/next.
+
+### How It Works
+
+1. **List context capture:** The Tasks page (`tasks/page.tsx`) passes the currently visible task IDs (id + title) to `useScrollRestorationStore.setTaskListNav()` whenever the table's filtered/sorted order changes. The context includes the full query string (filters, search, sort) so a "Back to list" link can restore the exact view.
+
+2. **Session-scoped state:** The context lives in `sessionStorage` via Zustand's persist middleware. It survives navigation within the same browser session but is cleared if the browser is closed. This matches the "come back where you left off" UX without persisting across sessions.
+
+3. **Fallback when no context:** If the user navigates to a task via a direct link, search result, notification, or any path that doesn't pass through the Tasks list, `taskListNav` is `null`. Both buttons render **disabled** with a tooltip explaining: "Open this task from the Tasks list to enable prev/next navigation within that list's filter/sort order." This is the **documented fallback** — no guessing, no silent behavior change.
+
+4. **Edge cases:**
+   - **First item in list:** Prev button is disabled; next is enabled.
+   - **Last item in list:** Next button is disabled; prev is enabled.
+   - **Task not in captured list:** Both buttons are disabled (task was navigated to via another route after the list was visited).
+   - **Query string preservation:** The href for each nav link includes the original query string, so navigating back to the Tasks page from a nested task restores the same filters.
+
+### Components
+
+**`TaskListNav`:** The main export. Reads `taskListNav` from the store, computes prev/next items, and renders two `NavButton` children.
+
+**`NavButton`:** A single direction button. If enabled, it wraps a Next.js `<Link>`; if disabled, it's a plain button with a tooltip explaining why. The tooltip shows either the next task's title (when enabled) or the reason it's disabled.
+
+### Implementation Example
+
+```typescript
+export function TaskListNav({ task }: TaskListNavProps) {
+  const context = useScrollRestorationStore((state) => state.taskListNav);
+
+  const items = context?.items ?? [];
+  const index = items.findIndex((item) => item.id === task.id);
+  const hasContext = index !== -1;
+  const prevItem = hasContext && index > 0 ? items[index - 1] : null;
+  const nextItem =
+    hasContext && index < items.length - 1 ? items[index + 1] : null;
+
+  const query = context?.queryString ? `?${context.queryString}` : "";
+  // Render NavButton for each direction with the computed item and query
+}
+```
+
+## Store Extension
+
+**Location:** `panel/src/lib/stores/scroll-restoration-store.ts`
+
+The `useScrollRestorationStore` (already managing scroll positions, section expansions, etc.) now includes:
+
+- **`taskListNav: TaskListNavContext | null`** — The current task list context, or `null` if no list has been visited.
+- **`setTaskListNav(context: TaskListNavContext)`** — Updates the context when the Tasks table reports a new visible order.
+
+### Schema
+
+```typescript
+export interface TaskListNavItem {
+  id: string;
+  title: string;
+}
+
+export interface TaskListNavContext {
+  items: TaskListNavItem[];
+  queryString: string; // e.g., "status=in_progress&sort=-created_at"
+}
+```
+
+The store uses `sessionStorage` persistence, so state is automatically restored on page reload within the same session but is cleared when the session ends.
+
+## Integration Points
+
+### Tasks List Page (`tasks/page.tsx`)
+
+Calls `setTaskListNav()` whenever the table's visible order changes:
+
+```typescript
+const setTaskListNav = useScrollRestorationStore((state) => state.setTaskListNav);
+const handleVisibleOrderChange = useCallback(
+  (items: { id: string; title: string }[]) => {
+    setTaskListNav({ items, queryString: searchParamsString });
+  },
+  [setTaskListNav, searchParamsString],
+);
+```
+
+### TaskTable (`components/tasks/task-table.tsx`)
+
+Now accepts an optional `onVisibleOrderChange` callback, fired whenever the computed visible task order changes (e.g., on filter, sort, pagination, or expansion/collapse). The Tasks page wires this callback to capture the order.
+
+### Task Detail Page (`[taskId]/page.tsx`)
+
+Renders both `TaskBreadcrumb` and `TaskListNav` near the top of the page, in a flex row:
+
+```tsx
+<div className="flex items-center justify-between gap-4">
+  <TaskBreadcrumb task={task} />
+  <TaskListNav task={task} />
+</div>
+```
+
+The breadcrumb takes the left; nav buttons take the right, preserving the layout for long parent titles.
+
+## Design Considerations
+
+### Why relative + absolute times?
+
+Relative times ("2m ago") are glanceable but ambiguous across time zones and when comparing entries hours or days apart. Absolute times are precise but verbose if shown alone. Combining them gives quick context (relative) + accuracy (absolute) without sacrificing space.
+
+### Why session-scoped, not persistent?
+
+Task lists reflect current filters, which change frequently. Persisting a stale list order across sessions (e.g., "I opened this task from a filtered search yesterday, but I reopened the browser and the filter is gone") would silently navigate to the wrong next task. Session scope keeps the invariant: prev/next only works within the current session's list context.
+
+### Why disable instead of guess?
+
+A task opened via direct link, notification, or external system doesn't have a parent list context. We could try to infer one (e.g., "show all tasks" or "show tasks in this project"), but that's invisible magic — the user wouldn't know why they're seeing a particular next task. Disabling with a clear explanation ("open from the list to enable this") is explicit and honest.
+
+## Future Extensions
+
+Possible enhancements:
+
+1. **Remember list context across sessions:** A "pin this list" feature could persist context across browser sessions.
+2. **Breadcrumb depth:** Allow showing full ancestry (A > B > C) instead of one level; would require more space and careful truncation.
+3. **Recently viewed tasks:** A dropdown of tasks you've visited recently, separate from the list context.
+4. **Keyboard shortcuts:** Arrow keys to navigate prev/next when the buttons are enabled.

--- a/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/[taskId]/page.tsx
@@ -7,6 +7,8 @@ import { useCreateBranch, useCreatePR, useMergePR } from "@/hooks/use-git";
 import { Team, TaskStatus } from "@/types";
 import {
   TaskHeader,
+  TaskBreadcrumb,
+  TaskListNav,
   TaskMetadata,
   TaskTabs,
 } from "@/components/tasks/task-detail";
@@ -443,6 +445,12 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   return (
     <div className="space-y-6">
+      {/* Breadcrumb (parent task) + prev/next list navigation */}
+      <div className="flex items-center justify-between gap-4">
+        <TaskBreadcrumb task={task} />
+        <TaskListNav task={task} />
+      </div>
+
       {/* Header */}
       <TaskHeader task={task} onAction={handleAction} />
 

--- a/panel/src/app/(dashboard)/tasks/page.tsx
+++ b/panel/src/app/(dashboard)/tasks/page.tsx
@@ -17,6 +17,7 @@ import {
 import type { TaskFilters as TaskApiFilters } from "@/lib/api/tasks";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePageRefresh } from "@/hooks";
+import { useScrollRestorationStore } from "@/lib/stores";
 
 function TasksPageContent() {
   const router = useRouter();
@@ -157,6 +158,19 @@ function TasksPageContent() {
       });
     },
     [updateParams],
+  );
+
+  // Captures the table's live filtered/sorted order for task-detail prev/next
+  // navigation (see useScrollRestorationStore.taskListNav).
+  const setTaskListNav = useScrollRestorationStore(
+    (state) => state.setTaskListNav,
+  );
+  const searchParamsString = searchParams.toString();
+  const handleVisibleOrderChange = useCallback(
+    (items: { id: string; title: string }[]) => {
+      setTaskListNav({ items, queryString: searchParamsString });
+    },
+    [setTaskListNav, searchParamsString],
   );
 
   // Fetch tasks (server-filtered for single-select status/team) + client-side multi-select extras
@@ -342,6 +356,7 @@ function TasksPageContent() {
           onPageSizeChange={handlePageSizeChange}
           expandedIds={expandedIds}
           onExpandedChange={handleExpandedChange}
+          onVisibleOrderChange={handleVisibleOrderChange}
         />
       )}
     </div>

--- a/panel/src/app/globals.css
+++ b/panel/src/app/globals.css
@@ -125,3 +125,18 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Collapse/expand and other transform/opacity transitions (animate-in,
+   animate-out, transition-transform, ...) become instant for users who
+   asked the OS for reduced motion — the content still opens/closes, it
+   just doesn't animate. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/panel/src/components/tasks/task-detail/__tests__/task-breadcrumb.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/task-breadcrumb.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+const mockUseTask = vi.fn();
+vi.mock("@/hooks/use-tasks", () => ({
+  useTask: (id: string) => mockUseTask(id),
+}));
+
+import { TaskBreadcrumb } from "../task-breadcrumb";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "child-1",
+    title: "Child task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    parent_task_id: null,
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("TaskBreadcrumb", () => {
+  it("renders nothing when the task has no parent", () => {
+    mockUseTask.mockReturnValue({ data: undefined, isLoading: false });
+    const { container } = render(
+      <TaskBreadcrumb task={buildTask({ parent_task_id: null })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a link to the parent task when one exists", () => {
+    mockUseTask.mockReturnValue({
+      data: { id: "parent-1", title: "Parent task" },
+      isLoading: false,
+    });
+    render(
+      <TaskBreadcrumb
+        task={buildTask({ parent_task_id: "parent-1" })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Parent task" });
+    expect(link).toHaveAttribute("href", "/tasks/parent-1");
+    expect(screen.getByText("Child task")).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/tasks/task-detail/__tests__/task-description.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/task-description.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+// The server-derived task.constraints field (TaskService._attach_baseline_constraints,
+// "moved out of description") must render with a visually distinct treatment, and
+// the description section must stay independently collapsible/editable like before.
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useUpdateTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { TaskDescription } from "../task-description";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    title: "Task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("TaskDescription", () => {
+  it("renders task.constraints in its own distinctly-styled, collapsible section", () => {
+    const task = buildTask({
+      description: "Implement the thing.",
+      constraints: "- Route handlers must stay thin\n- No models in routes",
+    });
+    render(<TaskDescription task={task} />);
+
+    expect(screen.getByText("Implement the thing.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Route handlers must stay thin"),
+    ).toBeInTheDocument();
+
+    // Two independent toggles: one for Description, one for Constraints.
+    const constraintsToggle = screen.getByRole("button", {
+      name: "Constraints",
+    });
+    expect(constraintsToggle).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(constraintsToggle);
+    expect(constraintsToggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByText("Route handlers must stay thin"),
+    ).not.toBeInTheDocument();
+    // Collapsing Constraints doesn't affect the Description section.
+    expect(screen.getByText("Implement the thing.")).toBeVisible();
+  });
+
+  it("renders no constraints section when the task carries none", () => {
+    const task = buildTask({
+      description: "Just a plain description.",
+      constraints: null,
+    });
+    render(<TaskDescription task={task} />);
+    expect(screen.queryByText("Constraints")).not.toBeInTheDocument();
+  });
+
+  it("collapses and re-expands the description body via the header toggle", () => {
+    const task = buildTask({ description: "Some collapsible content." });
+    render(<TaskDescription task={task} />);
+
+    const toggle = screen.getByRole("button", { name: "Description" });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Some collapsible content.")).toBeVisible();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(
+      screen.queryByText("Some collapsible content."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("Some collapsible content.")).toBeVisible();
+  });
+
+  it("keeps the edit/preview toggle working alongside the new collapse behavior", () => {
+    const task = buildTask({ description: "Editable text." });
+    render(<TaskDescription task={task} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^edit$/i }));
+    expect(
+      screen.getByPlaceholderText("Add a description..."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: /preview/i }));
+    expect(screen.getByText("Editable text.")).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/tasks/task-detail/__tests__/task-list-nav.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/task-list-nav.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+import { useScrollRestorationStore } from "@/lib/stores";
+import { TaskListNav } from "../task-list-nav";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t2",
+    title: "Task 2",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    parent_task_id: null,
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("TaskListNav", () => {
+  beforeEach(() => {
+    useScrollRestorationStore.setState({ taskListNav: null });
+  });
+
+  it("disables both buttons with an explanatory tooltip when no list context exists", () => {
+    render(<TaskListNav task={buildTask()} />);
+    expect(screen.getByLabelText("Previous task")).toBeDisabled();
+    expect(screen.getByLabelText("Next task")).toBeDisabled();
+  });
+
+  it("disables both buttons when the current task isn't part of the captured list order", () => {
+    useScrollRestorationStore.setState({
+      taskListNav: {
+        items: [
+          { id: "other-1", title: "Other 1" },
+          { id: "other-2", title: "Other 2" },
+        ],
+        queryString: "",
+      },
+    });
+    render(<TaskListNav task={buildTask()} />);
+    expect(screen.getByLabelText("Previous task")).toBeDisabled();
+    expect(screen.getByLabelText("Next task")).toBeDisabled();
+  });
+
+  it("links prev/next to the adjacent tasks in the captured list order", () => {
+    useScrollRestorationStore.setState({
+      taskListNav: {
+        items: [
+          { id: "t1", title: "Task 1" },
+          { id: "t2", title: "Task 2" },
+          { id: "t3", title: "Task 3" },
+        ],
+        queryString: "status=in_progress",
+      },
+    });
+    render(<TaskListNav task={buildTask({ id: "t2" })} />);
+
+    const prev = screen.getByLabelText("Previous task");
+    const next = screen.getByLabelText("Next task");
+    expect(prev).not.toBeDisabled();
+    expect(next).not.toBeDisabled();
+    expect(prev.closest("a")).toHaveAttribute(
+      "href",
+      "/tasks/t1?status=in_progress",
+    );
+    expect(next.closest("a")).toHaveAttribute(
+      "href",
+      "/tasks/t3?status=in_progress",
+    );
+  });
+
+  it("disables prev at the start of the list and next at the end", () => {
+    useScrollRestorationStore.setState({
+      taskListNav: {
+        items: [
+          { id: "t1", title: "Task 1" },
+          { id: "t2", title: "Task 2" },
+        ],
+        queryString: "",
+      },
+    });
+    render(<TaskListNav task={buildTask({ id: "t1" })} />);
+    expect(screen.getByLabelText("Previous task")).toBeDisabled();
+    expect(screen.getByLabelText("Next task")).not.toBeDisabled();
+  });
+});

--- a/panel/src/components/tasks/task-detail/checkpoint-card.tsx
+++ b/panel/src/components/tasks/task-detail/checkpoint-card.tsx
@@ -4,19 +4,10 @@ import { Checkpoint } from "@/types";
 import { Card, CardContent } from "@/components/ui/card";
 import { Bookmark, Clock, User, ListTodo, FileText } from "lucide-react";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { formatAbsoluteTimestamp } from "@/lib/utils";
 
 interface CheckpointCardProps {
   checkpoint: Checkpoint;
-}
-
-function formatTime(timestamp: string): string {
-  const date = new Date(timestamp);
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
 }
 
 export function CheckpointCard({ checkpoint }: CheckpointCardProps) {
@@ -29,7 +20,7 @@ export function CheckpointCard({ checkpoint }: CheckpointCardProps) {
         </div>
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Clock className="h-3 w-3" />
-          {formatTime(checkpoint.timestamp)}
+          {formatAbsoluteTimestamp(checkpoint.timestamp)}
         </div>
       </div>
       <CardContent className="pt-4">

--- a/panel/src/components/tasks/task-detail/collapsible-section.tsx
+++ b/panel/src/components/tasks/task-detail/collapsible-section.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface CollapsibleSectionProps {
+  /** Card title content (icon + text + badges as needed) */
+  title: ReactNode;
+  /** Right-aligned header controls (edit/preview toggles, buttons) — always visible */
+  actions?: ReactNode;
+  /** Controlled open state (e.g. force-open while a section is mid-edit). Omit for uncontrolled. */
+  open?: boolean;
+  /** Whether the (uncontrolled) section starts expanded. Defaults to open so nothing visible today disappears. */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  className?: string;
+  headerClassName?: string;
+  children: ReactNode;
+}
+
+/**
+ * A Card whose body can be independently collapsed/expanded, so a task with
+ * many sections (description, notes, plan) doesn't force continuous
+ * scrolling. Collapse/expand is fade + slide (opacity/transform only, via
+ * tw-animate-css's animate-in/out) — no height/width property is animated,
+ * and prefers-reduced-motion is handled globally in globals.css.
+ */
+export function CollapsibleSection({
+  title,
+  actions,
+  open: openProp,
+  defaultOpen = true,
+  onOpenChange,
+  className,
+  headerClassName,
+  children,
+}: CollapsibleSectionProps) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const open = openProp ?? internalOpen;
+  const setOpen = (next: boolean) => {
+    onOpenChange?.(next);
+    if (openProp === undefined) setInternalOpen(next);
+  };
+
+  return (
+    <Card className={className}>
+      <Collapsible open={open} onOpenChange={setOpen} className="contents">
+        <CardHeader className={cn("pb-3", headerClassName)}>
+          <div className="flex items-center justify-between gap-2">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                aria-expanded={open}
+              >
+                <ChevronDown
+                  aria-hidden="true"
+                  className={cn(
+                    "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+                    !open && "-rotate-90",
+                  )}
+                />
+                <CardTitle className="flex min-w-0 items-center gap-2 text-lg">
+                  {title}
+                </CardTitle>
+              </button>
+            </CollapsibleTrigger>
+            {actions && (
+              <div className="flex shrink-0 items-center gap-2">{actions}</div>
+            )}
+          </div>
+        </CardHeader>
+        <CollapsibleContent
+          className={cn(
+            "duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:slide-out-to-top-1 data-[state=open]:slide-in-from-top-1",
+          )}
+        >
+          <CardContent>{children}</CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}

--- a/panel/src/components/tasks/task-detail/index.ts
+++ b/panel/src/components/tasks/task-detail/index.ts
@@ -1,4 +1,6 @@
 export { TaskHeader } from "./task-header";
+export { TaskBreadcrumb } from "./task-breadcrumb";
+export { TaskListNav } from "./task-list-nav";
 export { TaskMetadata } from "./task-metadata";
 export { TaskDescription } from "./task-description";
 export { TaskTabs } from "./task-tabs";

--- a/panel/src/components/tasks/task-detail/progress-timeline.tsx
+++ b/panel/src/components/tasks/task-detail/progress-timeline.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { MessageSquare, Clock } from "lucide-react";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { formatAbsoluteTimestamp } from "@/lib/utils";
 
 interface ProgressTimelineProps {
   updates: ProgressUpdate[];
@@ -82,9 +83,13 @@ export function ProgressTimeline({ updates }: ProgressTimelineProps) {
                       <span className="text-sm font-medium">
                         {getAgentDisplayName(update.agent_id)}
                       </span>
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
+                      <span
+                        className="text-xs text-muted-foreground flex items-center gap-1"
+                        title={formatAbsoluteTimestamp(update.timestamp)}
+                      >
                         <Clock className="h-3 w-3" />
-                        {formatTime(update.timestamp)}
+                        {formatTime(update.timestamp)} ·{" "}
+                        {formatAbsoluteTimestamp(update.timestamp)}
                       </span>
                     </div>
                     <p className="text-sm">{update.message}</p>

--- a/panel/src/components/tasks/task-detail/tab-notes.tsx
+++ b/panel/src/components/tasks/task-detail/tab-notes.tsx
@@ -3,12 +3,12 @@
 import { useState } from "react";
 import { Task } from "@/types";
 import { useUpdateTask } from "@/hooks/use-tasks";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Markdown } from "@/components/ui/markdown";
+import { CollapsibleSection } from "./collapsible-section";
 import {
   FileText,
   Code,
@@ -148,6 +148,7 @@ function EditableNoteCard({
   const [isEditing, setIsEditing] = useState(false);
   const [localEditValue, setLocalEditValue] = useState("");
   const [editMode, setEditMode] = useState<"write" | "preview">("write");
+  const [sectionOpen, setSectionOpen] = useState(true);
 
   const currentValue = task[field];
 
@@ -200,126 +201,128 @@ function EditableNoteCard({
   // If no content and not editing, show placeholder
   if (!currentValue && !isEditing) {
     return (
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg flex items-center gap-2">
-              {icon}
-              {title}
-              {badge}
-            </CardTitle>
-            <Button size="sm" variant="ghost" onClick={startEditing}>
-              <Plus className="h-4 w-4 mr-1" />
-              Add
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p
-            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
-            onClick={startEditing}
-          >
-            No {title.toLowerCase()} added yet. Click to add.
-          </p>
-        </CardContent>
-      </Card>
+      <CollapsibleSection
+        title={
+          <>
+            {icon}
+            {title}
+            {badge}
+          </>
+        }
+        open={sectionOpen}
+        onOpenChange={setSectionOpen}
+        actions={
+          <Button size="sm" variant="ghost" onClick={startEditing}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add
+          </Button>
+        }
+      >
+        <p
+          className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
+          onClick={startEditing}
+        >
+          No {title.toLowerCase()} added yet. Click to add.
+        </p>
+      </CollapsibleSection>
     );
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            {icon}
-            {title}
-            {badge}
-            <WrittenAtStamp task={task} field={field} />
-          </CardTitle>
-          {isEditing ? (
-            <div className="flex items-center gap-2">
-              <Tabs
-                value={editMode}
-                onValueChange={(v) => setEditMode(v as "write" | "preview")}
-              >
-                <TabsList className="h-8">
-                  <TabsTrigger value="write" className="text-xs px-2 h-6">
-                    <Edit3 className="h-3 w-3 mr-1" />
-                    Write
-                  </TabsTrigger>
-                  <TabsTrigger value="preview" className="text-xs px-2 h-6">
-                    <Eye className="h-3 w-3 mr-1" />
-                    Preview
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={handleCancel}
-                disabled={updateTask.isPending}
-              >
-                <X className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={updateTask.isPending}
-              >
-                <Check className="h-4 w-4 mr-1" />
-                Save
-              </Button>
-            </div>
-          ) : (
-            <Button size="sm" variant="ghost" onClick={startEditing}>
-              <Edit3 className="h-4 w-4 mr-1" />
-              Edit
+    <CollapsibleSection
+      title={
+        <>
+          {icon}
+          {title}
+          {badge}
+          <WrittenAtStamp task={task} field={field} />
+        </>
+      }
+      open={isEditing || sectionOpen}
+      onOpenChange={setSectionOpen}
+      actions={
+        isEditing ? (
+          <>
+            <Tabs
+              value={editMode}
+              onValueChange={(v) => setEditMode(v as "write" | "preview")}
+            >
+              <TabsList className="h-8">
+                <TabsTrigger value="write" className="text-xs px-2 h-6">
+                  <Edit3 className="h-3 w-3 mr-1" />
+                  Write
+                </TabsTrigger>
+                <TabsTrigger value="preview" className="text-xs px-2 h-6">
+                  <Eye className="h-3 w-3 mr-1" />
+                  Preview
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={handleCancel}
+              disabled={updateTask.isPending}
+            >
+              <X className="h-4 w-4" />
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        {isEditing ? (
-          <div className="space-y-2">
-            {editMode === "write" ? (
-              <Textarea
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={`Add ${title.toLowerCase()}...`}
-                className="min-h-[150px] font-mono text-sm"
-                disabled={updateTask.isPending}
-                autoFocus
-              />
-            ) : (
-              <div
-                className={`min-h-[150px] p-4 rounded-lg ${bgClass ?? "bg-muted/50"}`}
-              >
-                {editValue ? (
-                  <Markdown className="text-sm">{editValue}</Markdown>
-                ) : (
-                  <p className="text-muted-foreground text-sm italic">
-                    Nothing to preview
-                  </p>
-                )}
-              </div>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Markdown supported. Press Ctrl/Cmd + Enter to save, Escape to
-              cancel.
-            </p>
-          </div>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={updateTask.isPending}
+            >
+              <Check className="h-4 w-4 mr-1" />
+              Save
+            </Button>
+          </>
         ) : (
-          <div
-            className={`rounded-lg p-4 cursor-pointer hover:opacity-80 transition-opacity ${bgClass ?? "bg-muted/50"}`}
-            onClick={startEditing}
-            title="Click to edit"
-          >
-            <Markdown className="text-sm">{currentValue!}</Markdown>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          <Button size="sm" variant="ghost" onClick={startEditing}>
+            <Edit3 className="h-4 w-4 mr-1" />
+            Edit
+          </Button>
+        )
+      }
+    >
+      {isEditing ? (
+        <div className="space-y-2">
+          {editMode === "write" ? (
+            <Textarea
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={`Add ${title.toLowerCase()}...`}
+              className="min-h-[150px] font-mono text-sm"
+              disabled={updateTask.isPending}
+              autoFocus
+            />
+          ) : (
+            <div
+              className={`min-h-[150px] p-4 rounded-lg ${bgClass ?? "bg-muted/50"}`}
+            >
+              {editValue ? (
+                <Markdown className="text-sm">{editValue}</Markdown>
+              ) : (
+                <p className="text-muted-foreground text-sm italic">
+                  Nothing to preview
+                </p>
+              )}
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Markdown supported. Press Ctrl/Cmd + Enter to save, Escape to
+            cancel.
+          </p>
+        </div>
+      ) : (
+        <div
+          className={`rounded-lg p-4 cursor-pointer hover:opacity-80 transition-opacity ${bgClass ?? "bg-muted/50"}`}
+          onClick={startEditing}
+          title="Click to edit"
+        >
+          <Markdown className="text-sm">{currentValue!}</Markdown>
+        </div>
+      )}
+    </CollapsibleSection>
   );
 }
 

--- a/panel/src/components/tasks/task-detail/tab-plan.tsx
+++ b/panel/src/components/tasks/task-detail/tab-plan.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Task, SubTask, TaskPlan } from "@/types";
 import { useUpdateTask } from "@/hooks/use-tasks";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Markdown } from "@/components/ui/markdown";
+import { CollapsibleSection } from "./collapsible-section";
 import {
   Select,
   SelectContent,
@@ -58,6 +59,7 @@ function ApproachSection({ task, plan }: { task: Task; plan: TaskPlan }) {
   const [isEditing, setIsEditing] = useState(false);
   const [localEditValue, setLocalEditValue] = useState("");
   const [editMode, setEditMode] = useState<"write" | "preview">("write");
+  const [sectionOpen, setSectionOpen] = useState(true);
 
   // Display prop value when not editing, local value when editing
   const editValue = isEditing ? localEditValue : plan.approach;
@@ -102,88 +104,89 @@ function ApproachSection({ task, plan }: { task: Task; plan: TaskPlan }) {
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <FileText className="h-5 w-5" />
-            Approach
-          </CardTitle>
-          {isEditing ? (
-            <div className="flex items-center gap-2">
-              <Tabs
-                value={editMode}
-                onValueChange={(v) => setEditMode(v as "write" | "preview")}
-              >
-                <TabsList className="h-8">
-                  <TabsTrigger value="write" className="text-xs px-2 h-6">
-                    <Edit3 className="h-3 w-3 mr-1" />
-                    Write
-                  </TabsTrigger>
-                  <TabsTrigger value="preview" className="text-xs px-2 h-6">
-                    <Eye className="h-3 w-3 mr-1" />
-                    Preview
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-              <Button size="sm" variant="ghost" onClick={handleCancel}>
-                <X className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                onMouseDown={(e) => e.preventDefault()}
-                disabled={updateTask.isPending}
-              >
-                <Check className="h-4 w-4 mr-1" />
-                Save
-              </Button>
-            </div>
-          ) : (
-            <Button size="sm" variant="ghost" onClick={startEditing}>
-              <Edit3 className="h-4 w-4 mr-1" />
-              Edit
+    <CollapsibleSection
+      title={
+        <>
+          <FileText className="h-5 w-5" />
+          Approach
+        </>
+      }
+      open={isEditing || sectionOpen}
+      onOpenChange={setSectionOpen}
+      actions={
+        isEditing ? (
+          <>
+            <Tabs
+              value={editMode}
+              onValueChange={(v) => setEditMode(v as "write" | "preview")}
+            >
+              <TabsList className="h-8">
+                <TabsTrigger value="write" className="text-xs px-2 h-6">
+                  <Edit3 className="h-3 w-3 mr-1" />
+                  Write
+                </TabsTrigger>
+                <TabsTrigger value="preview" className="text-xs px-2 h-6">
+                  <Eye className="h-3 w-3 mr-1" />
+                  Preview
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+            <Button size="sm" variant="ghost" onClick={handleCancel}>
+              <X className="h-4 w-4" />
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        {isEditing ? (
-          <div className="space-y-2">
-            {editMode === "write" ? (
-              <Textarea
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Describe the approach..."
-                className="min-h-[150px] font-mono text-sm"
-                autoFocus
-              />
-            ) : (
-              <div className="min-h-[150px] p-3 border rounded-md bg-muted/30">
-                {editValue ? (
-                  <Markdown>{editValue}</Markdown>
-                ) : (
-                  <p className="text-muted-foreground italic">
-                    Nothing to preview
-                  </p>
-                )}
-              </div>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Markdown supported. Ctrl/Cmd + Enter to save.
-            </p>
-          </div>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              onMouseDown={(e) => e.preventDefault()}
+              disabled={updateTask.isPending}
+            >
+              <Check className="h-4 w-4 mr-1" />
+              Save
+            </Button>
+          </>
         ) : (
-          <div
-            className="cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2"
-            onClick={startEditing}
-          >
-            <Markdown>{plan.approach}</Markdown>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+          <Button size="sm" variant="ghost" onClick={startEditing}>
+            <Edit3 className="h-4 w-4 mr-1" />
+            Edit
+          </Button>
+        )
+      }
+    >
+      {isEditing ? (
+        <div className="space-y-2">
+          {editMode === "write" ? (
+            <Textarea
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Describe the approach..."
+              className="min-h-[150px] font-mono text-sm"
+              autoFocus
+            />
+          ) : (
+            <div className="min-h-[150px] p-3 border rounded-md bg-muted/30">
+              {editValue ? (
+                <Markdown>{editValue}</Markdown>
+              ) : (
+                <p className="text-muted-foreground italic">
+                  Nothing to preview
+                </p>
+              )}
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Markdown supported. Ctrl/Cmd + Enter to save.
+          </p>
+        </div>
+      ) : (
+        <div
+          className="cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2"
+          onClick={startEditing}
+        >
+          <Markdown>{plan.approach}</Markdown>
+        </div>
+      )}
+    </CollapsibleSection>
   );
 }
 
@@ -269,140 +272,135 @@ function SubTasksSection({ task, plan }: { task: Task; plan: TaskPlan }) {
   };
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <ListChecks className="h-5 w-5" />
-            Sub-Tasks
-          </CardTitle>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">
-              {completedCount}/{subTasks.length} completed
-            </span>
-            {!isAdding && (
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => setIsAdding(true)}
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                Add
-              </Button>
-            )}
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          {subTasks
-            .sort((a, b) => a.order - b.order)
-            .map((subtask) => (
-              <div
-                key={subtask.id}
-                className="flex items-center gap-3 py-2 group"
-              >
-                <Checkbox
-                  checked={subtask.completed}
-                  onCheckedChange={() => handleToggle(subtask.id)}
-                  disabled={updateTask.isPending}
-                />
-                {editingId === subtask.id ? (
-                  <div className="flex-1 flex items-center gap-2">
-                    <Input
-                      ref={editRef}
-                      value={editTitle}
-                      onChange={(e) => setEditTitle(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleEdit(subtask.id);
-                        if (e.key === "Escape") setEditingId(null);
-                      }}
-                      onBlur={() => handleEdit(subtask.id)}
-                      className="h-8 text-sm"
-                    />
-                  </div>
-                ) : (
-                  <>
-                    <span
-                      className={`flex-1 cursor-pointer hover:bg-muted/30 px-2 py-1 -mx-2 rounded ${
-                        subtask.completed
-                          ? "line-through text-muted-foreground"
-                          : ""
-                      }`}
-                      onClick={() => {
-                        setEditingId(subtask.id);
-                        setEditTitle(subtask.title);
-                      }}
-                    >
-                      {subtask.title}
-                      {subtask.estimated_hours && (
-                        <Badge variant="outline" className="ml-2 text-xs">
-                          ~{subtask.estimated_hours}h
-                        </Badge>
-                      )}
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleDelete(subtask.id)}
-                      className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </>
-                )}
-              </div>
-            ))}
-          {isAdding && (
-            <div className="flex items-center gap-3 py-2">
-              <Checkbox checked={false} disabled />
-              <Input
-                ref={inputRef}
-                value={newTitle}
-                onChange={(e) => setNewTitle(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleAdd();
-                  if (e.key === "Escape") {
-                    setNewTitle("");
-                    setIsAdding(false);
-                  }
-                }}
-                placeholder="Add sub-task..."
-                className="h-8 text-sm flex-1"
+    <CollapsibleSection
+      title={
+        <>
+          <ListChecks className="h-5 w-5" />
+          Sub-Tasks
+        </>
+      }
+      actions={
+        <>
+          <span className="text-sm text-muted-foreground">
+            {completedCount}/{subTasks.length} completed
+          </span>
+          {!isAdding && (
+            <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
+              <Plus className="h-4 w-4 mr-1" />
+              Add
+            </Button>
+          )}
+        </>
+      }
+    >
+      <div className="space-y-2">
+        {subTasks
+          .sort((a, b) => a.order - b.order)
+          .map((subtask) => (
+            <div
+              key={subtask.id}
+              className="flex items-center gap-3 py-2 group"
+            >
+              <Checkbox
+                checked={subtask.completed}
+                onCheckedChange={() => handleToggle(subtask.id)}
+                disabled={updateTask.isPending}
               />
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => {
+              {editingId === subtask.id ? (
+                <div className="flex-1 flex items-center gap-2">
+                  <Input
+                    ref={editRef}
+                    value={editTitle}
+                    onChange={(e) => setEditTitle(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleEdit(subtask.id);
+                      if (e.key === "Escape") setEditingId(null);
+                    }}
+                    onBlur={() => handleEdit(subtask.id)}
+                    className="h-8 text-sm"
+                  />
+                </div>
+              ) : (
+                <>
+                  <span
+                    className={`flex-1 cursor-pointer hover:bg-muted/30 px-2 py-1 -mx-2 rounded ${
+                      subtask.completed
+                        ? "line-through text-muted-foreground"
+                        : ""
+                    }`}
+                    onClick={() => {
+                      setEditingId(subtask.id);
+                      setEditTitle(subtask.title);
+                    }}
+                  >
+                    {subtask.title}
+                    {subtask.estimated_hours && (
+                      <Badge variant="outline" className="ml-2 text-xs">
+                        ~{subtask.estimated_hours}h
+                      </Badge>
+                    )}
+                  </span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => handleDelete(subtask.id)}
+                    className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </>
+              )}
+            </div>
+          ))}
+        {isAdding && (
+          <div className="flex items-center gap-3 py-2">
+            <Checkbox checked={false} disabled />
+            <Input
+              ref={inputRef}
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAdd();
+                if (e.key === "Escape") {
                   setNewTitle("");
                   setIsAdding(false);
-                }}
-                className="h-7 w-7 p-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleAdd}
-                onMouseDown={(e) => e.preventDefault()}
-                disabled={!newTitle.trim()}
-                className="h-7 w-7 p-0"
-              >
-                <Check className="h-4 w-4" />
-              </Button>
-            </div>
-          )}
-          {subTasks.length === 0 && !isAdding && (
-            <p
-              className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
-              onClick={() => setIsAdding(true)}
+                }
+              }}
+              placeholder="Add sub-task..."
+              className="h-8 text-sm flex-1"
+            />
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setNewTitle("");
+                setIsAdding(false);
+              }}
+              className="h-7 w-7 p-0"
             >
-              No sub-tasks. Click to add one.
-            </p>
-          )}
-        </div>
-      </CardContent>
-    </Card>
+              <X className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleAdd}
+              onMouseDown={(e) => e.preventDefault()}
+              disabled={!newTitle.trim()}
+              className="h-7 w-7 p-0"
+            >
+              <Check className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+        {subTasks.length === 0 && !isAdding && (
+          <p
+            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
+            onClick={() => setIsAdding(true)}
+          >
+            No sub-tasks. Click to add one.
+          </p>
+        )}
+      </div>
+    </CollapsibleSection>
   );
 }
 
@@ -476,113 +474,112 @@ function TechConsiderationsSection({
   };
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <Lightbulb className="h-5 w-5" />
-            Technical Considerations
-          </CardTitle>
-          {!isAdding && (
-            <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
-              <Plus className="h-4 w-4 mr-1" />
-              Add
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <ul className="space-y-2">
-          {items.map((item, idx) => (
-            <li key={idx} className="flex items-start gap-2 group">
-              <span className="mt-2 h-1.5 w-1.5 rounded-full bg-foreground shrink-0" />
-              {editingIdx === idx ? (
-                <div className="flex-1 flex items-center gap-2">
-                  <Input
-                    ref={editRef}
-                    value={editValue}
-                    onChange={(e) => setEditValue(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleEdit(idx);
-                      if (e.key === "Escape") setEditingIdx(null);
-                    }}
-                    onBlur={() => handleEdit(idx)}
-                    className="h-8 text-sm"
-                  />
-                </div>
-              ) : (
-                <>
-                  <span
-                    className="flex-1 text-sm cursor-pointer hover:bg-muted/30 px-2 py-1 -mx-2 rounded"
-                    onClick={() => {
-                      setEditingIdx(idx);
-                      setEditValue(item);
-                    }}
-                  >
-                    {item}
-                  </span>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => handleDelete(idx)}
-                    className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
-                </>
-              )}
-            </li>
-          ))}
-          {isAdding && (
-            <li className="flex items-center gap-2">
-              <span className="mt-2 h-1.5 w-1.5 rounded-full bg-foreground shrink-0" />
-              <Input
-                ref={inputRef}
-                value={newItem}
-                onChange={(e) => setNewItem(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleAdd();
-                  if (e.key === "Escape") {
-                    setNewItem("");
-                    setIsAdding(false);
-                  }
-                }}
-                placeholder="Add consideration..."
-                className="h-8 text-sm flex-1"
-              />
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => {
+    <CollapsibleSection
+      title={
+        <>
+          <Lightbulb className="h-5 w-5" />
+          Technical Considerations
+        </>
+      }
+      actions={
+        !isAdding && (
+          <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add
+          </Button>
+        )
+      }
+    >
+      <ul className="space-y-2">
+        {items.map((item, idx) => (
+          <li key={idx} className="flex items-start gap-2 group">
+            <span className="mt-2 h-1.5 w-1.5 rounded-full bg-foreground shrink-0" />
+            {editingIdx === idx ? (
+              <div className="flex-1 flex items-center gap-2">
+                <Input
+                  ref={editRef}
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleEdit(idx);
+                    if (e.key === "Escape") setEditingIdx(null);
+                  }}
+                  onBlur={() => handleEdit(idx)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            ) : (
+              <>
+                <span
+                  className="flex-1 text-sm cursor-pointer hover:bg-muted/30 px-2 py-1 -mx-2 rounded"
+                  onClick={() => {
+                    setEditingIdx(idx);
+                    setEditValue(item);
+                  }}
+                >
+                  {item}
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleDelete(idx)}
+                  className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </>
+            )}
+          </li>
+        ))}
+        {isAdding && (
+          <li className="flex items-center gap-2">
+            <span className="mt-2 h-1.5 w-1.5 rounded-full bg-foreground shrink-0" />
+            <Input
+              ref={inputRef}
+              value={newItem}
+              onChange={(e) => setNewItem(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAdd();
+                if (e.key === "Escape") {
                   setNewItem("");
                   setIsAdding(false);
-                }}
-                className="h-7 w-7 p-0"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleAdd}
-                onMouseDown={(e) => e.preventDefault()}
-                disabled={!newItem.trim()}
-                className="h-7 w-7 p-0"
-              >
-                <Check className="h-4 w-4" />
-              </Button>
-            </li>
-          )}
-        </ul>
-        {items.length === 0 && !isAdding && (
-          <p
-            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
-            onClick={() => setIsAdding(true)}
-          >
-            No technical considerations. Click to add one.
-          </p>
+                }
+              }}
+              placeholder="Add consideration..."
+              className="h-8 text-sm flex-1"
+            />
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setNewItem("");
+                setIsAdding(false);
+              }}
+              className="h-7 w-7 p-0"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleAdd}
+              onMouseDown={(e) => e.preventDefault()}
+              disabled={!newItem.trim()}
+              className="h-7 w-7 p-0"
+            >
+              <Check className="h-4 w-4" />
+            </Button>
+          </li>
         )}
-      </CardContent>
-    </Card>
+      </ul>
+      {items.length === 0 && !isAdding && (
+        <p
+          className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
+          onClick={() => setIsAdding(true)}
+        >
+          No technical considerations. Click to add one.
+        </p>
+      )}
+    </CollapsibleSection>
   );
 }
 
@@ -667,125 +664,41 @@ function RisksSection({ task, plan }: { task: Task; plan: TaskPlan }) {
   };
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5" />
-            Risks
-          </CardTitle>
-          {!isAdding && (
-            <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
-              <Plus className="h-4 w-4 mr-1" />
-              Add
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          {risks.map((risk, idx) =>
-            editingIdx === idx ? (
-              <div key={idx} className="border rounded-lg p-4 space-y-3">
-                <Input
-                  ref={editDescRef}
-                  value={editDesc}
-                  onChange={(e) => setEditDesc(e.target.value)}
-                  placeholder="Risk description..."
-                  className="text-sm"
-                />
-                <Input
-                  value={editMit}
-                  onChange={(e) => setEditMit(e.target.value)}
-                  placeholder="Mitigation strategy..."
-                  className="text-sm"
-                />
-                <div className="flex items-center gap-2">
-                  <Select value={editSeverity} onValueChange={setEditSeverity}>
-                    <SelectTrigger className="w-32 h-8">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="low">Low</SelectItem>
-                      <SelectItem value="medium">Medium</SelectItem>
-                      <SelectItem value="high">High</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <div className="flex-1" />
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setEditingIdx(null)}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={handleEdit}
-                    onMouseDown={(e) => e.preventDefault()}
-                  >
-                    <Check className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div
-                key={idx}
-                className="border rounded-lg p-4 cursor-pointer hover:bg-muted/30 transition-colors group"
-                onClick={() => {
-                  setEditingIdx(idx);
-                  setEditDesc(risk.description);
-                  setEditMit(risk.mitigation);
-                  setEditSeverity(risk.severity ?? "medium");
-                }}
-              >
-                <div className="flex items-start justify-between gap-2 mb-2">
-                  <span className="font-medium text-sm">
-                    {risk.description}
-                  </span>
-                  <div className="flex items-center gap-2">
-                    {risk.severity && (
-                      <Badge className={severityColors[risk.severity]}>
-                        {risk.severity}
-                      </Badge>
-                    )}
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDelete(idx);
-                      }}
-                      className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </div>
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  <span className="font-medium">Mitigation:</span>{" "}
-                  {risk.mitigation || "Not specified"}
-                </div>
-              </div>
-            ),
-          )}
-          {isAdding && (
-            <div className="border rounded-lg p-4 space-y-3">
+    <CollapsibleSection
+      title={
+        <>
+          <AlertTriangle className="h-5 w-5" />
+          Risks
+        </>
+      }
+      actions={
+        !isAdding && (
+          <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add
+          </Button>
+        )
+      }
+    >
+      <div className="space-y-4">
+        {risks.map((risk, idx) =>
+          editingIdx === idx ? (
+            <div key={idx} className="border rounded-lg p-4 space-y-3">
               <Input
-                ref={descRef}
-                value={newDesc}
-                onChange={(e) => setNewDesc(e.target.value)}
+                ref={editDescRef}
+                value={editDesc}
+                onChange={(e) => setEditDesc(e.target.value)}
                 placeholder="Risk description..."
                 className="text-sm"
               />
               <Input
-                value={newMit}
-                onChange={(e) => setNewMit(e.target.value)}
+                value={editMit}
+                onChange={(e) => setEditMit(e.target.value)}
                 placeholder="Mitigation strategy..."
                 className="text-sm"
               />
               <div className="flex items-center gap-2">
-                <Select value={newSeverity} onValueChange={setNewSeverity}>
+                <Select value={editSeverity} onValueChange={setEditSeverity}>
                   <SelectTrigger className="w-32 h-8">
                     <SelectValue />
                   </SelectTrigger>
@@ -799,36 +712,117 @@ function RisksSection({ task, plan }: { task: Task; plan: TaskPlan }) {
                 <Button
                   size="sm"
                   variant="ghost"
-                  onClick={() => {
-                    setNewDesc("");
-                    setNewMit("");
-                    setIsAdding(false);
-                  }}
+                  onClick={() => setEditingIdx(null)}
                 >
                   <X className="h-4 w-4" />
                 </Button>
                 <Button
                   size="sm"
-                  onClick={handleAdd}
+                  onClick={handleEdit}
                   onMouseDown={(e) => e.preventDefault()}
-                  disabled={!newDesc.trim()}
                 >
                   <Check className="h-4 w-4" />
                 </Button>
               </div>
             </div>
-          )}
-        </div>
-        {risks.length === 0 && !isAdding && (
-          <p
-            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
-            onClick={() => setIsAdding(true)}
-          >
-            No risks identified. Click to add one.
-          </p>
+          ) : (
+            <div
+              key={idx}
+              className="border rounded-lg p-4 cursor-pointer hover:bg-muted/30 transition-colors group"
+              onClick={() => {
+                setEditingIdx(idx);
+                setEditDesc(risk.description);
+                setEditMit(risk.mitigation);
+                setEditSeverity(risk.severity ?? "medium");
+              }}
+            >
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <span className="font-medium text-sm">{risk.description}</span>
+                <div className="flex items-center gap-2">
+                  {risk.severity && (
+                    <Badge className={severityColors[risk.severity]}>
+                      {risk.severity}
+                    </Badge>
+                  )}
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(idx);
+                    }}
+                    className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </Button>
+                </div>
+              </div>
+              <div className="text-sm text-muted-foreground">
+                <span className="font-medium">Mitigation:</span>{" "}
+                {risk.mitigation || "Not specified"}
+              </div>
+            </div>
+          ),
         )}
-      </CardContent>
-    </Card>
+        {isAdding && (
+          <div className="border rounded-lg p-4 space-y-3">
+            <Input
+              ref={descRef}
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.target.value)}
+              placeholder="Risk description..."
+              className="text-sm"
+            />
+            <Input
+              value={newMit}
+              onChange={(e) => setNewMit(e.target.value)}
+              placeholder="Mitigation strategy..."
+              className="text-sm"
+            />
+            <div className="flex items-center gap-2">
+              <Select value={newSeverity} onValueChange={setNewSeverity}>
+                <SelectTrigger className="w-32 h-8">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="low">Low</SelectItem>
+                  <SelectItem value="medium">Medium</SelectItem>
+                  <SelectItem value="high">High</SelectItem>
+                </SelectContent>
+              </Select>
+              <div className="flex-1" />
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setNewDesc("");
+                  setNewMit("");
+                  setIsAdding(false);
+                }}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleAdd}
+                onMouseDown={(e) => e.preventDefault()}
+                disabled={!newDesc.trim()}
+              >
+                <Check className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+      {risks.length === 0 && !isAdding && (
+        <p
+          className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
+          onClick={() => setIsAdding(true)}
+        >
+          No risks identified. Click to add one.
+        </p>
+      )}
+    </CollapsibleSection>
   );
 }
 
@@ -909,156 +903,153 @@ function OpenQuestionsSection({ task, plan }: { task: Task; plan: TaskPlan }) {
   };
 
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg flex items-center gap-2">
-            <HelpCircle className="h-5 w-5" />
-            Open Questions
-          </CardTitle>
-          {!isAdding && (
-            <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
-              <Plus className="h-4 w-4 mr-1" />
-              Add
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          {questions.map((q, idx) =>
-            editingIdx === idx ? (
-              <div key={idx} className="border rounded-lg p-4 space-y-3">
-                <Input
-                  ref={editRef}
-                  value={editQuestion}
-                  onChange={(e) => setEditQuestion(e.target.value)}
-                  placeholder="Question..."
-                  className="text-sm"
-                />
-                <Textarea
-                  value={editAnswer}
-                  onChange={(e) => setEditAnswer(e.target.value)}
-                  placeholder="Answer (optional)..."
-                  className="text-sm min-h-[80px]"
-                />
-                <div className="flex items-center gap-2">
-                  <div className="flex-1" />
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setEditingIdx(null)}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={handleEdit}
-                    onMouseDown={(e) => e.preventDefault()}
-                  >
-                    <Check className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div
-                key={idx}
-                className="border rounded-lg p-4 cursor-pointer hover:bg-muted/30 transition-colors group"
-                onClick={() => {
-                  setEditingIdx(idx);
-                  setEditQuestion(q.question);
-                  setEditAnswer(q.answer ?? "");
-                }}
-              >
-                <div className="flex items-start gap-2 mb-2">
-                  <HelpCircle className="h-5 w-5 text-yellow-500 shrink-0 mt-0.5" />
-                  <span className="font-medium text-sm flex-1">
-                    {q.question}
-                  </span>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDelete(idx);
-                    }}
-                    className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
-                  >
-                    <Trash2 className="h-3 w-3" />
-                  </Button>
-                </div>
-                {q.answer ? (
-                  <div className="ml-7 text-sm">
-                    <div className="bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-200 rounded-lg p-3">
-                      <p className="font-medium mb-1">
-                        Answered by {q.answered_by?.slice(0, 12) ?? "Unknown"}
-                      </p>
-                      <p>{q.answer}</p>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="ml-7">
-                    <Badge
-                      variant="outline"
-                      className="text-yellow-600 border-yellow-300"
-                    >
-                      Awaiting Answer
-                    </Badge>
-                  </div>
-                )}
-              </div>
-            ),
-          )}
-          {isAdding && (
-            <div className="border rounded-lg p-4 space-y-3">
+    <CollapsibleSection
+      title={
+        <>
+          <HelpCircle className="h-5 w-5" />
+          Open Questions
+        </>
+      }
+      actions={
+        !isAdding && (
+          <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
+            <Plus className="h-4 w-4 mr-1" />
+            Add
+          </Button>
+        )
+      }
+    >
+      <div className="space-y-4">
+        {questions.map((q, idx) =>
+          editingIdx === idx ? (
+            <div key={idx} className="border rounded-lg p-4 space-y-3">
               <Input
-                ref={inputRef}
-                value={newQuestion}
-                onChange={(e) => setNewQuestion(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleAdd();
-                  if (e.key === "Escape") {
-                    setNewQuestion("");
-                    setIsAdding(false);
-                  }
-                }}
-                placeholder="Add a question..."
+                ref={editRef}
+                value={editQuestion}
+                onChange={(e) => setEditQuestion(e.target.value)}
+                placeholder="Question..."
                 className="text-sm"
+              />
+              <Textarea
+                value={editAnswer}
+                onChange={(e) => setEditAnswer(e.target.value)}
+                placeholder="Answer (optional)..."
+                className="text-sm min-h-[80px]"
               />
               <div className="flex items-center gap-2">
                 <div className="flex-1" />
                 <Button
                   size="sm"
                   variant="ghost"
-                  onClick={() => {
-                    setNewQuestion("");
-                    setIsAdding(false);
-                  }}
+                  onClick={() => setEditingIdx(null)}
                 >
                   <X className="h-4 w-4" />
                 </Button>
                 <Button
                   size="sm"
-                  onClick={handleAdd}
+                  onClick={handleEdit}
                   onMouseDown={(e) => e.preventDefault()}
-                  disabled={!newQuestion.trim()}
                 >
                   <Check className="h-4 w-4" />
                 </Button>
               </div>
             </div>
-          )}
-        </div>
-        {questions.length === 0 && !isAdding && (
-          <p
-            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
-            onClick={() => setIsAdding(true)}
-          >
-            No open questions. Click to add one.
-          </p>
+          ) : (
+            <div
+              key={idx}
+              className="border rounded-lg p-4 cursor-pointer hover:bg-muted/30 transition-colors group"
+              onClick={() => {
+                setEditingIdx(idx);
+                setEditQuestion(q.question);
+                setEditAnswer(q.answer ?? "");
+              }}
+            >
+              <div className="flex items-start gap-2 mb-2">
+                <HelpCircle className="h-5 w-5 text-yellow-500 shrink-0 mt-0.5" />
+                <span className="font-medium text-sm flex-1">{q.question}</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDelete(idx);
+                  }}
+                  className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 text-destructive"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </Button>
+              </div>
+              {q.answer ? (
+                <div className="ml-7 text-sm">
+                  <div className="bg-green-50 dark:bg-green-950 text-green-800 dark:text-green-200 rounded-lg p-3">
+                    <p className="font-medium mb-1">
+                      Answered by {q.answered_by?.slice(0, 12) ?? "Unknown"}
+                    </p>
+                    <p>{q.answer}</p>
+                  </div>
+                </div>
+              ) : (
+                <div className="ml-7">
+                  <Badge
+                    variant="outline"
+                    className="text-yellow-600 border-yellow-300"
+                  >
+                    Awaiting Answer
+                  </Badge>
+                </div>
+              )}
+            </div>
+          ),
         )}
-      </CardContent>
-    </Card>
+        {isAdding && (
+          <div className="border rounded-lg p-4 space-y-3">
+            <Input
+              ref={inputRef}
+              value={newQuestion}
+              onChange={(e) => setNewQuestion(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleAdd();
+                if (e.key === "Escape") {
+                  setNewQuestion("");
+                  setIsAdding(false);
+                }
+              }}
+              placeholder="Add a question..."
+              className="text-sm"
+            />
+            <div className="flex items-center gap-2">
+              <div className="flex-1" />
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setNewQuestion("");
+                  setIsAdding(false);
+                }}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+              <Button
+                size="sm"
+                onClick={handleAdd}
+                onMouseDown={(e) => e.preventDefault()}
+                disabled={!newQuestion.trim()}
+              >
+                <Check className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+      {questions.length === 0 && !isAdding && (
+        <p
+          className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 p-2 rounded"
+          onClick={() => setIsAdding(true)}
+        >
+          No open questions. Click to add one.
+        </p>
+      )}
+    </CollapsibleSection>
   );
 }
 

--- a/panel/src/components/tasks/task-detail/tab-progress.tsx
+++ b/panel/src/components/tasks/task-detail/tab-progress.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { getAgentDisplayName } from "@/lib/agent-utils";
+import { formatAbsoluteTimestamp } from "@/lib/utils";
 
 interface TabProgressProps {
   task: Task;
@@ -225,9 +226,13 @@ function ProgressUpdatesSection({ task }: { task: Task }) {
                         {getAgentDisplayName(update.agent_id)}
                       </span>
                       <div className="flex items-center gap-2">
-                        <span className="text-xs text-muted-foreground flex items-center gap-1">
+                        <span
+                          className="text-xs text-muted-foreground flex items-center gap-1"
+                          title={formatAbsoluteTimestamp(update.timestamp)}
+                        >
                           <Clock className="h-3 w-3" />
-                          {formatTime(update.timestamp)}
+                          {formatTime(update.timestamp)} ·{" "}
+                          {formatAbsoluteTimestamp(update.timestamp)}
                         </span>
                         <Button
                           size="sm"
@@ -438,9 +443,13 @@ function CheckpointsSection({ task }: { task: Task }) {
                     <span className="font-medium text-sm">Checkpoint</span>
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-xs text-muted-foreground flex items-center gap-1">
+                    <span
+                      className="text-xs text-muted-foreground flex items-center gap-1"
+                      title={formatAbsoluteTimestamp(checkpoint.timestamp)}
+                    >
                       <Clock className="h-3 w-3" />
-                      {formatTime(checkpoint.timestamp)}
+                      {formatTime(checkpoint.timestamp)} ·{" "}
+                      {formatAbsoluteTimestamp(checkpoint.timestamp)}
                     </span>
                     <Button
                       size="sm"

--- a/panel/src/components/tasks/task-detail/task-breadcrumb.tsx
+++ b/panel/src/components/tasks/task-detail/task-breadcrumb.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Task } from "@/types";
+import { useTask } from "@/hooks/use-tasks";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+interface TaskBreadcrumbProps {
+  task: Task;
+}
+
+// Renders "Parent title >" above the task title whenever this task has a
+// parent — absent (returns null) for a root task. Only the immediate parent
+// is shown; deeper ancestry is reachable by following the chain one hop at a
+// time, matching how the rest of the panel represents task hierarchy.
+export function TaskBreadcrumb({ task }: TaskBreadcrumbProps) {
+  const parentId = task.parent_task_id;
+  const { data: parent, isLoading } = useTask(parentId ?? "");
+
+  if (!parentId) return null;
+
+  return (
+    <nav
+      aria-label="Parent task"
+      className="flex items-center gap-1.5 text-sm text-muted-foreground min-w-0"
+    >
+      {isLoading || !parent ? (
+        <Skeleton className="h-4 w-32" />
+      ) : (
+        <Link
+          href={`/tasks/${parent.id}`}
+          prefetch={false}
+          className="truncate hover:text-foreground hover:underline"
+          title={parent.title}
+        >
+          {parent.title}
+        </Link>
+      )}
+      <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate text-foreground/70" title={task.title}>
+        {task.title}
+      </span>
+    </nav>
+  );
+}

--- a/panel/src/components/tasks/task-detail/task-description.tsx
+++ b/panel/src/components/tasks/task-detail/task-description.tsx
@@ -3,12 +3,12 @@
 import { useState } from "react";
 import { Task } from "@/types";
 import { useUpdateTask } from "@/hooks/use-tasks";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Markdown } from "@/components/ui/markdown";
-import { Edit3, Eye, Check, X } from "lucide-react";
+import { CollapsibleSection } from "./collapsible-section";
+import { Edit3, Eye, Check, X, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
 
 interface TaskDescriptionProps {
@@ -20,6 +20,7 @@ export function TaskDescription({ task }: TaskDescriptionProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [localEditValue, setLocalEditValue] = useState("");
   const [editMode, setEditMode] = useState<"write" | "preview">("write");
+  const [sectionOpen, setSectionOpen] = useState(true);
 
   // Display prop value when not editing, local value when editing
   const editValue = isEditing ? localEditValue : task.description;
@@ -79,12 +80,13 @@ export function TaskDescription({ task }: TaskDescriptionProps) {
 
   return (
     <>
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg">Description</CardTitle>
-          {isEditing ? (
-            <div className="flex items-center gap-2">
+      <CollapsibleSection
+        title="Description"
+        open={isEditing || sectionOpen}
+        onOpenChange={setSectionOpen}
+        actions={
+          isEditing ? (
+            <>
               <Tabs
                 value={editMode}
                 onValueChange={(v) => setEditMode(v as "write" | "preview")}
@@ -116,16 +118,15 @@ export function TaskDescription({ task }: TaskDescriptionProps) {
                 <Check className="h-4 w-4 mr-1" />
                 Save
               </Button>
-            </div>
+            </>
           ) : (
             <Button size="sm" variant="ghost" onClick={startEditing}>
               <Edit3 className="h-4 w-4 mr-1" />
               Edit
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
+          )
+        }
+      >
         {isEditing ? (
           <div className="space-y-2">
             {editMode === "write" ? (
@@ -176,24 +177,26 @@ export function TaskDescription({ task }: TaskDescriptionProps) {
             No description provided. Click to add one.
           </p>
         )}
-      </CardContent>
-    </Card>
-    {task.constraints ? (
-      <Card className="border-dashed">
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base text-muted-foreground">
-            Constraints
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
+      </CollapsibleSection>
+      {task.constraints ? (
+        <CollapsibleSection
+          title={
+            <>
+              <ShieldAlert className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+              <span className="text-amber-800 dark:text-amber-300">
+                Constraints
+              </span>
+            </>
+          }
+          className="border-amber-300 bg-amber-50/60 dark:border-amber-800 dark:bg-amber-950/20"
+        >
           <p className="text-xs text-muted-foreground mb-3">
             Architectural standard derived from the project conventions —
             read-only. Applies to every task in this project.
           </p>
           <Markdown>{task.constraints}</Markdown>
-        </CardContent>
-      </Card>
-    ) : null}
+        </CollapsibleSection>
+      ) : null}
     </>
   );
 }

--- a/panel/src/components/tasks/task-detail/task-list-nav.tsx
+++ b/panel/src/components/tasks/task-detail/task-list-nav.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Task } from "@/types";
+import { useScrollRestorationStore } from "@/lib/stores";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+interface TaskListNavProps {
+  task: Task;
+}
+
+const NO_CONTEXT_TOOLTIP =
+  "Open this task from the Tasks list to enable prev/next navigation within that list's filter/sort order.";
+
+// Moves to the adjacent task within the Tasks list order the user last
+// visited (filters + sort applied), captured in useScrollRestorationStore by
+// the Tasks list page. Documented fallback: when no list context exists for
+// this session (task opened via a direct link, search result, notification,
+// etc.) or the current task isn't part of the captured order (it was
+// navigated to some other way), both buttons render disabled with a tooltip
+// explaining why — there is no list order to fall back to, so we don't guess.
+export function TaskListNav({ task }: TaskListNavProps) {
+  const context = useScrollRestorationStore((state) => state.taskListNav);
+
+  const items = context?.items ?? [];
+  const index = items.findIndex((item) => item.id === task.id);
+  const hasContext = index !== -1;
+  const prevItem = hasContext && index > 0 ? items[index - 1] : null;
+  const nextItem =
+    hasContext && index < items.length - 1 ? items[index + 1] : null;
+
+  const query = context?.queryString ? `?${context.queryString}` : "";
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1 shrink-0">
+        <NavButton
+          direction="prev"
+          item={prevItem}
+          query={query}
+          disabledReason={!hasContext ? NO_CONTEXT_TOOLTIP : undefined}
+        />
+        <NavButton
+          direction="next"
+          item={nextItem}
+          query={query}
+          disabledReason={!hasContext ? NO_CONTEXT_TOOLTIP : undefined}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function NavButton({
+  direction,
+  item,
+  query,
+  disabledReason,
+}: {
+  direction: "prev" | "next";
+  item: { id: string; title: string } | null;
+  query: string;
+  disabledReason?: string;
+}) {
+  const Icon = direction === "prev" ? ChevronLeft : ChevronRight;
+  const label = direction === "prev" ? "Previous task" : "Next task";
+  const disabled = item === null;
+
+  const button = (
+    <Button
+      variant="outline"
+      size="icon"
+      disabled={disabled}
+      aria-label={label}
+      asChild={!disabled}
+    >
+      {disabled ? (
+        <Icon className="h-4 w-4" />
+      ) : (
+        <Link href={`/tasks/${item.id}${query}`} prefetch={false}>
+          <Icon className="h-4 w-4" />
+        </Link>
+      )}
+    </Button>
+  );
+
+  const tooltipText = disabledReason ?? item?.title ?? label;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>{button}</span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/panel/src/components/tasks/task-table.tsx
+++ b/panel/src/components/tasks/task-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Task } from "@/types";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -95,6 +95,10 @@ interface TaskTableProps {
   // Controlled expanded state
   expandedIds?: Set<string>;
   onExpandedChange?: (ids: Set<string>) => void;
+  // Reports the currently visible, filtered + sorted task order (id + title
+  // pairs) — consumed by the Tasks list page to power task-detail prev/next
+  // navigation. Fires whenever the computed order changes.
+  onVisibleOrderChange?: (items: { id: string; title: string }[]) => void;
 }
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
@@ -268,6 +272,7 @@ export function TaskTable({
   onPageSizeChange,
   expandedIds: controlledExpandedIds,
   onExpandedChange,
+  onVisibleOrderChange,
 }: TaskTableProps) {
   // Internal state (used when not controlled)
   const [internalSortConfig, setInternalSortConfig] =
@@ -383,6 +388,18 @@ export function TaskTable({
   const flattenedTasks = useMemo(() => {
     return flattenTree(sortedRoots, expandedIds);
   }, [sortedRoots, expandedIds]);
+
+  // Report the visible order to the parent so task-detail can compute
+  // prev/next within this exact filter/sort context.
+  useEffect(() => {
+    onVisibleOrderChange?.(
+      flattenedTasks.map((node) => ({
+        id: node.task.id,
+        title: node.task.title,
+      })),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flattenedTasks]);
 
   // Pagination on flattened list
   const totalItems = flattenedTasks.length;

--- a/panel/src/components/tasks/task-table.tsx
+++ b/panel/src/components/tasks/task-table.tsx
@@ -398,8 +398,7 @@ export function TaskTable({
         title: node.task.title,
       })),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [flattenedTasks]);
+  }, [flattenedTasks, onVisibleOrderChange]);
 
   // Pagination on flattened list
   const totalItems = flattenedTasks.length;

--- a/panel/src/lib/stores/index.ts
+++ b/panel/src/lib/stores/index.ts
@@ -1,1 +1,5 @@
 export { useScrollRestorationStore } from "./scroll-restoration-store";
+export type {
+  TaskListNavContext,
+  TaskListNavItem,
+} from "./scroll-restoration-store";

--- a/panel/src/lib/stores/scroll-restoration-store.ts
+++ b/panel/src/lib/stores/scroll-restoration-store.ts
@@ -15,6 +15,21 @@ interface ScrollPosition {
   y: number;
 }
 
+// A single entry in the current Tasks list order (filter + sort applied),
+// captured by the Tasks list page so the task-detail page can compute
+// prev/next without re-implementing the list's filter/sort logic.
+export interface TaskListNavItem {
+  id: string;
+  title: string;
+}
+
+export interface TaskListNavContext {
+  items: TaskListNavItem[];
+  // The Tasks list's current query string (filters/sort/search), so a "Back
+  // to list" link can restore the exact context the user navigated from.
+  queryString: string;
+}
+
 interface ScrollRestorationState {
   // Scroll positions per route
   scrollPositions: Record<string, ScrollPosition>;
@@ -27,6 +42,11 @@ interface ScrollRestorationState {
 
   // Last visited routes per section (for "back" behavior)
   lastVisited: Record<string, string>;
+
+  // Current Tasks list order (filter/sort context) for task-detail prev/next
+  // navigation. Null when no list has been visited this session — the
+  // documented fallback for task-detail is to disable prev/next then.
+  taskListNav: TaskListNavContext | null;
 
   // Actions
   setScrollPosition: (route: string, position: ScrollPosition) => void;
@@ -42,6 +62,8 @@ interface ScrollRestorationState {
 
   setLastVisited: (section: string, route: string) => void;
   getLastVisited: (section: string) => string | undefined;
+
+  setTaskListNav: (context: TaskListNavContext) => void;
 }
 
 export const useScrollRestorationStore = create<ScrollRestorationState>()(
@@ -51,6 +73,7 @@ export const useScrollRestorationStore = create<ScrollRestorationState>()(
       expandedSections: {},
       selectedItems: {},
       lastVisited: {},
+      taskListNav: null,
 
       // Scroll position management
       setScrollPosition: (route, position) =>
@@ -102,6 +125,8 @@ export const useScrollRestorationStore = create<ScrollRestorationState>()(
         })),
 
       getLastVisited: (section) => get().lastVisited[section],
+
+      setTaskListNav: (context) => set({ taskListNav: context }),
     }),
     {
       name: "roboco-ui-state",
@@ -111,6 +136,7 @@ export const useScrollRestorationStore = create<ScrollRestorationState>()(
         scrollPositions: state.scrollPositions,
         expandedSections: state.expandedSections,
         lastVisited: state.lastVisited,
+        taskListNav: state.taskListNav,
         // Don't persist selectedItems - they're temporary
       }),
     },

--- a/panel/src/lib/utils.ts
+++ b/panel/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// Absolute inline timestamp shown alongside relative "Xm ago" text — e.g.
+// "Jul 10, 2026, 3:45 PM". Shared so progress updates and checkpoints render
+// the same format instead of each screen inventing its own.
+export function formatAbsoluteTimestamp(timestamp: string): string {
+  return new Date(timestamp).toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}


### PR DESCRIPTION
Implement the markdown rendering, navigation (breadcrumb + prev/next), collapsible sections, and inline timestamps design produced by the ux_ui cell for the task-detail page overhaul, including the visually distinct Constraints-section treatment.