### PR TITLE
[f563bbc9] Implement conversation-first A2A layout, identity colors, connection states, transcript motion, and empty/error states

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -16,6 +16,8 @@ Documentation for the Frontend Cell team.
 
 ## Available docs
 
+- [`a2a-filtering.md`](./a2a-filtering.md) — A2A filter bar, conversation list, and pulse-flash hook
+- [`a2a-conversation-first-layout.md`](./a2a-conversation-first-layout.md) — Agent identity colors, connection states, context pane, transcript motion, and empty/error states
 - [`hooks.md`](./hooks.md) — `usePageRefresh` and `PageRefreshProvider` usage and API reference
 
 ## Contributing

--- a/docs/frontend/a2a-conversation-first-layout.md
+++ b/docs/frontend/a2a-conversation-first-layout.md
@@ -1,0 +1,519 @@
+# A2A Conversation-First Layout: Identity Colors, Connection States, Transcript Motion, and Empty States
+
+## Overview
+
+The A2A page now features a conversation-first design with three major enhancements:
+
+1. **Agent identity colors** — every agent is assigned a team-scoped color bucket (Backend, Frontend, UX/UI, Board, CEO, System)
+2. **Collapsible context pane** (xl:+ breakpoint) — participant identity cards, linked task summary, and a no-task hint
+3. **Live connection states** — four distinct visual states (connected, connecting, reconnecting, disconnected) with dismissable banners
+4. **Transcript entrance motion** — new rows fade in with `transform`/`opacity` transitions, guarded by `prefers-reduced-motion`
+5. **Split empty/error states** — distinct messaging for "no conversation selected", "selected but empty", and "fetch failed with retry"
+
+This document covers the component API, integration, and usage patterns.
+
+## Agent Team Colors
+
+### Overview
+
+Agent colors are scoped to **team** (cell), not per-agent, because it remains legible at 22-agent scale and never requires new tokens when a cell grows.
+
+**File:** `panel/src/lib/agent-utils.ts`
+
+### `AgentTeamColor` Type
+
+```typescript
+export type AgentTeamColor =
+  | "backend"
+  | "frontend"
+  | "ux_ui"
+  | "board"
+  | "ceo"
+  | "system";
+```
+
+### `getAgentTeamColor(agentId: string | null | undefined): AgentTeamColor`
+
+Resolves an agent slug (or UUID) to its team color by inspecting the slug prefix. Unknown slugs fall back to `system` — color is a scanning aid, never critical, so unknown agents don't throw.
+
+**Resolution rules:**
+
+- `ceo` or `CEO` → `"ceo"`
+- Slug starts with `be-` → `"backend"`
+- Slug starts with `fe-` → `"frontend"`
+- Slug starts with `ux-` → `"ux_ui"`
+- `main-pm`, `product-owner`, `head-marketing`, `auditor` → `"board"`
+- All others → `"system"`
+
+**Example:**
+
+```tsx
+import { getAgentTeamColor } from "@/lib/agent-utils";
+
+const color = getAgentTeamColor("fe-dev-1");
+// Returns "frontend"
+
+const fallback = getAgentTeamColor("unknown-slug");
+// Returns "system"
+```
+
+### `TEAM_COLOR_CLASSES: Record<AgentTeamColor, string>`
+
+Maps each team color to a pre-composed Tailwind class string with `bg-{color}/15`, `border-{color}/40`, and `text-{color}` weights for light and dark modes.
+
+**Exported classes:**
+
+```typescript
+{
+  backend:   "bg-blue-500/15 border-blue-500/40 text-blue-700 dark:text-blue-400",
+  frontend:  "bg-violet-500/15 border-violet-500/40 text-violet-700 dark:text-violet-400",
+  ux_ui:     "bg-fuchsia-500/15 border-fuchsia-500/40 text-fuchsia-700 dark:text-fuchsia-400",
+  board:     "bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-400",
+  ceo:       "bg-primary/15 border-primary/40 text-primary",
+  system:    "bg-slate-500/15 border-slate-500/40 text-slate-700 dark:text-slate-400",
+}
+```
+
+**No new Tailwind tokens are introduced** — all colors reuse existing families already in the codebase.
+
+**Usage:**
+
+```tsx
+import { getAgentTeamColor, TEAM_COLOR_CLASSES, cn } from "@/lib/agent-utils";
+
+export function AgentBadge({ agentId }: { agentId: string }) {
+  const teamColor = getAgentTeamColor(agentId);
+  return (
+    <div className={cn("p-2 rounded border", TEAM_COLOR_CLASSES[teamColor])}>
+      {getAgentDisplayName(agentId)}
+    </div>
+  );
+}
+```
+
+## Context Pane (xl:+ Collapsible)
+
+The context pane renders participant identity cards, linked task summary, and a no-task hint at the `xl:` breakpoint and above. It is read-only and collapsible via a button in the page header.
+
+**File:** `panel/src/components/a2a/a2a-context-pane.tsx`
+
+### `A2AContextPane` Component
+
+```typescript
+interface A2AContextPaneProps {
+  agentA: string;        // Participant slug
+  agentB: string;        // Participant slug
+  taskId: string | null; // Linked task UUID, or null when no task
+}
+
+export function A2AContextPane({ agentA, agentB, taskId }: A2AContextPaneProps)
+```
+
+### Rendered Sections
+
+#### Identity Cards
+
+Each participant renders as an `IdentityCard` subcomponent:
+
+- **Avatar:** 9×9px circle with agent initials, colored by `TEAM_COLOR_CLASSES`
+- **Name:** Agent display name from `getAgentDisplayName()`
+- **Team badge:** Colored outline badge showing team (e.g. "frontend", "board")
+- **Link target:** Clicking navigates to `/agents/{slug}`
+
+#### Linked Task Summary
+
+When `taskId` is provided:
+
+- **Title:** Task name (truncated to one line)
+- **Status badge:** Colored badge for task status (e.g. "in_progress", "completed")
+- **View link:** "View task" hyperlink to `/tasks/{taskId}`
+- **Skeleton loading state:** While the task is being fetched
+
+When `taskId` is null or not provided:
+
+- **No-task hint:** "This conversation has no linked task"
+
+### Styling
+
+- Light, minimal 3px padding per section
+- Separator border below the "Context" header
+- Smooth hover state on identity cards (light background tint)
+- Uses existing `border-b` dividers and `space-y-` gap utilities
+
+### Page Integration
+
+The pane is integrated into the A2A page grid layout:
+
+- **Below `xl:`** — hidden (full width for Roster and Stream columns)
+- **`xl:` and above** — visible as a third column when open (localStorage-persisted toggle via the page header button)
+
+**Layout grid (xl:+):**
+
+```
+Roster (col-span-3) | Stream (col-span-6) | Context (col-span-3)
+```
+
+When context pane is closed, grid falls back to:
+
+```
+Roster (col-span-4) | Stream (col-span-8)
+```
+
+## Connection State Rendering
+
+The connection badge renders in the pane header, and a dismissable banner appears above the message list when reconnecting or disconnected.
+
+**File:** `panel/src/components/a2a/a2a-connection-badge.tsx`
+**Utils:** `panel/src/components/a2a/a2a-utils.ts`
+
+### `ConnectionState` Type (from `@/lib/websocket/connection`)
+
+```typescript
+type ConnectionState = "connected" | "connecting" | "reconnecting" | "disconnected";
+```
+
+### `A2AConnectionBadge` Component
+
+```typescript
+export function A2AConnectionBadge({ state }: { state: ConnectionState })
+```
+
+**Rendering:**
+
+- **Dot:** 2×2px circle with color based on state (see `connectionDotClasses()`)
+- **Label:** Text label from `connectionStateLabel()`
+- **Icon:** Spinner for `connecting`/`reconnecting`, WiFi-off for `disconnected`
+
+**All four states render distinctly:**
+
+| State | Dot | Label | Icon | Notes |
+|-------|-----|-------|------|-------|
+| `connected` | Emerald, static | "Live" | None | No motion (live conversation) |
+| `connecting` | Amber, pulsing | "Connecting…" | Spinner | On first connect |
+| `reconnecting` | Amber, pulsing | "Reconnecting…" | Spinner | After a drop; messages may be stale |
+| `disconnected` | Muted, static | "Offline" | WiFi-off | No auto-recovery |
+
+**Pulsing animation** (`animate-pulse`) is guarded by `motion-reduce:animate-none`, respecting user accessibility settings.
+
+### `A2AConnectionBanner` Component
+
+```typescript
+interface A2AConnectionBannerProps {
+  state: "reconnecting" | "disconnected";
+  onDismiss: () => void;
+}
+
+export function A2AConnectionBanner({
+  state,
+  onDismiss,
+}: A2AConnectionBannerProps)
+```
+
+**Rendering:**
+
+- **Container:** Full-width strip above the message list
+- **Background color:** Amber tint for reconnecting; destructive (red) tint for disconnected
+- **Message:** "Reconnecting — messages may be out of date" or "Disconnected — reconnecting automatically"
+- **Dismiss button:** X icon, right-aligned; fires `onDismiss` callback
+
+The banner is **scoped to the stream pane** — not a page-level `OfflineState` — so multiple A2A tabs can render independent connection states.
+
+### Helper Functions
+
+**`connectionStateLabel(state: ConnectionState): string`**
+
+Returns human-readable label for the connection badge.
+
+**`connectionDotClasses(state: ConnectionState): string`**
+
+Returns Tailwind classes for the connection dot:
+
+- `connected`: `"bg-emerald-500"` (no pulse)
+- `connecting` / `reconnecting`: `"bg-amber-500 animate-pulse motion-reduce:animate-none"`
+- `disconnected`: `"bg-muted-foreground/40"` (muted static)
+
+## Transcript Entrance Motion & Empty/Error States
+
+The transcript component now supports motion-reduced entrance transitions, a scrolled-up "New messages" pill, and split empty/error states.
+
+**File:** `panel/src/components/a2a/a2a-transcript.tsx`
+
+### `A2ATranscript` Component
+
+```typescript
+interface A2ATranscriptProps {
+  messages: A2AChatMessage[];
+  isLoading: boolean;
+  /** False when no conversation/pair is selected at all — distinguishes
+   * "nothing to show yet" from "selected but empty" (design doc §5).
+   * Defaults true (existing callers). */
+  hasSelection?: boolean;
+  /** True when the messages fetch itself failed — a scoped retry, not the
+   * page-level OfflineState. */
+  error?: boolean;
+  onRetry?: () => void;
+}
+
+export function A2ATranscript({
+  messages,
+  isLoading,
+  hasSelection = true,
+  error = false,
+  onRetry,
+}: A2ATranscriptProps)
+```
+
+### Entrance Motion
+
+New transcript rows render with `transform`/`opacity` only (no layout thrashing):
+
+- **Initial state:** `opacity-0 scale-y-95 origin-bottom` (transparent, scaled down from bottom)
+- **Animation:** One paint frame after the row renders, transitions to `opacity-100 scale-y-100` with `transition-[opacity,transform] duration-200`
+- **prefers-reduced-motion guard:** Falls back to instant `opacity-100` and no scale transform
+
+**Implementation:**
+
+The component tracks message IDs via render-phase state (`seenIds`). Newly arrived IDs are flagged in `newRowIds` for one paint frame, then cleared. A `requestAnimationFrame` batches the class application to avoid layout thrashing.
+
+**No external libraries required** — uses native CSS transitions.
+
+### New Messages Pill
+
+When the user scrolls up and new messages arrive, a dismissable "New messages ↓" pill appears above the transcript, prompting them to scroll to the bottom.
+
+**Behavior:**
+
+- **At bottom:** New rows animate in; pill is hidden
+- **Scrolled up:** New rows don't animate in; pill appears instead, allowing the user to catch up at their own pace
+- **On dismiss:** Pill vanishes but messages remain in the list
+- **On scroll to bottom:** Pill hides and newly arrived rows resume animating in
+
+### Empty & Error States
+
+#### No Conversation Selected
+
+When `hasSelection === false`:
+
+```
+┌──────────────────────────────┐
+│                              │
+│  [Messages icon]             │
+│  "Select a conversation"     │
+│                              │
+└──────────────────────────────┘
+```
+
+#### Conversation Selected, No Messages
+
+When `hasSelection === true`, `messages.length === 0`, and `error === false`:
+
+```
+┌──────────────────────────────┐
+│                              │
+│  [Messages icon]             │
+│  "No messages yet"           │
+│                              │
+└──────────────────────────────┘
+```
+
+#### Fetch Error (Scoped Retry)
+
+When `error === true`:
+
+```
+┌──────────────────────────────┐
+│                              │
+│  [Alert Triangle icon]       │
+│  "Failed to load messages"   │
+│  [Retry button]              │
+│                              │
+└──────────────────────────────┘
+```
+
+Clicking "Retry" fires the `onRetry()` callback; the consumer is responsible for re-fetching and clearing the `error` flag.
+
+**This is a scoped, transcript-level retry** — not the page-level `OfflineState` that handles network down.
+
+### Message Row Styling
+
+Each message row uses the agent's team color via `TEAM_COLOR_CLASSES`:
+
+- **Avatar:** Colored circle with initials
+- **Sender name:** Rendered above the message
+- **Timestamp:** Relative time (e.g. "2 minutes ago") from `date-fns`
+- **Message body:** Rendered as Markdown via the `<Markdown>` component
+
+## Page Integration
+
+**File:** `panel/src/app/(dashboard)/a2a/page.tsx`
+
+### Grid Layout
+
+The page wires the new components into an `xl:`-responsive grid:
+
+```tsx
+<div className="grid grid-cols-4 xl:grid-cols-12 gap-4">
+  {/* Roster (col-span-3 or col-span-4) */}
+  {/* Stream (col-span-6 or col-span-8, grows when context is closed) */}
+  {/* Context pane (col-span-3, hidden below xl:) */}
+</div>
+```
+
+### Context Pane Toggle
+
+A button in the page header (or Stream pane header) controls the context pane open/closed state, persisted via the `ui-store` zustand slice:
+
+- **Key:** `a2aContextOpen` (boolean, localStorage-backed via zustand)
+- **Button:** `PanelRightClose` / `PanelRightOpen` icon from lucide-react
+- **Callback:** `setA2aContextOpen(!a2aContextOpen)`
+
+### Connection Badge & Banner
+
+The Stream pane header renders the `A2AConnectionBadge` with the current WebSocket state. When state is `reconnecting` or `disconnected`, the `A2AConnectionBanner` appears above the message list.
+
+**Connection state** is managed via the `useWebSocket()` hook and passed down from page to Stream pane.
+
+### Usage Example
+
+```tsx
+import { A2AContextPane } from "@/components/a2a/a2a-context-pane";
+import { A2AConnectionBadge, A2AConnectionBanner } from "@/components/a2a/a2a-connection-badge";
+import { A2ATranscript } from "@/components/a2a/a2a-transcript";
+
+export function A2AStreamPane({
+  agentA,
+  agentB,
+  taskId,
+  messages,
+  connectionState,
+  isLoading,
+  error,
+  onRetry,
+}: {
+  agentA: string;
+  agentB: string;
+  taskId: string | null;
+  messages: A2AChatMessage[];
+  connectionState: ConnectionState;
+  isLoading: boolean;
+  error?: boolean;
+  onRetry?: () => void;
+}) {
+  const [dismissedBanner, setDismissedBanner] = useState(false);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-3 py-2 border-b">
+        <h2 className="font-medium">
+          {getAgentDisplayName(agentA)} ↔ {getAgentDisplayName(agentB)}
+        </h2>
+        <A2AConnectionBadge state={connectionState} />
+      </div>
+
+      {connectionState !== "connected" && !dismissedBanner && (
+        <A2AConnectionBanner
+          state={connectionState as "reconnecting" | "disconnected"}
+          onDismiss={() => setDismissedBanner(true)}
+        />
+      )}
+
+      <A2ATranscript
+        messages={messages}
+        isLoading={isLoading}
+        hasSelection={true}
+        error={error}
+        onRetry={onRetry}
+      />
+    </div>
+  );
+}
+```
+
+## Testing
+
+All new components and utilities are covered by unit tests:
+
+- **`agent-utils.test.ts`** — `getAgentTeamColor()`, `TEAM_COLOR_CLASSES` access
+- **`a2a-context-pane.test.tsx`** — Identity card rendering, linked task summary, no-task hint
+- **`a2a-connection-badge.test.tsx`** — All four connection states, banner dismiss, icon presence
+- **`a2a-utils.test.ts`** — `connectionStateLabel()`, `connectionDotClasses()`
+- **`a2a-transcript.test.tsx`** — Empty states, entrance motion, new messages pill, error retry
+
+Run tests with:
+
+```bash
+cd panel
+pnpm test
+```
+
+## Accessibility & Responsiveness
+
+### Breakpoints
+
+- **Below `md:`** — Stack vertically, full width
+- **`md:` to below `xl:`** — Roster + Stream side-by-side, context pane hidden
+- **`xl:` and above** — Roster + Stream + Context (when open)
+
+### Motion
+
+All entrance animations respect `prefers-reduced-motion`:
+
+- Transcript row entry: Falls back to instant `opacity-100`
+- Connection dot pulse: Falls back to static `animate-none`
+- New messages pill: No motion applied (fade in/out handled by CSS class application)
+
+### Focus & Keyboard
+
+- **Identity card links** — Keyboard-navigable to `/agents/{slug}` and `/tasks/{taskId}`
+- **Banner dismiss button** — `aria-label="Dismiss"` for screen readers
+- **Connection badge** — No interactive element (informational only)
+
+## Migration & Breaking Changes
+
+### `A2ATranscript` props
+
+The `hasSelection` and `error` props are new but **backward compatible**:
+
+- `hasSelection` defaults to `true` (existing behavior)
+- `error` defaults to `false` (no error state)
+- `onRetry` is optional (only called if implemented)
+
+Old code continues to work:
+
+```tsx
+// Old code (still works)
+<A2ATranscript messages={messages} isLoading={false} />
+
+// New code (explicit states)
+<A2ATranscript
+  messages={messages}
+  isLoading={false}
+  hasSelection={selectedConversationId !== null}
+  error={fetchError}
+  onRetry={refetchMessages}
+/>
+```
+
+## Design Notes
+
+### Why Team Colors, Not Per-Agent?
+
+Team scoping (Backend, Frontend, etc.) scales to 22 agents without visual noise and doesn't require adding new Tailwind tokens per agent. It maps to the organizational structure and is sufficient for scanning.
+
+### Why `/15` and `/40` Opacity?
+
+The `/15` background and `/40` border provide:
+
+- Visual distinction without overwhelming
+- Sufficient contrast for WCAG AA compliance
+- Consistency with existing `PairAvatar` pulse treatment
+
+### Why `transform`/`opacity` Only?
+
+Layout-thrashing animations (animating `width`, `height`, `left`, `top`) cause forced reflows on every frame. `transform` and `opacity` changes are GPU-accelerated and don't force layout recalculation, keeping animations smooth.
+
+## Future Enhancements
+
+- Persist context pane width preference (currently only open/closed toggle)
+- Add a "Topic" summary in the context pane (when `taskId` is null)
+- Extend connection state to show "cached" mode (reading from local storage while reconnecting)

--- a/panel/UPGRADE.md
+++ b/panel/UPGRADE.md
@@ -13,6 +13,7 @@ When you bump the `next` package, **always update `eslint-config-next` to match*
 ### Upgrade Procedure
 
 1. **Update package.json** with the new version(s):
+
    ```json
    {
      "dependencies": {
@@ -25,13 +26,16 @@ When you bump the `next` package, **always update `eslint-config-next` to match*
    ```
 
 2. **Regenerate the lockfile without deleting node_modules:**
+
    ```bash
    cd panel
    pnpm install
    ```
-This updates `pnpm-lock.yaml` while preserving `node_modules`, keeping the resolution deterministic.
+
+   This updates `pnpm-lock.yaml` while preserving `node_modules`, keeping the resolution deterministic.
 
 3. **Run the quality gate:**
+
    ```bash
    cd panel
    pnpm lint
@@ -39,7 +43,8 @@ This updates `pnpm-lock.yaml` while preserving `node_modules`, keeping the resol
    pnpm test
    pnpm build
    ```
-All must pass with no errors before committing.
+
+   All must pass with no errors before committing.
 
 4. **Commit the changes:**
    ```bash
@@ -50,6 +55,7 @@ All must pass with no errors before committing.
 ### What Changed in 16.1.1 → 16.2.6
 
 This bump included updates to:
+
 - `@babel/parser`, `@babel/types`, `@babel/template`, `@babel/traverse` — minor version improvements
 - `@babel/generator`, `@babel/helper-module-imports`, `@babel/helper-validator-identifier` — updated to handle edge cases
 - `tinyglobby` — dependency used by ESLint, upgraded from 0.2.15 to 0.2.17

--- a/panel/lib/lifecycle.json
+++ b/panel/lib/lifecycle.json
@@ -1,38 +1,19 @@
 {
   "claim_rules": {
     "auditor": [],
-    "cell_pm": [
-      "needs_revision",
-      "pending"
-    ],
+    "cell_pm": ["needs_revision", "pending"],
     "ceo": [],
-    "developer": [
-      "needs_revision",
-      "pending"
-    ],
-    "documenter": [
-      "awaiting_documentation",
-      "pending"
-    ],
+    "developer": ["needs_revision", "pending"],
+    "documenter": ["awaiting_documentation", "pending"],
     "head_marketing": [],
-    "main_pm": [
-      "needs_revision",
-      "pending"
-    ],
-    "pr_reviewer": [
-      "awaiting_pr_review",
-      "pending"
-    ],
+    "main_pm": ["needs_revision", "pending"],
+    "pr_reviewer": ["awaiting_pr_review", "pending"],
     "product_owner": [],
-    "qa": [
-      "awaiting_qa"
-    ]
+    "qa": ["awaiting_qa"]
   },
   "intents": [
     {
-      "allowed_roles": [
-        "documenter"
-      ],
+      "allowed_roles": ["documenter"],
       "composes": [],
       "description": "Claim awaiting_documentation. Returns evidence inline.",
       "name": "claim_doc_task",
@@ -40,9 +21,7 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "pr_reviewer"
-      ],
+      "allowed_roles": ["pr_reviewer"],
       "composes": [],
       "description": "Claim an assembled-PR review task (awaiting_pr_review) WITHOUT transitioning it \u2014 mirrors QA's claim_review. The assembled diff and the parent task's acceptance criteria are returned inline.",
       "name": "claim_gate_review",
@@ -50,22 +29,15 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "pr_reviewer"
-      ],
-      "composes": [
-        "claim",
-        "start"
-      ],
+      "allowed_roles": ["pr_reviewer"],
+      "composes": ["claim", "start"],
       "description": "Claim an inbound external-PR review task and start work. pending -> claimed -> in_progress.",
       "name": "claim_pr_review",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "qa"
-      ],
+      "allowed_roles": ["qa"],
       "composes": [],
       "description": "Claim a task in awaiting_qa for review. Returns evidence inline.",
       "name": "claim_review",
@@ -73,23 +45,15 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
-      "composes": [
-        "complete"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
+      "composes": ["complete"],
       "description": "Cell PM merges the PR (leaf into the cell branch, or the gated cell\u2192root PR into the root branch) + transitions to completed; Main PM escalates the root to the CEO (who merges root\u2192master). The merge runs BEFORE the complete transition: TaskService.complete asserts the PR is already merged, so the choreographer verb body (cell_pm_complete / main_pm_complete) owns the merge-first ordering \u2014 no trailing pr_merge side_effect is declared here.",
       "name": "complete",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
       "composes": [],
       "description": "Stamp parent acceptance criteria onto an existing child's parent_ac_refs after the fact \u2014 for a replacement child whose delegate omitted covers_parent_criteria. Or, targeting your OWN root/coordination task, declare criteria as root-owned (only your own machinery satisfies them \u2014 never push these into a cell). No status change; the verb body owns ownership + criterion validation.",
       "name": "declare_coverage",
@@ -97,37 +61,23 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
-      "composes": [
-        "create_subtask"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
+      "composes": ["create_subtask"],
       "description": "Create a subtask under the current task. Validates the delegation chain (main_pm->cell_pm; cell_pm->its team's devs) and the assignee-vs-task_type rule (Cell PMs get planning-typed tasks; devs get code/research, UX devs also design). documentation is NOT delegatable \u2014 the lifecycle auto-creates the doc phase after the code subtask passes QA.",
       "name": "delegate",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "head_marketing",
-        "main_pm",
-        "product_owner"
-      ],
-      "composes": [
-        "escalate_to_ceo"
-      ],
+      "allowed_roles": ["head_marketing", "main_pm", "product_owner"],
+      "composes": ["escalate_to_ceo"],
       "description": "Escalate to CEO with reason. Transitions to awaiting_ceo_approval.",
       "name": "escalate_to_ceo",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
       "composes": [],
       "description": "Escalate to your role's escalation_target.",
       "name": "escalate_up",
@@ -135,12 +85,8 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "qa"
-      ],
-      "composes": [
-        "qa_fail"
-      ],
+      "allowed_roles": ["qa"],
+      "composes": ["qa_fail"],
       "description": "Fail QA with concrete issues. Transitions to needs_revision.",
       "name": "fail_review",
       "pre_side_effects": [],
@@ -162,27 +108,16 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "developer",
-        "documenter",
-        "qa"
-      ],
-      "composes": [
-        "block"
-      ],
+      "allowed_roles": ["developer", "documenter", "qa"],
+      "composes": ["block"],
       "description": "Escalate to PM. Logs a struggle journal entry.",
       "name": "i_am_blocked",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "developer"
-      ],
-      "composes": [
-        "submit_verification",
-        "submit_qa"
-      ],
+      "allowed_roles": ["developer"],
+      "composes": ["submit_verification", "submit_qa"],
       "description": "Submit work for QA. Auto-runs in_progress->verifying then verifying->awaiting_qa. Strict - PR must be open (call open_pr first) and >=1 commit.",
       "name": "i_am_done",
       "pre_side_effects": [],
@@ -209,111 +144,71 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "documenter"
-      ],
-      "composes": [
-        "docs_complete"
-      ],
+      "allowed_roles": ["documenter"],
+      "composes": ["docs_complete"],
       "description": "Signal docs complete. Transitions to awaiting_pm_review.",
       "name": "i_documented",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
-      "composes": [
-        "claim",
-        "set_plan",
-        "start"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
+      "composes": ["claim", "set_plan", "start"],
       "description": "PM mirror of i_will_work_on for parent tasks. Claim, plan, transition to in_progress; from there delegate subtasks.",
       "name": "i_will_plan",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "developer"
-      ],
-      "composes": [
-        "claim",
-        "set_plan",
-        "start"
-      ],
+      "allowed_roles": ["developer"],
+      "composes": ["claim", "set_plan", "start"],
       "description": "Claim a task, set the plan, and transition to in_progress. Atomic - preconditions checked before any state mutation.",
       "name": "i_will_work_on",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "developer"
-      ],
+      "allowed_roles": ["developer"],
       "composes": [],
       "description": "Push the branch and open a PR. Atomic - preconditions (assignee, >=1 commit, no prior PR) checked BEFORE any git operation. After success, call i_am_done.",
       "name": "open_pr",
       "pre_side_effects": [],
-      "side_effects": [
-        "push_branch",
-        "create_pr"
-      ]
+      "side_effects": ["push_branch", "create_pr"]
     },
     {
-      "allowed_roles": [
-        "qa"
-      ],
-      "composes": [
-        "qa_pass"
-      ],
+      "allowed_roles": ["qa"],
+      "composes": ["qa_pass"],
       "description": "Pass QA. Transitions awaiting_qa -> awaiting_documentation.",
       "name": "pass_review",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "pr_reviewer"
-      ],
-      "composes": [
-        "pr_review_done"
-      ],
+      "allowed_roles": ["pr_reviewer"],
+      "composes": ["pr_review_done"],
       "description": "Post one complete change-request to the external PR and finish the review task. in_progress -> completed.",
       "name": "post_pr_review",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "pr_reviewer"
-      ],
-      "composes": [
-        "pr_fail"
-      ],
+      "allowed_roles": ["pr_reviewer"],
+      "composes": ["pr_fail"],
       "description": "Fail the assembled-PR review with concrete issues. Transitions awaiting_pr_review -> needs_revision, routed back like a QA fail.",
       "name": "pr_fail",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "pr_reviewer"
-      ],
-      "composes": [
-        "pr_pass"
-      ],
+      "allowed_roles": ["pr_reviewer"],
+      "composes": ["pr_pass"],
       "description": "Pass the assembled-PR review. Transitions awaiting_pr_review -> awaiting_pm_review so the PM can merge.",
       "name": "pr_pass",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm"
-      ],
+      "allowed_roles": ["cell_pm"],
       "composes": [],
       "description": "Hand a claimed/in_progress task to another developer in your own cell. The branch is keyed to the task (not the agent), so it is preserved \u2014 the new developer continues the work-in-progress. No status change.",
       "name": "reassign",
@@ -321,66 +216,39 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
-      "composes": [
-        "request_changes"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
+      "composes": ["request_changes"],
       "description": "Reject the merge review with concrete issues. Transitions awaiting_pm_review -> needs_revision, routed back like a QA fail (original developer for a leaf, revision PM for an assembled task). Use this for an AC/scope violation caught at merge review \u2014 never i_am_blocked/escalate, which have no revision routing.",
       "name": "request_changes",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "developer",
-        "documenter",
-        "main_pm",
-        "qa"
-      ],
-      "composes": [
-        "resume"
-      ],
+      "allowed_roles": ["cell_pm", "developer", "documenter", "main_pm", "qa"],
+      "composes": ["resume"],
       "description": "Resume a paused task you own. paused -> in_progress.",
       "name": "resume",
       "pre_side_effects": [],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "main_pm"
-      ],
-      "composes": [
-        "submit_for_review"
-      ],
+      "allowed_roles": ["main_pm"],
+      "composes": ["submit_for_review"],
       "description": "Main PM opens the root\u2192master PR and moves the root task to awaiting_pr_review for the main reviewer (the root analogue of the cell PM's submit_up). After pr_pass, call complete to escalate to the CEO. For branch-bearing roots (a Main-PM root-subtask assembles the cells' merged work); branchless coordination roots skip the gate and complete directly. The gate is branch-keyed, not task_type-keyed \u2014 a Main-PM root is planning-typed, never code.",
       "name": "submit_root",
-      "pre_side_effects": [
-        "create_root_pr"
-      ],
+      "pre_side_effects": ["create_root_pr"],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm"
-      ],
-      "composes": [
-        "submit_for_review"
-      ],
+      "allowed_roles": ["cell_pm"],
+      "composes": ["submit_for_review"],
       "description": "Cell PM opens the cell\u2192root PR and moves the cell task into the PR-review gate (awaiting_pr_review). The cell reviewer reviews the assembled diff; after pr_pass the same Cell PM completes it.",
       "name": "submit_up",
-      "pre_side_effects": [
-        "create_pr"
-      ],
+      "pre_side_effects": ["create_pr"],
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "developer"
-      ],
+      "allowed_roles": ["developer"],
       "composes": [],
       "description": "Rebase your task's branch onto its current base THROUGH the gate (raw git is denied). Use when your branch has fallen behind its base \u2014 e.g. a sibling task's PR merged into the parent branch while you worked. Fetches origin, rebases head onto base, and force-pushes (with-lease). No DB state change. On conflicts the rebase is aborted and the conflicted files are returned \u2014 resolve by hand, commit, then sync_branch again. Pass stash=True to auto-stash uncommitted changes instead of refusing DIRTY_WORKSPACE; they are restored after the rebase.",
       "name": "sync_branch",
@@ -402,9 +270,7 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "main_pm"
-      ],
+      "allowed_roles": ["main_pm"],
       "composes": [],
       "description": "List actionable tasks across all teams (Main PM only).",
       "name": "triage_all",
@@ -412,13 +278,8 @@
       "side_effects": []
     },
     {
-      "allowed_roles": [
-        "cell_pm",
-        "main_pm"
-      ],
-      "composes": [
-        "unblock"
-      ],
+      "allowed_roles": ["cell_pm", "main_pm"],
+      "composes": ["unblock"],
       "description": "PM unblocks a blocked task; restores pre-block state.",
       "name": "unblock",
       "pre_side_effects": [],
@@ -443,175 +304,121 @@
   "transitions": [
     {
       "action": "cancel",
-      "roles": [
-        "ceo"
-      ],
+      "roles": ["ceo"],
       "source": "awaiting_ceo_approval",
       "target": "cancelled"
     },
     {
       "action": "ceo_approve",
-      "roles": [
-        "ceo"
-      ],
+      "roles": ["ceo"],
       "source": "awaiting_ceo_approval",
       "target": "completed"
     },
     {
       "action": "ceo_reject",
-      "roles": [
-        "ceo"
-      ],
+      "roles": ["ceo"],
       "source": "awaiting_ceo_approval",
       "target": "needs_revision"
     },
     {
       "action": "ceo_reject_to_pool",
-      "roles": [
-        "ceo"
-      ],
+      "roles": ["ceo"],
       "source": "awaiting_ceo_approval",
       "target": "pending"
     },
     {
       "action": "docs_complete",
-      "roles": [
-        "documenter"
-      ],
+      "roles": ["documenter"],
       "source": "awaiting_documentation",
       "target": "awaiting_pm_review"
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "awaiting_documentation",
       "target": "cancelled"
     },
     {
       "action": "claim",
-      "roles": [
-        "documenter"
-      ],
+      "roles": ["documenter"],
       "source": "awaiting_documentation",
       "target": "claimed"
     },
     {
       "action": "escalate_to_ceo",
-      "roles": [
-        "head_marketing",
-        "main_pm",
-        "product_owner"
-      ],
+      "roles": ["head_marketing", "main_pm", "product_owner"],
       "source": "awaiting_pm_review",
       "target": "awaiting_ceo_approval"
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "awaiting_pm_review",
       "target": "cancelled"
     },
     {
       "action": "complete",
-      "roles": [
-        "cell_pm",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "main_pm"],
       "source": "awaiting_pm_review",
       "target": "completed"
     },
     {
       "action": "request_changes",
-      "roles": [
-        "cell_pm",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "main_pm"],
       "source": "awaiting_pm_review",
       "target": "needs_revision"
     },
     {
       "action": "pr_pass",
-      "roles": [
-        "pr_reviewer"
-      ],
+      "roles": ["pr_reviewer"],
       "source": "awaiting_pr_review",
       "target": "awaiting_pm_review"
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "awaiting_pr_review",
       "target": "cancelled"
     },
     {
       "action": "claim",
-      "roles": [
-        "pr_reviewer"
-      ],
+      "roles": ["pr_reviewer"],
       "source": "awaiting_pr_review",
       "target": "claimed"
     },
     {
       "action": "pr_fail",
-      "roles": [
-        "pr_reviewer"
-      ],
+      "roles": ["pr_reviewer"],
       "source": "awaiting_pr_review",
       "target": "needs_revision"
     },
     {
       "action": "qa_pass",
-      "roles": [
-        "qa"
-      ],
+      "roles": ["qa"],
       "source": "awaiting_qa",
       "target": "awaiting_documentation"
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "awaiting_qa",
       "target": "cancelled"
     },
     {
       "action": "claim",
-      "roles": [
-        "qa"
-      ],
+      "roles": ["qa"],
       "source": "awaiting_qa",
       "target": "claimed"
     },
     {
       "action": "qa_fail",
-      "roles": [
-        "qa"
-      ],
+      "roles": ["qa"],
       "source": "awaiting_qa",
       "target": "needs_revision"
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "backlog",
       "target": "cancelled"
     },
@@ -623,21 +430,13 @@
     },
     {
       "action": "escalate_to_ceo",
-      "roles": [
-        "head_marketing",
-        "main_pm",
-        "product_owner"
-      ],
+      "roles": ["head_marketing", "main_pm", "product_owner"],
       "source": "blocked",
       "target": "awaiting_ceo_approval"
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "blocked",
       "target": "cancelled"
     },
@@ -655,11 +454,7 @@
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "claimed",
       "target": "cancelled"
     },
@@ -689,19 +484,13 @@
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "in_progress",
       "target": "cancelled"
     },
     {
       "action": "pr_review_done",
-      "roles": [
-        "pr_reviewer"
-      ],
+      "roles": ["pr_reviewer"],
       "source": "in_progress",
       "target": "completed"
     },
@@ -719,11 +508,7 @@
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "needs_revision",
       "target": "cancelled"
     },
@@ -735,11 +520,7 @@
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "paused",
       "target": "cancelled"
     },
@@ -751,11 +532,7 @@
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "pending",
       "target": "cancelled"
     },
@@ -773,11 +550,7 @@
     },
     {
       "action": "cancel",
-      "roles": [
-        "cell_pm",
-        "ceo",
-        "main_pm"
-      ],
+      "roles": ["cell_pm", "ceo", "main_pm"],
       "source": "verifying",
       "target": "cancelled"
     }

--- a/panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx
+++ b/panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx
@@ -47,6 +47,12 @@ vi.mock("@/hooks/use-websocket", () => ({
   useA2ALiveStream,
 }));
 
+// The xl:+ context pane's linked-task summary fetches via useTask — stub it
+// so this suite doesn't need a real QueryClientProvider.
+vi.mock("@/hooks/use-tasks", () => ({
+  useTask: () => ({ data: undefined, isLoading: false }),
+}));
+
 vi.mock("@tanstack/react-query", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
   return {
@@ -144,6 +150,7 @@ describe("A2APage", () => {
       lastMessage: null,
       a2aMessages: [],
       isConnected: true,
+      state: "connected",
     });
   });
 
@@ -201,6 +208,7 @@ describe("A2APage", () => {
       },
       a2aMessages: [],
       isConnected: true,
+      state: "connected",
     });
     render(withPageRefresh(<A2APage />));
     expect(invalidateQueries).toHaveBeenCalledWith({
@@ -223,6 +231,7 @@ describe("A2APage", () => {
       },
       a2aMessages: [],
       isConnected: false,
+      state: "disconnected",
     });
     render(withPageRefresh(<A2APage />));
     expect(invalidateQueries).toHaveBeenCalledWith({
@@ -273,6 +282,7 @@ describe("A2APage", () => {
       lastMessage: null,
       a2aMessages: [],
       isConnected: false,
+      state: "disconnected",
     });
     const { rerender } = render(withPageRefresh(<A2APage />));
     // No invalidation while offline.
@@ -285,6 +295,7 @@ describe("A2APage", () => {
       lastMessage: null,
       a2aMessages: [],
       isConnected: true,
+      state: "connected",
     });
     act(() => {
       rerender(withPageRefresh(<A2APage />));
@@ -302,6 +313,7 @@ describe("A2APage", () => {
       lastMessage: null,
       a2aMessages: [],
       isConnected: true,
+      state: "connected",
     });
     render(withPageRefresh(<A2APage />));
     expect(invalidateQueries).not.toHaveBeenCalledWith({

--- a/panel/src/app/(dashboard)/a2a/page.tsx
+++ b/panel/src/app/(dashboard)/a2a/page.tsx
@@ -23,6 +23,11 @@ import { A2ASwitchboard } from "@/components/a2a/a2a-switchboard";
 import { A2ATranscript } from "@/components/a2a/a2a-transcript";
 import { A2AReplyComposer } from "@/components/a2a/a2a-reply-composer";
 import { A2AFilterBar } from "@/components/a2a/a2a-filter-bar";
+import { A2AContextPane } from "@/components/a2a/a2a-context-pane";
+import {
+  A2AConnectionBadge,
+  A2AConnectionBanner,
+} from "@/components/a2a/a2a-connection-badge";
 import { latestPulseTimestamps } from "@/components/a2a/a2a-switchboard-utils";
 import {
   filterConversations,
@@ -35,6 +40,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { OfflineState } from "@/components/ui/offline-state";
+import { useUIStore } from "@/store";
 import { getAgentDisplayName } from "@/lib/agent-utils";
 import { lastSenderOf } from "@/components/a2a/a2a-utils";
 import { cn } from "@/lib/utils";
@@ -43,6 +49,8 @@ import {
   LayoutGrid,
   List as ListIcon,
   MessagesSquare,
+  PanelRightClose,
+  PanelRightOpen,
   Radio,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
@@ -52,23 +60,6 @@ type A2AView = "switchboard" | "list";
 interface PeekedPair {
   agent_a: string;
   agent_b: string;
-}
-
-function EmptyPanel({
-  icon: Icon,
-  message,
-}: {
-  icon: typeof MessagesSquare;
-  message: string;
-}) {
-  return (
-    <div className="h-full flex items-center justify-center text-muted-foreground">
-      <div className="text-center p-4">
-        <Icon className="h-8 w-8 mx-auto mb-2 opacity-50" />
-        <p className="text-sm">{message}</p>
-      </div>
-    </div>
-  );
 }
 
 function A2APageContent() {
@@ -91,6 +82,20 @@ function A2APageContent() {
   const [statusFilter, setStatusFilter] = useState<A2AStatusFilter>("all");
   const [search, setSearch] = useState("");
 
+  // xl:+ context pane collapse, persisted via the shared UI store — same
+  // idiom as sidebar/theme preferences (design doc §1).
+  const contextOpen = useUIStore((s) => s.a2aContextOpen);
+  const toggleContext = useUIStore((s) => s.toggleA2AContext);
+
+  // Reconnecting/disconnected banner strip, dismissable per occurrence — it
+  // reappears the next time the connection drops (design doc §3). Render-phase
+  // reset (compared against the previous connectionState, same idiom as
+  // A2APairCard's usePulseFlash) rather than an effect.
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const [lastConnectionState, setLastConnectionState] = useState<string | null>(
+    null,
+  );
+
   const {
     data: conversationData,
     isLoading: loadingConversations,
@@ -105,6 +110,7 @@ function A2APageContent() {
   const {
     data: messagesData,
     isLoading: loadingMessages,
+    error: messagesError,
     refetch: refetchMessages,
   } = useA2AMessages(selectedId);
 
@@ -138,7 +144,12 @@ function A2APageContent() {
   // `a2a.message` frame. Invalidate-on-frame (the session-detail idiom) — the
   // frame's excerpt is capped by design, so REST stays the source of truth and
   // react-query refetches the affected queries.
-  const { lastMessage, a2aMessages, isConnected } = useA2ALiveStream();
+  const {
+    lastMessage,
+    a2aMessages,
+    isConnected,
+    state: connectionState,
+  } = useA2ALiveStream();
   useEffect(() => {
     if (lastMessage?.type !== "a2a.message") return;
     queryClient.invalidateQueries({ queryKey: a2aLiveKeys.conversations });
@@ -149,6 +160,18 @@ function A2APageContent() {
       });
     }
   }, [lastMessage, queryClient, selectedId]);
+
+  // Re-arm the dismissable banner the next time the connection actually
+  // drops, rather than leaving it dismissed forever after the first hiccup.
+  if (connectionState !== lastConnectionState) {
+    setLastConnectionState(connectionState);
+    if (
+      connectionState !== "reconnecting" &&
+      connectionState !== "disconnected"
+    ) {
+      setBannerDismissed(false);
+    }
+  }
 
   // On /ws/system reconnect (false → true) the A2A list is stale — events
   // missed during the disconnect. Invalidate the a2a query family so
@@ -242,19 +265,24 @@ function A2APageContent() {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <span
-              className={cn(
-                "h-2 w-2 rounded-full",
-                isConnected
-                  ? "bg-emerald-500 animate-pulse"
-                  : "bg-muted-foreground/40",
-              )}
-            />
-            <span className="text-xs text-muted-foreground">
-              {isConnected ? "Live" : "Offline"}
-            </span>
-          </div>
+          <A2AConnectionBadge state={connectionState} />
+          {/* Context pane never appears below xl — its toggle is hidden
+              there too, matching the switchboard/list toggle's placement
+              idiom (design doc §1). */}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="hidden h-7 px-2 xl:inline-flex"
+            onClick={toggleContext}
+            title={contextOpen ? "Hide context panel" : "Show context panel"}
+          >
+            {contextOpen ? (
+              <PanelRightClose className="h-3.5 w-3.5" />
+            ) : (
+              <PanelRightOpen className="h-3.5 w-3.5" />
+            )}
+          </Button>
         </div>
       </div>
 
@@ -284,6 +312,7 @@ function A2APageContent() {
             <Card
               className={cn(
                 "col-span-12 flex-col overflow-hidden lg:col-span-4 lg:flex",
+                contextOpen && "xl:col-span-3",
                 onDetailLevel ? "hidden" : "flex",
               )}
             >
@@ -350,64 +379,12 @@ function A2APageContent() {
             <Card
               className={cn(
                 "col-span-12 flex-col overflow-hidden lg:col-span-8 lg:flex",
+                contextOpen && "xl:col-span-6",
                 onDetailLevel ? "flex" : "hidden",
               )}
             >
               <CardContent className="p-3 flex flex-col h-full">
-                {selected ? (
-                  <>
-                    <div className="flex items-center gap-2 mb-3 pb-2 border-b flex-wrap">
-                      <MessagesSquare className="h-4 w-4 text-muted-foreground" />
-                      <span className="text-sm font-medium">
-                        {getAgentDisplayName(selected.agent_a)}
-                        {" ↔ "}
-                        {getAgentDisplayName(selected.agent_b)}
-                      </span>
-                      <Badge
-                        variant={
-                          selected.status === "active" ? "default" : "secondary"
-                        }
-                        className="text-xs"
-                      >
-                        {selected.status}
-                      </Badge>
-                      <span className="text-xs text-muted-foreground ml-auto">
-                        {selected.message_count} msgs · updated{" "}
-                        {formatDistanceToNow(new Date(selected.updated_at))} ago
-                      </span>
-                    </div>
-                    <div className="flex-1 overflow-hidden -mx-3">
-                      <A2ATranscript
-                        messages={messages}
-                        isLoading={loadingMessages}
-                      />
-                    </div>
-                    {/* Reply composer. The backend's reply route rejects with
-                      400 exactly when the watched conversation has no task
-                      link (replies ride the gateway send path, which requires
-                      one), so a task-less conversation is read-only — say why
-                      instead of letting the send bounce. Status does NOT gate
-                      the composer: the CEO's reply lands in their own direct
-                      thread with the participant, not in this conversation. */}
-                    <div className="shrink-0 border-t -mx-3">
-                      {selected.task_id ? (
-                        <A2AReplyComposer
-                          key={selected.id}
-                          conversationId={selected.id}
-                          agentA={selected.agent_a}
-                          agentB={selected.agent_b}
-                          lastSender={lastSender}
-                        />
-                      ) : (
-                        <div className="p-4 text-center text-sm text-muted-foreground">
-                          This conversation has no linked task, so a reply
-                          can&apos;t be sent (A2A messages are always scoped to
-                          a task).
-                        </div>
-                      )}
-                    </div>
-                  </>
-                ) : peekedPair ? (
+                {peekedPair ? (
                   <div className="h-full flex items-center justify-center text-muted-foreground">
                     <div className="text-center p-4 max-w-xs">
                       <MessagesSquare className="h-8 w-8 mx-auto mb-2 opacity-50" />
@@ -419,13 +396,113 @@ function A2APageContent() {
                     </div>
                   </div>
                 ) : (
-                  <EmptyPanel
-                    icon={MessagesSquare}
-                    message="Select a conversation to watch it live"
-                  />
+                  <>
+                    {selected && (
+                      <div className="flex items-center gap-2 mb-3 pb-2 border-b flex-wrap">
+                        <MessagesSquare className="h-4 w-4 text-muted-foreground" />
+                        <span className="text-sm font-medium">
+                          {getAgentDisplayName(selected.agent_a)}
+                          {" ↔ "}
+                          {getAgentDisplayName(selected.agent_b)}
+                        </span>
+                        <Badge
+                          variant={
+                            selected.status === "active"
+                              ? "default"
+                              : "secondary"
+                          }
+                          className="text-xs"
+                        >
+                          {selected.status}
+                        </Badge>
+                        <span className="text-xs text-muted-foreground ml-auto">
+                          {selected.message_count} msgs · updated{" "}
+                          {formatDistanceToNow(new Date(selected.updated_at))}{" "}
+                          ago
+                        </span>
+                      </div>
+                    )}
+                    {/* Scoped to the stream pane, not a full-page takeover —
+                      a live-connection hint, distinct from OfflineState. */}
+                    {(connectionState === "reconnecting" ||
+                      connectionState === "disconnected") &&
+                      !bannerDismissed && (
+                        <div className="-mx-3 mb-3">
+                          <A2AConnectionBanner
+                            state={connectionState}
+                            onDismiss={() => setBannerDismissed(true)}
+                          />
+                        </div>
+                      )}
+                    {/* All three loading/empty/error states live inside
+                      A2ATranscript now — the pane chrome above stays mounted
+                      and stable while only this area swaps (design doc §5). */}
+                    <div className="flex-1 overflow-hidden -mx-3">
+                      <A2ATranscript
+                        messages={messages}
+                        isLoading={loadingMessages}
+                        hasSelection={!!selected}
+                        error={!!messagesError}
+                        onRetry={() => void refetchMessages()}
+                      />
+                    </div>
+                    {/* Reply composer. The backend's reply route rejects with
+                      400 exactly when the watched conversation has no task
+                      link (replies ride the gateway send path, which requires
+                      one), so a task-less conversation is read-only — say why
+                      instead of letting the send bounce. Status does NOT gate
+                      the composer: the CEO's reply lands in their own direct
+                      thread with the participant, not in this conversation. */}
+                    {selected && (
+                      <div className="shrink-0 border-t -mx-3">
+                        {selected.task_id ? (
+                          <A2AReplyComposer
+                            key={selected.id}
+                            conversationId={selected.id}
+                            agentA={selected.agent_a}
+                            agentB={selected.agent_b}
+                            lastSender={lastSender}
+                          />
+                        ) : (
+                          <div className="p-4 text-center text-sm text-muted-foreground">
+                            This conversation has no linked task, so a reply
+                            can&apos;t be sent (A2A messages are always scoped
+                            to a task).
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </>
                 )}
               </CardContent>
             </Card>
+
+            {/* Panel 3: Context (xl:+ only, dismissible) — participant
+              identity cards + linked-task summary, read-only (design doc
+              §1). */}
+            {contextOpen && (
+              <Card className="hidden xl:col-span-3 xl:flex xl:flex-col overflow-hidden">
+                <CardContent className="p-0 flex-1 overflow-y-auto">
+                  {selected ? (
+                    <A2AContextPane
+                      agentA={selected.agent_a}
+                      agentB={selected.agent_b}
+                      taskId={selected.task_id}
+                    />
+                  ) : peekedPair ? (
+                    <A2AContextPane
+                      agentA={peekedPair.agent_a}
+                      agentB={peekedPair.agent_b}
+                      taskId={null}
+                    />
+                  ) : (
+                    <div className="h-full flex items-center justify-center text-muted-foreground p-4 text-center text-sm">
+                      Select a conversation to see participant details
+                    </div>
+                  )}
+                </CardContent>
+              </Card>
+            )}
           </div>
         </>
       )}

--- a/panel/src/components/a2a/__tests__/a2a-connection-badge.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-connection-badge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ConnectionState } from "@/lib/websocket/connection";
+import {
+  A2AConnectionBadge,
+  A2AConnectionBanner,
+} from "../a2a-connection-badge";
+
+describe("A2AConnectionBadge", () => {
+  it.each([
+    ["connected", "Live"],
+    ["connecting", "Connecting…"],
+    ["reconnecting", "Reconnecting…"],
+    ["disconnected", "Offline"],
+  ] satisfies [ConnectionState, string][])(
+    "renders a distinct label for %s",
+    (state, label) => {
+      render(<A2AConnectionBadge state={state} />);
+      expect(screen.getByText(label)).toBeInTheDocument();
+    },
+  );
+});
+
+describe("A2AConnectionBanner", () => {
+  it("reads 'Reconnecting' for the reconnecting state", () => {
+    render(<A2AConnectionBanner state="reconnecting" onDismiss={vi.fn()} />);
+    expect(
+      screen.getByText(/Reconnecting — messages may be out of date/),
+    ).toBeInTheDocument();
+  });
+
+  it("reads 'Disconnected' for the disconnected state", () => {
+    render(<A2AConnectionBanner state="disconnected" onDismiss={vi.fn()} />);
+    expect(
+      screen.getByText(/Disconnected — reconnecting automatically/),
+    ).toBeInTheDocument();
+  });
+
+  it("dismiss button fires onDismiss", () => {
+    const onDismiss = vi.fn();
+    render(<A2AConnectionBanner state="disconnected" onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/panel/src/components/a2a/__tests__/a2a-context-pane.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-context-pane.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    title: "Ship the context pane",
+    description: "",
+    acceptance_criteria: [],
+    status: TaskStatus.IN_PROGRESS,
+    priority: 1,
+    project_id: "proj-1",
+    task_type: TaskType.CODE,
+    team: Team.FRONTEND,
+    assigned_to: null,
+    parent_task_id: null,
+    branch_name: null,
+    pr_number: null,
+    pr_url: null,
+    created_at: "2026-07-02T10:00:00Z",
+    updated_at: "2026-07-02T10:00:00Z",
+    ...overrides,
+  } as Task;
+}
+
+let mockTask: Task | undefined;
+let mockIsLoading = false;
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useTask: () => ({ data: mockTask, isLoading: mockIsLoading }),
+}));
+
+import { A2AContextPane } from "../a2a-context-pane";
+
+describe("A2AContextPane", () => {
+  it("renders both participants' identity cards linking to /agents/{slug}", () => {
+    mockTask = undefined;
+    mockIsLoading = false;
+    render(<A2AContextPane agentA="be-dev-1" agentB="be-qa" taskId={null} />);
+    expect(screen.getByText("Backend Dev 1")).toBeInTheDocument();
+    expect(screen.getByText("Backend QA")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Backend Dev 1/ })).toHaveAttribute(
+      "href",
+      "/agents/be-dev-1",
+    );
+  });
+
+  it("shows the no-task hint when the conversation has no linked task", () => {
+    mockTask = undefined;
+    mockIsLoading = false;
+    render(<A2AContextPane agentA="be-dev-1" agentB="be-qa" taskId={null} />);
+    expect(
+      screen.getByText("This conversation has no linked task"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the linked task's title, status, and a View task link", () => {
+    mockTask = buildTask({ title: "Ship the context pane" });
+    mockIsLoading = false;
+    render(<A2AContextPane agentA="be-dev-1" agentB="be-qa" taskId="task-1" />);
+    expect(screen.getByText("Ship the context pane")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /View task/ })).toHaveAttribute(
+      "href",
+      "/tasks/task-1",
+    );
+  });
+});

--- a/panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts
+++ b/panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type {
-  AdminConversationSummary,
-  AdminPairSummary,
-} from "@/lib/api/a2a";
+import type { AdminConversationSummary, AdminPairSummary } from "@/lib/api/a2a";
 import { filterConversations, filterPairs } from "../a2a-filter-utils";
 
 function buildConversation(
@@ -62,9 +59,9 @@ describe("filterConversations", () => {
 
   it("matches search against agent display name (case-insensitive)", () => {
     const conversations = [buildConversation()];
-    expect(filterConversations(conversations, "all", "backend qa")).toHaveLength(
-      1,
-    );
+    expect(
+      filterConversations(conversations, "all", "backend qa"),
+    ).toHaveLength(1);
     expect(filterConversations(conversations, "all", "nope")).toHaveLength(0);
   });
 

--- a/panel/src/components/a2a/__tests__/a2a-pair-card.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-pair-card.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { AdminPairSummary } from "@/lib/api/a2a";
-import { A2APairCard } from "../a2a-pair-card";
+import { A2APairCard, PairAvatar } from "../a2a-pair-card";
 
 function buildPair(
   overrides: Partial<AdminPairSummary> = {},
@@ -49,6 +49,13 @@ describe("A2APairCard", () => {
     expect(screen.getByTestId("pair-card")).toHaveClass("opacity-60");
     // No message-count badge for a pair with no history.
     expect(screen.queryByText("5")).not.toBeInTheDocument();
+  });
+
+  it("colors each avatar by team, not a per-agent hue", () => {
+    render(<PairAvatar slug="fe-dev-1" />);
+    expect(screen.getByTitle("Frontend Dev 1")).toHaveClass(
+      "border-violet-500/40",
+    );
   });
 
   it("marks the card as selected via aria-pressed", () => {

--- a/panel/src/components/a2a/__tests__/a2a-transcript.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-transcript.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { A2AChatMessage } from "@/lib/api/a2a";
 
 // react-markdown is heavyweight and irrelevant here — render bodies as-is.
@@ -74,5 +74,101 @@ describe("A2ATranscript", () => {
     expect(
       screen.getByText(/No messages in this conversation yet/),
     ).toBeInTheDocument();
+  });
+
+  it("shows a distinct nothing-selected hint when hasSelection is false", () => {
+    render(
+      <A2ATranscript messages={[]} isLoading={false} hasSelection={false} />,
+    );
+    expect(
+      screen.getByText("Select a conversation to view messages"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No messages in this conversation yet/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the scoped error state with a working Retry button", () => {
+    const onRetry = vi.fn();
+    render(
+      <A2ATranscript messages={[]} isLoading={false} error onRetry={onRetry} />,
+    );
+    expect(
+      screen.getByText("Couldn't load this conversation"),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("error state takes precedence over the empty/nothing-selected states", () => {
+    render(<A2ATranscript messages={[]} isLoading={false} error />);
+    expect(
+      screen.queryByText(/No messages in this conversation yet/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("A2ATranscript new-row entrance (frame -> row fades in, then settles)", () => {
+  // Deterministic rAF, same idiom as A2APairCard's pulse test.
+  let rafCallback: FrameRequestCallback | null = null;
+
+  beforeEach(() => {
+    rafCallback = null;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallback = cb;
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders initially-loaded messages settled (never marked new)", () => {
+    render(
+      <A2ATranscript
+        messages={[buildMessage({ id: "m1" })]}
+        isLoading={false}
+      />,
+    );
+    const rows = screen.getAllByTestId("transcript-row");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveAttribute("data-new", "false");
+  });
+
+  it("marks a message arriving after initial load as new, then settles it next frame", () => {
+    const { rerender } = render(
+      <A2ATranscript
+        messages={[buildMessage({ id: "m1" })]}
+        isLoading={false}
+      />,
+    );
+
+    rerender(
+      <A2ATranscript
+        messages={[
+          buildMessage({ id: "m1" }),
+          buildMessage({
+            id: "m2",
+            content: "second",
+            created_at: "2026-07-02T10:05:00Z",
+          }),
+        ]}
+        isLoading={false}
+      />,
+    );
+
+    const rows = screen.getAllByTestId("transcript-row");
+    const newRow = rows.find((r) => r.textContent?.includes("second"));
+    expect(newRow).toHaveAttribute("data-new", "true");
+
+    act(() => {
+      rafCallback?.(0);
+    });
+
+    const settledRows = screen.getAllByTestId("transcript-row");
+    for (const row of settledRows) {
+      expect(row).toHaveAttribute("data-new", "false");
+    }
   });
 });

--- a/panel/src/components/a2a/__tests__/a2a-utils.test.ts
+++ b/panel/src/components/a2a/__tests__/a2a-utils.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
+  connectionDotClasses,
+  connectionStateLabel,
   lastSenderOf,
   pickDefaultRecipient,
   recipientOptions,
 } from "../a2a-utils";
+import type { ConnectionState } from "@/lib/websocket/connection";
 
 describe("lastSenderOf", () => {
   it("returns null for an empty transcript", () => {
@@ -50,5 +53,39 @@ describe("recipientOptions", () => {
 
   it("excludes the CEO when it's agent_b", () => {
     expect(recipientOptions("be-dev-1", "ceo")).toEqual(["be-dev-1"]);
+  });
+});
+
+describe("connectionStateLabel (design doc §3 — all four states distinct)", () => {
+  it.each([
+    ["connected", "Live"],
+    ["connecting", "Connecting…"],
+    ["reconnecting", "Reconnecting…"],
+    ["disconnected", "Offline"],
+  ] satisfies [ConnectionState, string][])(
+    "labels %s as %s",
+    (state, label) => {
+      expect(connectionStateLabel(state)).toBe(label);
+    },
+  );
+});
+
+describe("connectionDotClasses", () => {
+  it("connected is static — no pulse", () => {
+    expect(connectionDotClasses("connected")).not.toContain("animate-pulse");
+  });
+
+  it("connecting and reconnecting pulse with a motion-reduce guard", () => {
+    for (const state of ["connecting", "reconnecting"] as ConnectionState[]) {
+      const classes = connectionDotClasses(state);
+      expect(classes).toContain("animate-pulse");
+      expect(classes).toContain("motion-reduce:animate-none");
+    }
+  });
+
+  it("disconnected is static and muted", () => {
+    const classes = connectionDotClasses("disconnected");
+    expect(classes).not.toContain("animate-pulse");
+    expect(classes).toContain("muted-foreground");
   });
 });

--- a/panel/src/components/a2a/a2a-connection-badge.tsx
+++ b/panel/src/components/a2a/a2a-connection-badge.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Loader2, WifiOff, X } from "lucide-react";
+import type { ConnectionState } from "@/lib/websocket/connection";
+import { cn } from "@/lib/utils";
+import { connectionDotClasses, connectionStateLabel } from "./a2a-utils";
+
+/** Pane-header connection indicator: dot + label, plus a spinner/offline icon
+ * for the connecting/reconnecting/disconnected states (design doc §3). All
+ * four `ConnectionState` values render distinctly — a live-but-quiet
+ * conversation must read differently from a stream that is the problem. */
+export function A2AConnectionBadge({ state }: { state: ConnectionState }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={cn("h-2 w-2 rounded-full", connectionDotClasses(state))}
+      />
+      <span className="text-xs text-muted-foreground">
+        {connectionStateLabel(state)}
+      </span>
+      {(state === "connecting" || state === "reconnecting") && (
+        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+      )}
+      {state === "disconnected" && (
+        <WifiOff className="h-3 w-3 text-muted-foreground" />
+      )}
+    </div>
+  );
+}
+
+interface A2AConnectionBannerProps {
+  state: "reconnecting" | "disconnected";
+  onDismiss: () => void;
+}
+
+/** Dismissable strip above the stream pane's message list — a scoped
+ * live-connection hint, not the full-page `OfflineState` (design doc §3). */
+export function A2AConnectionBanner({
+  state,
+  onDismiss,
+}: A2AConnectionBannerProps) {
+  const isDisconnected = state === "disconnected";
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-2 border-b text-xs px-3 py-1.5",
+        isDisconnected
+          ? "bg-destructive/10 border-destructive/30 text-destructive"
+          : "bg-amber-500/10 border-amber-500/30 text-amber-700 dark:text-amber-400",
+      )}
+    >
+      <span>
+        {isDisconnected
+          ? "Disconnected — reconnecting automatically"
+          : "Reconnecting — messages may be out of date"}
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="shrink-0 opacity-70 hover:opacity-100"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/panel/src/components/a2a/a2a-context-pane.tsx
+++ b/panel/src/components/a2a/a2a-context-pane.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  getAgentDisplayName,
+  getAgentInitials,
+  getAgentTeamColor,
+  TEAM_COLOR_CLASSES,
+} from "@/lib/agent-utils";
+import { useTask } from "@/hooks/use-tasks";
+import { cn } from "@/lib/utils";
+import { ListTodo, Users } from "lucide-react";
+
+/** One participant's identity card — avatar, name, team badge — linking to
+ * the agent's own detail page (design doc §1/§2). Read-only, same team-color
+ * mapping every other identity affordance uses. */
+function IdentityCard({ slug }: { slug: string }) {
+  const teamColor = getAgentTeamColor(slug);
+  return (
+    <Link
+      href={`/agents/${slug}`}
+      className="flex items-center gap-2 rounded-lg border p-2 hover:bg-muted/50 transition-colors"
+    >
+      <div
+        className={cn(
+          "h-9 w-9 rounded-full border flex items-center justify-center shrink-0",
+          TEAM_COLOR_CLASSES[teamColor],
+        )}
+        title={getAgentDisplayName(slug)}
+      >
+        <span className="text-[10px] font-bold tracking-tight">
+          {getAgentInitials(slug)}
+        </span>
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium truncate">
+          {getAgentDisplayName(slug)}
+        </div>
+        <Badge
+          variant="outline"
+          className={cn("text-[10px] mt-0.5", TEAM_COLOR_CLASSES[teamColor])}
+        >
+          {teamColor.replace("_", "/")}
+        </Badge>
+      </div>
+    </Link>
+  );
+}
+
+interface A2AContextPaneProps {
+  agentA: string;
+  agentB: string;
+  /** null when this conversation (or peeked pair) has no linked task. */
+  taskId: string | null;
+}
+
+/** The `xl:`+ context region: both participants' identity cards, a linked-task
+ * summary, and a no-task hint when there isn't one — read-only, never a
+ * second place to act on the conversation (design doc §1). */
+export function A2AContextPane({
+  agentA,
+  agentB,
+  taskId,
+}: A2AContextPaneProps) {
+  const { data: task, isLoading } = useTask(taskId ?? "");
+
+  return (
+    <div className="p-3 space-y-4">
+      <div className="flex items-center gap-2 pb-2 border-b">
+        <Users className="h-4 w-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Context</span>
+      </div>
+
+      <div className="space-y-2">
+        <IdentityCard slug={agentA} />
+        <IdentityCard slug={agentB} />
+      </div>
+
+      <div className="space-y-2">
+        <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+          Linked task
+        </div>
+        {!taskId ? (
+          <p className="text-xs text-muted-foreground">
+            This conversation has no linked task
+          </p>
+        ) : isLoading || !task ? (
+          <Skeleton className="h-16 w-full" />
+        ) : (
+          <div className="rounded-lg border p-2.5 space-y-1.5">
+            <div className="text-sm font-medium truncate">{task.title}</div>
+            <div className="flex items-center justify-between gap-2">
+              <Badge
+                variant={task.status === "completed" ? "default" : "secondary"}
+                className="text-xs"
+              >
+                {task.status}
+              </Badge>
+              <Link
+                prefetch={false}
+                href={`/tasks/${taskId}`}
+                className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <ListTodo className="h-3 w-3" />
+                View task
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/panel/src/components/a2a/a2a-conversation-list.tsx
+++ b/panel/src/components/a2a/a2a-conversation-list.tsx
@@ -109,9 +109,7 @@ function ConversationRow({
         </div>
         <div className="flex flex-col items-end gap-1 shrink-0">
           <Badge
-            variant={
-              conversation.status === "active" ? "default" : "secondary"
-            }
+            variant={conversation.status === "active" ? "default" : "secondary"}
             className="text-xs"
           >
             {conversation.status}

--- a/panel/src/components/a2a/a2a-filter-utils.ts
+++ b/panel/src/components/a2a/a2a-filter-utils.ts
@@ -4,10 +4,7 @@
  * inputs narrow both views to the matching subset.
  */
 
-import type {
-  AdminConversationSummary,
-  AdminPairSummary,
-} from "@/lib/api/a2a";
+import type { AdminConversationSummary, AdminPairSummary } from "@/lib/api/a2a";
 import { getAgentDisplayName } from "@/lib/agent-utils";
 
 /** "active" narrows to items with a live/talked conversation; "all" is no

--- a/panel/src/components/a2a/a2a-pair-card.tsx
+++ b/panel/src/components/a2a/a2a-pair-card.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { getAgentDisplayName, getAgentInitials } from "@/lib/agent-utils";
+import {
+  getAgentDisplayName,
+  getAgentInitials,
+  getAgentTeamColor,
+  TEAM_COLOR_CLASSES,
+} from "@/lib/agent-utils";
 import type { AdminPairSummary } from "@/lib/api/a2a";
 import { cn } from "@/lib/utils";
 import { usePulseFlash } from "@/hooks/use-pulse-flash";
@@ -23,7 +28,10 @@ interface A2APairCardProps {
 export function PairAvatar({ slug }: { slug: string }) {
   return (
     <div
-      className="h-7 w-7 rounded-full bg-primary/10 border flex items-center justify-center shrink-0"
+      className={cn(
+        "h-7 w-7 rounded-full border flex items-center justify-center shrink-0",
+        TEAM_COLOR_CLASSES[getAgentTeamColor(slug)],
+      )}
       title={getAgentDisplayName(slug)}
     >
       <span className="text-[9px] font-bold tracking-tight">

--- a/panel/src/components/a2a/a2a-transcript.tsx
+++ b/panel/src/components/a2a/a2a-transcript.tsx
@@ -1,28 +1,111 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Markdown } from "@/components/ui/markdown";
-import { getAgentDisplayName, getAgentInitials } from "@/lib/agent-utils";
+import {
+  getAgentDisplayName,
+  getAgentInitials,
+  getAgentTeamColor,
+  TEAM_COLOR_CLASSES,
+} from "@/lib/agent-utils";
+import { cn } from "@/lib/utils";
 import type { A2AChatMessage } from "@/lib/api/a2a";
 import { formatDistanceToNow } from "date-fns";
-import { MessagesSquare } from "lucide-react";
+import { AlertTriangle, MessagesSquare } from "lucide-react";
 
 interface A2ATranscriptProps {
   messages: A2AChatMessage[];
   isLoading: boolean;
+  /** False when no conversation/pair is selected at all — distinguishes
+   * "nothing to show yet" from "this conversation genuinely has no
+   * messages" (design doc §5). Defaults true (existing callers). */
+  hasSelection?: boolean;
+  /** True when the messages fetch itself failed — a scoped retry, not the
+   * page-level OfflineState (design doc §5). */
+  error?: boolean;
+  onRetry?: () => void;
 }
 
-export function A2ATranscript({ messages, isLoading }: A2ATranscriptProps) {
+/** How close to the bottom (px) still counts as "at the bottom" for the
+ * auto-scroll / new-messages-pill decision. */
+const BOTTOM_THRESHOLD_PX = 48;
+
+function EmptyState({
+  icon: Icon,
+  message,
+}: {
+  icon: typeof MessagesSquare;
+  message: string;
+}) {
+  return (
+    <div className="h-full flex items-center justify-center text-muted-foreground">
+      <div className="text-center p-4">
+        <Icon className="h-8 w-8 mx-auto mb-2 opacity-50" />
+        <p className="text-sm">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export function A2ATranscript({
+  messages,
+  isLoading,
+  hasSelection = true,
+  error = false,
+  onRetry,
+}: A2ATranscriptProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const hasScrolledRef = useRef(false);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+  const [seenIds, setSeenIds] = useState<Set<string> | null>(null);
+  const [newRowIds, setNewRowIds] = useState<ReadonlySet<string>>(new Set());
+  const [showJumpPill, setShowJumpPill] = useState(false);
+  const [pillEntering, setPillEntering] = useState(false);
 
   // Chronological (oldest first) regardless of payload ordering.
   const sorted = [...messages].sort(
     (a, b) =>
       new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
   );
+  const currentIds = sorted.map((m) => m.id);
+
+  // Render-phase derivation (same idiom as A2APairCard's usePulseFlash — state,
+  // not a ref, compared against the current props): the first time a batch of
+  // ids appears it seeds "seen" without flagging anything new — messages
+  // present at initial load must render settled, never animate in. A later id
+  // absent from "seen" is a genuine arrival.
+  if (seenIds === null) {
+    setSeenIds(new Set(currentIds));
+  } else {
+    const freshIds = currentIds.filter((id) => !seenIds.has(id));
+    if (freshIds.length > 0) {
+      setSeenIds(new Set([...seenIds, ...freshIds]));
+      if (isAtBottom) {
+        setNewRowIds((prev) => new Set([...prev, ...freshIds]));
+      } else {
+        // Scrolled up: the new row is off-screen — surface the "New
+        // messages" pill instead of an invisible entrance transition.
+        setShowJumpPill(true);
+        setPillEntering(true);
+      }
+    }
+  }
+
+  // Settle the entrance transition one paint frame after new rows appear.
+  useEffect(() => {
+    if (newRowIds.size === 0) return;
+    const raf = requestAnimationFrame(() => setNewRowIds(new Set()));
+    return () => cancelAnimationFrame(raf);
+  }, [newRowIds]);
+
+  useEffect(() => {
+    if (!pillEntering) return;
+    const raf = requestAnimationFrame(() => setPillEntering(false));
+    return () => cancelAnimationFrame(raf);
+  }, [pillEntering]);
 
   // Auto-scroll to bottom only once on initial load.
   useEffect(() => {
@@ -31,6 +114,23 @@ export function A2ATranscript({ messages, isLoading }: A2ATranscriptProps) {
       hasScrolledRef.current = true;
     }
   }, [sorted.length]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_THRESHOLD_PX;
+    setIsAtBottom(atBottom);
+    if (atBottom) setShowJumpPill(false);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    scrollRef.current?.scrollTo({
+      top: scrollRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+    setShowJumpPill(false);
+  }, []);
 
   if (isLoading) {
     return (
@@ -48,51 +148,117 @@ export function A2ATranscript({ messages, isLoading }: A2ATranscriptProps) {
     );
   }
 
-  if (sorted.length === 0) {
+  if (error) {
     return (
       <div className="h-full flex items-center justify-center text-muted-foreground">
         <div className="text-center p-4">
-          <MessagesSquare className="h-8 w-8 mx-auto mb-2 opacity-50" />
-          <p className="text-sm">No messages in this conversation yet</p>
+          <AlertTriangle className="h-8 w-8 mx-auto mb-2 opacity-50 text-destructive" />
+          <p className="text-sm mb-3">Couldn&apos;t load this conversation</p>
+          {onRetry && (
+            <Button variant="outline" size="sm" onClick={onRetry}>
+              Retry
+            </Button>
+          )}
         </div>
       </div>
     );
   }
 
+  if (!hasSelection) {
+    return (
+      <EmptyState
+        icon={MessagesSquare}
+        message="Select a conversation to view messages"
+      />
+    );
+  }
+
+  if (sorted.length === 0) {
+    return (
+      <EmptyState
+        icon={MessagesSquare}
+        message="No messages in this conversation yet"
+      />
+    );
+  }
+
   return (
-    <div ref={scrollRef} className="h-full overflow-y-auto p-4">
-      <div className="space-y-3">
-        {sorted.map((message) => (
-          <div
-            key={message.id}
-            className="flex gap-3 p-3 rounded-lg border bg-card hover:bg-muted/30 transition-colors"
-          >
-            <div className="h-9 w-10 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 border">
-              <span className="text-[10px] font-bold tracking-tight">
-                {getAgentInitials(message.from_agent)}
-              </span>
-            </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1.5">
-                <span className="font-semibold text-sm">
-                  {getAgentDisplayName(message.from_agent)}
-                </span>
-                {message.message_kind && (
-                  <Badge variant="outline" className="text-[10px]">
-                    {message.message_kind}
-                  </Badge>
+    <div className="relative h-full">
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        className="h-full overflow-y-auto p-4"
+      >
+        <div className="space-y-3">
+          {sorted.map((message) => {
+            const isNew = newRowIds.has(message.id);
+            const teamColor = getAgentTeamColor(message.from_agent);
+            return (
+              <div
+                key={message.id}
+                data-testid="transcript-row"
+                data-new={isNew}
+                className={cn(
+                  "flex gap-3 p-3 rounded-lg border hover:bg-muted/30",
+                  // ponytail: one shared 200ms transition covers
+                  // opacity/transform/background so the reduced-motion
+                  // background flash rides the same timing as the
+                  // full-motion fade-in instead of a second bespoke duration.
+                  "transition-[opacity,transform,background-color] duration-200 ease-out",
+                  "motion-reduce:transition-colors motion-reduce:translate-y-0",
+                  isNew
+                    ? "opacity-0 translate-y-1 bg-muted/50 motion-reduce:opacity-100"
+                    : "opacity-100 translate-y-0 bg-card",
                 )}
-                <span className="text-xs text-muted-foreground ml-auto">
-                  {formatDistanceToNow(new Date(message.created_at))} ago
-                </span>
+              >
+                <div
+                  className={cn(
+                    "h-9 w-10 rounded-lg flex items-center justify-center shrink-0 border",
+                    TEAM_COLOR_CLASSES[teamColor],
+                  )}
+                >
+                  <span className="text-[10px] font-bold tracking-tight">
+                    {getAgentInitials(message.from_agent)}
+                  </span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <span className="font-semibold text-sm">
+                      {getAgentDisplayName(message.from_agent)}
+                    </span>
+                    {message.message_kind && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {message.message_kind}
+                      </Badge>
+                    )}
+                    <span className="text-xs text-muted-foreground ml-auto">
+                      {formatDistanceToNow(new Date(message.created_at))} ago
+                    </span>
+                  </div>
+                  <div className="text-sm prose prose-sm dark:prose-invert max-w-none">
+                    <Markdown>{message.content}</Markdown>
+                  </div>
+                </div>
               </div>
-              <div className="text-sm prose prose-sm dark:prose-invert max-w-none">
-                <Markdown>{message.content}</Markdown>
-              </div>
-            </div>
-          </div>
-        ))}
+            );
+          })}
+        </div>
       </div>
+      {showJumpPill && (
+        <button
+          type="button"
+          onClick={scrollToBottom}
+          className={cn(
+            "absolute bottom-3 left-1/2 rounded-full bg-primary text-primary-foreground text-xs px-3 py-1 shadow-md",
+            "transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none",
+            pillEntering
+              ? "opacity-0 translate-x-[-50%] translate-y-1 motion-reduce:opacity-100 motion-reduce:translate-y-0"
+              : "opacity-100 translate-x-[-50%] translate-y-0",
+          )}
+        >
+          New messages ↓
+        </button>
+      )}
     </div>
   );
 }

--- a/panel/src/components/a2a/a2a-utils.ts
+++ b/panel/src/components/a2a/a2a-utils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { A2AChatMessage } from "@/lib/api/a2a";
+import type { ConnectionState } from "@/lib/websocket/connection";
 
 /** The human CEO's fixed slug — never a valid reply target (the CEO composes
  * as itself, so it can't be its own recipient). */
@@ -46,4 +47,33 @@ export function pickDefaultRecipient(
 ): string {
   if (lastSender === agentA || lastSender === agentB) return lastSender;
   return agentA;
+}
+
+/** Label for the pane-header connection badge (design doc §3). */
+export function connectionStateLabel(state: ConnectionState): string {
+  switch (state) {
+    case "connected":
+      return "Live";
+    case "connecting":
+      return "Connecting…";
+    case "reconnecting":
+      return "Reconnecting…";
+    case "disconnected":
+      return "Offline";
+  }
+}
+
+/** Dot color for the pane-header connection badge — `connected` is static
+ * (no pulse); `connecting`/`reconnecting` share the amber pulsing family,
+ * guarded against `prefers-reduced-motion` (design doc §3). */
+export function connectionDotClasses(state: ConnectionState): string {
+  switch (state) {
+    case "connected":
+      return "bg-emerald-500";
+    case "connecting":
+    case "reconnecting":
+      return "bg-amber-500 animate-pulse motion-reduce:animate-none";
+    case "disconnected":
+      return "bg-muted-foreground/40";
+  }
 }

--- a/panel/src/components/dashboard/__tests__/video-pipeline-utils.test.ts
+++ b/panel/src/components/dashboard/__tests__/video-pipeline-utils.test.ts
@@ -91,9 +91,9 @@ describe("pipelineStageLabel", () => {
     expect(
       pipelineStageLabel({ kind: "rendering", attempt: 2, maxAttempts: 5 }),
     ).toBe("Rendering (attempt 2/5)");
-    expect(
-      pipelineStageLabel({ kind: "render_failed", reason: "boom" }),
-    ).toBe("Render failed: boom");
+    expect(pipelineStageLabel({ kind: "render_failed", reason: "boom" })).toBe(
+      "Render failed: boom",
+    );
     expect(pipelineStageLabel({ kind: "render_failed", reason: null })).toBe(
       "Render failed",
     );

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -8,52 +8,46 @@ const { resolveApproveRef } = vi.hoisted(() => ({
   resolveApproveRef: { current: null as null | ((v: unknown) => void) },
 }));
 
-const {
-  listPosts,
-  listPipeline,
-  approve,
-  reject,
-  requestVideo,
-  getMediaBlob,
-} = vi.hoisted(() => ({
-  listPosts: vi.fn(
-    async () =>
-      [
-        {
-          task_id: "v-1",
-          source: "video_post",
-          title: "Video: release v0.19.0",
-          status: "pending",
-          occasion: "release",
-          script: "RoboCo v0.19.0 just shipped!",
-          platforms: ["x", "tiktok"],
-          x_caption: "RoboCo v0.19.0 is here!",
-          tiktok_caption: "New RoboCo drop!",
-          mp4_paths: {
-            vertical: "/fake/vertical.mp4",
-            square: "/fake/square.mp4",
+const { listPosts, listPipeline, approve, reject, requestVideo, getMediaBlob } =
+  vi.hoisted(() => ({
+    listPosts: vi.fn(
+      async () =>
+        [
+          {
+            task_id: "v-1",
+            source: "video_post",
+            title: "Video: release v0.19.0",
+            status: "pending",
+            occasion: "release",
+            script: "RoboCo v0.19.0 just shipped!",
+            platforms: ["x", "tiktok"],
+            x_caption: "RoboCo v0.19.0 is here!",
+            tiktok_caption: "New RoboCo drop!",
+            mp4_paths: {
+              vertical: "/fake/vertical.mp4",
+              square: "/fake/square.mp4",
+            },
           },
-        },
-      ] as VideoPost[],
-  ),
-  listPipeline: vi.fn(async (): Promise<VideoPipelineItem[]> => []),
-  // Deferred so the test can freeze the approve mid-flight.
-  approve: vi.fn(
-    () =>
-      new Promise((r) => {
-        resolveApproveRef.current = r as (v: unknown) => void;
-      }),
-  ),
-  reject: vi.fn(async () => ({})),
-  requestVideo: vi.fn(async () => ({
-    status: "opened",
-    task_id: "v-2",
-    detail: "Video-authoring task opened.",
-  })),
-  getMediaBlob: vi.fn(
-    async () => new Blob(["fake-mp4-bytes"], { type: "video/mp4" }),
-  ),
-}));
+        ] as VideoPost[],
+    ),
+    listPipeline: vi.fn(async (): Promise<VideoPipelineItem[]> => []),
+    // Deferred so the test can freeze the approve mid-flight.
+    approve: vi.fn(
+      () =>
+        new Promise((r) => {
+          resolveApproveRef.current = r as (v: unknown) => void;
+        }),
+    ),
+    reject: vi.fn(async () => ({})),
+    requestVideo: vi.fn(async () => ({
+      status: "opened",
+      task_id: "v-2",
+      detail: "Video-authoring task opened.",
+    })),
+    getMediaBlob: vi.fn(
+      async () => new Blob(["fake-mp4-bytes"], { type: "video/mp4" }),
+    ),
+  }));
 
 vi.mock("@/lib/api", () => ({
   videoApi: {

--- a/panel/src/components/dashboard/social-history-section.tsx
+++ b/panel/src/components/dashboard/social-history-section.tsx
@@ -150,10 +150,12 @@ export function SocialHistorySection({ className }: { className?: string }) {
   const isLoading = open && (xLoading || videoLoading);
   const rows: UnifiedRow[] = [
     ...(xHistory ?? []).map((entry): UnifiedRow => ({ kind: "x", entry })),
-    ...(videoHistory ?? []).map((entry): UnifiedRow => ({
-      kind: "video",
-      entry,
-    })),
+    ...(videoHistory ?? []).map(
+      (entry): UnifiedRow => ({
+        kind: "video",
+        entry,
+      }),
+    ),
   ].sort(
     (a, b) =>
       new Date(b.entry.acted_at).getTime() -

--- a/panel/src/components/dashboard/video-pipeline-utils.ts
+++ b/panel/src/components/dashboard/video-pipeline-utils.ts
@@ -32,7 +32,11 @@ const IN_REVIEW_STATUSES = new Set([
 export function derivePipelineStage(
   item: Pick<
     VideoPipelineItem,
-    "status" | "render_status" | "render_attempts" | "max_attempts" | "render_error"
+    | "status"
+    | "render_status"
+    | "render_attempts"
+    | "max_attempts"
+    | "render_error"
   >,
 ): PipelineStage {
   if (item.status === "completed") {
@@ -46,7 +50,8 @@ export function derivePipelineStage(
       maxAttempts: item.max_attempts,
     };
   }
-  if (item.status === "awaiting_ceo_approval") return { kind: "awaiting_approval" };
+  if (item.status === "awaiting_ceo_approval")
+    return { kind: "awaiting_approval" };
   if (IN_REVIEW_STATUSES.has(item.status)) return { kind: "in_review" };
   return { kind: "authoring" };
 }

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -176,7 +176,9 @@ function VideoPostRow({
             size="sm"
             variant={cut === "square" ? "default" : "outline"}
             disabled={!post.mp4_paths?.square}
-            title={post.mp4_paths?.square ? undefined : "1:1 hasn't rendered yet"}
+            title={
+              post.mp4_paths?.square ? undefined : "1:1 hasn't rendered yet"
+            }
             onClick={() => setCut("square")}
           >
             1:1{!post.mp4_paths?.square && " (missing)"}

--- a/panel/src/components/tasks/task-detail/task-description.tsx
+++ b/panel/src/components/tasks/task-detail/task-description.tsx
@@ -79,121 +79,121 @@ export function TaskDescription({ task }: TaskDescriptionProps) {
 
   return (
     <>
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-lg">Description</CardTitle>
-          {isEditing ? (
-            <div className="flex items-center gap-2">
-              <Tabs
-                value={editMode}
-                onValueChange={(v) => setEditMode(v as "write" | "preview")}
-              >
-                <TabsList className="h-8">
-                  <TabsTrigger value="write" className="text-xs px-2 h-6">
-                    <Edit3 className="h-3 w-3 mr-1" />
-                    Write
-                  </TabsTrigger>
-                  <TabsTrigger value="preview" className="text-xs px-2 h-6">
-                    <Eye className="h-3 w-3 mr-1" />
-                    Preview
-                  </TabsTrigger>
-                </TabsList>
-              </Tabs>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={handleCancel}
-                disabled={updateTask.isPending}
-              >
-                <X className="h-4 w-4" />
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={updateTask.isPending}
-              >
-                <Check className="h-4 w-4 mr-1" />
-                Save
-              </Button>
-            </div>
-          ) : (
-            <Button size="sm" variant="ghost" onClick={startEditing}>
-              <Edit3 className="h-4 w-4 mr-1" />
-              Edit
-            </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent>
-        {isEditing ? (
-          <div className="space-y-2">
-            {editMode === "write" ? (
-              <Textarea
-                value={editValue}
-                onChange={(e) => setEditValue(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder="Add a description..."
-                className="min-h-[200px] font-mono text-sm"
-                disabled={updateTask.isPending}
-                autoFocus
-              />
-            ) : (
-              <div className="min-h-[200px] p-3 border rounded-md bg-muted/30">
-                {editValue ? (
-                  <Markdown>{editValue}</Markdown>
-                ) : (
-                  <p className="text-muted-foreground text-sm italic">
-                    Nothing to preview
-                  </p>
-                )}
-              </div>
-            )}
-            <p className="text-xs text-muted-foreground">
-              Markdown supported. Press Ctrl/Cmd + Enter to save, Escape to
-              cancel.
-            </p>
-          </div>
-        ) : task.description ? (
-          <div
-            className="cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
-            onClick={startEditing}
-            title="Click to edit"
-          >
-            <Markdown
-              onCheckboxChange={handleCheckboxChange}
-              disabled={updateTask.isPending}
-            >
-              {task.description}
-            </Markdown>
-          </div>
-        ) : (
-          <p
-            className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
-            onClick={startEditing}
-            title="Click to add description"
-          >
-            No description provided. Click to add one.
-          </p>
-        )}
-      </CardContent>
-    </Card>
-    {task.constraints ? (
-      <Card className="border-dashed">
+      <Card>
         <CardHeader className="pb-3">
-          <CardTitle className="text-base text-muted-foreground">
-            Constraints
-          </CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">Description</CardTitle>
+            {isEditing ? (
+              <div className="flex items-center gap-2">
+                <Tabs
+                  value={editMode}
+                  onValueChange={(v) => setEditMode(v as "write" | "preview")}
+                >
+                  <TabsList className="h-8">
+                    <TabsTrigger value="write" className="text-xs px-2 h-6">
+                      <Edit3 className="h-3 w-3 mr-1" />
+                      Write
+                    </TabsTrigger>
+                    <TabsTrigger value="preview" className="text-xs px-2 h-6">
+                      <Eye className="h-3 w-3 mr-1" />
+                      Preview
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleCancel}
+                  disabled={updateTask.isPending}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={updateTask.isPending}
+                >
+                  <Check className="h-4 w-4 mr-1" />
+                  Save
+                </Button>
+              </div>
+            ) : (
+              <Button size="sm" variant="ghost" onClick={startEditing}>
+                <Edit3 className="h-4 w-4 mr-1" />
+                Edit
+              </Button>
+            )}
+          </div>
         </CardHeader>
         <CardContent>
-          <p className="text-xs text-muted-foreground mb-3">
-            Architectural standard derived from the project conventions —
-            read-only. Applies to every task in this project.
-          </p>
-          <Markdown>{task.constraints}</Markdown>
+          {isEditing ? (
+            <div className="space-y-2">
+              {editMode === "write" ? (
+                <Textarea
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Add a description..."
+                  className="min-h-[200px] font-mono text-sm"
+                  disabled={updateTask.isPending}
+                  autoFocus
+                />
+              ) : (
+                <div className="min-h-[200px] p-3 border rounded-md bg-muted/30">
+                  {editValue ? (
+                    <Markdown>{editValue}</Markdown>
+                  ) : (
+                    <p className="text-muted-foreground text-sm italic">
+                      Nothing to preview
+                    </p>
+                  )}
+                </div>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Markdown supported. Press Ctrl/Cmd + Enter to save, Escape to
+                cancel.
+              </p>
+            </div>
+          ) : task.description ? (
+            <div
+              className="cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
+              onClick={startEditing}
+              title="Click to edit"
+            >
+              <Markdown
+                onCheckboxChange={handleCheckboxChange}
+                disabled={updateTask.isPending}
+              >
+                {task.description}
+              </Markdown>
+            </div>
+          ) : (
+            <p
+              className="text-muted-foreground italic cursor-pointer hover:bg-muted/30 rounded-md p-2 -m-2 transition-colors"
+              onClick={startEditing}
+              title="Click to add description"
+            >
+              No description provided. Click to add one.
+            </p>
+          )}
         </CardContent>
       </Card>
-    ) : null}
+      {task.constraints ? (
+        <Card className="border-dashed">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base text-muted-foreground">
+              Constraints
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-muted-foreground mb-3">
+              Architectural standard derived from the project conventions —
+              read-only. Applies to every task in this project.
+            </p>
+            <Markdown>{task.constraints}</Markdown>
+          </CardContent>
+        </Card>
+      ) : null}
     </>
   );
 }

--- a/panel/src/lib/__tests__/agent-utils.test.ts
+++ b/panel/src/lib/__tests__/agent-utils.test.ts
@@ -3,8 +3,11 @@ import {
   resolveToSlug,
   getAgentDisplayName,
   getAgentInitials,
+  getAgentTeamColor,
   isKnownAgent,
   registerAgentRoster,
+  TEAM_COLOR_CLASSES,
+  type AgentTeamColor,
 } from "@/lib/agent-utils";
 
 // Canonical UUIDs from the backend roster (roboco/foundation/identity.py).
@@ -85,5 +88,53 @@ describe("agent-utils existing roster (regression guard)", () => {
 
   it("returns Unassigned for null", () => {
     expect(getAgentDisplayName(null)).toBe("Unassigned");
+  });
+});
+
+describe("getAgentTeamColor (design doc §2 — six buckets)", () => {
+  it.each([
+    ["be-dev-1", "backend"],
+    ["be-pm", "backend"],
+    ["fe-dev-2", "frontend"],
+    ["fe-qa", "frontend"],
+    ["ux-dev-1", "ux_ui"],
+    ["ux-doc", "ux_ui"],
+    ["main-pm", "board"],
+    ["product-owner", "board"],
+    ["head-marketing", "board"],
+    ["auditor", "board"],
+    ["ceo", "ceo"],
+    ["CEO", "ceo"],
+    ["intake-1", "system"],
+    ["secretary-1", "system"],
+    ["pr-reviewer-1", "system"],
+  ] satisfies [string, AgentTeamColor][])(
+    "buckets %s as %s",
+    (slug, expected) => {
+      expect(getAgentTeamColor(slug)).toBe(expected);
+    },
+  );
+
+  it("resolves a UUID to its team bucket via the slug map", () => {
+    expect(getAgentTeamColor(BE_DEV_1_UUID)).toBe("backend");
+  });
+
+  it("falls back to system for an unrecognized id, never throwing", () => {
+    expect(getAgentTeamColor("some-unknown-agent")).toBe("system");
+    expect(getAgentTeamColor(null)).toBe("system");
+  });
+
+  it("gives every bucket a class string with no new color families beyond the six", () => {
+    const buckets: AgentTeamColor[] = [
+      "backend",
+      "frontend",
+      "ux_ui",
+      "board",
+      "ceo",
+      "system",
+    ];
+    for (const bucket of buckets) {
+      expect(TEAM_COLOR_CLASSES[bucket]).toBeTruthy();
+    }
   });
 });

--- a/panel/src/lib/agent-utils.ts
+++ b/panel/src/lib/agent-utils.ts
@@ -229,3 +229,59 @@ export function isKnownAgent(agentId: string | null | undefined): boolean {
   if (!agentId) return false;
   return liveByKey.has(agentId) || agentId in AGENT_NAMES;
 }
+
+// ---------------------------------------------------------------------------
+// Team-color identity (design doc:
+// docs/ux_ui/design/02-conversation-first-layout-agent-identity-live-stream.md
+// §2). Color is scoped to the CELL an agent belongs to, not a per-agent hue —
+// legible at 22-agent scale and needs no new bucket when a cell grows.
+// ---------------------------------------------------------------------------
+
+export type AgentTeamColor =
+  | "backend"
+  | "frontend"
+  | "ux_ui"
+  | "board"
+  | "ceo"
+  | "system";
+
+/** Every value here is an existing Tailwind color family already used
+ * elsewhere in the codebase at the same `/15` bg + `/40` border weight
+ * (`a2a-pair-card.tsx`'s pulse treatment) — no new tokens introduced. */
+export const TEAM_COLOR_CLASSES: Record<AgentTeamColor, string> = {
+  backend: "bg-blue-500/15 border-blue-500/40 text-blue-700 dark:text-blue-400",
+  frontend:
+    "bg-violet-500/15 border-violet-500/40 text-violet-700 dark:text-violet-400",
+  ux_ui:
+    "bg-fuchsia-500/15 border-fuchsia-500/40 text-fuchsia-700 dark:text-fuchsia-400",
+  board:
+    "bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-400",
+  // The one human gets the app's own accent, not a team bucket.
+  ceo: "bg-primary/15 border-primary/40 text-primary",
+  system:
+    "bg-slate-500/15 border-slate-500/40 text-slate-700 dark:text-slate-400",
+};
+
+/**
+ * Resolve an agent id (slug or UUID) to its cell color bucket, derived from
+ * the slug prefix. Unknown/unresolved slugs fall back to `system` — a color
+ * layer is a scanning aid, never something that should throw on a stray id.
+ */
+export function getAgentTeamColor(
+  agentId: string | null | undefined,
+): AgentTeamColor {
+  const slug = resolveToSlug(agentId);
+  if (slug === "ceo" || slug === "CEO") return "ceo";
+  if (slug.startsWith("be-")) return "backend";
+  if (slug.startsWith("fe-")) return "frontend";
+  if (slug.startsWith("ux-")) return "ux_ui";
+  if (
+    slug === "main-pm" ||
+    slug === "product-owner" ||
+    slug === "head-marketing" ||
+    slug === "auditor"
+  ) {
+    return "board";
+  }
+  return "system";
+}

--- a/panel/src/store/ui-store.ts
+++ b/panel/src/store/ui-store.ts
@@ -13,11 +13,16 @@ interface UIState {
   // Current context
   currentTeam: Team | null;
 
+  // A2A live view: xl:+ context pane collapse (conversation-first layout
+  // design doc §1) — same persisted-preference idiom as sidebar/theme.
+  a2aContextOpen: boolean;
+
   // Actions
   toggleSidebar: () => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   setTheme: (theme: "light" | "dark" | "system") => void;
   setCurrentTeam: (team: Team | null) => void;
+  toggleA2AContext: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -27,12 +32,15 @@ export const useUIStore = create<UIState>()(
       sidebarCollapsed: false,
       theme: "system",
       currentTeam: null,
+      a2aContextOpen: true,
 
       toggleSidebar: () =>
         set((state) => ({ sidebarOpen: !state.sidebarOpen })),
       setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
       setTheme: (theme) => set({ theme }),
       setCurrentTeam: (team) => set({ currentTeam: team }),
+      toggleA2AContext: () =>
+        set((state) => ({ a2aContextOpen: !state.a2aContextOpen })),
     }),
     {
       name: "roboco-ui-storage",
@@ -40,6 +48,7 @@ export const useUIStore = create<UIState>()(
         sidebarCollapsed: state.sidebarCollapsed,
         theme: state.theme,
         currentTeam: state.currentTeam,
+        a2aContextOpen: state.a2aContextOpen,
       }),
     },
   ),


### PR DESCRIPTION
Implement the full conversation-first A2A redesign per docs/ux_ui/design/02-conversation-first-layout-agent-identity-live-stream.md §1-§5 in a single PR.

§1 Layout: /a2a grid (panel/src/app/(dashboard)/a2a/page.tsx) gains an xl:+ collapsible three-region Roster/Stream/Context layout. The Context pane toggle state persists in localStorage. Context pane shows agent identity cards, a linked-task summary, and a no-task-linked hint; it is read-only.

§2 Identity colors: panel/src/lib/agent-utils.ts exports getAgentTeamColor(team) and a TEAM_COLOR_CLASSES map covering six team buckets. Apply consistently to PairAvatar (a2a-pair-card.tsx), the transcript row avatar (a2a-transcript.tsx), and the new context-pane identity cards. No new Tailwind tokens beyond these six color families — reuse existing spacing/radius/shadow scale everywhere else.

§3 Connection states: the pane header (page.tsx / connection-status.tsx) renders all four ConnectionState values (from panel/src/lib/websocket/connection.ts) distinctly, with a dismissable banner strip specifically for reconnecting and disconnected states, and a prefers-reduced-motion guard on the pulsing connection dot.

§4 Transcript motion: new rows in a2a-transcript.tsx animate in using a transform/opacity-only transition (no top/left/width/height, no raw scroll listeners), plus a scrolled-up 'New messages' pill when the user isn't at the bottom. Both the entrance transition and the pill respect prefers-reduced-motion.

§5 Empty/error states: the transcript distinguishes a 'conversation selected but no messages yet' state from a 'nothing selected' state, and adds a new scoped Retry error state for failed loads — none of these are generic spinners.

Read the spec doc in full before starting; it is the source of truth for exact copy/behavior nuances beyond what's summarized here. This is a revision — check for any prior branch/PR history under this task id before assuming a clean slate (evidence showed none as of task claim, but re-verify).