### PR TITLE
[e0b8a401] Backend: CI-status guard on pr_pass + literal per-AC reviewer prompt

### DIFF
--- a/tests/unit/gateway/test_pr_pass_ci_status_guard.py
+++ b/tests/unit/gateway/test_pr_pass_ci_status_guard.py
@@ -15,6 +15,7 @@ entirely, and the separate inbound ``PRReviewerMixin`` surface
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -255,3 +256,45 @@ def test_pr_review_mixin_has_no_ci_status_coupling() -> None:
     assert "get_pr_ci_status" not in source
     assert "_ci_status_guard" not in source
     assert not hasattr(pr_review.PRReviewerMixin, "_ci_status_guard")
+
+
+# ---------------------------------------------------------------------------
+# Regression-lock: this task's 7 ACs mapped to the test(s) that cover each
+# ---------------------------------------------------------------------------
+
+
+def test_ac_coverage_map_and_pr_reviewer_prompt_states_ci_guard() -> None:
+    """Explicit AC-to-test mapping for this task's 7 acceptance criteria.
+
+    AC1 (CI failure names the failing check) ->
+        test_pr_pass_blocked_on_failing_ci (this file, line ~90)
+    AC2 (pending vs error are distinct invalid_state envelopes with a
+        different remediate text) -> test_pr_pass_blocked_on_pending_ci
+        (~111), test_pr_pass_blocked_on_github_api_error (~140)
+    AC3 (pending_not_scheduled is the retryable not-yet-scheduled case) ->
+        test_pr_pass_blocked_on_zero_checks_workflows_pending (~126)
+    AC4 (no_ci_configured passes through + stamps the ci_status verdict
+        note) -> test_pr_pass_passes_through_when_no_ci_configured_and_
+        stamps_evidence (~175)
+    AC5 (all-green CI passes through with no note) ->
+        test_pr_pass_succeeds_on_all_green (~155)
+    AC6 (pr_fail and the inbound PRReviewerMixin have zero CI-status
+        coupling) -> test_pr_fail_succeeds_regardless_of_ci_state (~221),
+        test_pr_review_mixin_has_no_ci_status_coupling (~245)
+    AC7 (the pr_reviewer prompt states the per-AC evidence-walk + CI-status
+        guard section) -> asserted directly below. Previously verified only
+        by manual reading during self-verification, with no test-level
+        regression lock — this closes that gap.
+    """
+    prompt_path = (
+        Path(__file__).resolve().parents[3]
+        / "agents"
+        / "prompts"
+        / "roles"
+        / "pr_reviewer.md"
+    )
+    text = prompt_path.read_text(encoding="utf-8")
+    assert "per-AC evidence-walk" in text
+    assert "named-deliverable/silent-drop rule" in text
+    assert "CI status:" in text
+    assert 'ci_status: "no CI configured on this project"' in text


### PR DESCRIPTION
Add a CI-status guard to the in-path PR-review gate's pr_pass verb, and harden the pr_reviewer prompt to require literal per-criterion evidence from the diff instead of a gestalt "looks reasonable" pass.

Goal: pr_pass must refuse to pass a PR whose CI on the assembled PR's head commit is not resolvably green — failing, pending, unscheduled, or unresolvable-due-to-API-error must all block (never silently treated as green) — while a project with zero CI configured at all still passes through cleanly. Additionally, the pr_reviewer prompt's in-path gate review section must require reviewers to walk every acceptance criterion one at a time and pin it to a concrete file:line in the diff, and must state the named-deliverable/silent-drop rule (a claimed deliverable that's missing/stubbed/dropped is an automatic pr_fail, never a pass with a note-for-later).

Constraints / existing surfaces to fit into:
- GitService lives in roboco/services/git.py; the gate lives in roboco/services/gateway/choreographer/pr_gate.py (PRGateMixin._pr_pass_blocked already runs a toolchain guard and a conventions guard in sequence — add the CI guard as a third guard in the same pattern, returning a tuple of (rejection, ci_note) rather than just a rejection, since the guard needs to pass evidence through to the verdict note on the no-CI-configured pass-through case).
- The verdict-note stamping machinery is _record_gate_verdict_for / _record_gate_verdict — thread the ci_note through so the PM/CEO can see the guard ran.
- pr_fail must stay completely unaffected — no CI guard runs there.
- The external/fork inbound review path (claim_pr_review / post_pr_review) must stay completely unaffected — this guard is in-path-gate-only.
- The prompt to update is agents/prompts/roles/pr_reviewer.md, in the section describing the in-path PR-review gate (the section right after the existing pr_pass/pr_fail description and the toolchain-blocked note).
- Fail-open discipline: any config gap (missing project/git_url/token, unresolvable head SHA, GitHub API transport error should NOT be conflated with a real "no CI configured" state — a transport error is retryable, distinct from genuinely zero checks with no workflow files in the repo).

Work breakdown (parallelizable across your two devs):
1. GitService.get_pr_ci_status(project, pr_number) plus classification helpers: three-case disambiguation between (a) checks present → classify by conclusions, (b) a genuine GitHub API transport/lookup error → distinct retryable state, (c) zero check-runs → probe for workflow-definition existence to distinguish "not yet scheduled" (retryable) from "no CI configured on this project" (pass-through).
2. Wire a new guard into PRGateMixin._pr_pass_blocked (third guard alongside toolchain/conventions), verdict-note ci_status stamping, and the pr_reviewer.md prompt update.
3. Unit/integration test coverage for every branch named in the acceptance criteria below, plus regression coverage proving pr_fail and the external review path are untouched.

This is server-side gateway/verb-service logic and reviewer-prompt content consumed only by agent roles — no frontend/UX surface. PO and Head of Marketing already reviewed and approved this scope with no changes.