### PR TITLE
Fix reflow-check CI failure + orchestrator Playwright-allowance analysis

### DIFF
--- a/docs/backend/qa/browser-verification.md
+++ b/docs/backend/qa/browser-verification.md
@@ -1,6 +1,7 @@
 # Browser Verification with Playwright
 
 **For:** Frontend QA (`fe-qa`) and UX QA (`ux-qa`) agents
+
 **Purpose:** Verify rendered output, computed styles, a11y trees, and visual design when code review and diff analysis cannot settle an acceptance criterion
 
 ## When to use browser verification


### PR DESCRIPTION
## Summary

- Fixes the reflow-check CI failure in `docs/backend/qa/browser-verification.md` by inserting a blank line between the `**For:**` and `**Purpose:**` metadata lines, so `scripts/reflow_md.py`'s paragraph-joiner no longer treats them as one hard-wrapped paragraph. `uv run python scripts/reflow_md.py --check` now passes; the prose's non-whitespace token sequence is unchanged (verified by comparing `orig.split() == new.split()` against `reflow_md.py`'s own `reflow()` function before and after the edit).
- `roboco/runtime/orchestrator.py` is **not modified**. Analysis below shows the QA/UX-QA browser-verification workflow documented in `browser-verification.md` already works under the current permission model — this is a no-op.

## Orchestrator Playwright-allowance analysis (no-op)

The task asked to verify whether `fe-qa`/`ux-qa` agents can actually run the browser-verification.md examples, e.g.:

```
/app/.venv/bin/python -c "
from playwright.sync_api import sync_playwright
with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto('http://localhost:3000/some-route')
    ...
"
```

I traced every Bash-relevant rule that could plausibly block this, in both `_get_role_permissions()` (`roboco/runtime/orchestrator.py`) and `docker/scripts/bash-guard-hook.sh` (the `PreToolUse` guard on `Bash`):

1. **`_get_role_permissions()`'s `qa` entry** carries `allow=[]`, `deny=["Write(*)", "Edit(*)"]` — no Bash-specific rule at all. Under `defaultMode=bypassPermissions`, an unlisted operation (running Bash) proceeds without a prompt, so Bash itself is unrestricted for QA/UX-QA.
2. **git-ops / credential-exfil checks** (`bash-guard-hook.sh` lines ~93-300): the Playwright command contains no git verb and references no credential file path — none of these fire.
3. **curl/wget-to-github / curl/wget-to-internal-host checks** (lines ~184, ~226): both require the *first token* to be `curl`/`wget`/`http`/`https`/`httpie`. The command's first token is `python`, so these don't match.
4. **interpreter/library-HTTP-to-internal-host check** (lines ~249-253) — the one rule that could plausibly catch a Python script hitting `localhost:3000`: it requires the command to reference one of `httpx|requests|urllib|aiohttp|http.client|httplib|http.request|net/http|net::http|httparty|faraday|lwp|libwww|httpurlconnection|okhttp|node-fetch|axios|xmlhttprequest|websocket|fetch(`. **Playwright's `sync_playwright`/`chromium.launch`/`page.goto` names appear in none of these** — the rule is scoped to known raw-HTTP-client libraries, and a browser-automation library goes through the browser process's own networking, not a Python HTTP client. This rule does not fire.
5. **`/app`-venv-mutation checks** (lines ~364-384): require a package-install/sync verb (`uv sync`/`uv pip install`/`pip install`/`uv run ... /app.venv`/etc). The doc's command is a bare interpreter invocation (`/app/.venv/bin/python -c "..."`), not a mutation verb — doesn't fire.
6. **roboco-internals-import check** (lines ~313-317): requires `import roboco` / `from roboco` / `-m roboco` / `roboco.(mcp|services|runtime|foundation|api|enforcement)`. The Playwright script imports none of these — doesn't fire.

No rule in the current permission model blocks the documented commands. Adding a new explicit allowance for something that is already unrestricted would be dead code with nothing to test against. I'm treating this AC as satisfied by this written analysis rather than a speculative code change.

## Scope

Only `docs/backend/qa/browser-verification.md` was touched (whitespace-only). `roboco/runtime/orchestrator.py` was read/analyzed but not edited.

## Test plan

- [x] `python3 scripts/reflow_md.py --check` passes locally for the doc
- [x] Verified the doc's non-whitespace token sequence is unchanged via `reflow_md.reflow()` round-trip
- [x] Traced `_get_role_permissions()` + `bash-guard-hook.sh` rule-by-rule against the doc's exact Playwright command (see analysis above)
- [ ] CI: Python quality gate (includes reflow-check) green