### PR TITLE
[99c3ed9c] Reflow two backend docs to unblock make quality gate

### DIFF
--- a/docs/backend/api/video-engine-endpoints.md
+++ b/docs/backend/api/video-engine-endpoints.md
@@ -176,7 +176,7 @@ CEO-only (401 if not CEO).
 1. **Task lookup**: Fetches task; validates it's a video task (`source=VIDEO_SOURCE`) with `project_id`.
 2. **Project resolution**: Looks up project by `project_id`.
 3. **Workspace fetch**: Ensures project's read-clone is available (clones if needed).
-4. **Path resolution**: 
+4. **Path resolution**:
    - Strips leading `/` from `file_path`
    - Resolves against workspace root
    - Validates resolved path is under root and is a regular file
@@ -220,7 +220,7 @@ curl -H 'X-Agent-Token: <ceo-token>' \
 Previously, the video engine hardcoded `settings.self_heal_project_slug` everywhere. Now:
 
 1. **On-demand requests** (`POST /video/request`): `project_id` required in request body
-2. **Authoring tasks**: Each task stores its own `project_id`  
+2. **Authoring tasks**: Each task stores its own `project_id`
 3. **Render loop** (`orchestrator._render_both_cuts`): Uses task's `project_id` to resolve motion/ workspace, not hardcoded setting
 
 ### Rationale

--- a/docs/backend/migrations/video-project-scoping.md
+++ b/docs/backend/migrations/video-project-scoping.md
@@ -1,9 +1,6 @@
 # Migration: Video Engine Project-Scoping
 
-**Date**: 2026-07-10  
-**PR**: #386  
-**Commits**: 88ab5c6d, f2a08702  
-**Breaking Change**: Yes
+**Date**: 2026-07-10 **PR**: #386 **Commits**: 88ab5c6d, f2a08702 **Breaking Change**: Yes
 
 ---
 


### PR DESCRIPTION
The cell PR (#439, branch feature/ux_ui/f7d0a61a--e4ed92d6--8e912c3e) failed the in-path PR review gate. The target UX doc docs/ux_ui/design/01-video-request-composition-controls.md already passes `make reflow-check`, but the project-wide `make quality` check fails because two other docs present on this branch are hard-wrapped: docs/backend/api/video-engine-endpoints.md and docs/backend/migrations/video-project-scoping.md.

Run `make reflow-docs` (or manually rewrap the prose) on those two files so both pass `make reflow-check`. Then run the full `make quality` (or at least `make reflow-check`) project-wide to confirm nothing else fails. Commit with a formatting-only change — do not alter the wording/content of any file. Re-verify docs/ux_ui/design/01-video-request-composition-controls.md is still unmodified in content and still passes the check, then open/update the PR so it's ready for re-review.