### PR TITLE
[ccfe2015] Reflow video UX design doc to pass quality gate

### DIFF
--- a/docs/ux_ui/design/01-video-request-composition-controls.md
+++ b/docs/ux_ui/design/01-video-request-composition-controls.md
@@ -1,15 +1,10 @@
 # Video request: project picker, re-render control, composition preview panel
 
-Interaction spec for three additions to the existing on-demand video flow: a
-project picker in the request dialog, a re-render control with four visual
-states, and a composition preview panel (live iframe + captions side by
-side) in the approval screen. Written so a frontend developer can implement
-directly from this document without further design clarification.
+Interaction spec for three additions to the existing on-demand video flow: a project picker in the request dialog, a re-render control with four visual states, and a composition preview panel (live iframe + captions side by side) in the approval screen. Written so a frontend developer can implement directly from this document without further design clarification.
 
 ## Scope and where this lives
 
-All three pieces extend one existing file:
-`panel/src/components/dashboard/video-post-queue.tsx`.
+All three pieces extend one existing file: `panel/src/components/dashboard/video-post-queue.tsx`.
 
 | Piece | Existing component it extends | New sub-component to add |
 |---|---|---|
@@ -17,23 +12,11 @@ All three pieces extend one existing file:
 | Re-render control | `VideoPostRow` (one card in the approval queue) | `RerenderControl` |
 | Composition preview panel | `VideoPostRow` | `CompositionPreviewPanel` |
 
-None of this replaces the existing rendered-MP4 preview and caption
-textareas already in `VideoPostRow` (lines 145-258 of the current file) —
-the composition preview panel is a new block shown above them, giving the
-CEO a fast, pre-render look at the live composition before the MP4 cuts
-exist or while iterating.
+None of this replaces the existing rendered-MP4 preview and caption textareas already in `VideoPostRow` (lines 145-258 of the current file) — the composition preview panel is a new block shown above them, giving the CEO a fast, pre-render look at the live composition before the MP4 cuts exist or while iterating.
 
-This spec does not cover the backend contract (`project_id` on
-`VideoRequestBody`, the re-render action route, or the composition-HTML
-proxy route) — those are backend/frontend implementation details tracked on
-the sibling code task. Every prop name below is written as the request
-shape the frontend needs; the implementer wires it to whatever route lands.
+This spec does not cover the backend contract (`project_id` on `VideoRequestBody`, the re-render action route, or the composition-HTML proxy route) — those are backend/frontend implementation details tracked on the sibling code task. Every prop name below is written as the request shape the frontend needs; the implementer wires it to whatever route lands.
 
-**Design bar dial read:** this is dense product UI (an approval queue
-inside the existing panel chrome), not a landing surface — variance 2,
-motion 2, density 7, per the UX/UI cell's default for dashboard work. No new
-color, radius, or shadow tokens; every value below is a token or class
-already used in `video-post-queue.tsx` or `release-proposal-card.tsx`.
+**Design bar dial read:** this is dense product UI (an approval queue inside the existing panel chrome), not a landing surface — variance 2, motion 2, density 7, per the UX/UI cell's default for dashboard work. No new color, radius, or shadow tokens; every value below is a token or class already used in `video-post-queue.tsx` or `release-proposal-card.tsx`.
 
 ---
 
@@ -41,14 +24,9 @@ already used in `video-post-queue.tsx` or `release-proposal-card.tsx`.
 
 ### Component
 
-Reuse `ProjectSelector` from `panel/src/components/projects/project-selector.tsx`
-as-is — it already renders a `Select` grouped by cell (Backend / Frontend /
-UX/UI / Other) with a `FolderGit2` icon and a cell `Badge`, matching this
-dialog's existing shadcn/ui primitives (`Select`, `Label`, `Input`,
-`Textarea`, `Checkbox` are already imported in this file).
+Reuse `ProjectSelector` from `panel/src/components/projects/project-selector.tsx` as-is — it already renders a `Select` grouped by cell (Backend / Frontend / UX/UI / Other) with a `FolderGit2` icon and a cell `Badge`, matching this dialog's existing shadcn/ui primitives (`Select`, `Label`, `Input`, `Textarea`, `Checkbox` are already imported in this file).
 
-`ProjectSelector` today has no way to restrict the list to video-enabled
-projects. Add one optional prop rather than a new component:
+`ProjectSelector` today has no way to restrict the list to video-enabled projects. Add one optional prop rather than a new component:
 
 ```tsx
 interface ProjectSelectorProps {
@@ -57,19 +35,11 @@ interface ProjectSelectorProps {
 }
 ```
 
-`video_engine_enabled` is already a field on `Project` (`panel/src/types/index.ts:1026`)
-but is **not** on `ProjectSummary` (the shape `useProjects()` / `GET /projects`
-returns today, `panel/src/types/index.ts:1081-1090`) — the backend task must
-add `video_engine_enabled: boolean` to `ProjectSummary` for this filter to
-work client-side. `RequestVideoDialog` passes `videoEngineOnly`.
+`video_engine_enabled` is already a field on `Project` (`panel/src/types/index.ts:1026`) but is **not** on `ProjectSummary` (the shape `useProjects()` / `GET /projects` returns today, `panel/src/types/index.ts:1081-1090`) — the backend task must add `video_engine_enabled: boolean` to `ProjectSummary` for this filter to work client-side. `RequestVideoDialog` passes `videoEngineOnly`.
 
 ### Placement
 
-Insert the picker as the **first** field inside `RequestVideoDialog`'s
-`<div className="space-y-4">` (currently Occasion, Brief, Platforms — see
-`video-post-queue.tsx:346-386`), before Occasion, using the exact same
-`space-y-2` wrapper and `Label` pattern every other field in this dialog
-uses:
+Insert the picker as the **first** field inside `RequestVideoDialog`'s `<div className="space-y-4">` (currently Occasion, Brief, Platforms — see `video-post-queue.tsx:346-386`), before Occasion, using the exact same `space-y-2` wrapper and `Label` pattern every other field in this dialog uses:
 
 ```tsx
 <div className="space-y-2">
@@ -84,9 +54,7 @@ uses:
 </div>
 ```
 
-`projectId` is new dialog state (`useState<string | null>(null)`), reset in
-the same `onSuccess`/cancel paths that already reset `occasion`/`brief`/
-`platforms` (`video-post-queue.tsx:308-311`).
+`projectId` is new dialog state (`useState<string | null>(null)`), reset in the same `onSuccess`/cancel paths that already reset `occasion`/`brief`/ `platforms` (`video-post-queue.tsx:308-311`).
 
 ### States
 
@@ -99,9 +67,7 @@ the same `onSuccess`/cancel paths that already reset `occasion`/`brief`/
 
 ### Validation
 
-`canSubmit` (`video-post-queue.tsx:330-333`) gains `projectId !== null` as a
-fourth condition alongside occasion/brief/platforms — the picker is
-required, matching every other field in this dialog.
+`canSubmit` (`video-post-queue.tsx:330-333`) gains `projectId !== null` as a fourth condition alongside occasion/brief/platforms — the picker is required, matching every other field in this dialog.
 
 ---
 
@@ -109,9 +75,7 @@ required, matching every other field in this dialog.
 
 ### Component
 
-New `RerenderControl` sub-component, colocated in `video-post-queue.tsx`
-next to `VideoPostRow` (mirrors how `RequestVideoDialog` already sits next
-to `VideoPostQueue` in the same file):
+New `RerenderControl` sub-component, colocated in `video-post-queue.tsx` next to `VideoPostRow` (mirrors how `RequestVideoDialog` already sits next to `VideoPostQueue` in the same file):
 
 ```tsx
 type RerenderState = "idle" | "loading" | "stale" | "error";
@@ -125,18 +89,11 @@ function RerenderControl({
 }) { /* ... */ }
 ```
 
-`state` is derived, not stored redundantly: `stale` when the draft's
-captions or occasion have been edited locally since the last successful
-render (compare against the same `edited*`/local-state pattern `VideoPostRow`
-already uses for captions, `video-post-queue.tsx:98-101`); `loading` while
-the re-render mutation is in flight; `error` when that mutation's last
-attempt failed; `idle` otherwise (freshly rendered, nothing pending, no
-error).
+`state` is derived, not stored redundantly: `stale` when the draft's captions or occasion have been edited locally since the last successful render (compare against the same `edited*`/local-state pattern `VideoPostRow` already uses for captions, `video-post-queue.tsx:98-101`); `loading` while the re-render mutation is in flight; `error` when that mutation's last attempt failed; `idle` otherwise (freshly rendered, nothing pending, no error).
 
 ### Placement
 
-Directly above the cut-switcher buttons (`video-post-queue.tsx:160-184`),
-right-aligned, same row as the cut buttons on `sm:` and up:
+Directly above the cut-switcher buttons (`video-post-queue.tsx:160-184`), right-aligned, same row as the cut buttons on `sm:` and up:
 
 ```
 ┌ VideoPostRow ─────────────────────────────────────────────┐
@@ -154,10 +111,7 @@ right-aligned, same row as the cut buttons on `sm:` and up:
 
 ### Visual spec per state
 
-Same `Button` primitive already imported in this file, `size="sm"`, plus
-`lucide-react` icons already available in the codebase (`RefreshCw`,
-`AlertTriangle`, `CheckCircle2` — the last two already imported elsewhere
-in this file).
+Same `Button` primitive already imported in this file, `size="sm"`, plus `lucide-react` icons already available in the codebase (`RefreshCw`, `AlertTriangle`, `CheckCircle2` — the last two already imported elsewhere in this file).
 
 | State | Button `variant` | Icon | Label | Disabled | Extra |
 |---|---|---|---|---|---|
@@ -166,13 +120,7 @@ in this file).
 | `stale` | `default` (filled — draws the eye, matches how `bg-amber-500/10` gaps banner in `release-proposal-card.tsx:181` is used to flag "needs attention") with an added `text-amber-950 bg-amber-500 hover:bg-amber-500/90` override | `RefreshCw` | "Re-render (edited)" | No | A small `Badge variant="outline"` reading "stale" is not needed — the button label already carries the meaning; do not duplicate it in a second element |
 | `error` | `destructive` | `AlertTriangle` | "Retry re-render" | No | `title` attribute carries the last error message (mirrors the disabled-cut-button `title` pattern at `video-post-queue.tsx:166-169`); a one-line `<p className="text-xs text-destructive">` under the button shows the same message so it is not tooltip-only |
 
-State transitions: `idle`/`stale`/`error` → click → `loading` → mutation
-resolves → `idle` (success) or `error` (failure). Editing a caption or the
-occasion while in `idle` → `stale`. There is no user action that transitions
-directly out of `loading` except the mutation settling — the button stays
-`disabled` for the whole request, preventing double-submission (same
-re-entrancy concern already handled via `submittingRef` in
-`spawn-agent-dialog.tsx:40`).
+State transitions: `idle`/`stale`/`error` → click → `loading` → mutation resolves → `idle` (success) or `error` (failure). Editing a caption or the occasion while in `idle` → `stale`. There is no user action that transitions directly out of `loading` except the mutation settling — the button stays `disabled` for the whole request, preventing double-submission (same re-entrancy concern already handled via `submittingRef` in `spawn-agent-dialog.tsx:40`).
 
 ---
 
@@ -194,18 +142,11 @@ function CompositionPreviewPanel({
 }) { /* ... */ }
 ```
 
-It renders inside `VideoPostRow`, between the cut-switcher/re-render row and
-the existing MP4 `<video>` block, only when a live `previewUrl` is
-available (composition authored but not yet rendered, or re-rendering) —
-once the MP4 exists it stays visible as a lighter-weight way to sanity-check
-captions against the composition without scrubbing the video.
+It renders inside `VideoPostRow`, between the cut-switcher/re-render row and the existing MP4 `<video>` block, only when a live `previewUrl` is available (composition authored but not yet rendered, or re-rendering) — once the MP4 exists it stays visible as a lighter-weight way to sanity-check captions against the composition without scrubbing the video.
 
 ### Layout
 
-A two-column grid at `md:` and up, stacked single column below it — the
-same collapse breakpoint already used for this row's own action buttons
-(`flex-col-reverse gap-2 pt-1 sm:flex-row`, `video-post-queue.tsx:260`), but
-`md:` here because the iframe needs more horizontal room than a button row:
+A two-column grid at `md:` and up, stacked single column below it — the same collapse breakpoint already used for this row's own action buttons (`flex-col-reverse gap-2 pt-1 sm:flex-row`, `video-post-queue.tsx:260`), but `md:` here because the iframe needs more horizontal room than a button row:
 
 ```tsx
 <div className="grid grid-cols-1 gap-3 rounded-lg border p-3 md:grid-cols-2">
@@ -214,9 +155,7 @@ same collapse breakpoint already used for this row's own action buttons
 </div>
 ```
 
-`rounded-lg border p-3` matches the existing `VideoPostRow` container's own
-`rounded-lg border p-4` (one step down in padding, since this is a nested
-block) — no new radius or border-color token.
+`rounded-lg border p-3` matches the existing `VideoPostRow` container's own `rounded-lg border p-4` (one step down in padding, since this is a nested block) — no new radius or border-color token.
 
 ### Left column: iframe
 
@@ -231,30 +170,14 @@ block) — no new radius or border-color token.
 </div>
 ```
 
-- `sandbox="allow-scripts"` only — no `allow-same-origin`, no
-  `allow-popups`, no network access implied (the compositions are already
-  built offline-only per `motion/README.md`'s render constraints, so the
-  sandboxed iframe cannot reach anything the composition doesn't already
-  vendor).
-- The composition's native canvas is 1080px wide (vertical: 1080×1920,
-  square: 1080×1080, per `motion/README.md`); the iframe is displayed at a
-  fixed max-width scaled thumbnail (180px vertical / 240px square) rather
-  than 1:1, matching how the MP4 `<video>` below it is already constrained
-  (`mx-auto max-h-96 w-full`, `video-post-queue.tsx:189`) — full-size
-  inspection is not this panel's job, it is a fast sanity check.
-- `bg-muted` fills any letterboxing while the iframe loads, mirroring the
-  "missing cut" placeholder's `border-dashed` box use of the same muted
-  surface (`video-post-queue.tsx:195-197`).
-- Reuses the row's existing `cut` state (the same `vertical`/`square`
-  toggle buttons drive both the iframe and the MP4 preview below it — no
-  second switcher).
+- `sandbox="allow-scripts"` only — no `allow-same-origin`, no `allow-popups`, no network access implied (the compositions are already built offline-only per `motion/README.md`'s render constraints, so the sandboxed iframe cannot reach anything the composition doesn't already vendor).
+- The composition's native canvas is 1080px wide (vertical: 1080×1920, square: 1080×1080, per `motion/README.md`); the iframe is displayed at a fixed max-width scaled thumbnail (180px vertical / 240px square) rather than 1:1, matching how the MP4 `<video>` below it is already constrained (`mx-auto max-h-96 w-full`, `video-post-queue.tsx:189`) — full-size inspection is not this panel's job, it is a fast sanity check.
+- `bg-muted` fills any letterboxing while the iframe loads, mirroring the "missing cut" placeholder's `border-dashed` box use of the same muted surface (`video-post-queue.tsx:195-197`).
+- Reuses the row's existing `cut` state (the same `vertical`/`square` toggle buttons drive both the iframe and the MP4 preview below it — no second switcher).
 
 ### Right column: captions
 
-Read-only display of the same captions the composition's `captions.json`
-proposes (per `motion/README.md`'s `captions.json` schema) — this is a
-preview of what will be sent, not an edit surface (editing already happens
-in the existing textareas further down the card):
+Read-only display of the same captions the composition's `captions.json` proposes (per `motion/README.md`'s `captions.json` schema) — this is a preview of what will be sent, not an edit surface (editing already happens in the existing textareas further down the card):
 
 ```tsx
 <div className="space-y-2 text-sm">
@@ -269,21 +192,11 @@ in the existing textareas further down the card):
 </div>
 ```
 
-Typography matches the "Drafted CHANGELOG" label pattern already used in
-`release-proposal-card.tsx:200-205` (`text-xs font-semibold uppercase
-tracking-wide text-muted-foreground` for the eyebrow label).
+Typography matches the "Drafted CHANGELOG" label pattern already used in `release-proposal-card.tsx:200-205` (`text-xs font-semibold uppercase tracking-wide text-muted-foreground` for the eyebrow label).
 
 ### Narrow-viewport behavior
 
-Below `md:` (768px) the grid collapses to a single column: iframe first,
-captions second, each taking the full row width, `gap-3` between them (the
-`grid-cols-1` default already declared above — no separate mobile-only
-class needed). The iframe keeps its own `max-w-[180px]`/`max-w-[240px]`
-cap and centers via the parent's `flex items-center justify-center`, so it
-never stretches edge-to-edge on a narrow card even though the grid cell
-does. This matches how the existing cut-switcher buttons and action row
-already reflow from a row to a stacked column on narrow viewports
-(`flex-col-reverse gap-2 ... sm:flex-row`).
+Below `md:` (768px) the grid collapses to a single column: iframe first, captions second, each taking the full row width, `gap-3` between them (the `grid-cols-1` default already declared above — no separate mobile-only class needed). The iframe keeps its own `max-w-[180px]`/`max-w-[240px]` cap and centers via the parent's `flex items-center justify-center`, so it never stretches edge-to-edge on a narrow card even though the grid cell does. This matches how the existing cut-switcher buttons and action row already reflow from a row to a stacked column on narrow viewports (`flex-col-reverse gap-2 ... sm:flex-row`).
 
 ---
 


### PR DESCRIPTION
The file docs/ux_ui/design/01-video-request-composition-controls.md is hard-wrapped in a way that fails `make reflow-check` (and the CI Python quality gate that runs it). Rewrap the prose paragraphs to the project's line-length convention so the check passes. Do NOT change any wording, headers, list content, or code fences — this is a pure formatting/line-wrap fix. Run `make reflow-check` locally before opening the PR to confirm it's green.