### PR TITLE
[61b9f9e1] Expose video_engine_enabled on ProjectSummaryResponse

### DIFF
--- a/roboco/api/schemas/project.py
+++ b/roboco/api/schemas/project.py
@@ -67,7 +67,12 @@ class ProjectResponse(BaseModel):
 
 
 class ProjectSummaryResponse(BaseModel):
-    """Compact project response for list views."""
+    """Compact project response for list views.
+
+    Returned by GET /api/projects; includes essential project metadata
+    for list-view cards. The `video_engine_enabled` field indicates
+    whether this project is opted in to the video engine subsystem.
+    """
 
     id: UUID
     name: str
@@ -78,6 +83,7 @@ class ProjectSummaryResponse(BaseModel):
     is_active: bool
     has_workspace: bool = False
     has_git_token: bool = False
+    video_engine_enabled: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -255,4 +261,5 @@ def project_to_summary(project: "ProjectTable") -> ProjectSummaryResponse:
         is_active=bool(project.is_active),
         has_workspace=bool(project.workspace_path),
         has_git_token=bool(project.git_token_encrypted),
+        video_engine_enabled=bool(project.video_engine_enabled),
     )

--- a/tests/integration/test_project_routes.py
+++ b/tests/integration/test_project_routes.py
@@ -224,6 +224,33 @@ async def test_list_projects_includes_default_branch(
 
 
 @pytest.mark.asyncio
+async def test_list_projects_includes_video_engine_enabled(
+    project_client: AsyncClient,
+) -> None:
+    payload = _payload()
+    create = await project_client.post("/api/projects", json=payload, headers=_HDR)
+    assert create.status_code == HTTPStatus.CREATED
+
+    default_listed = {
+        p["slug"]: p
+        for p in (await project_client.get("/api/projects", headers=_HDR)).json()
+    }
+    assert default_listed[payload["slug"]]["video_engine_enabled"] is False
+
+    patched = await project_client.patch(
+        f"/api/projects/{payload['slug']}",
+        json={"video_engine_enabled": True},
+        headers=_HDR,
+    )
+    assert patched.status_code == HTTPStatus.OK
+
+    response = await project_client.get("/api/projects", headers=_HDR)
+    assert response.status_code == HTTPStatus.OK
+    listed = {p["slug"]: p for p in response.json()}
+    assert listed[payload["slug"]]["video_engine_enabled"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_project_by_slug_not_found(project_client: AsyncClient) -> None:
     response = await project_client.get(
         "/api/projects/ghost-project-slug", headers=_HDR


### PR DESCRIPTION
CEO rejected the video-pipeline PR partly because the panel's project picker cannot filter to video-enabled projects: video_engine_enabled exists on the full ProjectResponse (roboco/api/schemas/project.py) but not on the compact ProjectSummaryResponse that list views use. Add the field to ProjectSummaryResponse and thread it through project_to_summary() so GET /projects returns it for every project. This is additive -- the underlying column already exists on the project model and on ProjectResponse -- no migration, no behavior change to any existing consumer. The frontend picker fix (sibling task) is blocked on this field being live on the wire.