### PR TITLE
[f2f3e89f] Fix RerenderControl gating/placement across queue and strip views

### DIFF
--- a/panel/src/components/dashboard/__tests__/video-pipeline-strip.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-pipeline-strip.test.tsx
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import type { VideoPipelineItem } from "@/lib/api/video";
 
-const { listPipeline } = vi.hoisted(() => ({
+const { listPipeline, rerender } = vi.hoisted(() => ({
   listPipeline: vi.fn(async (): Promise<VideoPipelineItem[]> => []),
+  rerender: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/api", () => ({
-  videoApi: { listPipeline },
+  videoApi: { listPipeline, rerender },
 }));
 
 import { VideoPipelineStrip } from "../video-pipeline-strip";
@@ -61,6 +62,7 @@ const FAILED: VideoPipelineItem = {
 describe("VideoPipelineStrip", () => {
   beforeEach(() => {
     listPipeline.mockClear();
+    rerender.mockClear();
   });
   afterEach(() => {
     vi.clearAllMocks();
@@ -98,5 +100,36 @@ describe("VideoPipelineStrip", () => {
     const reviewLinks = screen.getAllByRole("link", { name: "Review" });
     expect(reviewLinks).toHaveLength(1);
     expect(reviewLinks[0]).toHaveAttribute("href", "/tasks/vp-2");
+  });
+
+  it("shows a re-render button on rendering and render_failed rows with a composition, but not on authoring/awaiting-approval rows", async () => {
+    listPipeline.mockResolvedValueOnce([
+      AUTHORING,
+      AWAITING_APPROVAL,
+      RENDERING,
+      FAILED,
+    ]);
+    render(withQueryClient(<VideoPipelineStrip />));
+    await screen.findByText("Video Pipeline");
+
+    const rerenderButtons = screen.getAllByRole("button", {
+      name: /Re-render/,
+    });
+    expect(rerenderButtons).toHaveLength(2);
+  });
+
+  it("triggers the backend re-render action for the clicked row's authoring task id, behind a confirm dialog", async () => {
+    listPipeline.mockResolvedValueOnce([FAILED]);
+    render(withQueryClient(<VideoPipelineStrip />));
+    await screen.findByText("Video Pipeline");
+
+    fireEvent.click(screen.getByRole("button", { name: /Re-render/ }));
+    expect(rerender).not.toHaveBeenCalled();
+    const confirmButton = await screen.findByRole("button", {
+      name: /Re-render/,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(rerender).toHaveBeenCalledWith("vp-4"));
   });
 });

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -364,7 +364,7 @@ describe("VideoPostQueue", () => {
     expect(screen.queryByText(/No drafts yet/)).not.toBeInTheDocument();
   });
 
-  it("does not show a re-render button when the draft's render is healthy", async () => {
+  it("does not show a re-render button when the draft has no source_task_id/composition_id", async () => {
     render(withQueryClient(<VideoPostQueue />));
     await screen.findByText("release");
     expect(
@@ -372,7 +372,7 @@ describe("VideoPostQueue", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows a re-render button only on a stale draft and triggers the backend re-render action", async () => {
+  it("shows a re-render button on a draft with a composition regardless of render_status, behind a confirm dialog", async () => {
     listPosts.mockResolvedValueOnce([
       {
         task_id: "v-1",
@@ -386,6 +386,7 @@ describe("VideoPostQueue", () => {
         tiktok_caption: "New RoboCo drop!",
         mp4_paths: { vertical: "/fake/vertical.mp4" },
         source_task_id: "auth-1",
+        composition_id: "release-recap",
         render_status: "failed",
       },
     ] as VideoPost[]);
@@ -395,7 +396,41 @@ describe("VideoPostQueue", () => {
     const rerenderButton = screen.getByRole("button", { name: /Re-render/ });
     fireEvent.click(rerenderButton);
 
+    // The action is gated behind a confirm dialog — clicking the trigger
+    // alone must not call the backend.
+    expect(rerender).not.toHaveBeenCalled();
+    const confirmButton = await screen.findByRole("button", {
+      name: /Re-render/,
+    });
+    fireEvent.click(confirmButton);
+
     await waitFor(() => expect(rerender).toHaveBeenCalledWith("auth-1"));
+  });
+
+  it("renders the re-render button for a post with render_status='rendered'", async () => {
+    listPosts.mockResolvedValueOnce([
+      {
+        task_id: "v-1",
+        source: "video_post",
+        title: "Video: release v0.19.0",
+        status: "pending",
+        occasion: "release",
+        script: "RoboCo v0.19.0 just shipped!",
+        platforms: ["x", "tiktok"],
+        x_caption: "RoboCo v0.19.0 is here!",
+        tiktok_caption: "New RoboCo drop!",
+        mp4_paths: { vertical: "/fake/vertical.mp4" },
+        source_task_id: "auth-1",
+        composition_id: "release-recap",
+        render_status: "rendered",
+      },
+    ] as VideoPost[]);
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    expect(
+      screen.getByRole("button", { name: /Re-render/ }),
+    ).toBeInTheDocument();
   });
 
   it("shows the live composition preview iframe with captions when composition_id is present", async () => {

--- a/panel/src/components/dashboard/video-pipeline-strip.tsx
+++ b/panel/src/components/dashboard/video-pipeline-strip.tsx
@@ -9,6 +9,7 @@ import {
   pipelineStageColor,
   pipelineStageLabel,
 } from "./video-pipeline-utils";
+import { RerenderControl } from "@/components/dashboard/video-rerender-control";
 import {
   Card,
   CardContent,
@@ -24,9 +25,17 @@ import { Film } from "lucide-react";
 // derived (never fetched) from status + render_status/render_attempts —
 // see video-pipeline-utils.ts, unit-tested directly there. Only the
 // "awaiting your approval" stage deep-links out (the CEO decision the
-// pipeline is surfacing); every other stage is just visibility.
+// pipeline is surfacing); every other stage is just visibility. The
+// re-render control (shared with video-post-queue.tsx) shows for any item
+// carrying a proposed composition — the "rendering" and "render_failed"
+// stages are the only ones where the item's own task_id doubles as the
+// authoring task id the rerender endpoint needs, regardless of whether the
+// render is currently retrying or has failed outright.
 function PipelineRow({ item }: { item: VideoPipelineItem }) {
   const stage = derivePipelineStage(item);
+  const canRerender =
+    (stage.kind === "rendering" || stage.kind === "render_failed") &&
+    !!item.composition_id;
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-lg border p-3 text-sm">
       <Film className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -45,6 +54,11 @@ function PipelineRow({ item }: { item: VideoPipelineItem }) {
             Review
           </Button>
         </Link>
+      )}
+      {canRerender && (
+        <div className="ml-auto">
+          <RerenderControl authoringTaskId={item.task_id} />
+        </div>
       )}
     </div>
   );

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -32,7 +32,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProjectSelector } from "@/components/projects/project-selector";
-import { CheckCircle2, Film, RefreshCw, Sparkles, XCircle } from "lucide-react";
+import { RerenderControl } from "@/components/dashboard/video-rerender-control";
+import { CheckCircle2, Film, Sparkles, XCircle } from "lucide-react";
 import { toast } from "sonner";
 
 const MAX_X_CAPTION_CHARS = 280;
@@ -64,51 +65,6 @@ function describeExecuteResult(result: VideoPostExecuteResult): string {
   if (result.status === "redis_unavailable")
     return "Redis is unavailable — can't acquire the post lock.";
   return `${result.status}: ${result.detail}`;
-}
-
-// Re-render retry control — only rendered by the caller when the draft's
-// render is stale (render_status === "failed"; see VideoPostRow). Three
-// visual states: idle (button, ready to click), loading (mutation
-// in-flight), error (the retry itself failed — button re-enables so the CEO
-// can try again). Mirrors the pipeline strip's render_failed derivation in
-// video-pipeline-utils.ts.
-function RerenderControl({ authoringTaskId }: { authoringTaskId: string }) {
-  const queryClient = useQueryClient();
-  const rerenderMutation = useMutation({
-    mutationFn: () => videoApi.rerender(authoringTaskId),
-    onSuccess: () => {
-      toast.success("Re-render queued — it will re-pick up on the next cycle.");
-      queryClient.invalidateQueries({ queryKey: ["video", "pipeline"] });
-    },
-    onError: (e) =>
-      toast.error(
-        `Re-render failed: ${e instanceof Error ? e.message : "error"}`,
-      ),
-  });
-
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={rerenderMutation.isPending}
-      onClick={() => rerenderMutation.mutate()}
-      className={
-        rerenderMutation.isError
-          ? "border-destructive text-destructive"
-          : undefined
-      }
-    >
-      <RefreshCw
-        className={`mr-1 h-4 w-4 ${rerenderMutation.isPending ? "animate-spin" : ""}`}
-      />
-      {rerenderMutation.isPending
-        ? "Re-rendering..."
-        : rerenderMutation.isError
-          ? "Retry re-render"
-          : "Re-render"}
-    </Button>
-  );
 }
 
 // Live composition preview: the authoring task's actual HyperFrames HTML for
@@ -228,11 +184,11 @@ function VideoPostRow({
   const tiktokOverLimit =
     editTiktok && tiktokCaption.length > MAX_TIKTOK_CAPTION_CHARS;
   const overLimit = xOverLimit || tiktokOverLimit;
-  // The re-render (CEO retry) endpoint's use case is retrying a render that
-  // hit a terminal failed state — mirrors video-pipeline-utils.ts's
-  // render_failed derivation. Undefined render_status (backend not yet
-  // exposing it on this response, or a healthy render) never shows the button.
-  const isStale = post.render_status === "failed" && !!post.source_task_id;
+  // The re-render endpoint only requires a completed authoring task with a
+  // proposed composition — it doesn't require a failed render, so the
+  // button shows for ANY draft that carries both, regardless of
+  // render_status (a healthy render can be deliberately redone too).
+  const canRerender = !!post.source_task_id && !!post.composition_id;
 
   const handleApprove = () => {
     onApprove(post.task_id, {
@@ -247,9 +203,9 @@ function VideoPostRow({
         <meta.icon className="h-4 w-4 text-muted-foreground" />
         <span className="font-medium">{meta.label}</span>
         {post.occasion && <Badge variant="outline">{post.occasion}</Badge>}
-        {isStale && post.source_task_id && (
+        {canRerender && (
           <div className="ml-auto">
-            <RerenderControl authoringTaskId={post.source_task_id} />
+            <RerenderControl authoringTaskId={post.source_task_id as string} />
           </div>
         )}
       </div>

--- a/panel/src/components/dashboard/video-rerender-control.tsx
+++ b/panel/src/components/dashboard/video-rerender-control.tsx
@@ -15,20 +15,59 @@ import {
 import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
-// Shared re-render control — video-post-queue.tsx (a rendered draft) and
-// video-pipeline-strip.tsx (a still-in-flight authoring task) both render
-// this for any composition-bearing task, regardless of its current
-// render_status: the backend's rerender endpoint only requires a completed
-// authoring task with a proposed composition, not a failed render, so a
-// healthy render can be deliberately redone too. A confirm dialog guards the
-// action since it discards whatever already rendered. Three visual states on
-// the trigger button: idle (ready to click), loading (mutation in-flight),
-// error (the retry itself failed — button re-enables so the CEO can try
-// again). Mirrors the pipeline strip's render_failed derivation in
-// video-pipeline-utils.ts.
+/**
+ * Shared re-render control — renders a button + confirm dialog for re-triggering
+ * video render operations. Used by both video-post-queue.tsx (a rendered draft)
+ * and video-pipeline-strip.tsx (a still-in-flight authoring task).
+ *
+ * @component
+ *
+ * Gating Logic:
+ * - Shows for any task with source_task_id + composition_id, regardless of
+ *   render_status. The backend's rerender endpoint only requires a completed
+ *   authoring task with a proposed composition, not a failed render, so a
+ *   healthy render can be deliberately redone too.
+ *
+ * Behavior:
+ * - Trigger button opens a Dialog with Cancel and Re-render buttons (guards
+ *   against accidental clicks, since re-rendering discards whatever already
+ *   rendered).
+ * - Only the confirm click calls videoApi.rerender(authoringTaskId).
+ * - Three visual states on the trigger button:
+ *   1. Idle: "Re-render" (ready to click)
+ *   2. Loading: "Re-rendering..." with spinning icon (mutation in-flight)
+ *   3. Error: "Retry re-render" in red (the retry itself failed; button stays
+ *      enabled so the CEO can try again).
+ *
+ * @example
+ * ```tsx
+ * // Usage in video-post-queue for a rendered draft:
+ * {canRerender && (
+ *   <div className="ml-auto">
+ *     <RerenderControl authoringTaskId={post.source_task_id as string} />
+ *   </div>
+ * )}
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Usage in video-pipeline-strip for an in-flight authoring task:
+ * {canRerender && (
+ *   <div className="ml-auto">
+ *     <RerenderControl authoringTaskId={item.task_id} />
+ *   </div>
+ * )}
+ * ```
+ */
 export function RerenderControl({
   authoringTaskId,
 }: {
+  /**
+   * The authoring task ID to re-render. Passed to videoApi.rerender(authoringTaskId).
+   * For video-post-queue: the post's source_task_id.
+   * For video-pipeline-strip: the pipeline item's own task_id (a pipeline item IS
+   * the authoring task).
+   */
   authoringTaskId: string;
 }) {
   const queryClient = useQueryClient();

--- a/panel/src/components/dashboard/video-rerender-control.tsx
+++ b/panel/src/components/dashboard/video-rerender-control.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { videoApi } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+
+// Shared re-render control — video-post-queue.tsx (a rendered draft) and
+// video-pipeline-strip.tsx (a still-in-flight authoring task) both render
+// this for any composition-bearing task, regardless of its current
+// render_status: the backend's rerender endpoint only requires a completed
+// authoring task with a proposed composition, not a failed render, so a
+// healthy render can be deliberately redone too. A confirm dialog guards the
+// action since it discards whatever already rendered. Three visual states on
+// the trigger button: idle (ready to click), loading (mutation in-flight),
+// error (the retry itself failed — button re-enables so the CEO can try
+// again). Mirrors the pipeline strip's render_failed derivation in
+// video-pipeline-utils.ts.
+export function RerenderControl({
+  authoringTaskId,
+}: {
+  authoringTaskId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const rerenderMutation = useMutation({
+    mutationFn: () => videoApi.rerender(authoringTaskId),
+    onSuccess: () => {
+      toast.success("Re-render queued — it will re-pick up on the next cycle.");
+      queryClient.invalidateQueries({ queryKey: ["video", "pipeline"] });
+      queryClient.invalidateQueries({ queryKey: ["video", "posts"] });
+    },
+    onError: (e) =>
+      toast.error(
+        `Re-render failed: ${e instanceof Error ? e.message : "error"}`,
+      ),
+  });
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={rerenderMutation.isPending}
+        onClick={() => setConfirmOpen(true)}
+        className={
+          rerenderMutation.isError
+            ? "border-destructive text-destructive"
+            : undefined
+        }
+      >
+        <RefreshCw
+          className={`mr-1 h-4 w-4 ${rerenderMutation.isPending ? "animate-spin" : ""}`}
+        />
+        {rerenderMutation.isPending
+          ? "Re-rendering..."
+          : rerenderMutation.isError
+            ? "Retry re-render"
+            : "Re-render"}
+      </Button>
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Re-render this video?</DialogTitle>
+            <DialogDescription>
+              This clears the current render and queues a fresh one from the
+              same composition. Any already-rendered cuts stay visible until
+              the new render finishes.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                setConfirmOpen(false);
+                rerenderMutation.mutate();
+              }}
+            >
+              Re-render
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
RerenderControl currently only shows for failed renders. Fix it so it renders for ANY post that has a source_task_id and a composition, regardless of render_status (including render_status='rendered'), gated behind a confirm dialog to prevent accidental re-renders. Do not regress the existing failed-state re-render path — extend, don't replace, its coverage. Ensure the SAME shared component (not a fork) with the SAME confirm-dialog copy is used in both panel/src/components/video-post-queue.tsx and panel/src/components/video-pipeline-strip.tsx. Add a test asserting the re-render button renders for a post with render_status='rendered'. Run pnpm lint/typecheck/test before submitting.