### PR TITLE
[73f8311f] Fix exhaustive-deps lint suppression in task-table.tsx

### DIFF
--- a/panel/src/components/tasks/task-table.tsx
+++ b/panel/src/components/tasks/task-table.tsx
@@ -398,8 +398,7 @@ export function TaskTable({
         title: node.task.title,
       })),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [flattenedTasks]);
+  }, [flattenedTasks, onVisibleOrderChange]);
 
   // Pagination on flattened list
   const totalItems = flattenedTasks.length;


### PR DESCRIPTION
The gate review of PR #408 flagged a convention violation: panel/src/components/tasks/task-table.tsx has a `// eslint-disable-next-line react-hooks/exhaustive-deps` comment on the useEffect around line 389 that reports the visible task order via the `onVisibleOrderChange` callback. Remove the suppression comment and add `onVisibleOrderChange` to the effect's dependency array (it should read `}, [flattenedTasks, onVisibleOrderChange]);`). Before doing so, confirm the call site in panel/src/app/(dashboard)/tasks/page.tsx already wraps `handleVisibleOrderChange` in `useCallback` with stable dependencies (`setTaskListNav`, `searchParamsString`) — it does per the reviewer's note, so adding the callback to the deps array should not cause an infinite render loop. Run lint/typecheck/tests locally to confirm no regression. Do not add a waiver to .roboco/conventions.yml — this is a genuine fix, not a false positive.