### PR TITLE
[03607ab9] Fix re-render control gating/placement and project picker filter

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -11,6 +11,7 @@ Documentation for the Frontend Cell team.
 
 - `/components/` - Component documentation
   - [Page-scoped refresh provider](./components/page-refresh-provider.md) — `PageRefreshProvider` callback registry that lets the navbar refresh button re-fetch only the current page.
+  - [Project selector](./components/project-selector.md) — `ProjectSelector` dropdown for picking a project, with optional filtering by team and video-engine enablement.
 - `/hooks/` - Hook documentation
 - `/qa/` - QA-related docs
 

--- a/docs/frontend/components/project-selector.md
+++ b/docs/frontend/components/project-selector.md
@@ -1,0 +1,209 @@
+# ProjectSelector component
+
+A reusable dropdown selector for picking a project, with optional filtering by team and video-engine opt-in status.
+
+## Purpose
+
+Panels and dialogs that need to let users pick a project use `ProjectSelector` to display and filter the list. The component fetches the project list via the `useProjects` hook, groups projects by their assigned team, and optionally filters by team membership or video-engine enablement.
+
+## Files
+
+| File | Role |
+|------|------|
+| `panel/src/components/projects/project-selector.tsx` | Main component and `ProjectSelectorProps` type. |
+| `panel/src/components/projects/__tests__/project-selector.test.tsx` | Component tests (filter, grouping). |
+| `panel/src/lib/api/projects.ts` | `useProjects` hook and mock-mode project data. |
+| `panel/src/types/index.ts` | `ProjectSummary` type (includes `video_engine_enabled`). |
+
+## API
+
+### `ProjectSelectorProps`
+
+```typescript
+interface ProjectSelectorProps {
+  // The currently selected project ID (null for unselected)
+  value: string | null;
+  // Called when the user selects a project
+  onChange: (projectId: string | null) => void;
+  // Placeholder text shown when no project is selected
+  placeholder?: string;
+  // Filter to projects assigned to a specific team (optional)
+  filterByTeam?: Team;
+  // Disable the selector (optional, default: false)
+  disabled?: boolean;
+  // Whether to clear the selection when the user deselects (optional, default: true)
+  allowClear?: boolean;
+  // Restrict the list to projects with video_engine_enabled = true (optional, default: false)
+  videoEngineOnly?: boolean;
+}
+```
+
+**Props explained:**
+
+- `value` — the currently selected project's ID, or `null` if unselected. The selector updates this via `onChange`.
+- `onChange` — callback fired when the user selects a project (receives the project ID) or clears the selection (receives `null` if `allowClear` is true).
+- `placeholder` — text shown in the trigger button when `value` is `null`. Defaults to "Select a project...".
+- `filterByTeam` — if set, only show projects assigned to this team (e.g. `Team.FRONTEND`). Useful when an operation is scoped to a single team.
+- `disabled` — if true, the dropdown is unclickable and grayed out.
+- `allowClear` — if true (default), the user can click a clear button to set `value` to `null` and trigger `onChange(null)`. If false, a selection is mandatory.
+- `videoEngineOnly` — if true, filter the project list to only projects with `video_engine_enabled === true`. Used by video-authoring flows (e.g. `RequestVideoDialog`) to show only opted-in projects.
+
+### `ProjectSummary`
+
+The shape of each project in the list:
+
+```typescript
+interface ProjectSummary {
+  id: string;
+  name: string;
+  slug: string;
+  git_url: string;
+  assigned_cell: Team;
+  is_active: boolean;
+  has_workspace: boolean;
+  has_git_token: boolean;
+  video_engine_enabled: boolean;
+}
+```
+
+- `video_engine_enabled` — whether the project has opted into the video engine. Used by the `videoEngineOnly` filter.
+
+## How to use
+
+### Basic usage
+
+Pick any project in the list:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { ProjectSelector } from "@/components/projects/project-selector";
+
+export default function MyComponent() {
+  const [projectId, setProjectId] = useState<string | null>(null);
+
+  return (
+    <div>
+      <ProjectSelector
+        value={projectId}
+        onChange={setProjectId}
+        placeholder="Select a project..."
+      />
+      {projectId && <p>You picked: {projectId}</p>}
+    </div>
+  );
+}
+```
+
+### Filter by team
+
+Show only projects in a specific team:
+
+```tsx
+import { Team } from "@/types";
+
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  filterByTeam={Team.FRONTEND}
+  placeholder="Select a frontend project..."
+/>
+```
+
+### Filter by video-engine opt-in
+
+Show only projects that have opted into the video engine (for video-authoring dialogs):
+
+```tsx
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  videoEngineOnly
+  placeholder="Select a project with video enabled..."
+/>
+```
+
+### Mandatory selection
+
+Disable the clear button so the user must pick a project:
+
+```tsx
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  allowClear={false}
+  placeholder="Project (required)"
+/>
+```
+
+### Combine filters
+
+Both team and video-engine filters can be used together:
+
+```tsx
+<ProjectSelector
+  value={projectId}
+  onChange={setProjectId}
+  filterByTeam={Team.BACKEND}
+  videoEngineOnly
+  placeholder="Backend projects with video enabled..."
+/>
+```
+
+## Filtering order
+
+Filters are applied in this order:
+
+1. **Video-engine filter** (if `videoEngineOnly` is true) — keep only projects with `video_engine_enabled === true`.
+2. **Team filter** (if `filterByTeam` is set) — keep only projects assigned to the given team.
+3. **Grouping** — group the remaining projects by their assigned team for display.
+
+This ensures a video-engine-filtered list still groups correctly, and a team-filtered list can still have the video-engine filter applied on top.
+
+## Empty states
+
+The component handles empty states gracefully:
+
+- **No projects in the data source** — the dropdown shows the placeholder and is disabled.
+- **All projects filtered out** — the dropdown shows the placeholder and is disabled. This happens when all available projects are filtered by `videoEngineOnly` or `filterByTeam`.
+- **No projects with video enabled** (when `videoEngineOnly` is true) — a calling dialog (like `RequestVideoDialog`) should check `videoProjects.length` and show a friendly empty-state message to the user.
+
+## Loading state
+
+The selector uses the `useProjects` hook, which may return `isLoading: true` while fetching the project list. The selector passes this through as a `disabled` state until the data arrives.
+
+## Design decisions
+
+- **Radix UI Select**: built on Radix's `<Select>` primitive for accessibility (keyboard navigation, ARIA labels).
+- **TanStack Query caching**: projects are fetched once via `useProjects` and cached, so multiple selectors on the same page share the same query.
+- **Usable without TypeScript**: the component type-checks all inputs but can be used from plain JS contexts (e.g. test fixtures) by omitting types.
+- **Memoized grouping**: the grouping computation is memoized with a dependency array so re-renders don't re-compute groups unless the filter props change.
+
+## Testing
+
+Run the selector tests with:
+
+```bash
+cd panel
+pnpm test project-selector
+```
+
+Covered behaviors:
+
+- `videoEngineOnly` filters out projects with `video_engine_enabled === false`.
+- Without `videoEngineOnly`, all projects appear in the list.
+- Team filtering works independently and in combination with video-engine filtering.
+- Selecting a project calls `onChange` with the project ID.
+- Clearing a selection (when `allowClear` is true) calls `onChange(null)`.
+- The selector is disabled when `disabled` prop is true or while data is loading.
+- The selector is disabled when all projects are filtered out.
+
+## Related work
+
+- **RequestVideoDialog** (`panel/src/components/dashboard/video-post-queue.tsx`) — uses `videoEngineOnly` to show only projects that have opted into the video engine for on-demand video requests.
+- **ProjectsPage** (`app/(dashboard)/projects/page.tsx`) — uses the base selector without filters to list and manage all projects.
+
+## Migration / rollout
+
+No breaking changes. The new `videoEngineOnly` prop defaults to `false`, so existing uses of `ProjectSelector` are unaffected. New code that needs to filter by video-engine opt-in status should pass `videoEngineOnly={true}`.

--- a/panel/docs/video-post-queue.md
+++ b/panel/docs/video-post-queue.md
@@ -39,15 +39,16 @@ const canSubmit =
 
 The picker prevents submission of the video request until a project is explicitly selected, ensuring every on-demand video is scoped to a specific project.
 
-## Re-render Control for Stale Drafts
+## Re-render Control for Any Composition-Bearing Draft
 
-The `RerenderControl` component appears only on drafts whose render has failed (`render_status === "failed"`), giving the CEO a way to retry a failed render without creating a new request.
+The `RerenderControl` component (`panel/src/components/dashboard/video-rerender-control.tsx`) appears on any draft that has both an authoring task and a proposed composition, giving the CEO a way to retry — or deliberately redo — a render without creating a new request.
 
 ### When It Appears
 
-- Only rendered in `VideoPostRow` when both conditions hold:
-  - `post.render_status === "failed"`
+- Rendered in `VideoPostRow` when both conditions hold:
   - `post.source_task_id` is truthy (the authoring task exists)
+  - `post.composition_id` is truthy (a composition was proposed)
+- This is regardless of `render_status` — the backend's rerender endpoint only requires a completed authoring task with a proposed composition, not a failed render, so a healthy render can be deliberately redone too
 - Positioned in the draft header row, right-aligned after the occasion badge
 
 ### Visual States
@@ -179,9 +180,11 @@ All three features integrate into `VideoPostRow` via:
 
 1. **Re-render button** appears in the header row (between the occasion badge and the edge):
    ```typescript
-   {isStale && post.source_task_id && (
+   const canRerender = !!post.source_task_id && !!post.composition_id;
+
+   {canRerender && (
      <div className="ml-auto">
-       <RerenderControl authoringTaskId={post.source_task_id} />
+       <RerenderControl authoringTaskId={post.source_task_id as string} />
      </div>
    )}
    ```
@@ -195,7 +198,7 @@ This placement gives the CEO a visual hierarchy: draft metadata → live composi
 
 ## Design Notes
 
-- **Stale detection**: The `isStale` computation (`render_status === "failed" && !!source_task_id`) mirrors the pipeline strip's render-failure logic in `video-pipeline-utils.ts`, keeping both UI surfaces consistent.
+- **Rerender gating**: The `canRerender` computation (`!!source_task_id && !!composition_id`) shows the control for any composition-bearing draft regardless of `render_status`, matching `RerenderControl`'s own gating in `video-pipeline-strip.tsx`, keeping both UI surfaces consistent.
 - **Composition preview sizing**: Uses `aspect-video` to maintain the standard 16:9 ratio for the iframe, with `w-full` for responsive scaling.
 - **Lazy loading**: The iframe uses `loading="lazy"` so it only fetches when scrolled into view, reducing initial page load on the queue.
 - **Sandbox isolation**: The iframe runs with `sandbox="allow-scripts"` to execute the composition's interactive elements while preventing navigation or form submission from escaping the preview.

--- a/panel/src/components/dashboard/__tests__/video-pipeline-strip.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-pipeline-strip.test.tsx
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import type { VideoPipelineItem } from "@/lib/api/video";
 
-const { listPipeline } = vi.hoisted(() => ({
+const { listPipeline, rerender } = vi.hoisted(() => ({
   listPipeline: vi.fn(async (): Promise<VideoPipelineItem[]> => []),
+  rerender: vi.fn(async () => undefined),
 }));
 
 vi.mock("@/lib/api", () => ({
-  videoApi: { listPipeline },
+  videoApi: { listPipeline, rerender },
 }));
 
 import { VideoPipelineStrip } from "../video-pipeline-strip";
@@ -61,6 +62,7 @@ const FAILED: VideoPipelineItem = {
 describe("VideoPipelineStrip", () => {
   beforeEach(() => {
     listPipeline.mockClear();
+    rerender.mockClear();
   });
   afterEach(() => {
     vi.clearAllMocks();
@@ -98,5 +100,36 @@ describe("VideoPipelineStrip", () => {
     const reviewLinks = screen.getAllByRole("link", { name: "Review" });
     expect(reviewLinks).toHaveLength(1);
     expect(reviewLinks[0]).toHaveAttribute("href", "/tasks/vp-2");
+  });
+
+  it("shows a re-render button on rendering and render_failed rows with a composition, but not on authoring/awaiting-approval rows", async () => {
+    listPipeline.mockResolvedValueOnce([
+      AUTHORING,
+      AWAITING_APPROVAL,
+      RENDERING,
+      FAILED,
+    ]);
+    render(withQueryClient(<VideoPipelineStrip />));
+    await screen.findByText("Video Pipeline");
+
+    const rerenderButtons = screen.getAllByRole("button", {
+      name: /Re-render/,
+    });
+    expect(rerenderButtons).toHaveLength(2);
+  });
+
+  it("triggers the backend re-render action for the clicked row's authoring task id, behind a confirm dialog", async () => {
+    listPipeline.mockResolvedValueOnce([FAILED]);
+    render(withQueryClient(<VideoPipelineStrip />));
+    await screen.findByText("Video Pipeline");
+
+    fireEvent.click(screen.getByRole("button", { name: /Re-render/ }));
+    expect(rerender).not.toHaveBeenCalled();
+    const confirmButton = await screen.findByRole("button", {
+      name: /Re-render/,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(rerender).toHaveBeenCalledWith("vp-4"));
   });
 });

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -364,7 +364,7 @@ describe("VideoPostQueue", () => {
     expect(screen.queryByText(/No drafts yet/)).not.toBeInTheDocument();
   });
 
-  it("does not show a re-render button when the draft's render is healthy", async () => {
+  it("does not show a re-render button when the draft has no source_task_id/composition_id", async () => {
     render(withQueryClient(<VideoPostQueue />));
     await screen.findByText("release");
     expect(
@@ -372,7 +372,7 @@ describe("VideoPostQueue", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows a re-render button only on a stale draft and triggers the backend re-render action", async () => {
+  it("shows a re-render button on a draft with a composition regardless of render_status, behind a confirm dialog", async () => {
     listPosts.mockResolvedValueOnce([
       {
         task_id: "v-1",
@@ -386,6 +386,7 @@ describe("VideoPostQueue", () => {
         tiktok_caption: "New RoboCo drop!",
         mp4_paths: { vertical: "/fake/vertical.mp4" },
         source_task_id: "auth-1",
+        composition_id: "release-recap",
         render_status: "failed",
       },
     ] as VideoPost[]);
@@ -395,7 +396,41 @@ describe("VideoPostQueue", () => {
     const rerenderButton = screen.getByRole("button", { name: /Re-render/ });
     fireEvent.click(rerenderButton);
 
+    // The action is gated behind a confirm dialog — clicking the trigger
+    // alone must not call the backend.
+    expect(rerender).not.toHaveBeenCalled();
+    const confirmButton = await screen.findByRole("button", {
+      name: /Re-render/,
+    });
+    fireEvent.click(confirmButton);
+
     await waitFor(() => expect(rerender).toHaveBeenCalledWith("auth-1"));
+  });
+
+  it("renders the re-render button for a post with render_status='rendered'", async () => {
+    listPosts.mockResolvedValueOnce([
+      {
+        task_id: "v-1",
+        source: "video_post",
+        title: "Video: release v0.19.0",
+        status: "pending",
+        occasion: "release",
+        script: "RoboCo v0.19.0 just shipped!",
+        platforms: ["x", "tiktok"],
+        x_caption: "RoboCo v0.19.0 is here!",
+        tiktok_caption: "New RoboCo drop!",
+        mp4_paths: { vertical: "/fake/vertical.mp4" },
+        source_task_id: "auth-1",
+        composition_id: "release-recap",
+        render_status: "rendered",
+      },
+    ] as VideoPost[]);
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    expect(
+      screen.getByRole("button", { name: /Re-render/ }),
+    ).toBeInTheDocument();
   });
 
   it("shows the live composition preview iframe with captions when composition_id is present", async () => {

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -8,6 +8,30 @@ const { resolveApproveRef } = vi.hoisted(() => ({
   resolveApproveRef: { current: null as null | ((v: unknown) => void) },
 }));
 
+const { useProjects } = vi.hoisted(() => ({
+  // One video-enabled project by default ("p-1", matching the mocked
+  // ProjectSelector's onChange value below) so the dialog can default-select
+  // it — tests that need the empty-state override this per-test.
+  useProjects: vi.fn(() => ({
+    data: [
+      {
+        id: "p-1",
+        name: "roboco-panel",
+        slug: "roboco-panel",
+        git_url: "https://example.com/roboco-panel.git",
+        assigned_cell: "frontend",
+        is_active: true,
+        has_workspace: true,
+        has_git_token: true,
+        video_engine_enabled: true,
+      },
+    ],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-projects", () => ({ useProjects }));
+
 const {
   listPosts,
   listPipeline,
@@ -314,21 +338,63 @@ describe("VideoPostQueue", () => {
     );
   });
 
-  it("keeps Request disabled until a project is picked", async () => {
+  it("defaults the project to the current (first) video-enabled project so Request enables without an explicit pick", async () => {
     render(withQueryClient(<VideoPostQueue />));
     await screen.findByText("release");
 
     fireEvent.click(screen.getByRole("button", { name: /Request a video/ }));
+    // Request still needs occasion/brief filled...
+    expect(screen.getByRole("button", { name: "Request" })).toBeDisabled();
     fireEvent.change(screen.getByLabelText("Occasion"), {
       target: { value: "Founder's Day" },
     });
     fireEvent.change(screen.getByLabelText("Brief"), {
       target: { value: "Celebrate the founding." },
     });
-    expect(screen.getByRole("button", { name: "Request" })).toBeDisabled();
-
-    fireEvent.click(screen.getByRole("button", { name: "Set Project" }));
+    // ...but never a manual "Set Project" click — the picker already
+    // defaulted to the sole video-enabled project.
     expect(screen.getByRole("button", { name: "Request" })).not.toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Request" }));
+    await waitFor(() =>
+      expect(requestVideo).toHaveBeenCalledWith(
+        expect.objectContaining({ project_id: "p-1" }),
+      ),
+    );
+  });
+
+  it("shows a friendly empty-state when no project has the video engine enabled", async () => {
+    // mockReturnValue (not -Once): RequestVideoDialog re-renders more than
+    // once before the assertions run, and a -Once override would only cover
+    // the first of those renders.
+    useProjects.mockReturnValue({
+      data: [
+        {
+          id: "p-2",
+          name: "not-opted-in",
+          slug: "not-opted-in",
+          git_url: "https://example.com/not-opted-in.git",
+          assigned_cell: "backend",
+          is_active: true,
+          has_workspace: true,
+          has_git_token: true,
+          video_engine_enabled: false,
+        },
+      ],
+      isLoading: false,
+    });
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+
+    fireEvent.click(screen.getByRole("button", { name: /Request a video/ }));
+    expect(
+      screen.getByText(/No projects have the video engine enabled/),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Occasion")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Request" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
   it("shows the keys/engine empty copy when nothing is in the pipeline either", async () => {

--- a/panel/src/components/dashboard/video-pipeline-strip.tsx
+++ b/panel/src/components/dashboard/video-pipeline-strip.tsx
@@ -9,6 +9,7 @@ import {
   pipelineStageColor,
   pipelineStageLabel,
 } from "./video-pipeline-utils";
+import { RerenderControl } from "@/components/dashboard/video-rerender-control";
 import {
   Card,
   CardContent,
@@ -24,9 +25,17 @@ import { Film } from "lucide-react";
 // derived (never fetched) from status + render_status/render_attempts —
 // see video-pipeline-utils.ts, unit-tested directly there. Only the
 // "awaiting your approval" stage deep-links out (the CEO decision the
-// pipeline is surfacing); every other stage is just visibility.
+// pipeline is surfacing); every other stage is just visibility. The
+// re-render control (shared with video-post-queue.tsx) shows for any item
+// carrying a proposed composition — the "rendering" and "render_failed"
+// stages are the only ones where the item's own task_id doubles as the
+// authoring task id the rerender endpoint needs, regardless of whether the
+// render is currently retrying or has failed outright.
 function PipelineRow({ item }: { item: VideoPipelineItem }) {
   const stage = derivePipelineStage(item);
+  const canRerender =
+    (stage.kind === "rendering" || stage.kind === "render_failed") &&
+    !!item.composition_id;
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-lg border p-3 text-sm">
       <Film className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -45,6 +54,11 @@ function PipelineRow({ item }: { item: VideoPipelineItem }) {
             Review
           </Button>
         </Link>
+      )}
+      {canRerender && (
+        <div className="ml-auto">
+          <RerenderControl authoringTaskId={item.task_id} />
+        </div>
       )}
     </div>
   );

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -33,7 +33,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProjectSelector } from "@/components/projects/project-selector";
 import { useProjects } from "@/hooks/use-projects";
-import { CheckCircle2, Film, RefreshCw, Sparkles, XCircle } from "lucide-react";
+import { RerenderControl } from "@/components/dashboard/video-rerender-control";
+import { CheckCircle2, Film, Sparkles, XCircle } from "lucide-react";
 import { toast } from "sonner";
 
 const MAX_X_CAPTION_CHARS = 280;

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -32,7 +32,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProjectSelector } from "@/components/projects/project-selector";
-import { CheckCircle2, Film, RefreshCw, Sparkles, XCircle } from "lucide-react";
+import { RerenderControl } from "@/components/dashboard/video-rerender-control";
+import { CheckCircle2, Film, Sparkles, XCircle } from "lucide-react";
 import { toast } from "sonner";
 
 const MAX_X_CAPTION_CHARS = 280;
@@ -64,51 +65,6 @@ function describeExecuteResult(result: VideoPostExecuteResult): string {
   if (result.status === "redis_unavailable")
     return "Redis is unavailable — can't acquire the post lock.";
   return `${result.status}: ${result.detail}`;
-}
-
-// Re-render retry control — only rendered by the caller when the draft's
-// render is stale (render_status === "failed"; see VideoPostRow). Three
-// visual states: idle (button, ready to click), loading (mutation
-// in-flight), error (the retry itself failed — button re-enables so the CEO
-// can try again). Mirrors the pipeline strip's render_failed derivation in
-// video-pipeline-utils.ts.
-function RerenderControl({ authoringTaskId }: { authoringTaskId: string }) {
-  const queryClient = useQueryClient();
-  const rerenderMutation = useMutation({
-    mutationFn: () => videoApi.rerender(authoringTaskId),
-    onSuccess: () => {
-      toast.success("Re-render queued — it will re-pick up on the next cycle.");
-      queryClient.invalidateQueries({ queryKey: ["video", "pipeline"] });
-    },
-    onError: (e) =>
-      toast.error(
-        `Re-render failed: ${e instanceof Error ? e.message : "error"}`,
-      ),
-  });
-
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={rerenderMutation.isPending}
-      onClick={() => rerenderMutation.mutate()}
-      className={
-        rerenderMutation.isError
-          ? "border-destructive text-destructive"
-          : undefined
-      }
-    >
-      <RefreshCw
-        className={`mr-1 h-4 w-4 ${rerenderMutation.isPending ? "animate-spin" : ""}`}
-      />
-      {rerenderMutation.isPending
-        ? "Re-rendering..."
-        : rerenderMutation.isError
-          ? "Retry re-render"
-          : "Re-render"}
-    </Button>
-  );
 }
 
 // Live composition preview: the authoring task's actual HyperFrames HTML for
@@ -228,11 +184,11 @@ function VideoPostRow({
   const tiktokOverLimit =
     editTiktok && tiktokCaption.length > MAX_TIKTOK_CAPTION_CHARS;
   const overLimit = xOverLimit || tiktokOverLimit;
-  // The re-render (CEO retry) endpoint's use case is retrying a render that
-  // hit a terminal failed state — mirrors video-pipeline-utils.ts's
-  // render_failed derivation. Undefined render_status (backend not yet
-  // exposing it on this response, or a healthy render) never shows the button.
-  const isStale = post.render_status === "failed" && !!post.source_task_id;
+  // The re-render endpoint only requires a completed authoring task with a
+  // proposed composition — it doesn't require a failed render, so the
+  // button shows for ANY draft that carries both, regardless of
+  // render_status (a healthy render can be deliberately redone too).
+  const canRerender = !!post.source_task_id && !!post.composition_id;
 
   const handleApprove = () => {
     onApprove(post.task_id, {
@@ -247,9 +203,9 @@ function VideoPostRow({
         <meta.icon className="h-4 w-4 text-muted-foreground" />
         <span className="font-medium">{meta.label}</span>
         {post.occasion && <Badge variant="outline">{post.occasion}</Badge>}
-        {isStale && post.source_task_id && (
+        {canRerender && (
           <div className="ml-auto">
-            <RerenderControl authoringTaskId={post.source_task_id} />
+            <RerenderControl authoringTaskId={post.source_task_id as string} />
           </div>
         )}
       </div>

--- a/panel/src/components/dashboard/video-post-queue.tsx
+++ b/panel/src/components/dashboard/video-post-queue.tsx
@@ -32,8 +32,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProjectSelector } from "@/components/projects/project-selector";
-import { RerenderControl } from "@/components/dashboard/video-rerender-control";
-import { CheckCircle2, Film, Sparkles, XCircle } from "lucide-react";
+import { useProjects } from "@/hooks/use-projects";
+import { CheckCircle2, Film, RefreshCw, Sparkles, XCircle } from "lucide-react";
 import { toast } from "sonner";
 
 const MAX_X_CAPTION_CHARS = 280;
@@ -358,7 +358,14 @@ function RequestVideoDialog({
   const [occasion, setOccasion] = useState("");
   const [brief, setBrief] = useState("");
   const [platforms, setPlatforms] = useState<string[]>(["x", "tiktok"]);
+  // null means "no explicit pick yet" — derived below to the current (first)
+  // video-enabled project, mirroring the caption-tracking pattern elsewhere
+  // in this file (`editedX ?? post.x_caption`) rather than syncing via effect.
   const [projectId, setProjectId] = useState<string | null>(null);
+  const { data: allProjects = [] } = useProjects();
+  const videoProjects = allProjects.filter((p) => p.video_engine_enabled);
+  const hasVideoProjects = videoProjects.length > 0;
+  const effectiveProjectId = projectId ?? videoProjects[0]?.id ?? null;
 
   const requestMutation = useMutation({
     mutationFn: () =>
@@ -366,7 +373,7 @@ function RequestVideoDialog({
         occasion: occasion.trim(),
         brief: brief.trim(),
         platforms,
-        project_id: projectId as string,
+        project_id: effectiveProjectId as string,
       }),
     onSuccess: (result) => {
       if (result.status === "opened") {
@@ -395,7 +402,7 @@ function RequestVideoDialog({
   };
 
   const canSubmit =
-    !!projectId &&
+    !!effectiveProjectId &&
     occasion.trim().length > 0 &&
     brief.trim().length > 0 &&
     platforms.length > 0;
@@ -411,67 +418,85 @@ function RequestVideoDialog({
             rendering finishes.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label>Project</Label>
-            <ProjectSelector
-              value={projectId}
-              onChange={setProjectId}
-              placeholder="Select the project this video is about..."
-              allowClear={false}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="video-request-occasion">Occasion</Label>
-            <Input
-              id="video-request-occasion"
-              placeholder="e.g. v0.19.0 launch, Founder's Day..."
-              value={occasion}
-              onChange={(e) => setOccasion(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="video-request-brief">Brief</Label>
-            <Textarea
-              id="video-request-brief"
-              placeholder="What should this video cover?"
-              value={brief}
-              onChange={(e) => setBrief(e.target.value)}
-              rows={4}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Platforms</Label>
-            <div className="flex gap-4">
-              {REQUEST_PLATFORMS.map((platform) => (
-                <div key={platform} className="flex items-center gap-2">
-                  <Checkbox
-                    id={`video-request-${platform}`}
-                    checked={platforms.includes(platform)}
-                    onCheckedChange={() => togglePlatform(platform)}
-                  />
-                  <Label
-                    htmlFor={`video-request-${platform}`}
-                    className="text-sm font-normal"
-                  >
-                    {PLATFORM_LABELS[platform]}
-                  </Label>
+        {hasVideoProjects ? (
+          <>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label>Project</Label>
+                <ProjectSelector
+                  value={effectiveProjectId}
+                  onChange={setProjectId}
+                  placeholder="Select the project this video is about..."
+                  allowClear={false}
+                  videoEngineOnly
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="video-request-occasion">Occasion</Label>
+                <Input
+                  id="video-request-occasion"
+                  placeholder="e.g. v0.19.0 launch, Founder's Day..."
+                  value={occasion}
+                  onChange={(e) => setOccasion(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="video-request-brief">Brief</Label>
+                <Textarea
+                  id="video-request-brief"
+                  placeholder="What should this video cover?"
+                  value={brief}
+                  onChange={(e) => setBrief(e.target.value)}
+                  rows={4}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Platforms</Label>
+                <div className="flex gap-4">
+                  {REQUEST_PLATFORMS.map((platform) => (
+                    <div key={platform} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`video-request-${platform}`}
+                        checked={platforms.includes(platform)}
+                        onCheckedChange={() => togglePlatform(platform)}
+                      />
+                      <Label
+                        htmlFor={`video-request-${platform}`}
+                        className="text-sm font-normal"
+                      >
+                        {PLATFORM_LABELS[platform]}
+                      </Label>
+                    </div>
+                  ))}
                 </div>
-              ))}
+              </div>
             </div>
-          </div>
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            onClick={() => requestMutation.mutate()}
-            disabled={!canSubmit || requestMutation.isPending}
-          >
-            {requestMutation.isPending ? "Requesting..." : "Request"}
-          </Button>
-        </DialogFooter>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                onClick={() => requestMutation.mutate()}
+                disabled={!canSubmit || requestMutation.isPending}
+              >
+                {requestMutation.isPending ? "Requesting..." : "Request"}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-muted-foreground">
+              No projects have the video engine enabled yet. Turn it on for a
+              project in its edit dialog (Projects → Edit) before requesting a
+              video.
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+            </DialogFooter>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/panel/src/components/dashboard/video-rerender-control.tsx
+++ b/panel/src/components/dashboard/video-rerender-control.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { videoApi } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * Shared re-render control — renders a button + confirm dialog for re-triggering
+ * video render operations. Used by both video-post-queue.tsx (a rendered draft)
+ * and video-pipeline-strip.tsx (a still-in-flight authoring task).
+ *
+ * @component
+ *
+ * Gating Logic:
+ * - Shows for any task with source_task_id + composition_id, regardless of
+ *   render_status. The backend's rerender endpoint only requires a completed
+ *   authoring task with a proposed composition, not a failed render, so a
+ *   healthy render can be deliberately redone too.
+ *
+ * Behavior:
+ * - Trigger button opens a Dialog with Cancel and Re-render buttons (guards
+ *   against accidental clicks, since re-rendering discards whatever already
+ *   rendered).
+ * - Only the confirm click calls videoApi.rerender(authoringTaskId).
+ * - Three visual states on the trigger button:
+ *   1. Idle: "Re-render" (ready to click)
+ *   2. Loading: "Re-rendering..." with spinning icon (mutation in-flight)
+ *   3. Error: "Retry re-render" in red (the retry itself failed; button stays
+ *      enabled so the CEO can try again).
+ *
+ * @example
+ * ```tsx
+ * // Usage in video-post-queue for a rendered draft:
+ * {canRerender && (
+ *   <div className="ml-auto">
+ *     <RerenderControl authoringTaskId={post.source_task_id as string} />
+ *   </div>
+ * )}
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Usage in video-pipeline-strip for an in-flight authoring task:
+ * {canRerender && (
+ *   <div className="ml-auto">
+ *     <RerenderControl authoringTaskId={item.task_id} />
+ *   </div>
+ * )}
+ * ```
+ */
+export function RerenderControl({
+  authoringTaskId,
+}: {
+  /**
+   * The authoring task ID to re-render. Passed to videoApi.rerender(authoringTaskId).
+   * For video-post-queue: the post's source_task_id.
+   * For video-pipeline-strip: the pipeline item's own task_id (a pipeline item IS
+   * the authoring task).
+   */
+  authoringTaskId: string;
+}) {
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const rerenderMutation = useMutation({
+    mutationFn: () => videoApi.rerender(authoringTaskId),
+    onSuccess: () => {
+      toast.success("Re-render queued — it will re-pick up on the next cycle.");
+      queryClient.invalidateQueries({ queryKey: ["video", "pipeline"] });
+      queryClient.invalidateQueries({ queryKey: ["video", "posts"] });
+    },
+    onError: (e) =>
+      toast.error(
+        `Re-render failed: ${e instanceof Error ? e.message : "error"}`,
+      ),
+  });
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={rerenderMutation.isPending}
+        onClick={() => setConfirmOpen(true)}
+        className={
+          rerenderMutation.isError
+            ? "border-destructive text-destructive"
+            : undefined
+        }
+      >
+        <RefreshCw
+          className={`mr-1 h-4 w-4 ${rerenderMutation.isPending ? "animate-spin" : ""}`}
+        />
+        {rerenderMutation.isPending
+          ? "Re-rendering..."
+          : rerenderMutation.isError
+            ? "Retry re-render"
+            : "Re-render"}
+      </Button>
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Re-render this video?</DialogTitle>
+            <DialogDescription>
+              This clears the current render and queues a fresh one from the
+              same composition. Any already-rendered cuts stay visible until
+              the new render finishes.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                setConfirmOpen(false);
+                rerenderMutation.mutate();
+              }}
+            >
+              Re-render
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/panel/src/components/projects/__tests__/project-selector.test.tsx
+++ b/panel/src/components/projects/__tests__/project-selector.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Team } from "@/types";
+import type { ProjectSummary } from "@/types";
+
+const { useProjects } = vi.hoisted(() => ({ useProjects: vi.fn() }));
+vi.mock("@/hooks/use-projects", () => ({ useProjects }));
+
+// Make the Select testable without Radix's portal/pointer machinery — mirrors
+// a2a-reply-composer.test.tsx: SelectContent always renders its children, so
+// the assertions below can query rendered project names directly.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectLabel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import { ProjectSelector } from "../project-selector";
+
+function project(overrides: Partial<ProjectSummary>): ProjectSummary {
+  return {
+    id: "p-id",
+    name: "project",
+    slug: "project",
+    git_url: "https://example.com/project.git",
+    assigned_cell: Team.FRONTEND,
+    is_active: true,
+    has_workspace: true,
+    has_git_token: true,
+    video_engine_enabled: false,
+    ...overrides,
+  };
+}
+
+describe("ProjectSelector", () => {
+  it("videoEngineOnly excludes projects that have not opted into the video engine", () => {
+    useProjects.mockReturnValue({
+      data: [
+        project({ id: "p-1", name: "Video Ready", video_engine_enabled: true }),
+        project({
+          id: "p-2",
+          name: "Not Opted In",
+          video_engine_enabled: false,
+        }),
+      ],
+      isLoading: false,
+    });
+
+    render(<ProjectSelector value={null} onChange={vi.fn()} videoEngineOnly />);
+
+    expect(screen.getByText("Video Ready")).toBeInTheDocument();
+    expect(screen.queryByText("Not Opted In")).not.toBeInTheDocument();
+  });
+
+  it("shows every project when videoEngineOnly is not set", () => {
+    useProjects.mockReturnValue({
+      data: [
+        project({ id: "p-1", name: "Video Ready", video_engine_enabled: true }),
+        project({
+          id: "p-2",
+          name: "Not Opted In",
+          video_engine_enabled: false,
+        }),
+      ],
+      isLoading: false,
+    });
+
+    render(<ProjectSelector value={null} onChange={vi.fn()} />);
+
+    expect(screen.getByText("Video Ready")).toBeInTheDocument();
+    expect(screen.getByText("Not Opted In")).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/projects/project-selector.tsx
+++ b/panel/src/components/projects/project-selector.tsx
@@ -22,6 +22,10 @@ interface ProjectSelectorProps {
   filterByTeam?: Team;
   disabled?: boolean;
   allowClear?: boolean;
+  // Restrict the list to projects with the video engine opted in
+  // (project.video_engine_enabled) — for pickers scoped to video-authoring
+  // flows (e.g. RequestVideoDialog).
+  videoEngineOnly?: boolean;
 }
 
 // Team display names for project cells
@@ -38,12 +42,18 @@ export function ProjectSelector({
   filterByTeam,
   disabled = false,
   allowClear = true,
+  videoEngineOnly = false,
 }: ProjectSelectorProps) {
   const { data: projects = [], isLoading } = useProjects();
 
   // Group projects by team/cell
   const groupedProjects = useMemo(() => {
     let filtered = projects;
+
+    // Restrict to video-engine-opted-in projects
+    if (videoEngineOnly) {
+      filtered = filtered.filter((p) => p.video_engine_enabled);
+    }
 
     // Apply team filter
     if (filterByTeam) {
@@ -71,7 +81,7 @@ export function ProjectSelector({
     }
 
     return groups;
-  }, [projects, filterByTeam]);
+  }, [projects, filterByTeam, videoEngineOnly]);
 
   // Find selected project for display
   const selectedProject = useMemo(() => {

--- a/panel/src/lib/api/projects.ts
+++ b/panel/src/lib/api/projects.ts
@@ -40,6 +40,7 @@ export const projectsApi = {
         is_active: p.is_active,
         has_workspace: !!p.workspace_path,
         has_git_token: false, // Mock mode has no tokens
+        video_engine_enabled: p.video_engine_enabled,
       }));
     }
 

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -1087,6 +1087,7 @@ export interface ProjectSummary {
   is_active: boolean;
   has_workspace: boolean;
   has_git_token: boolean;
+  video_engine_enabled: boolean;
 }
 
 export interface ProductCellMapping {


### PR DESCRIPTION
CEO rejected PR #403 citing two gaps in panel/src/components/dashboard/video-post-queue.tsx and the Request-Video dialog, per docs/ux_ui/design/01-video-request-composition-controls.md (already merged, still authoritative):

1. Re-render control: currently RerenderControl only renders when render_status === 'failed'. The task's own motivating case is a post whose marker already says 'rendered' but needs a fresh pass after a composition fix -- the backend rerender() endpoint already supports this regardless of status. Broaden the show-condition to any post with a source_task_id and a composition/composition_id, gated behind a confirm dialog (do not remove the existing failed-state path, extend it). Also add the control to panel/src/components/dashboard/video-pipeline-strip.tsx, the second placement the AC names that PR #403 never touched -- reuse the same RerenderControl component and confirm-dialog copy in both places.

2. Project picker: RequestVideoDialog's ProjectSelector currently lists every active project and defaults to none. The sibling backend subtask (61b9f9e1) adds video_engine_enabled to the GET /projects response; add the field to the client ProjectSummary type, add a videoEngineOnly prop to ProjectSelector that filters to opted-in projects, default the picker to the current project, and show a friendly empty-state ('no video-enabled projects') instead of letting a non-opted selection 404 into a generic toast.

This subtask depends on the backend subtask (61b9f9e1) landing the video_engine_enabled field first -- do not merge the picker filter until that field is confirmed live.