### PR TITLE
[f3210a16] Implement 2-column objectives grid in goals-tab.tsx

### DIFF
--- a/panel/src/components/business/__tests__/goals-tab.test.tsx
+++ b/panel/src/components/business/__tests__/goals-tab.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { CompanyGoals } from "@/lib/api/company-goals";
+
+// ---------------------------------------------------------------------------
+// Mock @tanstack/react-query so we can control useQuery/useMutation return
+// values without a real QueryClientProvider.
+// ---------------------------------------------------------------------------
+
+const { mockUseQuery, mockUseMutation, mockMutate } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+  mockUseMutation: vi.fn(),
+  mockMutate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+    useMutation: mockUseMutation,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+vi.mock("@/lib/api/company-goals", () => ({
+  companyGoalsApi: {
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks are set up
+// ---------------------------------------------------------------------------
+
+import { GoalsTab } from "../goals-tab";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildGoals(overrides: Partial<CompanyGoals> = {}): CompanyGoals {
+  return {
+    north_star: "Ship things",
+    objectives: [
+      { metric: "Lead time", target: "< 24h", status: "Active" },
+      { metric: "Escaped defects", target: "0", status: "Active" },
+    ],
+    constraints: [],
+    operating_policy: {},
+    brand_voice: "",
+    updated_at: null,
+    updated_by: null,
+    ...overrides,
+  };
+}
+
+function setup(goals: CompanyGoals) {
+  mockUseQuery.mockReturnValue({
+    data: goals,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  mockUseMutation.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  });
+}
+
+describe("GoalsTab — ObjectivesEditor grid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the objectives container as a 2-column grid that collapses to 1 column on mobile", () => {
+    setup(buildGoals());
+
+    render(<GoalsTab />);
+
+    const objectiveOne = screen.getByText("Objective #1");
+    // The grid wrapper is the parent of each objective card.
+    const gridContainer = objectiveOne.closest("div.rounded-lg")
+      ?.parentElement as HTMLElement;
+
+    expect(gridContainer).toHaveClass("grid");
+    expect(gridContainer).toHaveClass("grid-cols-1");
+    expect(gridContainer).toHaveClass("md:grid-cols-2");
+  });
+
+  it("keeps add/remove/edit objective behavior working", () => {
+    setup(buildGoals());
+
+    render(<GoalsTab />);
+
+    // Two seeded objectives render as separate cards.
+    expect(screen.getByText("Objective #1")).toBeInTheDocument();
+    expect(screen.getByText("Objective #2")).toBeInTheDocument();
+
+    // Edit a field on the first objective (both rows share the "metric" label,
+    // so grab the first one — it belongs to Objective #1's input group).
+    const metricInput = screen.getAllByLabelText(
+      "metric",
+    )[0] as HTMLInputElement;
+    fireEvent.change(metricInput, { target: { value: "Updated metric" } });
+    expect(metricInput.value).toBe("Updated metric");
+
+    // Add a new objective row.
+    fireEvent.click(screen.getByText("+ Add objective"));
+    expect(screen.getByText("Objective #3")).toBeInTheDocument();
+
+    // Remove the second objective row; remaining rows renumber to #1/#2.
+    const removeButtons = screen.getAllByText("Remove");
+    fireEvent.click(removeButtons[1]);
+    expect(screen.getAllByText(/^Objective #/)).toHaveLength(2);
+    expect(screen.queryByText("Objective #3")).not.toBeInTheDocument();
+  });
+});

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -52,6 +52,19 @@ interface ObjectivesEditorProps {
   disabled: boolean;
 }
 
+/**
+ * ObjectivesEditor renders a responsive 2-column grid of objective cards.
+ *
+ * Layout:
+ * - Desktop (md+): 2-column grid with 3px gap
+ * - Mobile: 1-column stack (full width)
+ *
+ * Each card shows a set of editable fields derived from the first objective
+ * (metric, target, status, etc.) with add/remove controls. The outer container
+ * maintains space-y-3 gap to separate the grid from the "Add objective" button.
+ *
+ * Tests: `goals-tab.test.tsx` asserts the grid classes and add/remove/edit behavior.
+ */
 function ObjectivesEditor({
   items,
   onChange,

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -80,42 +80,44 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      {items.map((item, rowIdx) => (
-        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
-              Objective #{rowIdx + 1}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={disabled}
-              onClick={() => removeRow(rowIdx)}
-              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-            >
-              Remove
-            </Button>
-          </div>
-          {keys.map((key) => (
-            <div key={key} className="space-y-1">
-              <Label
-                htmlFor={`obj-${rowIdx}-${key}`}
-                className="text-xs capitalize"
-              >
-                {key.replace(/_/g, " ")}
-              </Label>
-              <Input
-                id={`obj-${rowIdx}-${key}`}
-                value={String(item[key] ?? "")}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {items.map((item, rowIdx) => (
+          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                Objective #{rowIdx + 1}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
                 disabled={disabled}
-                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                className="h-8 text-sm"
-              />
+                onClick={() => removeRow(rowIdx)}
+                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+              >
+                Remove
+              </Button>
             </div>
-          ))}
-        </div>
-      ))}
+            {keys.map((key) => (
+              <div key={key} className="space-y-1">
+                <Label
+                  htmlFor={`obj-${rowIdx}-${key}`}
+                  className="text-xs capitalize"
+                >
+                  {key.replace(/_/g, " ")}
+                </Label>
+                <Input
+                  id={`obj-${rowIdx}-${key}`}
+                  value={String(item[key] ?? "")}
+                  disabled={disabled}
+                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
       <Button
         type="button"
         variant="outline"


### PR DESCRIPTION
In panel/src/components (goals-tab.tsx), change the ObjectivesEditor items container's className from `space-y-3` to a responsive grid: `grid grid-cols-1 md:grid-cols-2` plus an appropriate gap utility (e.g. gap-3), so objectives render in two columns at desktop (md:) width and collapse to a single column below md:. Do not change the add/remove/edit objective logic itself — only the container's layout classes. Run the existing objective add/remove/edit tests to confirm no regression. Add or update a test that asserts the grid layout has 2 columns at desktop width and collapses to a single column at mobile width (e.g. via computed class assertions or a viewport-width test util already used in the panel test suite). Do not touch panel/src/components/layout/sidebar.tsx or its test file — a prior task (dc518639) had to revert a similar change after it leaked into that file via an unrelated PR; keep this diff confined to goals-tab.tsx and its own test file.