### PR TITLE
[4e855d24] Apply content-readability-spec collapse thresholds to Progress and Acceptance Criteria surfaces

### DIFF
--- a/docs/frontend/components/collapsible-section.md
+++ b/docs/frontend/components/collapsible-section.md
@@ -31,8 +31,19 @@ interface CollapsibleSectionProps {
   /** Controlled open state (e.g. force-open while a section is mid-edit). Omit for uncontrolled. */
   open?: boolean;
   
-  /** Whether the (uncontrolled) section starts expanded. Defaults to true so nothing visible today disappears. */
+  /**
+   * Whether the (uncontrolled) section starts expanded. Takes precedence
+   * over `content`-derived collapsing. Omit to let `content` decide, or to
+   * default open when neither is given (so nothing visible today disappears).
+   */
   defaultOpen?: boolean;
+  
+  /**
+   * Plain-text representation of the section's body, used to derive
+   * `defaultOpen` per the content-readability spec (~10 lines / ~640 chars)
+   * when `defaultOpen` is not explicitly set. Ignored otherwise.
+   */
+  content?: string;
   
   /** Callback when the user toggles the section open/closed. */
   onOpenChange?: (open: boolean) => void;
@@ -50,8 +61,9 @@ interface CollapsibleSectionProps {
 
 ### Component behavior
 
-- **Uncontrolled mode** (omit `open` prop): component manages its own open state. `defaultOpen` determines initial state (defaults to `true`). `onOpenChange` is called when the user clicks the toggle; internal state updates automatically.
+- **Uncontrolled mode** (omit `open` prop): component manages its own open state. `defaultOpen` determines initial state; if `defaultOpen` is omitted, the component uses `content`-derived collapsing (if `content` is provided), or defaults to `true` if neither is set. `onOpenChange` is called when the user clicks the toggle; internal state updates automatically.
 - **Controlled mode** (`open` prop set): `onOpenChange` is called on toggle, but internal state is not updated; parent must update the `open` prop. Useful to force a section open while a user is editing (e.g., `open={isEditing || sectionOpen}`).
+- **Content-driven defaultOpen** (new): when `content` is provided without an explicit `defaultOpen`, the component checks if the content exceeds the readability thresholds (~10 lines / ~640 characters, per `content-readability.ts`). If it does, the section defaults collapsed; otherwise, it defaults open. This keeps long lists/sections from forcing continuous scrolling. An explicit `defaultOpen` prop always takes precedence over this logic, maintaining backward compatibility with existing callers.
 - **Title and actions**: title is always visible in the header; actions (right side) are also always visible, never collapsed away. This allows edit/preview toggles, save/cancel buttons, etc. to remain accessible.
 - **ChevronDown icon**: rotates -90° when closed, 0° when open. Uses `transition-transform duration-200` so the rotation animates smoothly.
 
@@ -83,6 +95,7 @@ import { FileText, Edit3 } from "lucide-react";
 export function MySection() {
   const [sectionOpen, setSectionOpen] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
+  const sectionText = "Section content here."; // Plain-text representation
 
   return (
     <CollapsibleSection
@@ -98,14 +111,36 @@ export function MySection() {
           Edit
         </Button>
       }
+      content={sectionText}  // Optional: drive defaultOpen based on content length
       open={isEditing || sectionOpen}
       onOpenChange={setSectionOpen}
     >
-      <p>Section content here.</p>
+      <p>{sectionText}</p>
     </CollapsibleSection>
   );
 }
 ```
+
+### Using content-driven defaultOpen
+
+To automatically collapse long sections without explicit `defaultOpen`:
+
+```tsx
+const listText = items.map(item => item.title).join("\n");
+
+<CollapsibleSection
+  title="Long List"
+  content={listText}  // Checked against ~10 lines / ~640 chars thresholds
+>
+  <ul>
+    {items.map(item => (
+      <li key={item.id}>{item.title}</li>
+    ))}
+  </ul>
+</CollapsibleSection>
+```
+
+If `listText` exceeds the readability thresholds, the section defaults collapsed; otherwise, it defaults open. No explicit `defaultOpen` prop needed.
 
 ### Controlled vs. uncontrolled
 
@@ -145,8 +180,12 @@ The component is now applied across task-detail pages:
 | `task-description.tsx` | Description, Constraints | Constraints section styled with amber border/background + ShieldAlert icon for visual distinction from authored content. |
 | `tab-notes.tsx` | Each editable note field (Description, Notes, Plan) | Edit/preview toggle forced open while editing via `open={isEditing \|\| sectionOpen}`. |
 | `tab-plan.tsx` | Approach, Sub-Tasks, Technical Considerations, Risks, Open Questions | Each sub-section independently collapsible. |
+| `acceptance-criteria.tsx` | Full acceptance criteria list | Wrapped in CollapsibleSection with `content={criteriaText}`, so a long AC list defaults collapsed per content-readability spec. Forced open while adding/editing via controlled `open` prop. |
+| `tab-progress.tsx` | Individual progress updates and checkpoints (via internal Radix Collapsible wrapper) | Each entry wrapped in a collapsible section; only the 2 most recent entries default open (gated by content length as well). Older entries default collapsed even if short, keeping task detail navigable without endless scrolling. |
 
 ## Design decisions
+
+- **Content-driven defaultOpen (new)**: instead of always defaulting open (which forced tasks with long histories to be fully expanded), the component now checks content length against readability thresholds (~10 lines / ~640 characters) when `defaultOpen` is not explicitly set. Long content defaults collapsed, keeping task-detail pages navigable. The explicit `defaultOpen` prop always takes precedence, so existing callers (task-description, tab-notes, tab-plan) that pass `open={...}` are unaffected — the content-length check only applies to uncontrolled sections. This is the "content-readability spec" driving progress and AC collapse in tab-progress and acceptance-criteria.
 
 - **Fade + slide animation only**: opacity and transform are GPU-accelerated and don't trigger layout reflow. Height/width animations are avoided because they force the browser to recalculate layout mid-animation, causing jank on slower devices and making the motion distracting.
 
@@ -189,20 +228,39 @@ For developers adding a new collapsible section to task-detail or other pages:
 1. Import `CollapsibleSection` from `./collapsible-section` (adjust path as needed).
 2. Wrap the section content, provide a `title` (can include icons, badges).
 3. Optionally provide `actions` (buttons, toggles that should stay visible).
-4. For editable content, use the controlled pattern: `open={isEditing || sectionOpen}` to force-open while editing.
-5. No extra state management is needed for read-only sections; the component handles it.
+4. **For sections with potentially long content** (lists, histories): pass a plain-text `content` prop so the section automatically collapses if the content is long. This defers to the content-readability spec thresholds (~10 lines / ~640 chars).
+5. For editable content, use the controlled pattern: `open={isEditing || sectionOpen}` to force-open while editing. The controlled `open` prop takes precedence over content-driven collapse.
+6. No extra state management is needed for read-only sections; the component handles it internally.
 
-Example:
+Example (uncontrolled with content-driven collapse):
+
+```tsx
+const listText = items.map(item => item.name).join("\n");
+
+<CollapsibleSection
+  title="My List"
+  content={listText}  // Drives defaultOpen based on length
+>
+  <ul>
+    {items.map(item => (
+      <li key={item.id}>{item.name}</li>
+    ))}
+  </ul>
+</CollapsibleSection>
+```
+
+Example (controlled, forcing open during edit):
 
 ```tsx
 const [sectionOpen, setSectionOpen] = useState(true);
+const [isEditing, setIsEditing] = useState(false);
 
 <CollapsibleSection
   title="My Section"
-  open={sectionOpen}
+  open={isEditing || sectionOpen}  // Controlled: explicit `open` wins over content
   onOpenChange={setSectionOpen}
 >
-  <p>Content here.</p>
+  {isEditing ? <textarea /> : <p>Content here.</p>}
 </CollapsibleSection>
 ```
 

--- a/docs/frontend/lib/content-readability.md
+++ b/docs/frontend/lib/content-readability.md
@@ -1,0 +1,123 @@
+# Content Readability Helper (`content-readability.ts`)
+
+A shared utility that defines thresholds and a checker for auto-collapsing long content in the task-detail view. It prevents tasks with long histories (many progress updates, checkpoints, or acceptance criteria) from forcing continuous scrolling through fully-expanded sections.
+
+## Rationale
+
+When a task accumulates 30+ progress entries, 20+ checkpoints, or a long acceptance-criteria list, rendering all entries open by default fills the viewport. Users must scroll through every item to reach later sections. This helper establishes a readability-driven threshold so long content defaults collapsed while short content stays visible.
+
+## Thresholds
+
+| Name | Value | Purpose |
+|------|-------|---------|
+| `READABILITY_LINE_THRESHOLD` | 10 | Content exceeding this many lines is considered "long" |
+| `READABILITY_CHAR_THRESHOLD` | 640 | Content exceeding this character count is considered "long" |
+
+A section defaults **collapsed** if either threshold is exceeded (OR logic). A section defaults **open** if both are satisfied (short by both measures).
+
+## API
+
+### `exceedsReadabilityThreshold(content: string): boolean`
+
+Returns `true` if the content exceeds readability thresholds, indicating it should default collapsed.
+
+```tsx
+import { exceedsReadabilityThreshold } from "@/lib/content-readability";
+
+const listText = items.map(i => i.name).join("\n");
+const shouldCollapse = exceedsReadabilityThreshold(listText);
+```
+
+**Parameters:**
+- `content` (string): Plain-text representation of the section body. Line breaks are respected; a multi-line string counts as multiple lines.
+
+**Returns:**
+- `true` if lineCount > 10 OR content.length > 640
+- `false` otherwise
+
+**Edge case:** empty or falsy content always returns `false` (empty content is always "readable" and defaults open).
+
+## Usage in CollapsibleSection
+
+`CollapsibleSection` integrates this checker via its optional `content` prop:
+
+```tsx
+<CollapsibleSection
+  title="Acceptance Criteria"
+  content={criteriaText}  // Plain-text list of all criteria, newline-joined
+>
+  <ul>
+    {criteria.map(c => (
+      <li key={c.id}>{c.text}</li>
+    ))}
+  </ul>
+</CollapsibleSection>
+```
+
+If `content` is provided without an explicit `defaultOpen`, the component calls `exceedsReadabilityThreshold(content)` and defaults:
+- **Collapsed** if `exceedsReadabilityThreshold` returns `true`
+- **Open** if it returns `false`
+
+An explicit `defaultOpen` prop always takes precedence, bypassing the content check.
+
+## Usage in Tab Progress / Checkpoints
+
+`tab-progress.tsx` wraps each progress update and checkpoint entry in a Radix Collapsible (not CollapsibleSection). A `defaultEntryOpen(idx, content)` function keeps only the **2 most recent entries open** (regardless of content length) and collapses all older entries. This applies even to short entries: older updates are collapsed to keep the list scannable.
+
+```tsx
+// Pseudo-code: each update is wrapped
+<Collapsible
+  defaultOpen={defaultEntryOpen(idx, updateContent)}
+  // ... which evaluates to:
+  // - true if idx < 2 AND content is short
+  // - false if idx >= 2 OR content is long
+>
+  {/* update body */}
+</Collapsible>
+```
+
+Test coverage: `tab-progress-collapse.test.tsx` verifies that a 30-entry task has entries 0–1 open and entries 2–29 closed, even if all entries are short.
+
+## Rationale for thresholds
+
+- **10 lines**: Enough to show a short paragraph or a 5-6 item list without scrolling the section itself. Most prose descriptions fit. A checkbox-list item typically takes 1 line; 10 items fits comfortably.
+- **640 characters**: ~4–5 sentences of prose, or ~20 short list items (32 chars/item). Roughly equivalent to 10 lines of average content. The threshold allows either metric to trigger collapse independently (a single very-long line counts; a tall list of short lines counts).
+
+Both must be satisfied to keep content open. This prevents edge cases where a small number of extremely long lines OR a tall list of 1-char items each individually pass but together are unreadable.
+
+## Testing
+
+`collapsible-section.test.tsx` covers the content-driven defaultOpen behavior:
+- Short content stays open by default
+- Long content (exceeding either threshold) defaults closed
+- Explicit `defaultOpen` prop overrides content-driven behavior
+- Controlled `open` prop is unaffected by content length
+
+Example:
+
+```tsx
+it("defaults collapsed when content exceeds the readability thresholds", () => {
+  render(
+    <CollapsibleSection
+      title="Section"
+      content={"a".repeat(READABILITY_CHAR_THRESHOLD + 1)}
+    >
+      <p>body</p>
+    </CollapsibleSection>,
+  );
+  expect(screen.getByRole("button", { name: "Section" })).toHaveAttribute(
+    "aria-expanded",
+    "false",
+  );
+});
+```
+
+## Related work
+
+- **CollapsibleSection component** (`collapsible-section.tsx`): integrates this helper via the `content` prop
+- **AcceptanceCriteria** (`acceptance-criteria.tsx`): wraps the full criteria list in CollapsibleSection with `content={criteriaText}`
+- **TabProgress** (`tab-progress.tsx`): wraps each update/checkpoint entry in a Radix Collapsible with `defaultEntryOpen(idx, content)`
+
+## Backward compatibility
+
+Existing consumers of `CollapsibleSection` (task-description, tab-notes, tab-plan) all pass an explicit `open` prop (controlled mode), so the content-readability check does not apply to them. This change is additive: no existing behavior changes; new consumers can opt into content-driven collapse by omitting `defaultOpen` and providing `content`.

--- a/panel/src/components/tasks/task-detail/__tests__/collapsible-section.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/collapsible-section.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { READABILITY_CHAR_THRESHOLD } from "@/lib/content-readability";
+import { CollapsibleSection } from "../collapsible-section";
+
+// Regression: defaultOpen used to be hardcoded to true regardless of the
+// section's content, forcing a long list to render fully expanded. It now
+// derives the uncontrolled default from the content-readability spec
+// (~10 lines / ~640 chars) unless a caller opts out via an explicit
+// defaultOpen/open prop.
+
+describe("CollapsibleSection content-driven default", () => {
+  it("defaults open when no content prop is given (back-compat)", () => {
+    render(
+      <CollapsibleSection title="Section">
+        <p>body</p>
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("button", { name: "Section" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("defaults open when content is within the readability thresholds", () => {
+    render(
+      <CollapsibleSection title="Section" content="short body text">
+        <p>body</p>
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("button", { name: "Section" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("defaults collapsed when content exceeds the readability thresholds", () => {
+    render(
+      <CollapsibleSection
+        title="Section"
+        content={"a".repeat(READABILITY_CHAR_THRESHOLD + 1)}
+      >
+        <p>body</p>
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("button", { name: "Section" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("an explicit defaultOpen wins over content-derived collapsing", () => {
+    render(
+      <CollapsibleSection
+        title="Section"
+        content={"a".repeat(READABILITY_CHAR_THRESHOLD + 1)}
+        defaultOpen={true}
+      >
+        <p>body</p>
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("button", { name: "Section" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("a controlled open prop is unaffected by content length", () => {
+    render(
+      <CollapsibleSection
+        title="Section"
+        content={"a".repeat(READABILITY_CHAR_THRESHOLD + 1)}
+        open={true}
+      >
+        <p>body</p>
+      </CollapsibleSection>,
+    );
+    expect(screen.getByRole("button", { name: "Section" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+});

--- a/panel/src/components/tasks/task-detail/__tests__/tab-progress-collapse.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/tab-progress-collapse.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+// Regression: a task with a long progress history used to render every
+// update fully expanded, forcing continuous scrolling. Only the 2 most
+// recent progress updates default open; older ones default collapsed.
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useUpdateTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { TabProgress } from "../tab-progress";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    title: "Task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    checkpoints: [],
+    progress_updates: [],
+    ...overrides,
+  } as unknown as Task;
+}
+
+function makeUpdates(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    timestamp: new Date(2026, 0, 1 + i).toISOString(),
+    agent_id: "be-dev-1",
+    message: `Update number ${i}`,
+    percentage: null,
+  }));
+}
+
+describe("TabProgress progress-update collapse", () => {
+  it("only the 2 most recent updates default expanded when there are many", () => {
+    const task = buildTask({ progress_updates: makeUpdates(30) });
+    const { container } = render(<TabProgress task={task} />);
+
+    // Each update's collapse trigger is the only <button> in its <li> that
+    // carries Radix's data-state attribute; list order matches sort order
+    // (newest first), so the first two entries are the 2 most recent.
+    const triggers = Array.from(
+      container.querySelectorAll("li button[data-state]"),
+    );
+    expect(triggers).toHaveLength(30);
+    expect(triggers[0]).toHaveAttribute("data-state", "open");
+    expect(triggers[1]).toHaveAttribute("data-state", "open");
+    expect(triggers[2]).toHaveAttribute("data-state", "closed");
+    expect(triggers[29]).toHaveAttribute("data-state", "closed");
+  });
+});

--- a/panel/src/components/tasks/task-detail/acceptance-criteria.tsx
+++ b/panel/src/components/tasks/task-detail/acceptance-criteria.tsx
@@ -279,7 +279,6 @@ export function AcceptanceCriteria({ task }: AcceptanceCriteriaProps) {
             );
           })}
 
-          {/* Add new criterion input */}
           {isAdding && (
             <li className="flex items-center gap-2">
               <Checkbox checked={false} disabled className="shrink-0" />

--- a/panel/src/components/tasks/task-detail/acceptance-criteria.tsx
+++ b/panel/src/components/tasks/task-detail/acceptance-criteria.tsx
@@ -3,12 +3,12 @@
 import { useState, useRef, useEffect } from "react";
 import { Task } from "@/types";
 import { useUpdateTask } from "@/hooks/use-tasks";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Plus, Trash2, Edit3, Check, X } from "lucide-react";
 import { toast } from "sonner";
+import { CollapsibleSection } from "./collapsible-section";
 
 interface AcceptanceCriteriaProps {
   task: Task;
@@ -173,149 +173,148 @@ export function AcceptanceCriteria({ task }: AcceptanceCriteriaProps) {
     }
   };
 
+  // Plain-text representation used to derive the default collapsed state
+  // per the content-readability spec — a long list starts collapsed.
+  const criteriaText = criteria.map((c) => parseCriterion(c).text).join("\n");
+
   return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg">Acceptance Criteria</CardTitle>
-          <div className="flex items-center gap-2">
-            <span className="text-sm text-muted-foreground">
-              {completedCount}/{criteria.length} completed
-            </span>
-            {!isAdding && (
+    <CollapsibleSection
+      title="Acceptance Criteria"
+      content={criteriaText}
+      open={isAdding || editingIndex !== null ? true : undefined}
+      actions={
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">
+            {completedCount}/{criteria.length} completed
+          </span>
+          {!isAdding && (
+            <Button size="sm" variant="ghost" onClick={() => setIsAdding(true)}>
+              <Plus className="h-4 w-4 mr-1" />
+              Add
+            </Button>
+          )}
+        </div>
+      }
+    >
+      {criteria.length === 0 && !isAdding ? (
+        <p
+          className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
+          onClick={() => setIsAdding(true)}
+        >
+          No acceptance criteria defined. Click to add one.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {criteria.map((criterion, idx) => {
+            const { text, completed } = parseCriterion(criterion);
+            const isEditingThis = editingIndex === idx;
+
+            return (
+              <li key={idx} className="flex items-center gap-2 group">
+                <Checkbox
+                  checked={completed}
+                  onCheckedChange={() => toggleCriterion(idx)}
+                  disabled={updateTask.isPending || isEditingThis}
+                  className="shrink-0"
+                />
+
+                {isEditingThis ? (
+                  <div className="flex-1 flex items-center gap-2">
+                    <Input
+                      ref={editInputRef}
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onKeyDown={handleEditKeyDown}
+                      onBlur={handleSaveEdit}
+                      className="h-8 text-sm flex-1"
+                      disabled={updateTask.isPending}
+                    />
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setEditingIndex(null)}
+                      className="h-7 w-7 p-0"
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={handleSaveEdit}
+                      onMouseDown={(e) => e.preventDefault()}
+                      className="h-7 w-7 p-0"
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ) : (
+                  <>
+                    <span
+                      className={`flex-1 cursor-pointer select-none hover:bg-muted/30 px-2 py-1 -mx-2 rounded transition-colors ${
+                        completed ? "line-through text-muted-foreground" : ""
+                      }`}
+                      onClick={() => startEditing(idx)}
+                      title="Click to edit"
+                    >
+                      {text}
+                    </span>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => startEditing(idx)}
+                      className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <Edit3 className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => handleDeleteCriterion(idx)}
+                      className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </Button>
+                  </>
+                )}
+              </li>
+            );
+          })}
+
+          {/* Add new criterion input */}
+          {isAdding && (
+            <li className="flex items-center gap-2">
+              <Checkbox checked={false} disabled className="shrink-0" />
+              <Input
+                ref={newInputRef}
+                value={newCriterion}
+                onChange={(e) => setNewCriterion(e.target.value)}
+                onKeyDown={handleAddKeyDown}
+                placeholder="Add criterion..."
+                className="h-8 text-sm flex-1"
+                disabled={updateTask.isPending}
+              />
               <Button
                 size="sm"
                 variant="ghost"
-                onClick={() => setIsAdding(true)}
+                onClick={() => {
+                  setNewCriterion("");
+                  setIsAdding(false);
+                }}
+                className="h-7 w-7 p-0"
               >
-                <Plus className="h-4 w-4 mr-1" />
-                Add
+                <X className="h-4 w-4" />
               </Button>
-            )}
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        {criteria.length === 0 && !isAdding ? (
-          <p
-            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
-            onClick={() => setIsAdding(true)}
-          >
-            No acceptance criteria defined. Click to add one.
-          </p>
-        ) : (
-          <ul className="space-y-2">
-            {criteria.map((criterion, idx) => {
-              const { text, completed } = parseCriterion(criterion);
-              const isEditingThis = editingIndex === idx;
-
-              return (
-                <li key={idx} className="flex items-center gap-2 group">
-                  <Checkbox
-                    checked={completed}
-                    onCheckedChange={() => toggleCriterion(idx)}
-                    disabled={updateTask.isPending || isEditingThis}
-                    className="shrink-0"
-                  />
-
-                  {isEditingThis ? (
-                    <div className="flex-1 flex items-center gap-2">
-                      <Input
-                        ref={editInputRef}
-                        value={editValue}
-                        onChange={(e) => setEditValue(e.target.value)}
-                        onKeyDown={handleEditKeyDown}
-                        onBlur={handleSaveEdit}
-                        className="h-8 text-sm flex-1"
-                        disabled={updateTask.isPending}
-                      />
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setEditingIndex(null)}
-                        className="h-7 w-7 p-0"
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        onClick={handleSaveEdit}
-                        onMouseDown={(e) => e.preventDefault()}
-                        className="h-7 w-7 p-0"
-                      >
-                        <Check className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <>
-                      <span
-                        className={`flex-1 cursor-pointer select-none hover:bg-muted/30 px-2 py-1 -mx-2 rounded transition-colors ${
-                          completed ? "line-through text-muted-foreground" : ""
-                        }`}
-                        onClick={() => startEditing(idx)}
-                        title="Click to edit"
-                      >
-                        {text}
-                      </span>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => startEditing(idx)}
-                        className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                      >
-                        <Edit3 className="h-3 w-3" />
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => handleDeleteCriterion(idx)}
-                        className="h-7 w-7 p-0 opacity-0 group-hover:opacity-100 transition-opacity text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="h-3 w-3" />
-                      </Button>
-                    </>
-                  )}
-                </li>
-              );
-            })}
-
-            {/* Add new criterion input */}
-            {isAdding && (
-              <li className="flex items-center gap-2">
-                <Checkbox checked={false} disabled className="shrink-0" />
-                <Input
-                  ref={newInputRef}
-                  value={newCriterion}
-                  onChange={(e) => setNewCriterion(e.target.value)}
-                  onKeyDown={handleAddKeyDown}
-                  placeholder="Add criterion..."
-                  className="h-8 text-sm flex-1"
-                  disabled={updateTask.isPending}
-                />
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => {
-                    setNewCriterion("");
-                    setIsAdding(false);
-                  }}
-                  className="h-7 w-7 p-0"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="sm"
-                  onClick={handleAddCriterion}
-                  disabled={!newCriterion.trim() || updateTask.isPending}
-                  className="h-7 w-7 p-0"
-                >
-                  <Check className="h-4 w-4" />
-                </Button>
-              </li>
-            )}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
+              <Button
+                size="sm"
+                onClick={handleAddCriterion}
+                disabled={!newCriterion.trim() || updateTask.isPending}
+                className="h-7 w-7 p-0"
+              >
+                <Check className="h-4 w-4" />
+              </Button>
+            </li>
+          )}
+        </ul>
+      )}
+    </CollapsibleSection>
   );
 }

--- a/panel/src/components/tasks/task-detail/collapsible-section.tsx
+++ b/panel/src/components/tasks/task-detail/collapsible-section.tsx
@@ -9,6 +9,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { exceedsReadabilityThreshold } from "@/lib/content-readability";
 
 interface CollapsibleSectionProps {
   /** Card title content (icon + text + badges as needed) */
@@ -17,8 +18,18 @@ interface CollapsibleSectionProps {
   actions?: ReactNode;
   /** Controlled open state (e.g. force-open while a section is mid-edit). Omit for uncontrolled. */
   open?: boolean;
-  /** Whether the (uncontrolled) section starts expanded. Defaults to open so nothing visible today disappears. */
+  /**
+   * Whether the (uncontrolled) section starts expanded. Takes precedence
+   * over `content`-derived collapsing. Omit to let `content` decide, or to
+   * default open when neither is given (so nothing visible today disappears).
+   */
   defaultOpen?: boolean;
+  /**
+   * Plain-text representation of the section's body, used to derive
+   * `defaultOpen` per the content-readability spec (~10 lines / ~640 chars)
+   * when `defaultOpen` is not explicitly set. Ignored otherwise.
+   */
+  content?: string;
   onOpenChange?: (open: boolean) => void;
   className?: string;
   headerClassName?: string;
@@ -36,13 +47,17 @@ export function CollapsibleSection({
   title,
   actions,
   open: openProp,
-  defaultOpen = true,
+  defaultOpen,
+  content,
   onOpenChange,
   className,
   headerClassName,
   children,
 }: CollapsibleSectionProps) {
-  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const resolvedDefaultOpen =
+    defaultOpen ??
+    (content !== undefined ? !exceedsReadabilityThreshold(content) : true);
+  const [internalOpen, setInternalOpen] = useState(resolvedDefaultOpen);
   const open = openProp ?? internalOpen;
   const setOpen = (next: boolean) => {
     onOpenChange?.(next);

--- a/panel/src/components/tasks/task-detail/tab-progress.tsx
+++ b/panel/src/components/tasks/task-detail/tab-progress.tsx
@@ -173,7 +173,6 @@ function ProgressUpdatesSection({ task }: { task: Task }) {
         )}
       </CardHeader>
       <CardContent>
-        {/* Add new update form */}
         {isAdding && (
           <div className="border rounded-lg p-4 mb-4 space-y-3">
             <Textarea
@@ -226,13 +225,11 @@ function ProgressUpdatesSection({ task }: { task: Task }) {
           </p>
         ) : (
           <div className="relative">
-            {/* Timeline line */}
             <div className="absolute left-3 top-0 bottom-0 w-0.5 bg-border" />
 
             <ul className="space-y-4">
               {sortedUpdates.map((update, idx) => (
                 <li key={idx} className="relative pl-8 group">
-                  {/* Timeline dot */}
                   <div className="absolute left-0 top-1.5 w-6 h-6 rounded-full bg-background border-2 border-primary flex items-center justify-center">
                     <MessageSquare className="h-3 w-3 text-primary" />
                   </div>
@@ -393,7 +390,6 @@ function CheckpointsSection({ task }: { task: Task }) {
         </div>
       </CardHeader>
       <CardContent>
-        {/* Add new checkpoint form */}
         {isAdding && (
           <div className="border rounded-lg p-4 mb-4 space-y-3">
             <div>
@@ -514,7 +510,6 @@ function CheckpointsSection({ task }: { task: Task }) {
                     </div>
                     <CollapsibleContent>
                       <CardContent className="py-4">
-                        {/* Agent */}
                         <div className="flex items-center gap-2 text-sm text-muted-foreground mb-3">
                           <User className="h-4 w-4" />
                           <span>
@@ -522,7 +517,6 @@ function CheckpointsSection({ task }: { task: Task }) {
                           </span>
                         </div>
 
-                        {/* State Summary */}
                         <div className="mb-4">
                           <h4 className="text-sm font-medium mb-1">
                             State Summary
@@ -532,7 +526,6 @@ function CheckpointsSection({ task }: { task: Task }) {
                           </p>
                         </div>
 
-                        {/* Remaining Work */}
                         {checkpoint.remaining_work.length > 0 && (
                           <div className="mb-4">
                             <div className="flex items-center gap-2 mb-2">
@@ -551,7 +544,6 @@ function CheckpointsSection({ task }: { task: Task }) {
                           </div>
                         )}
 
-                        {/* Notes */}
                         {checkpoint.notes && (
                           <div>
                             <div className="flex items-center gap-2 mb-2">
@@ -582,12 +574,10 @@ function CheckpointsSection({ task }: { task: Task }) {
 export function TabProgress({ task }: TabProgressProps) {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      {/* Progress Updates Column */}
       <div>
         <ProgressUpdatesSection task={task} />
       </div>
 
-      {/* Checkpoints Column */}
       <div>
         <CheckpointsSection task={task} />
       </div>

--- a/panel/src/components/tasks/task-detail/tab-progress.tsx
+++ b/panel/src/components/tasks/task-detail/tab-progress.tsx
@@ -9,6 +9,11 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Progress } from "@/components/ui/progress";
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
   Clock,
   Bookmark,
   Plus,
@@ -19,10 +24,22 @@ import {
   User,
   ListTodo,
   FileText,
+  ChevronDown,
 } from "lucide-react";
 import { toast } from "sonner";
 import { getAgentDisplayName } from "@/lib/agent-utils";
 import { formatAbsoluteTimestamp } from "@/lib/utils";
+import { exceedsReadabilityThreshold } from "@/lib/content-readability";
+
+// Only the 2 most recent entries default to expanded; older entries (and
+// any entry whose own content is long, per the content-readability spec)
+// default to collapsed so a task with a long history stays navigable.
+const RECENT_OPEN_COUNT = 2;
+
+function defaultEntryOpen(idx: number, content: string): boolean {
+  if (idx >= RECENT_OPEN_COUNT) return false;
+  return !exceedsReadabilityThreshold(content);
+}
 
 interface TabProgressProps {
   task: Task;
@@ -220,11 +237,22 @@ function ProgressUpdatesSection({ task }: { task: Task }) {
                     <MessageSquare className="h-3 w-3 text-primary" />
                   </div>
 
-                  <div className="bg-muted/50 rounded-lg p-3">
+                  <Collapsible
+                    defaultOpen={defaultEntryOpen(idx, update.message)}
+                    className="bg-muted/50 rounded-lg p-3"
+                  >
                     <div className="flex items-center justify-between mb-1">
-                      <span className="text-sm font-medium">
-                        {getAgentDisplayName(update.agent_id)}
-                      </span>
+                      <CollapsibleTrigger asChild>
+                        <button
+                          type="button"
+                          className="group/trigger flex min-w-0 items-center gap-1 text-left"
+                        >
+                          <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=closed]/trigger:-rotate-90" />
+                          <span className="text-sm font-medium">
+                            {getAgentDisplayName(update.agent_id)}
+                          </span>
+                        </button>
+                      </CollapsibleTrigger>
                       <div className="flex items-center gap-2">
                         <span
                           className="text-xs text-muted-foreground flex items-center gap-1"
@@ -244,21 +272,23 @@ function ProgressUpdatesSection({ task }: { task: Task }) {
                         </Button>
                       </div>
                     </div>
-                    <p className="text-sm">{update.message}</p>
-                    {update.percentage !== null && (
-                      <div className="mt-2">
-                        <div className="flex items-center gap-2">
-                          <Progress
-                            value={update.percentage}
-                            className="h-1.5 flex-1"
-                          />
-                          <span className="text-xs text-muted-foreground w-10 text-right">
-                            {update.percentage}%
-                          </span>
+                    <CollapsibleContent>
+                      <p className="text-sm">{update.message}</p>
+                      {update.percentage !== null && (
+                        <div className="mt-2">
+                          <div className="flex items-center gap-2">
+                            <Progress
+                              value={update.percentage}
+                              className="h-1.5 flex-1"
+                            />
+                            <span className="text-xs text-muted-foreground w-10 text-right">
+                              {update.percentage}%
+                            </span>
+                          </div>
                         </div>
-                      </div>
-                    )}
-                  </div>
+                      )}
+                    </CollapsibleContent>
+                  </Collapsible>
                 </li>
               ))}
             </ul>
@@ -435,79 +465,110 @@ function CheckpointsSection({ task }: { task: Task }) {
           </p>
         ) : (
           <div className="space-y-4">
-            {sortedCheckpoints.map((checkpoint) => (
-              <Card key={checkpoint.id} className="overflow-hidden group">
-                <div className="bg-primary/10 px-4 py-2 flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <Bookmark className="h-4 w-4 text-primary" />
-                    <span className="font-medium text-sm">Checkpoint</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="text-xs text-muted-foreground flex items-center gap-1"
-                      title={formatAbsoluteTimestamp(checkpoint.timestamp)}
-                    >
-                      <Clock className="h-3 w-3" />
-                      {formatTime(checkpoint.timestamp)} ·{" "}
-                      {formatAbsoluteTimestamp(checkpoint.timestamp)}
-                    </span>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => handleDelete(checkpoint.id)}
-                      className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 text-destructive"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                    </Button>
-                  </div>
-                </div>
-                <CardContent className="pt-4">
-                  {/* Agent */}
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground mb-3">
-                    <User className="h-4 w-4" />
-                    <span>
-                      Saved by {getAgentDisplayName(checkpoint.agent_id)}
-                    </span>
-                  </div>
+            {sortedCheckpoints.map((checkpoint, idx) => {
+              const checkpointContent = [
+                checkpoint.state_summary,
+                ...checkpoint.remaining_work,
+                checkpoint.notes ?? "",
+              ].join("\n");
 
-                  {/* State Summary */}
-                  <div className="mb-4">
-                    <h4 className="text-sm font-medium mb-1">State Summary</h4>
-                    <p className="text-sm text-muted-foreground whitespace-pre-wrap">
-                      {checkpoint.state_summary}
-                    </p>
-                  </div>
-
-                  {/* Remaining Work */}
-                  {checkpoint.remaining_work.length > 0 && (
-                    <div className="mb-4">
-                      <div className="flex items-center gap-2 mb-2">
-                        <ListTodo className="h-4 w-4 text-muted-foreground" />
-                        <h4 className="text-sm font-medium">Remaining Work</h4>
+              return (
+                <Card
+                  key={checkpoint.id}
+                  className="overflow-hidden group py-0"
+                >
+                  <Collapsible
+                    defaultOpen={defaultEntryOpen(idx, checkpointContent)}
+                  >
+                    <div className="bg-primary/10 px-4 py-2 flex items-center justify-between">
+                      <CollapsibleTrigger asChild>
+                        <button
+                          type="button"
+                          className="group/trigger flex min-w-0 items-center gap-2"
+                        >
+                          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=closed]/trigger:-rotate-90" />
+                          <Bookmark className="h-4 w-4 text-primary" />
+                          <span className="font-medium text-sm">
+                            Checkpoint
+                          </span>
+                        </button>
+                      </CollapsibleTrigger>
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="text-xs text-muted-foreground flex items-center gap-1"
+                          title={formatAbsoluteTimestamp(checkpoint.timestamp)}
+                        >
+                          <Clock className="h-3 w-3" />
+                          {formatTime(checkpoint.timestamp)} ·{" "}
+                          {formatAbsoluteTimestamp(checkpoint.timestamp)}
+                        </span>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => handleDelete(checkpoint.id)}
+                          className="h-6 w-6 p-0 opacity-0 group-hover:opacity-100 text-destructive"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </Button>
                       </div>
-                      <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
-                        {checkpoint.remaining_work.map((item, idx) => (
-                          <li key={idx}>{item}</li>
-                        ))}
-                      </ul>
                     </div>
-                  )}
+                    <CollapsibleContent>
+                      <CardContent className="py-4">
+                        {/* Agent */}
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground mb-3">
+                          <User className="h-4 w-4" />
+                          <span>
+                            Saved by {getAgentDisplayName(checkpoint.agent_id)}
+                          </span>
+                        </div>
 
-                  {/* Notes */}
-                  {checkpoint.notes && (
-                    <div>
-                      <div className="flex items-center gap-2 mb-2">
-                        <FileText className="h-4 w-4 text-muted-foreground" />
-                        <h4 className="text-sm font-medium">Notes</h4>
-                      </div>
-                      <p className="text-sm text-muted-foreground whitespace-pre-wrap">
-                        {checkpoint.notes}
-                      </p>
-                    </div>
-                  )}
-                </CardContent>
-              </Card>
-            ))}
+                        {/* State Summary */}
+                        <div className="mb-4">
+                          <h4 className="text-sm font-medium mb-1">
+                            State Summary
+                          </h4>
+                          <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                            {checkpoint.state_summary}
+                          </p>
+                        </div>
+
+                        {/* Remaining Work */}
+                        {checkpoint.remaining_work.length > 0 && (
+                          <div className="mb-4">
+                            <div className="flex items-center gap-2 mb-2">
+                              <ListTodo className="h-4 w-4 text-muted-foreground" />
+                              <h4 className="text-sm font-medium">
+                                Remaining Work
+                              </h4>
+                            </div>
+                            <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
+                              {checkpoint.remaining_work.map(
+                                (item, itemIdx) => (
+                                  <li key={itemIdx}>{item}</li>
+                                ),
+                              )}
+                            </ul>
+                          </div>
+                        )}
+
+                        {/* Notes */}
+                        {checkpoint.notes && (
+                          <div>
+                            <div className="flex items-center gap-2 mb-2">
+                              <FileText className="h-4 w-4 text-muted-foreground" />
+                              <h4 className="text-sm font-medium">Notes</h4>
+                            </div>
+                            <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                              {checkpoint.notes}
+                            </p>
+                          </div>
+                        )}
+                      </CardContent>
+                    </CollapsibleContent>
+                  </Collapsible>
+                </Card>
+              );
+            })}
           </div>
         )}
       </CardContent>

--- a/panel/src/lib/__tests__/content-readability.test.ts
+++ b/panel/src/lib/__tests__/content-readability.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  exceedsReadabilityThreshold,
+  READABILITY_LINE_THRESHOLD,
+  READABILITY_CHAR_THRESHOLD,
+} from "@/lib/content-readability";
+
+describe("exceedsReadabilityThreshold", () => {
+  it("is false for empty or short content", () => {
+    expect(exceedsReadabilityThreshold("")).toBe(false);
+    expect(exceedsReadabilityThreshold("A single short line.")).toBe(false);
+  });
+
+  it("is true once the line count exceeds the threshold", () => {
+    const lines = Array(READABILITY_LINE_THRESHOLD + 1)
+      .fill("x")
+      .join("\n");
+    expect(exceedsReadabilityThreshold(lines)).toBe(true);
+  });
+
+  it("is true once the character count exceeds the threshold", () => {
+    const long = "a".repeat(READABILITY_CHAR_THRESHOLD + 1);
+    expect(exceedsReadabilityThreshold(long)).toBe(true);
+  });
+
+  it("is false right at the thresholds", () => {
+    const atLineLimit = Array(READABILITY_LINE_THRESHOLD).fill("x").join("\n");
+    expect(exceedsReadabilityThreshold(atLineLimit)).toBe(false);
+    const atCharLimit = "a".repeat(READABILITY_CHAR_THRESHOLD);
+    expect(exceedsReadabilityThreshold(atCharLimit)).toBe(false);
+  });
+});

--- a/panel/src/lib/content-readability.ts
+++ b/panel/src/lib/content-readability.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared thresholds for auto-collapsing long content in the task detail
+ * view (CollapsibleSection, progress updates, checkpoints, acceptance
+ * criteria) so a task with a long history doesn't force continuous
+ * scrolling through fully-expanded sections.
+ */
+export const READABILITY_LINE_THRESHOLD = 10;
+export const READABILITY_CHAR_THRESHOLD = 640;
+
+/** True when content is long enough that it should default to collapsed. */
+export function exceedsReadabilityThreshold(content: string): boolean {
+  if (!content) return false;
+  const lineCount = content.split("\n").length;
+  return (
+    lineCount > READABILITY_LINE_THRESHOLD ||
+    content.length > READABILITY_CHAR_THRESHOLD
+  );
+}


### PR DESCRIPTION
docs/ux_ui/design/content-readability-spec.md (from PR #404) already specifies the collapse pattern: a body collapses when it exceeds ~10 lines or ~640 chars of source content, and a per-field default-open table (progress-timeline/journal entries: collapsed, most recent 2 entries open). Two surfaces were never wired up to it:

1. `panel/src/components/tasks/task-detail/collapsible-section.tsx` — `CollapsibleSection` hardcodes `defaultOpen = true` with no content-length awareness. Add a real check (measuring raw source text/entry position against the spec's thresholds) so the computed default follows the spec instead of always defaulting open. Consumers that pass an explicit `defaultOpen`/`open` prop (task-description.tsx, tab-notes.tsx, tab-plan.tsx) must keep working unchanged — only the *implicit* default (when no defaultOpen is passed) should become content-aware.

2. `panel/src/components/tasks/task-detail/tab-progress.tsx` — `ProgressUpdatesSection` and `CheckpointsSection` render every entry in a plain `ul`/timeline list with no collapsible wrapper at all. Wrap each entry (or the list past the first 2) in `CollapsibleSection` (or the underlying `Collapsible` primitive) so only the 2 most recent entries are open by default and older ones are collapsed, matching the spec's activity-feed convention. A task with 30+ progress updates must be navigable without scrolling through all of them expanded.

3. `panel/src/components/tasks/task-detail/acceptance-criteria.tsx` — renders every criterion in a flat, unlimited `ul`. Apply the same collapse/limit treatment for long lists (e.g. collapse past a threshold count with a "Show more" affordance), consistent with the spec's approach and CollapsibleSection's existing `Show more (N)`/`Show less` trigger pattern (see content-readability-spec.md §1 "Affordance").

Reuse the existing Radix `Collapsible`/`CollapsibleTrigger`/`CollapsibleContent` primitives already in the codebase (`panel/src/components/ui/collapsible.tsx`) — no new library or dependency, per the spec's explicit non-goals. Keep the fade/transform-only animation style CollapsibleSection already uses.