### PR TITLE
[a512f364] Add video_engine_enabled to ProjectSummaryResponse

### DIFF
--- a/roboco/api/schemas/project.py
+++ b/roboco/api/schemas/project.py
@@ -67,7 +67,12 @@ class ProjectResponse(BaseModel):
 
 
 class ProjectSummaryResponse(BaseModel):
-    """Compact project response for list views."""
+    """Compact project response for list views.
+
+    Returned by GET /api/projects; includes essential project metadata
+    for list-view cards. The `video_engine_enabled` field indicates
+    whether this project is opted in to the video engine subsystem.
+    """
 
     id: UUID
     name: str

--- a/roboco/api/schemas/project.py
+++ b/roboco/api/schemas/project.py
@@ -78,6 +78,7 @@ class ProjectSummaryResponse(BaseModel):
     is_active: bool
     has_workspace: bool = False
     has_git_token: bool = False
+    video_engine_enabled: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -255,4 +256,5 @@ def project_to_summary(project: "ProjectTable") -> ProjectSummaryResponse:
         is_active=bool(project.is_active),
         has_workspace=bool(project.workspace_path),
         has_git_token=bool(project.git_token_encrypted),
+        video_engine_enabled=bool(project.video_engine_enabled),
     )

--- a/tests/integration/test_project_routes.py
+++ b/tests/integration/test_project_routes.py
@@ -224,6 +224,33 @@ async def test_list_projects_includes_default_branch(
 
 
 @pytest.mark.asyncio
+async def test_list_projects_includes_video_engine_enabled(
+    project_client: AsyncClient,
+) -> None:
+    payload = _payload()
+    create = await project_client.post("/api/projects", json=payload, headers=_HDR)
+    assert create.status_code == HTTPStatus.CREATED
+
+    default_listed = {
+        p["slug"]: p
+        for p in (await project_client.get("/api/projects", headers=_HDR)).json()
+    }
+    assert default_listed[payload["slug"]]["video_engine_enabled"] is False
+
+    patched = await project_client.patch(
+        f"/api/projects/{payload['slug']}",
+        json={"video_engine_enabled": True},
+        headers=_HDR,
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    response = await project_client.get("/api/projects", headers=_HDR)
+    assert response.status_code == HTTPStatus.OK
+    listed = {p["slug"]: p for p in response.json()}
+    assert listed[payload["slug"]]["video_engine_enabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_project_by_slug_not_found(project_client: AsyncClient) -> None:
     response = await project_client.get(
         "/api/projects/ghost-project-slug", headers=_HDR


### PR DESCRIPTION
Add `video_engine_enabled: bool = False` to ProjectSummaryResponse in roboco/api/schemas/project.py. Populate it inside project_to_summary() by reading the corresponding attribute/flag off the project record (check the Project model first — this must be additive, no DB migration; if no source attribute exists yet, stop and flag back to be-pm before adding any migration). Extend the existing GET /projects test(s) to assert every project in the response includes video_engine_enabled with the correct value, and confirm no existing tests regress.