### PR TITLE
[e8f275d7] Verify CI-status guard + pr_reviewer prompt parity against 7 ACs

### DIFF
--- a/tests/unit/gateway/test_pr_pass_ci_status_guard.py
+++ b/tests/unit/gateway/test_pr_pass_ci_status_guard.py
@@ -15,6 +15,7 @@ entirely, and the separate inbound ``PRReviewerMixin`` surface
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -255,3 +256,45 @@ def test_pr_review_mixin_has_no_ci_status_coupling() -> None:
     assert "get_pr_ci_status" not in source
     assert "_ci_status_guard" not in source
     assert not hasattr(pr_review.PRReviewerMixin, "_ci_status_guard")
+
+
+# ---------------------------------------------------------------------------
+# Regression-lock: this task's 7 ACs mapped to the test(s) that cover each
+# ---------------------------------------------------------------------------
+
+
+def test_ac_coverage_map_and_pr_reviewer_prompt_states_ci_guard() -> None:
+    """Explicit AC-to-test mapping for this task's 7 acceptance criteria.
+
+    AC1 (CI failure names the failing check) ->
+        test_pr_pass_blocked_on_failing_ci (this file, line ~90)
+    AC2 (pending vs error are distinct invalid_state envelopes with a
+        different remediate text) -> test_pr_pass_blocked_on_pending_ci
+        (~111), test_pr_pass_blocked_on_github_api_error (~140)
+    AC3 (pending_not_scheduled is the retryable not-yet-scheduled case) ->
+        test_pr_pass_blocked_on_zero_checks_workflows_pending (~126)
+    AC4 (no_ci_configured passes through + stamps the ci_status verdict
+        note) -> test_pr_pass_passes_through_when_no_ci_configured_and_
+        stamps_evidence (~175)
+    AC5 (all-green CI passes through with no note) ->
+        test_pr_pass_succeeds_on_all_green (~155)
+    AC6 (pr_fail and the inbound PRReviewerMixin have zero CI-status
+        coupling) -> test_pr_fail_succeeds_regardless_of_ci_state (~221),
+        test_pr_review_mixin_has_no_ci_status_coupling (~245)
+    AC7 (the pr_reviewer prompt states the per-AC evidence-walk + CI-status
+        guard section) -> asserted directly below. Previously verified only
+        by manual reading during self-verification, with no test-level
+        regression lock — this closes that gap.
+    """
+    prompt_path = (
+        Path(__file__).resolve().parents[3]
+        / "agents"
+        / "prompts"
+        / "roles"
+        / "pr_reviewer.md"
+    )
+    text = prompt_path.read_text(encoding="utf-8")
+    assert "per-AC evidence-walk" in text
+    assert "named-deliverable/silent-drop rule" in text
+    assert "CI status:" in text
+    assert 'ci_status: "no CI configured on this project"' in text


### PR DESCRIPTION
This exact feature (a CI-status guard wired into pr_pass, plus a per-AC file:line walk added to the pr_reviewer prompt) already landed earlier today under prior tasks a1bde3b9 and c659c278 (merged as commit 000d8cd5, PR #417/#420). Your job is to verify parity rather than re-implement from scratch.

Inspect roboco/services/gateway/choreographer/pr_gate.py (`_ci_status_guard` / `_resolve_ci_status`), tests/unit/gateway/test_pr_pass_ci_status_guard.py, and agents/prompts/roles/pr_reviewer.md. Walk each of the 7 acceptance criteria below one at a time and pin it to the concrete file:line evidence that satisfies it. Run `uv run pytest tests/unit/gateway/test_pr_pass_ci_status_guard.py -q`, `uv run ruff check .`, and `uv run mypy roboco/` to confirm everything is green. If you find a genuine gap against any criterion, fix it with a minimal, scoped commit. If everything is already satisfied, make a small commit (e.g. a short doc/comment note in the test file's module docstring, or in this task's own notes) documenting the criterion→evidence mapping so there is a fresh, inspectable trace tied to this task id, then open the PR.

Do not touch pr_fail or the PRReviewerMixin (claim_pr_review/post_pr_review) surface — the existing regression test (`test_pr_review_mixin_has_no_ci_status_coupling`) asserts they stay uncoupled from CI status.