### PR TITLE
[cc355a2b] Add explicit written no-op analysis for orchestrator Playwright-allowance

### DIFF
--- a/docs/backend/qa/browser-verification.md
+++ b/docs/backend/qa/browser-verification.md
@@ -209,6 +209,18 @@ This documents what you checked and how for future reference.
 - Screenshots are saved to the container's filesystem (e.g., `/tmp/review.png`), not your host. They're local to the QA agent's environment and cannot be downloaded directly.
 - If you need visual output for review, use `page.evaluate()` to extract element properties or accessibility snapshots instead.
 
+## Why an orchestrator.py Playwright allowance is a no-op
+
+QA and UX QA agents already run Playwright without any orchestrator-level "allowance" — there is no gate in `roboco/runtime/orchestrator.py` that could grant or withhold Playwright access, because none of the three places such a change would need to touch actually govern it. This section is the explicit written analysis for anyone who later proposes adding one.
+
+**1. `_get_role_permissions` only scopes Write/Edit, never Bash.** `_get_role_permissions` (`roboco/runtime/orchestrator.py:1472`) builds a per-role Claude Code allow/deny list, and every role's entries in that function are `Write(...)`/`Edit(...)` patterns — the `qa` role's own entry (`roboco/runtime/orchestrator.py:1504-1511`) only denies `Write(*)`/`Edit(*)`. Playwright is invoked as `/app/.venv/bin/python -c "..."`, a `Bash` tool call, and no role's config in `_get_role_permissions` ever adds a `Bash` allow or deny entry for it. There is therefore nothing in `_get_role_permissions` that "allows" or "blocks" Playwright either way — the invocation is already permitted by the same unrestricted-Bash default every other shell command gets.
+
+**2. The browser binary and its env var are baked into the image, not set by the orchestrator.** `chromium-headless-shell` and `PLAYWRIGHT_BROWSERS_PATH` are installed and exported at image build time in `docker/agent-qa-fe.Dockerfile` and `docker/agent-ux.Dockerfile` (`ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers`, followed by `RUN npm install -g playwright && playwright install --with-deps chromium-headless-shell`). Neither `_generate_agent_settings` nor `_prepare_agent_spawn` in `roboco/runtime/orchestrator.py` sets this environment variable or mounts a browser at spawn time — whether the browser is reachable is decided once, when the image is built, not per-spawn by orchestrator code.
+
+**3. Playwright's sync API is a subprocess call, not an MCP tool, so no manifest entry is needed.** Every state-changing or gated capability an agent gets routes through the `mcp__roboco-flow__*`/`mcp__roboco-do__*` verbs listed in `role_config.py` and mounted as `/app/tool-manifest.json`. Playwright is called directly via its sync Python API inside a `Bash`-invoked subprocess (see the examples above) — it is never registered as an MCP tool, so there is no manifest entry to add, remove, or gate for a role to "get" Playwright access.
+
+Put together: an orchestrator.py change that tried to add a Playwright "allowance" would have no code path left to attach to — the browser is already installed, the env var is already set, and the invocation method (Bash plus the sync API) is already unrestricted for any role that isn't Write/Edit-denied on the invoking shell. That is why QA's own browser verification works today with zero orchestrator involvement, and why a dedicated allowance change is a no-op.
+
 ## Related documentation
 
 - **Identity prompts:** `agents/prompts/identities/fe-qa.md` and `ux-qa.md` contain the built-in browser verification guidance


### PR DESCRIPTION
PR #421's gate review rejected AC2: the diff has zero changes to roboco/runtime/orchestrator.py and no file contains an explicit written analysis proving the Playwright-tooling allowance is a no-op. Add a clearly labeled new section to docs/backend/qa/browser-verification.md (e.g. "Why no orchestrator.py change is needed") that states, in writing: (1) QA's role permissions in roboco/runtime/orchestrator.py's _get_role_permissions (~L1504) deny Write(*)/Edit(*) but do NOT deny Bash, so QA agents can invoke Playwright's Python API via the Bash tool without any new allowance; (2) the QA/UX Docker images already ship chromium-headless-shell with PLAYWRIGHT_BROWSERS_PATH set as a Dockerfile ENV, so the browser binary is present without any orchestrator wiring; (3) Playwright is invoked through its synchronous Python API directly (not as an MCP-mediated tool call), so no manifest/tool-allowance entry in orchestrator.py's QA settings/manifest generation is required. Cite the actual code (function name, approximate line) so the analysis is verifiable, not just asserted. Do not touch orchestrator.py itself unless your own reading of the code reveals the no-op claim is actually wrong — in that case, implement the minimal allowance change instead and say so in your dev notes. After adding the section, run `make reflow-check` locally and confirm it passes, and confirm the Python quality gate would be green. Do not touch any other files — this PR must show no unrelated scope changes.