### PR TITLE
[404d8ed3] Filter project picker to video-engine-enabled projects

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -11,6 +11,7 @@ Documentation for the Frontend Cell team.
 
 - `/components/` - Component documentation
   - [Page-scoped refresh provider](./components/page-refresh-provider.md) — `PageRefreshProvider` callback registry that lets the navbar refresh button re-fetch only the current page.
+  - [Project selector](./components/project-selector.md) — `ProjectSelector` dropdown for picking a project, with optional filtering by team and video-engine enablement.
 - `/hooks/` - Hook documentation
 - `/qa/` - QA-related docs
 

--- a/docs/frontend/components/project-selector.md
+++ b/docs/frontend/components/project-selector.md
@@ -1,0 +1,209 @@
+# ProjectSelector component
+
+A reusable dropdown selector for picking a project, with optional filtering by team and video-engine opt-in status.
+
+## Purpose
+
+Panels and dialogs that need to let users pick a project use `ProjectSelector` to display and filter the list. The component fetches the project list via the `useProjects` hook, groups projects by their assigned team, and optionally filters by team membership or video-engine enablement.
+
+## Files
+
+| File | Role |
+|------|------|
+| `panel/src/components/projects/project-selector.tsx` | Main component and `ProjectSelectorProps` type. |
+| `panel/src/components/projects/__tests__/project-selector.test.tsx` | Component tests (filter, grouping). |
+| `panel/src/lib/api/projects.ts` | `useProjects` hook and mock-mode project data. |
+| `panel/src/types/index.ts` | `ProjectSummary` type (includes `video_engine_enabled`). |
+
+## API
+
+### `ProjectSelectorProps`
+
+```typescript
+interface ProjectSelectorProps {
+  // The currently selected project ID (null for unselected)
+  value: string | null;
+  // Called when the user selects a project
+  onChange: (projectId: string | null) => void;
+  // Placeholder text shown when no project is selected
+  placeholder?: string;
+  // Filter to projects assigned to a specific team (optional)
+  filterByTeam?: Team;
+  // Disable the selector (optional, default: false)
+  disabled?: boolean;
+  // Whether to clear the selection when the user deselects (optional, default: true)
+  allowClear?: boolean;
+  // Restrict the list to projects with video_engine_enabled = true (optional, default: false)
+  videoEngineOnly?: boolean;
+}
+```
+
+**Props explained:**
+
+- `value` — the currently selected project's ID, or `null` if unselected. The selector updates this via `onChange`.
+- `onChange` — callback fired when the user selects a project (receives the project ID) or clears the selection (receives `null` if `allowClear` is true).
+- `placeholder` — text shown in the trigger button when `value` is `null`. Defaults to "Select a project...".
+- `filterByTeam` — if set, only show projects assigned to this team (e.g. `Team.FRONTEND`). Useful when an operation is scoped to a single team.
+- `disabled` — if true, the dropdown is unclickable and grayed out.
+- `allowClear` — if true (default), the user can click a clear button to set `value` to `null` and trigger `onChange(null)`. If false, a selection is mandatory.
+- `videoEngineOnly` — if true, filter the project list to only projects with `video_engine_enabled === true`. Used by video-authoring flows (e.g. `RequestVideoDialog`) to show only opted-in projects.
+
+### `ProjectSummary`
+
+The shape of each project in the list:
+
+```typescript
+interface ProjectSummary {
+  id: string;
+  name: string;
+  slug: string;
+  git_url: string;
+  assigned_cell: Team;
+  is_active: boolean;
+  has_workspace: boolean;
+  has_git_token: boolean;
+  video_engine_enabled: boolean;
+}
+```
+
+- `video_engine_enabled` — whether the project has opted into the video engine. Used by the `videoEngineOnly` filter.
+
+## How to use
+
+### Basic usage
+
+Pick any project in the list:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ProjectSelector } from "@/components/projects/project-selector";
+
+export default function MyComponent() {
+  const [projectId, setProjectId] = useState<string | null>(null);
+
+  return (
+    <div>
+      <ProjectSelector
+        value={projectId}
+        onChange={setProjectId}
+        placeholder="Select a project..."
+      />
+      {projectId && <p>You picked: {projectId}</p>}
+    </div>
+  );
+}
+```
+
+### Filter by team
+
+Show only projects in a specific team:
+
+```tsx
+import { Team } from "@/types";
+
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  filterByTeam={Team.FRONTEND}
+  placeholder="Select a frontend project..."
+/>
+```
+
+### Filter by video-engine opt-in
+
+Show only projects that have opted into the video engine (for video-authoring dialogs):
+
+```tsx
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  videoEngineOnly
+  placeholder="Select a project with video enabled..."
+/>
+```
+
+### Mandatory selection
+
+Disable the clear button so the user must pick a project:
+
+```tsx
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  allowClear={false}
+  placeholder="Project (required)"
+/>
+```
+
+### Combine filters
+
+Both team and video-engine filters can be used together:
+
+```tsx
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  filterByTeam={Team.BACKEND}
+  videoEngineOnly
+  placeholder="Backend projects with video enabled..."
+/>
+```
+
+## Filtering order
+
+Filters are applied in this order:
+
+1. **Video-engine filter** (if `videoEngineOnly` is true) — keep only projects with `video_engine_enabled === true`.
+2. **Team filter** (if `filterByTeam` is set) — keep only projects assigned to the given team.
+3. **Grouping** — group the remaining projects by their assigned team for display.
+
+This ensures a video-engine-filtered list still groups correctly, and a team-filtered list can still have the video-engine filter applied on top.
+
+## Empty states
+
+The component handles empty states gracefully:
+
+- **No projects in the data source** — the dropdown shows the placeholder and is disabled.
+- **All projects filtered out** — the dropdown shows the placeholder and is disabled. This happens when all available projects are filtered by `videoEngineOnly` or `filterByTeam`.
+- **No projects with video enabled** (when `videoEngineOnly` is true) — a calling dialog (like `RequestVideoDialog`) should check `videoProjects.length` and show a friendly empty-state message to the user.
+
+## Loading state
+
+The selector uses the `useProjects` hook, which may return `isLoading: true` while fetching the project list. The selector passes this through as a `disabled` state until the data arrives.
+
+## Design decisions
+
+- **Radix UI Select**: built on Radix's `<Select>` primitive for accessibility (keyboard navigation, ARIA labels).
+- **TanStack Query caching**: projects are fetched once via `useProjects` and cached, so multiple selectors on the same page share the same query.
+- **Usable without TypeScript**: the component type-checks all inputs but can be used from plain JS contexts (e.g. test fixtures) by omitting types.
+- **Memoized grouping**: the grouping computation is memoized with a dependency array so re-renders don't re-compute groups unless the filter props change.
+
+## Testing
+
+Run the selector tests with:
+
+```bash
+cd panel
+pnpm test project-selector
+```
+
+Covered behaviors:
+
+- `videoEngineOnly` filters out projects with `video_engine_enabled === false`.
+- Without `videoEngineOnly`, all projects appear in the list.
+- Team filtering works independently and in combination with video-engine filtering.
+- Selecting a project calls `onChange` with the project ID.
+- Clearing a selection (when `allowClear` is true) calls `onChange(null)`.
+- The selector is disabled when `disabled` prop is true or while data is loading.
+- The selector is disabled when all projects are filtered out.
+
+## Related work
+
+- **RequestVideoDialog** (`panel/src/components/dashboard/video-post-queue.tsx`) — uses `videoEngineOnly` to show only projects that have opted into the video engine for on-demand video requests.
+- **ProjectsPage** (`app/(dashboard)/projects/page.tsx`) — uses the base selector without filters to list and manage all projects.
+
+## Migration / rollout
+
+No breaking changes. The new `videoEngineOnly` prop defaults to `false`, so existing uses of `ProjectSelector` are unaffected. New code that needs to filter by video-engine opt-in status should pass `videoEngineOnly={true}`.

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -8,6 +8,30 @@ const { resolveApproveRef } = vi.hoisted(() => ({
   resolveApproveRef: { current: null as null | ((v: unknown) => void) },
 }));
 
+const { useProjects } = vi.hoisted(() => ({
+  // One video-enabled project by default ("p-1", matching the mocked
+  // ProjectSelector's onChange value below) so the dialog can default-select
+  // it — tests that need the empty-state override this per-test.
+  useProjects: vi.fn(() => ({
+    data: [
+      {
+        id: "p-1",
+        name: "roboco-panel",
+        slug: "roboco-panel",
+        git_url: "https://example.com/roboco-panel.git",
+        assigned_cell: "frontend",
+        is_active: true,
+        has_workspace: true,
+        has_git_token: true,
+        video_engine_enabled: true,
+      },
+    ],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-projects", () => ({ useProjects }));
+
 const {
   listPosts,
   listPipeline,
@@ -314,21 +338,63 @@ describe("VideoPostQueue", () => {
     );
   });
 
-  it("keeps Request disabled until a project is picked", async () => {
+  it("defaults the project to the current (first) video-enabled project so Request enables without an explicit pick", async () => {
     render(withQueryClient(<VideoPostQueue />));
     await screen.findByText("release");
 
     fireEvent.click(screen.getByRole("button", { name: /Request a video/ }));
+    // Request still needs occasion/brief filled...
+    expect(screen.getByRole("button", { name: "Request" })).toBeDisabled();
     fireEvent.change(screen.getByLabelText("Occasion"), {
       target: { value: "Founder's Day" },
     });
     fireEvent.change(screen.getByLabelText("Brief"), {
       target: { value: "Celebrate the founding." },
     });
-    expect(screen.getByRole("button", { name: "Request" })).toBeDisabled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Set Project" }));
+    // ...but never a manual "Set Project" click — the picker already
+    // defaulted to the sole video-enabled project.
     expect(screen.getByRole("button", { name: "Request" })).not.toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Request" }));
+    await waitFor(() =>
+      expect(requestVideo).toHaveBeenCalledWith(
+        expect.objectContaining({ project_id: "p-1" }),
+      ),
+    );
+  });
+
+  it("shows a friendly empty-state when no project has the video engine enabled", async () => {
+    // mockReturnValue (not -Once): RequestVideoDialog re-renders more than
+    // once before the assertions run, and a -Once override would only cover
+    // the first of those renders.
+    useProjects.mockReturnValue({
+      data: [
+        {
+          id: "p-2",
+          name: "not-opted-in",
+          slug: "not-opted-in",
+          git_url: "https://example.com/not-opted-in.git",
+          assigned_cell: "backend",
+          is_active: true,
+          has_workspace: true,
+          has_git_token: true,
+          video_engine_enabled: false,
+        },
+      ],
+      isLoading: false,
+    });
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    fireEvent.click(screen.getByRole("button", { name: /Request a video/ }));
+    expect(
+      screen.getByText(/No projects have the video engine enabled/),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Occasion")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Request" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("shows the keys/engine empty copy when nothing is in the pipeline either", async () => {

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -32,6 +32,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProjectSelector } from "@/components/projects/project-selector";
+import { useProjects } from "@/hooks/use-projects";
 import { CheckCircle2, Film, RefreshCw, Sparkles, XCircle } from "lucide-react";
 import { toast } from "sonner";
 
@@ -402,7 +403,14 @@ function RequestVideoDialog({
   const [occasion, setOccasion] = useState("");
   const [brief, setBrief] = useState("");
   const [platforms, setPlatforms] = useState<string[]>(["x", "tiktok"]);
+  // null means "no explicit pick yet" — derived below to the current (first)
+  // video-enabled project, mirroring the caption-tracking pattern elsewhere
+  // in this file (`editedX ?? post.x_caption`) rather than syncing via effect.
   const [projectId, setProjectId] = useState<string | null>(null);
+  const { data: allProjects = [] } = useProjects();
+  const videoProjects = allProjects.filter((p) => p.video_engine_enabled);
+  const hasVideoProjects = videoProjects.length > 0;
+  const effectiveProjectId = projectId ?? videoProjects[0]?.id ?? null;
 
   const requestMutation = useMutation({
     mutationFn: () =>
@@ -410,7 +418,7 @@ function RequestVideoDialog({
         occasion: occasion.trim(),
         brief: brief.trim(),
         platforms,
-        project_id: projectId as string,
+        project_id: effectiveProjectId as string,
       }),
     onSuccess: (result) => {
       if (result.status === "opened") {
@@ -439,7 +447,7 @@ function RequestVideoDialog({
   };
 
   const canSubmit =
-    !!projectId &&
+    !!effectiveProjectId &&
     occasion.trim().length > 0 &&
     brief.trim().length > 0 &&
     platforms.length > 0;
@@ -455,67 +463,85 @@ function RequestVideoDialog({
             rendering finishes.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label>Project</Label>
-            <ProjectSelector
-              value={projectId}
-              onChange={setProjectId}
-              placeholder="Select the project this video is about..."
-              allowClear={false}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="video-request-occasion">Occasion</Label>
-            <Input
-              id="video-request-occasion"
-              placeholder="e.g. v0.19.0 launch, Founder's Day..."
-              value={occasion}
-              onChange={(e) => setOccasion(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="video-request-brief">Brief</Label>
-            <Textarea
-              id="video-request-brief"
-              placeholder="What should this video cover?"
-              value={brief}
-              onChange={(e) => setBrief(e.target.value)}
-              rows={4}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Platforms</Label>
-            <div className="flex gap-4">
-              {REQUEST_PLATFORMS.map((platform) => (
-                <div key={platform} className="flex items-center gap-2">
-                  <Checkbox
-                    id={`video-request-${platform}`}
-                    checked={platforms.includes(platform)}
-                    onCheckedChange={() => togglePlatform(platform)}
-                  />
-                  <Label
-                    htmlFor={`video-request-${platform}`}
-                    className="text-sm font-normal"
-                  >
-                    {PLATFORM_LABELS[platform]}
-                  </Label>
+        {hasVideoProjects ? (
+          <>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>Project</Label>
+                <ProjectSelector
+                  value={effectiveProjectId}
+                  onChange={setProjectId}
+                  placeholder="Select the project this video is about..."
+                  allowClear={false}
+                  videoEngineOnly
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="video-request-occasion">Occasion</Label>
+                <Input
+                  id="video-request-occasion"
+                  placeholder="e.g. v0.19.0 launch, Founder's Day..."
+                  value={occasion}
+                  onChange={(e) => setOccasion(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="video-request-brief">Brief</Label>
+                <Textarea
+                  id="video-request-brief"
+                  placeholder="What should this video cover?"
+                  value={brief}
+                  onChange={(e) => setBrief(e.target.value)}
+                  rows={4}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Platforms</Label>
+                <div className="flex gap-4">
+                  {REQUEST_PLATFORMS.map((platform) => (
+                    <div key={platform} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`video-request-${platform}`}
+                        checked={platforms.includes(platform)}
+                        onCheckedChange={() => togglePlatform(platform)}
+                      />
+                      <Label
+                        htmlFor={`video-request-${platform}`}
+                        className="text-sm font-normal"
+                      >
+                        {PLATFORM_LABELS[platform]}
+                      </Label>
+                    </div>
+                  ))}
                 </div>
-              ))}
+              </div>
             </div>
-          </div>
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            onClick={() => requestMutation.mutate()}
-            disabled={!canSubmit || requestMutation.isPending}
-          >
-            {requestMutation.isPending ? "Requesting..." : "Request"}
-          </Button>
-        </DialogFooter>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() => requestMutation.mutate()}
+                disabled={!canSubmit || requestMutation.isPending}
+              >
+                {requestMutation.isPending ? "Requesting..." : "Request"}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              No projects have the video engine enabled yet. Turn it on for a
+              project in its edit dialog (Projects → Edit) before requesting a
+              video.
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/panel/src/components/projects/__tests__/project-selector.test.tsx
+++ b/panel/src/components/projects/__tests__/project-selector.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Team } from "@/types";
+import type { ProjectSummary } from "@/types";
+
+const { useProjects } = vi.hoisted(() => ({ useProjects: vi.fn() }));
+vi.mock("@/hooks/use-projects", () => ({ useProjects }));
+
+// Make the Select testable without Radix's portal/pointer machinery — mirrors
+// a2a-reply-composer.test.tsx: SelectContent always renders its children, so
+// the assertions below can query rendered project names directly.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectLabel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import { ProjectSelector } from "../project-selector";
+
+function project(overrides: Partial<ProjectSummary>): ProjectSummary {
+  return {
+    id: "p-id",
+    name: "project",
+    slug: "project",
+    git_url: "https://example.com/project.git",
+    assigned_cell: Team.FRONTEND,
+    is_active: true,
+    has_workspace: true,
+    has_git_token: true,
+    video_engine_enabled: false,
+    ...overrides,
+  };
+}
+
+describe("ProjectSelector", () => {
+  it("videoEngineOnly excludes projects that have not opted into the video engine", () => {
+    useProjects.mockReturnValue({
+      data: [
+        project({ id: "p-1", name: "Video Ready", video_engine_enabled: true }),
+        project({
+          id: "p-2",
+          name: "Not Opted In",
+          video_engine_enabled: false,
+        }),
+      ],
+      isLoading: false,
+    });
+
+    render(<ProjectSelector value={null} onChange={vi.fn()} videoEngineOnly />);
+
+    expect(screen.getByText("Video Ready")).toBeInTheDocument();
+    expect(screen.queryByText("Not Opted In")).not.toBeInTheDocument();
+  });
+
+  it("shows every project when videoEngineOnly is not set", () => {
+    useProjects.mockReturnValue({
+      data: [
+        project({ id: "p-1", name: "Video Ready", video_engine_enabled: true }),
+        project({
+          id: "p-2",
+          name: "Not Opted In",
+          video_engine_enabled: false,
+        }),
+      ],
+      isLoading: false,
+    });
+
+    render(<ProjectSelector value={null} onChange={vi.fn()} />);
+
+    expect(screen.getByText("Video Ready")).toBeInTheDocument();
+    expect(screen.getByText("Not Opted In")).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/projects/project-selector.tsx
+++ b/panel/src/components/projects/project-selector.tsx
@@ -22,6 +22,10 @@ interface ProjectSelectorProps {
   filterByTeam?: Team;
   disabled?: boolean;
   allowClear?: boolean;
+  // Restrict the list to projects with the video engine opted in
+  // (project.video_engine_enabled) — for pickers scoped to video-authoring
+  // flows (e.g. RequestVideoDialog).
+  videoEngineOnly?: boolean;
 }
 
 // Team display names for project cells
@@ -38,12 +42,18 @@ export function ProjectSelector({
   filterByTeam,
   disabled = false,
   allowClear = true,
+  videoEngineOnly = false,
 }: ProjectSelectorProps) {
   const { data: projects = [], isLoading } = useProjects();
 
   // Group projects by team/cell
   const groupedProjects = useMemo(() => {
     let filtered = projects;
+
+    // Restrict to video-engine-opted-in projects
+    if (videoEngineOnly) {
+      filtered = filtered.filter((p) => p.video_engine_enabled);
+    }
 
     // Apply team filter
     if (filterByTeam) {
@@ -71,7 +81,7 @@ export function ProjectSelector({
     }
 
     return groups;
-  }, [projects, filterByTeam]);
+  }, [projects, filterByTeam, videoEngineOnly]);
 
   // Find selected project for display
   const selectedProject = useMemo(() => {

--- a/panel/src/lib/api/projects.ts
+++ b/panel/src/lib/api/projects.ts
@@ -40,6 +40,7 @@ export const projectsApi = {
         is_active: p.is_active,
         has_workspace: !!p.workspace_path,
         has_git_token: false, // Mock mode has no tokens
+        video_engine_enabled: p.video_engine_enabled,
       }));
     }
 

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -1087,6 +1087,7 @@ export interface ProjectSummary {
   is_active: boolean;
   has_workspace: boolean;
   has_git_token: boolean;
+  video_engine_enabled: boolean;
 }
 
 export interface ProductCellMapping {


### PR DESCRIPTION
Add video_engine_enabled to the client ProjectSummary type (backend field already landed). Add a videoEngineOnly prop to ProjectSelector that, when true, filters the project list to only opted-in projects; default false/undefined so other callers of ProjectSelector are unaffected. Update RequestVideoDialog to pass videoEngineOnly, default its picker selection to the current project, and show a friendly empty-state message when no video-enabled projects exist. Add a test asserting the picker excludes non-opted-in projects. Run pnpm lint/typecheck/test before submitting.