### PR TITLE
[dc518639] Revert out-of-scope goals-tab.tsx change on PR #415

### DIFF
--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -44,20 +44,6 @@ function formatTs(ts: string | null | undefined): string {
 // ---------------------------------------------------------------------------
 // Objectives field — one text field per key derived from the first item.
 // Falls back to a single "value" field when array is empty.
-//
-// Renders a responsive grid of objective cards with the following layout:
-// - Mobile (< md): 1 column (grid-cols-1)
-// - Desktop (md+): 2 columns (md:grid-cols-2)
-// - The '+ Add objective' button sits below the grid as a full-width sibling
-//   (not as a grid item), maintaining consistent width across all breakpoints.
-//
-// Layout structure:
-//   <div className="space-y-3">
-//     <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-//       {objective cards as grid items}
-//     </div>
-//     <Button className="w-full">{+ Add objective}</Button>
-//   </div>
 // ---------------------------------------------------------------------------
 
 interface ObjectivesEditorProps {
@@ -94,51 +80,48 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        {items.map((item, rowIdx) => (
-          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-xs font-medium text-muted-foreground">
-                Objective #{rowIdx + 1}
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={disabled}
-                onClick={() => removeRow(rowIdx)}
-                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-              >
-                Remove
-              </Button>
-            </div>
-            {keys.map((key) => (
-              <div key={key} className="space-y-1">
-                <Label
-                  htmlFor={`obj-${rowIdx}-${key}`}
-                  className="text-xs capitalize"
-                >
-                  {key.replace(/_/g, " ")}
-                </Label>
-                <Input
-                  id={`obj-${rowIdx}-${key}`}
-                  value={String(item[key] ?? "")}
-                  disabled={disabled}
-                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                  className="h-8 text-sm"
-                />
-              </div>
-            ))}
+      {items.map((item, rowIdx) => (
+        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground">
+              Objective #{rowIdx + 1}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled}
+              onClick={() => removeRow(rowIdx)}
+              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+            >
+              Remove
+            </Button>
           </div>
-        ))}
-      </div>
+          {keys.map((key) => (
+            <div key={key} className="space-y-1">
+              <Label
+                htmlFor={`obj-${rowIdx}-${key}`}
+                className="text-xs capitalize"
+              >
+                {key.replace(/_/g, " ")}
+              </Label>
+              <Input
+                id={`obj-${rowIdx}-${key}`}
+                value={String(item[key] ?? "")}
+                disabled={disabled}
+                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                className="h-8 text-sm"
+              />
+            </div>
+          ))}
+        </div>
+      ))}
       <Button
         type="button"
         variant="outline"
         size="sm"
         disabled={disabled}
         onClick={addRow}
-        className="w-full"
       >
         + Add objective
       </Button>


### PR DESCRIPTION
PR #415 (branch feature/frontend/f7d0a61a--e56e6543--92a46054) correctly implements the sidebar flat navItems order, Business moved to footerItems before AI Providers, single Separator between nav and footer, and a rewritten sidebar.test.tsx. However it also modified panel/src/components/business/goals-tab.tsx (added a 2-column responsive grid layout for ObjectivesEditor and made the '+ Add objective' button full-width), which is out of scope — the task's acceptance criteria explicitly require goals-tab.tsx to be left untouched.

Revert panel/src/components/business/goals-tab.tsx to its state on the base branch (undo the grid-cols-1/md:grid-cols-2 wrapper div and the button's added w-full class), leaving it identical to base. Do not touch sidebar.tsx, sidebar.test.tsx, or docs/frontend/components/sidebar-navigation.md — those are already correct and reviewed. Push the revert as a new commit on the existing branch/PR.