### PR TITLE
[e2b50b06] Fix: implement 2-column objectives grid in goals-tab.tsx

### DIFF
--- a/panel/src/components/business/__tests__/goals-tab.test.tsx
+++ b/panel/src/components/business/__tests__/goals-tab.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { CompanyGoals } from "@/lib/api/company-goals";
+
+// ---------------------------------------------------------------------------
+// Mock @tanstack/react-query so we can control useQuery/useMutation return
+// values without a real QueryClientProvider.
+// ---------------------------------------------------------------------------
+
+const { mockUseQuery, mockUseMutation, mockMutate } = vi.hoisted(() => ({
+  mockUseQuery: vi.fn(),
+  mockUseMutation: vi.fn(),
+  mockMutate: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQuery: mockUseQuery,
+    useMutation: mockUseMutation,
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  };
+});
+
+vi.mock("@/lib/api/company-goals", () => ({
+  companyGoalsApi: {
+    get: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks are set up
+// ---------------------------------------------------------------------------
+
+import { GoalsTab } from "../goals-tab";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildGoals(overrides: Partial<CompanyGoals> = {}): CompanyGoals {
+  return {
+    north_star: "Ship things",
+    objectives: [
+      { metric: "Lead time", target: "< 24h", status: "Active" },
+      { metric: "Escaped defects", target: "0", status: "Active" },
+    ],
+    constraints: [],
+    operating_policy: {},
+    brand_voice: "",
+    updated_at: null,
+    updated_by: null,
+    ...overrides,
+  };
+}
+
+function setup(goals: CompanyGoals) {
+  mockUseQuery.mockReturnValue({
+    data: goals,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  mockUseMutation.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  });
+}
+
+describe("GoalsTab — ObjectivesEditor grid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the objectives container as a 2-column grid that collapses to 1 column on mobile", () => {
+    setup(buildGoals());
+
+    render(<GoalsTab />);
+
+    const objectiveOne = screen.getByText("Objective #1");
+    // The grid wrapper is the parent of each objective card.
+    const gridContainer = objectiveOne.closest("div.rounded-lg")
+      ?.parentElement as HTMLElement;
+
+    expect(gridContainer).toHaveClass("grid");
+    expect(gridContainer).toHaveClass("grid-cols-1");
+    expect(gridContainer).toHaveClass("md:grid-cols-2");
+  });
+
+  it("keeps add/remove/edit objective behavior working", () => {
+    setup(buildGoals());
+
+    render(<GoalsTab />);
+
+    // Two seeded objectives render as separate cards.
+    expect(screen.getByText("Objective #1")).toBeInTheDocument();
+    expect(screen.getByText("Objective #2")).toBeInTheDocument();
+
+    // Edit a field on the first objective (both rows share the "metric" label,
+    // so grab the first one — it belongs to Objective #1's input group).
+    const metricInput = screen.getAllByLabelText(
+      "metric",
+    )[0] as HTMLInputElement;
+    fireEvent.change(metricInput, { target: { value: "Updated metric" } });
+    expect(metricInput.value).toBe("Updated metric");
+
+    // Add a new objective row.
+    fireEvent.click(screen.getByText("+ Add objective"));
+    expect(screen.getByText("Objective #3")).toBeInTheDocument();
+
+    // Remove the second objective row; remaining rows renumber to #1/#2.
+    const removeButtons = screen.getAllByText("Remove");
+    fireEvent.click(removeButtons[1]);
+    expect(screen.getAllByText(/^Objective #/)).toHaveLength(2);
+    expect(screen.queryByText("Objective #3")).not.toBeInTheDocument();
+  });
+});

--- a/panel/src/components/business/goals-tab.tsx
+++ b/panel/src/components/business/goals-tab.tsx
@@ -52,6 +52,19 @@ interface ObjectivesEditorProps {
   disabled: boolean;
 }
 
+/**
+ * ObjectivesEditor renders a responsive 2-column grid of objective cards.
+ *
+ * Layout:
+ * - Desktop (md+): 2-column grid with 3px gap
+ * - Mobile: 1-column stack (full width)
+ *
+ * Each card shows a set of editable fields derived from the first objective
+ * (metric, target, status, etc.) with add/remove controls. The outer container
+ * maintains space-y-3 gap to separate the grid from the "Add objective" button.
+ *
+ * Tests: `goals-tab.test.tsx` asserts the grid classes and add/remove/edit behavior.
+ */
 function ObjectivesEditor({
   items,
   onChange,
@@ -80,42 +93,44 @@ function ObjectivesEditor({
 
   return (
     <div className="space-y-3">
-      {items.map((item, rowIdx) => (
-        <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
-          <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
-              Objective #{rowIdx + 1}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={disabled}
-              onClick={() => removeRow(rowIdx)}
-              className="h-6 px-2 text-xs text-destructive hover:text-destructive"
-            >
-              Remove
-            </Button>
-          </div>
-          {keys.map((key) => (
-            <div key={key} className="space-y-1">
-              <Label
-                htmlFor={`obj-${rowIdx}-${key}`}
-                className="text-xs capitalize"
-              >
-                {key.replace(/_/g, " ")}
-              </Label>
-              <Input
-                id={`obj-${rowIdx}-${key}`}
-                value={String(item[key] ?? "")}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {items.map((item, rowIdx) => (
+          <div key={rowIdx} className="rounded-lg border p-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground">
+                Objective #{rowIdx + 1}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
                 disabled={disabled}
-                onChange={(e) => handleChange(rowIdx, key, e.target.value)}
-                className="h-8 text-sm"
-              />
+                onClick={() => removeRow(rowIdx)}
+                className="h-6 px-2 text-xs text-destructive hover:text-destructive"
+              >
+                Remove
+              </Button>
             </div>
-          ))}
-        </div>
-      ))}
+            {keys.map((key) => (
+              <div key={key} className="space-y-1">
+                <Label
+                  htmlFor={`obj-${rowIdx}-${key}`}
+                  className="text-xs capitalize"
+                >
+                  {key.replace(/_/g, " ")}
+                </Label>
+                <Input
+                  id={`obj-${rowIdx}-${key}`}
+                  value={String(item[key] ?? "")}
+                  disabled={disabled}
+                  onChange={(e) => handleChange(rowIdx, key, e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
       <Button
         type="button"
         variant="outline"


### PR DESCRIPTION
The Company Charter's ObjectivesEditor component (panel/src/components/business/goals-tab.tsx) still renders objectives as a plain vertically-stacked list: the items container is `<div className="space-y-3">` with no grid classes at any breakpoint. A prior attempt at this grid was reverted by a since-merged leaf (commit 357c02da on subtask dc518639), so this needs to be re-implemented from the current state of the file — do not assume any grid scaffolding already exists.

Goal: apply a responsive grid to the objectives items container so objectives render 2-up at desktop widths and collapse to a single column on mobile (e.g. `grid grid-cols-1 md:grid-cols-2 gap-3`), matching the existing Tailwind responsive-grid convention used elsewhere in the panel. Preserve all existing functionality (add/remove/edit objective rows) — only the layout/container classes change.

Scope constraint: touch ONLY panel/src/components/business/goals-tab.tsx (and its test file). Do NOT modify panel/src/components/layout/sidebar.tsx or its tests — that work is already done, CEO-corrected, and merged; re-touching it risks reintroducing a regression.

Add a test (in the existing goals-tab test file, or a new one following the sidebar.test.tsx pattern already in this PR chain) asserting the objectives container has the 2-column desktop / 1-column mobile grid classes.