### PR TITLE
[478f027c] Implement A2A conversations filter control per conversations-filter-control.md

### DIFF
--- a/docs/components/a2a-filter-control.md
+++ b/docs/components/a2a-filter-control.md
@@ -1,0 +1,316 @@
+# A2A Conversations Filter Control
+
+**Location:** `panel/src/components/a2a/`  
+**Design spec:** `docs/ux_ui/design/conversations-filter-control.md`  
+**Related:** A2A page (`panel/src/app/(dashboard)/a2a/page.tsx`)
+
+## Overview
+
+The A2A filter control provides a multi-dimension Popover-triggered filter panel for narrowing down agent-to-agent conversations by Agent, Task, Status, and Date range. It replaces the previous free-text search + status toggle and applies different filter rules to the Switchboard (org-chart pairs) and Conversation List (message feeds) views per the design spec's per-view rules.
+
+**Key principle:** The same filter state manages both views, but which dimensions apply depends on the active view—Switchboard pairs only narrow by Agent (since they may have no conversation), while the Conversation List applies all four dimensions.
+
+## Component API
+
+### `A2AFilterBar`
+
+**Path:** `panel/src/components/a2a/a2a-filter-bar.tsx`
+
+```typescript
+interface A2AFilterBarProps {
+  filters: A2AFilters;
+  onFiltersChange: (filters: A2AFilters) => void;
+  agentOptions: string[];
+  view: "switchboard" | "list";
+}
+```
+
+**Props:**
+- `filters` — The current filter state (see `A2AFilters` below).
+- `onFiltersChange` — Callback fired on any filter change; receives the entire updated filter object.
+- `agentOptions` — Distinct agent slugs to display in the Agent checkbox list, already deduped and sorted. Derive this via `distinctA2AAgents(conversations, pairs)` in the parent component.
+- `view` — The active view mode. When `"switchboard"`, an inline note reminds that Task/Status/Date only apply to the List view.
+
+**Rendered output:**
+- **Collapsed (no filters):** A compact trigger button labeled `Filters` with a funnel icon.
+- **With active filters:** The trigger shows a count badge (`Filters · N`).
+- **Expanded:** A `Popover` displaying all four filter dimensions stacked vertically, plus an inline note if in Switchboard view.
+- **Chip row:** Below the header, a wrapping row of `Badge` chips—one per active filter value—with individual remove `X` buttons and a shared `Clear all` button. Only rendered when >=1 filter is active.
+
+## Filter State
+
+### `A2AFilters`
+
+**Path:** `panel/src/components/a2a/a2a-filter-utils.ts`
+
+```typescript
+interface A2AFilters {
+  agents: string[];              // Selected agent slugs
+  taskIdFragment: string;        // Free-text fragment to match against task_id
+  noLinkedTask: boolean;         // Match conversations with task_id === null
+  statuses: A2AConversationStatus[]; // "active" | "archived"
+  dateFrom: string;              // YYYY-MM-DD or ""
+  dateTo: string;                // YYYY-MM-DD or ""
+}
+```
+
+**Empty state:** `EMPTY_A2A_FILTERS` = all fields empty or falsy.
+
+## Filter Dimensions
+
+Each dimension narrows the loaded conversations or pairs via a pure matcher function in `a2a-filter-utils.ts`.
+
+### 1. Agent (applies to both views)
+
+- **Source:** `agent_a` and `agent_b` fields on `AdminConversationSummary` / `AdminPairSummary`.
+- **Match logic:** A conversation/pair matches if **either** participant is in the selected `agents` array.
+- **Widget:** Checkbox list in the Popover, with a `Clear` button when >=1 agent is selected.
+- **Empty behavior:** If `agents.length === 0`, all items pass (no agent filter applied).
+
+```typescript
+// Example: agents = ["be-dev-1"]
+// Match: conversation with agent_a="be-dev-1" agent_b="be-qa" ✓
+// Match: conversation with agent_a="ux-dev-1" agent_b="be-dev-1" ✓
+// No match: conversation with agent_a="ux-dev-1" agent_b="ux-qa" ✗
+```
+
+**Switchboard only:** Pairs are narrowed by Agent alone (design doc §1 "Per-view applicability").
+
+### 2. Task (List view only)
+
+Combines two controls for maximum flexibility:
+
+- **Task ID fragment input:** Free-text match against the full `task_id` (case-insensitive). Displayed as a single chip labeled `Task: <fragment>` when set.
+- **"No linked task" toggle:** Matches conversations with `task_id === null`. Displayed as a separate chip when active.
+
+**Match logic:**
+```
+IF (fragment is empty AND noLinkedTask is false)
+  PASS (no task filter)
+ELSE
+  PASS if (fragment matches task_id) OR (noLinkedTask is true AND task_id is null)
+```
+
+In other words: **if both controls are empty, no filtering; if one or both are set, match conversations that satisfy either condition (OR logic).**
+
+```typescript
+// Example 1: taskIdFragment="abcdef", noLinkedTask=false
+// Match: task_id="abcdef01-0000-..." ✓
+// No match: task_id="ffffffff-0000-..." ✗
+// No match: task_id=null ✗
+
+// Example 2: taskIdFragment="", noLinkedTask=true
+// No match: task_id="abcdef01-0000-..." ✗
+// Match: task_id=null ✓
+
+// Example 3: taskIdFragment="abcdef", noLinkedTask=true
+// Match: task_id="abcdef01-0000-..." ✓
+// No match: task_id="ffffffff-0000-..." ✗
+// Match: task_id=null ✓
+```
+
+**Switchboard:** This dimension does not apply (pairs may have no conversation to check a task against).
+
+### 3. Status (List view only)
+
+- **Source:** `status` field on `AdminConversationSummary` (values: `"active"` | `"archived"`).
+- **Widget:** Two toggle buttons (Active / Archived) with `aria-pressed`.
+- **Match logic:** A conversation matches if its `status` is in the selected `statuses` array.
+- **Empty behavior:** If `statuses.length === 0`, all items pass (no status filter applied).
+
+```typescript
+// Example: statuses = ["active"]
+// Match: conversation with status="active" ✓
+// No match: conversation with status="archived" ✗
+```
+
+**Switchboard:** This dimension does not apply.
+
+### 4. Date range (List view only)
+
+- **Source:** `last_message_at` field on `AdminConversationSummary`, falling back to `created_at` if null (same fallback the list already uses for display).
+- **Widget:** Two native `<input type="date">` fields (From / To), in the viewer's local timezone.
+- **Match logic:** Both dates are compared at day granularity. A conversation matches if:
+  ```
+  IF (dateFrom is empty AND dateTo is empty)
+    PASS (no date filter)
+  ELSE IF (timestamp is null/empty)
+    FAIL
+  ELSE
+    PASS if (timestamp >= dateFrom) AND (timestamp <= dateTo)
+  ```
+- **Rendered chips:** One chip per set date (`From <date>` / `To <date>`), independently removable.
+
+```typescript
+// Example: dateFrom="2026-07-01", dateTo="2026-07-05"
+// Match: last_message_at="2026-07-03T10:30:00Z" ✓
+// No match: last_message_at="2026-07-10T10:30:00Z" ✗
+// No match: last_message_at=null (falls back to created_at if null) [depends on created_at]
+```
+
+**Switchboard:** This dimension does not apply.
+
+## Usage in Components
+
+### Parent Setup
+
+In the parent component (e.g., `A2APage`), wire the filter state and compute the agent options:
+
+```typescript
+import { A2AFilterBar } from "@/components/a2a/a2a-filter-bar";
+import {
+  EMPTY_A2A_FILTERS,
+  distinctA2AAgents,
+  filterConversations,
+  filterPairs,
+  type A2AFilters,
+} from "@/components/a2a/a2a-filter-utils";
+
+function A2APageContent() {
+  const [filters, setFilters] = useState<A2AFilters>(EMPTY_A2A_FILTERS);
+
+  // Derive agent options from the loaded data
+  const agentOptions = useMemo(
+    () => distinctA2AAgents(conversations, pairs),
+    [conversations, pairs]
+  );
+
+  // Apply filters to both views
+  const filteredPairs = useMemo(
+    () => filterPairs(pairs, filters),
+    [pairs, filters]
+  );
+
+  const filteredConversations = useMemo(
+    () => filterConversations(conversations, filters),
+    [conversations, filters]
+  );
+
+  return (
+    <>
+      <A2AFilterBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        agentOptions={agentOptions}
+        view={view} // "switchboard" or "list"
+      />
+
+      {view === "switchboard" ? (
+        <A2ASwitchboard pairs={filteredPairs} />
+      ) : (
+        <A2AConversationList conversations={filteredConversations} />
+      )}
+    </>
+  );
+}
+```
+
+### Filter Functions
+
+**`filterConversations(conversations, filters): AdminConversationSummary[]`**  
+Applies all four dimensions (Agent, Task, Status, Date) to narrow the conversation list.
+
+**`filterPairs(pairs, filters): AdminPairSummary[]`**  
+Applies Agent dimension only to narrow switchboard pair cards.
+
+**`distinctA2AAgents(conversations, pairs): string[]`**  
+Derives the checkbox option set by scanning all loaded pairs and conversations, deduping agent slugs, and sorting alphabetically. Call this in a `useMemo` in the parent whenever pairs/conversations change.
+
+**`activeA2AFilterCount(filters): number`**  
+Returns the count of active filter values (one per chip). Drives the trigger's count badge. An empty fragment/date counts as 0; a set date counts as 1 per date.
+
+## Per-View Rules
+
+**This is critical:** Different dimensions apply depending on which view is active.
+
+| Dimension | Switchboard (pairs) | List (conversations) |
+|-----------|---------------------|----------------------|
+| Agent | ✓ (always applies) | ✓ |
+| Task | ✗ (N/A—pairs may have no conversation) | ✓ |
+| Status | ✗ | ✓ |
+| Date | ✗ | ✓ |
+
+**Switchboard hint:** When the view is `"switchboard"`, the Popover displays an inline note: *"Task, Status, and Date filters apply to the Conversation List view."* This prepares the user if they set those filters before switching to List.
+
+## Design Notes
+
+### Client-Side Filtering
+
+**Important limitation:** Filtering currently runs client-side over the already-fetched page of conversations/pairs (capped at `limit=100` from the backend). There are **no backend query params** for these dimensions yet.
+
+**Implication:** If the loaded data doesn't contain a matching item, the filter won't find it. This is acceptable for the current conversation volume and is explicitly noted in the design spec as "Future work."
+
+**Future task:** A later PR will add backend query params (`agent`, `task_id`, `status`, `from`, `to`) to `GET /a2a/chat/admin/conversations` so filtering can work server-side without this limitation.
+
+### Persistence
+
+Filter state is **local to the page component** (`useState`), not persisted to localStorage or the URL. Reloading the page resets filters to empty. This is intentional and consistent with the page's existing behavior (no search persistence today).
+
+### Debouncing
+
+The Task ID fragment input does **not** debounce; it updates the filter state on every keystroke. For a small dataset (100 conversations) this is fine. If performance becomes an issue with larger datasets, add a 300ms debounce in the parent using `useCallback` + `useRef` on the `onFiltersChange` callback.
+
+## Testing
+
+### Unit Tests
+
+**Component tests:** `panel/src/components/a2a/__tests__/a2a-filter-bar.test.tsx`
+- Trigger button rendering (collapsed and with badge count)
+- Popover open/close and focus management
+- Agent checkbox toggling and per-dimension clearing
+- Task input and "No linked task" toggle
+- Status button toggling
+- Date input binding
+- Chip row rendering (one chip per active value)
+- Chip `X` button removing individual filters
+- Clear all button resetting everything
+- Switchboard view hint message
+
+**Utility tests:** `panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts`
+- `filterConversations`: all four dimensions, combinations
+- `filterPairs`: Agent dimension only
+- `distinctA2AAgents`: dedup + sort correctness
+- `activeA2AFilterCount`: count logic per dimension
+- Edge cases: empty data, null values, case-insensitivity
+
+### Integration Tests
+
+`panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx` includes:
+- Rendering the filter trigger in the page header
+- Switching views and filtering by Agent in Switchboard
+- Switching to List and filtering by Agent, Task ID, and Status
+
+## Accessibility
+
+The component follows the design spec's accessibility contract:
+
+- **Trigger button:** `aria-expanded` reflects Popover open state, `aria-haspopup="dialog"`.
+- **Checkboxes:** Standard HTML `<label>` + `<Checkbox>` pair; the whole row is a hit target.
+- **Status toggle buttons:** Real `<button>` with `aria-pressed`, not `<div onClick>`.
+- **Date inputs:** Native `<input type="date">` with full keyboard support.
+- **Chip remove buttons:** Icon-only, with `aria-label="Remove <chip label> filter"`.
+- **Focus management:** Radix `Popover` handles focus trap and escape-to-close.
+- **Contrast:** All color pairs are existing shadcn/ui tokens already in production, meeting WCAG AA (4.5:1 minimum).
+
+## Related Files
+
+- **Component:** `panel/src/components/a2a/a2a-filter-bar.tsx`
+- **Utilities:** `panel/src/components/a2a/a2a-filter-utils.ts`
+- **Tests:** `a2a-filter-bar.test.tsx`, `a2a-filter-utils.test.ts`
+- **Page integration:** `panel/src/app/(dashboard)/a2a/page.tsx`
+- **Design spec:** `docs/ux_ui/design/conversations-filter-control.md`
+- **Related component (reference pattern):** `panel/src/components/tasks/task-filters.tsx` (the Popover + Checkbox + Badge-chip idiom this one mirrors)
+
+## Common Questions
+
+**Q: Why doesn't the fragment search the topic field anymore?**  
+A: The design spec replaced free-text search with four discrete dimensions. Task ID fragment and Agent are the most common filters; if you need to search topics, that would be a fifth dimension—raise it in design review if needed.
+
+**Q: Can I make filters persist across page reloads?**  
+A: Not in this version. To add localStorage persistence, wrap `setFilters` in the parent with `useEffect` to sync to localStorage and restore on mount. This would be a follow-up task.
+
+**Q: What happens to filtered state when new conversations arrive via WebSocket?**  
+A: Filters remain active. The `filterConversations` function is re-run against the refreshed list on every data update, so incoming messages are immediately re-evaluated against the current filters.
+
+**Q: Can filters be set via URL query params?**  
+A: Not currently. The state is ephemeral. To support deep-linking (e.g., `?agents=be-dev-1&status=active`), add a URL param sync layer in the parent using `useSearchParams` / `useRouter` from Next.js. This would be a follow-up task.

--- a/panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx
+++ b/panel/src/app/(dashboard)/a2a/__tests__/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { PageRefreshProvider } from "@/components/providers";
 import type {
@@ -321,7 +322,7 @@ describe("A2APage", () => {
     });
   });
 
-  it("renders the filter bar above the switchboard/list content", () => {
+  it("renders the filter trigger above the switchboard/list content", () => {
     useA2AAdminPairs.mockReturnValue({
       data: { items: [buildPair()], total: 1 },
       isLoading: false,
@@ -329,13 +330,12 @@ describe("A2APage", () => {
     });
     render(withPageRefresh(<A2APage />));
     expect(
-      screen.getByPlaceholderText("Search agent or topic..."),
+      screen.getByRole("button", { name: /^Filters$/ }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Active" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
   });
 
-  it("narrows the switchboard's pairs by search", () => {
+  it("narrows the switchboard's pairs by a selected agent", async () => {
+    const user = userEvent.setup();
     useA2AAdminPairs.mockReturnValue({
       data: {
         items: [
@@ -358,14 +358,15 @@ describe("A2APage", () => {
     expect(screen.getByText(/Backend Cell/)).toBeInTheDocument();
     expect(screen.getByText(/^Board$/)).toBeInTheDocument();
 
-    fireEvent.change(screen.getByPlaceholderText("Search agent or topic..."), {
-      target: { value: "auditor" },
-    });
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.click(screen.getByRole("checkbox", { name: "Auditor" }));
+
     expect(screen.queryByText(/Backend Cell/)).not.toBeInTheDocument();
     expect(screen.getByText(/^Board$/)).toBeInTheDocument();
   });
 
-  it("narrows the classic list's conversations by search", () => {
+  it("narrows the classic list's conversations by a selected agent", async () => {
+    const user = userEvent.setup();
     useA2AConversations.mockReturnValue({
       data: {
         items: [
@@ -388,10 +389,42 @@ describe("A2APage", () => {
     expect(screen.getByText("QA handoff")).toBeInTheDocument();
     expect(screen.getByText("Design review")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByPlaceholderText("Search agent or topic..."), {
-      target: { value: "design review" },
-    });
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.click(screen.getByRole("checkbox", { name: "UX/UI Dev 1" }));
+
     expect(screen.queryByText("QA handoff")).not.toBeInTheDocument();
     expect(screen.getByText("Design review")).toBeInTheDocument();
+  });
+
+  it("narrows the classic list's conversations by task id fragment", async () => {
+    const user = userEvent.setup();
+    useA2AConversations.mockReturnValue({
+      data: {
+        items: [
+          buildConversation({
+            task_id: "11111111-2222-3333-4444-555555555555",
+          }),
+          buildConversation({
+            id: "conv-2",
+            topic: "Design review",
+            task_id: "99999999-8888-7777-6666-555555555555",
+          }),
+        ],
+        total: 2,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    render(withPageRefresh(<A2APage />));
+    fireEvent.click(screen.getByTitle("Classic conversation list"));
+    expect(screen.getByText("QA handoff")).toBeInTheDocument();
+    expect(screen.getByText("Design review")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.type(screen.getByLabelText("Task id fragment"), "11111111");
+
+    expect(screen.getByText("QA handoff")).toBeInTheDocument();
+    expect(screen.queryByText("Design review")).not.toBeInTheDocument();
   });
 });

--- a/panel/src/app/(dashboard)/a2a/page.tsx
+++ b/panel/src/app/(dashboard)/a2a/page.tsx
@@ -30,9 +30,11 @@ import {
 } from "@/components/a2a/a2a-connection-badge";
 import { latestPulseTimestamps } from "@/components/a2a/a2a-switchboard-utils";
 import {
+  distinctA2AAgents,
   filterConversations,
   filterPairs,
-  type A2AStatusFilter,
+  EMPTY_A2A_FILTERS,
+  type A2AFilters,
 } from "@/components/a2a/a2a-filter-utils";
 import type { AdminPairSummary } from "@/lib/api/a2a";
 import { Card, CardContent } from "@/components/ui/card";
@@ -77,10 +79,10 @@ function A2APageContent() {
   // shown as an explicit "no A2A yet" state in the drill-in panel.
   const [peekedPair, setPeekedPair] = useState<PeekedPair | null>(null);
 
-  // Filter bar: status (active/all) + free-text search over agent name/topic
-  // — narrows both the switchboard's pairs and the list's conversations.
-  const [statusFilter, setStatusFilter] = useState<A2AStatusFilter>("all");
-  const [search, setSearch] = useState("");
+  // Filter panel: Agent, Task (id fragment + no-linked-task), Status, Date
+  // range — narrows both the switchboard's pairs (Agent only) and the
+  // list's conversations (all four), per the design doc's per-view rules.
+  const [filters, setFilters] = useState<A2AFilters>(EMPTY_A2A_FILTERS);
 
   // xl:+ context pane collapse, persisted via the shared UI store — same
   // idiom as sidebar/theme preferences (design doc §1).
@@ -193,8 +195,8 @@ function A2APageContent() {
     [a2aMessages, pairs],
   );
   const filteredPairs = useMemo(
-    () => filterPairs(pairs, statusFilter, search),
-    [pairs, statusFilter, search],
+    () => filterPairs(pairs, filters),
+    [pairs, filters],
   );
 
   const handleSelect = useCallback(
@@ -229,8 +231,12 @@ function A2APageContent() {
     [conversationData],
   );
   const filteredConversations = useMemo(
-    () => filterConversations(conversations, statusFilter, search),
-    [conversations, statusFilter, search],
+    () => filterConversations(conversations, filters),
+    [conversations, filters],
+  );
+  const agentOptions = useMemo(
+    () => distinctA2AAgents(conversations, pairs),
+    [conversations, pairs],
   );
   const selected = conversations.find((c) => c.id === selectedId) ?? null;
   const messages = messagesData?.items ?? [];
@@ -348,10 +354,10 @@ function A2APageContent() {
                   </div>
                 </div>
                 <A2AFilterBar
-                  status={statusFilter}
-                  onStatusChange={setStatusFilter}
-                  search={search}
-                  onSearchChange={setSearch}
+                  filters={filters}
+                  onFiltersChange={setFilters}
+                  agentOptions={agentOptions}
+                  view={view}
                 />
                 <div className="flex-1 overflow-hidden -mx-3">
                   {view === "switchboard" ? (

--- a/panel/src/components/a2a/__tests__/a2a-filter-bar.test.tsx
+++ b/panel/src/components/a2a/__tests__/a2a-filter-bar.test.tsx
@@ -1,70 +1,175 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { A2AFilterBar } from "../a2a-filter-bar";
+import { EMPTY_A2A_FILTERS, type A2AFilters } from "../a2a-filter-utils";
+
+function renderBar(
+  overrides: Partial<Omit<Parameters<typeof A2AFilterBar>[0], "filters">> & {
+    filters?: A2AFilters;
+  } = {},
+) {
+  const onFiltersChange = vi.fn();
+  const { filters, ...rest } = overrides;
+  render(
+    <A2AFilterBar
+      filters={filters ?? EMPTY_A2A_FILTERS}
+      onFiltersChange={onFiltersChange}
+      agentOptions={["be-dev-1", "be-qa"]}
+      view="list"
+      {...rest}
+    />,
+  );
+  return { onFiltersChange };
+}
 
 describe("A2AFilterBar", () => {
-  it("renders the search input and both status toggle buttons", () => {
-    render(
-      <A2AFilterBar
-        status="all"
-        onStatusChange={vi.fn()}
-        search=""
-        onSearchChange={vi.fn()}
-      />,
-    );
+  it("renders a collapsed trigger with no active-count badge by default", () => {
+    renderBar();
     expect(
-      screen.getByPlaceholderText("Search agent or topic..."),
+      screen.getByRole("button", { name: /^Filters$/ }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Active" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
   });
 
-  it("marks the current status button as pressed", () => {
-    render(
-      <A2AFilterBar
-        status="active"
-        onStatusChange={vi.fn()}
-        search=""
-        onSearchChange={vi.fn()}
-      />,
-    );
-    expect(screen.getByRole("button", { name: "Active" })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
-    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
+  it("shows the active-count badge on the trigger when filters are set", () => {
+    renderBar({ filters: { ...EMPTY_A2A_FILTERS, agents: ["be-dev-1"] } });
+    expect(
+      screen.getByRole("button", { name: "Filters · 1" }),
+    ).toBeInTheDocument();
   });
 
-  it("fires onStatusChange when a status button is clicked", () => {
-    const onStatusChange = vi.fn();
-    render(
-      <A2AFilterBar
-        status="all"
-        onStatusChange={onStatusChange}
-        search=""
-        onSearchChange={vi.fn()}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Active" }));
-    expect(onStatusChange).toHaveBeenCalledWith("active");
+  it("opens the popover and renders the Agent checkbox list", async () => {
+    const user = userEvent.setup();
+    renderBar();
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    expect(screen.getByText("Backend Dev 1")).toBeInTheDocument();
+    expect(screen.getByText("Backend QA")).toBeInTheDocument();
   });
 
-  it("fires onSearchChange as the user types", () => {
-    const onSearchChange = vi.fn();
-    render(
-      <A2AFilterBar
-        status="all"
-        onStatusChange={vi.fn()}
-        search=""
-        onSearchChange={onSearchChange}
-      />,
-    );
-    fireEvent.change(screen.getByPlaceholderText("Search agent or topic..."), {
-      target: { value: "be-qa" },
+  it("fires onFiltersChange when an Agent checkbox is toggled", async () => {
+    const user = userEvent.setup();
+    const { onFiltersChange } = renderBar();
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.click(screen.getByRole("checkbox", { name: "Backend Dev 1" }));
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...EMPTY_A2A_FILTERS,
+      agents: ["be-dev-1"],
     });
-    expect(onSearchChange).toHaveBeenCalledWith("be-qa");
+  });
+
+  it("renders the Task id-fragment input and the No linked task toggle", async () => {
+    const user = userEvent.setup();
+    renderBar();
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    expect(screen.getByLabelText("Task id fragment")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "No linked task" }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onFiltersChange when the task id fragment is typed", async () => {
+    const user = userEvent.setup();
+    const { onFiltersChange } = renderBar();
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.type(screen.getByLabelText("Task id fragment"), "a");
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...EMPTY_A2A_FILTERS,
+      taskIdFragment: "a",
+    });
+  });
+
+  it("renders Status toggle buttons and two date-range inputs", async () => {
+    const user = userEvent.setup();
+    renderBar();
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    expect(screen.getByRole("button", { name: "Active" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Archived" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("From date")).toBeInTheDocument();
+    expect(screen.getByLabelText("To date")).toBeInTheDocument();
+  });
+
+  it("fires onFiltersChange when a status button is toggled", async () => {
+    const user = userEvent.setup();
+    const { onFiltersChange } = renderBar();
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    await user.click(screen.getByRole("button", { name: "Active" }));
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...EMPTY_A2A_FILTERS,
+      statuses: ["active"],
+    });
+  });
+
+  it("shows an inline note that Task/Status/Date apply to the List view only when view=switchboard", async () => {
+    const user = userEvent.setup();
+    renderBar({ view: "switchboard" });
+    await user.click(screen.getByRole("button", { name: /^Filters$/ }));
+    expect(
+      screen.getByText(
+        "Task, Status, and Date filters apply to the Conversation List view.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one chip per active filter value plus a Clear all action", () => {
+    renderBar({
+      filters: {
+        agents: ["be-dev-1"],
+        taskIdFragment: "",
+        noLinkedTask: false,
+        statuses: ["active"],
+        dateFrom: "2026-07-01",
+        dateTo: "",
+      },
+    });
+    expect(screen.getByText("Backend Dev 1")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("From 2026-07-01")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Clear all" }),
+    ).toBeInTheDocument();
+  });
+
+  it("removes only the matching filter when a chip's remove button is clicked", async () => {
+    const user = userEvent.setup();
+    const { onFiltersChange } = renderBar({
+      filters: {
+        ...EMPTY_A2A_FILTERS,
+        agents: ["be-dev-1"],
+        statuses: ["active"],
+      },
+    });
+    await user.click(
+      screen.getByRole("button", { name: "Remove Active filter" }),
+    );
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...EMPTY_A2A_FILTERS,
+      agents: ["be-dev-1"],
+      statuses: [],
+    });
+  });
+
+  it("resets every dimension when Clear all is clicked", async () => {
+    const user = userEvent.setup();
+    const { onFiltersChange } = renderBar({
+      filters: {
+        agents: ["be-dev-1"],
+        taskIdFragment: "abc",
+        noLinkedTask: true,
+        statuses: ["active"],
+        dateFrom: "2026-07-01",
+        dateTo: "2026-07-05",
+      },
+    });
+    await user.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(onFiltersChange).toHaveBeenCalledWith(EMPTY_A2A_FILTERS);
+  });
+
+  it("renders no chip row or Clear all when no filters are active", () => {
+    renderBar();
+    expect(
+      screen.queryByRole("button", { name: "Clear all" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts
+++ b/panel/src/components/a2a/__tests__/a2a-filter-utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from "vitest";
 import type { AdminConversationSummary, AdminPairSummary } from "@/lib/api/a2a";
-import { filterConversations, filterPairs } from "../a2a-filter-utils";
+import {
+  EMPTY_A2A_FILTERS,
+  activeA2AFilterCount,
+  distinctA2AAgents,
+  filterConversations,
+  filterPairs,
+  type A2AFilters,
+} from "../a2a-filter-utils";
 
 function buildConversation(
   overrides: Partial<AdminConversationSummary> = {},
@@ -39,69 +46,181 @@ function buildPair(
   };
 }
 
+function filters(overrides: Partial<A2AFilters> = {}): A2AFilters {
+  return { ...EMPTY_A2A_FILTERS, ...overrides };
+}
+
 describe("filterConversations", () => {
-  it("passes everything through with an empty search and status=all", () => {
+  it("passes everything through with no active filters", () => {
     const conversations = [
       buildConversation({ status: "active" }),
-      buildConversation({ id: "conv-2", status: "closed" }),
+      buildConversation({ id: "conv-2", status: "archived" }),
     ];
-    expect(filterConversations(conversations, "all", "")).toHaveLength(2);
+    expect(filterConversations(conversations, filters())).toHaveLength(2);
   });
 
-  it("narrows to active-status conversations when status=active", () => {
+  it("narrows by selected agents (either participant matches)", () => {
     const conversations = [
-      buildConversation({ id: "conv-1", status: "active" }),
-      buildConversation({ id: "conv-2", status: "closed" }),
+      buildConversation({
+        id: "conv-1",
+        agent_a: "be-dev-1",
+        agent_b: "be-qa",
+      }),
+      buildConversation({
+        id: "conv-2",
+        agent_a: "ux-dev-1",
+        agent_b: "ux-qa",
+      }),
     ];
-    const result = filterConversations(conversations, "active", "");
+    const result = filterConversations(
+      conversations,
+      filters({ agents: ["be-qa"] }),
+    );
     expect(result.map((c) => c.id)).toEqual(["conv-1"]);
   });
 
-  it("matches search against agent display name (case-insensitive)", () => {
-    const conversations = [buildConversation()];
+  it("narrows by task id fragment (case-insensitive)", () => {
+    const conversations = [
+      buildConversation({ id: "conv-1", task_id: "abcdef01-0000" }),
+      buildConversation({ id: "conv-2", task_id: "ffffffff-0000" }),
+    ];
+    const result = filterConversations(
+      conversations,
+      filters({ taskIdFragment: "ABCDEF" }),
+    );
+    expect(result.map((c) => c.id)).toEqual(["conv-1"]);
+  });
+
+  it("narrows to task_id === null when noLinkedTask is set", () => {
+    const conversations = [
+      buildConversation({ id: "conv-1", task_id: null }),
+      buildConversation({ id: "conv-2", task_id: "abcdef01-0000" }),
+    ];
+    const result = filterConversations(
+      conversations,
+      filters({ noLinkedTask: true }),
+    );
+    expect(result.map((c) => c.id)).toEqual(["conv-1"]);
+  });
+
+  it("ORs the task fragment and no-linked-task toggle when both are set", () => {
+    const conversations = [
+      buildConversation({ id: "conv-1", task_id: null }),
+      buildConversation({ id: "conv-2", task_id: "abcdef01-0000" }),
+      buildConversation({ id: "conv-3", task_id: "zzzzzzzz-0000" }),
+    ];
+    const result = filterConversations(
+      conversations,
+      filters({ taskIdFragment: "abcdef", noLinkedTask: true }),
+    );
+    expect(result.map((c) => c.id).sort()).toEqual(["conv-1", "conv-2"]);
+  });
+
+  it("narrows by selected statuses", () => {
+    const conversations = [
+      buildConversation({ id: "conv-1", status: "active" }),
+      buildConversation({ id: "conv-2", status: "archived" }),
+    ];
+    const result = filterConversations(
+      conversations,
+      filters({ statuses: ["archived"] }),
+    );
+    expect(result.map((c) => c.id)).toEqual(["conv-2"]);
+  });
+
+  it("narrows by date range on last_message_at at day granularity", () => {
+    const conversations = [
+      buildConversation({
+        id: "conv-1",
+        last_message_at: "2026-07-02T12:00:00Z",
+      }),
+      buildConversation({
+        id: "conv-2",
+        last_message_at: "2026-07-05T12:00:00Z",
+      }),
+    ];
+    const result = filterConversations(
+      conversations,
+      filters({ dateFrom: "2026-07-03", dateTo: "2026-07-06" }),
+    );
+    expect(result.map((c) => c.id)).toEqual(["conv-2"]);
+  });
+
+  it("falls back to created_at for the date range when last_message_at is null", () => {
+    const conversations = [
+      buildConversation({
+        id: "conv-1",
+        last_message_at: null,
+        created_at: "2026-07-02T12:00:00Z",
+      }),
+    ];
     expect(
-      filterConversations(conversations, "all", "backend qa"),
+      filterConversations(
+        conversations,
+        filters({ dateFrom: "2026-07-02", dateTo: "2026-07-02" }),
+      ),
     ).toHaveLength(1);
-    expect(filterConversations(conversations, "all", "nope")).toHaveLength(0);
-  });
-
-  it("matches search against the topic", () => {
-    const conversations = [buildConversation({ topic: "QA handoff" })];
-    expect(filterConversations(conversations, "all", "handoff")).toHaveLength(
-      1,
-    );
-  });
-
-  it("matches search against a raw agent slug", () => {
-    const conversations = [buildConversation({ agent_a: "be-dev-1" })];
-    expect(filterConversations(conversations, "all", "be-dev-1")).toHaveLength(
-      1,
-    );
+    expect(
+      filterConversations(conversations, filters({ dateFrom: "2026-07-03" })),
+    ).toHaveLength(0);
   });
 });
 
 describe("filterPairs", () => {
-  it("passes everything through with an empty search and status=all", () => {
+  it("passes everything through with no active filters", () => {
     const pairs = [
       buildPair({ conversation_id: "conv-1" }),
       buildPair({ agent_a: "auditor", agent_b: "product-owner" }),
     ];
-    expect(filterPairs(pairs, "all", "")).toHaveLength(2);
+    expect(filterPairs(pairs, filters())).toHaveLength(2);
   });
 
-  it("narrows to pairs with a conversation when status=active", () => {
+  it("narrows by selected agents only — Task/Status/Date never apply", () => {
     const pairs = [
-      buildPair({ conversation_id: "conv-1" }),
+      buildPair({ agent_a: "be-dev-1", agent_b: "be-qa" }),
       buildPair({ agent_a: "auditor", agent_b: "product-owner" }),
     ];
-    const result = filterPairs(pairs, "active", "");
+    const result = filterPairs(
+      pairs,
+      filters({
+        agents: ["be-dev-1"],
+        statuses: ["archived"],
+        dateFrom: "2099-01-01",
+      }),
+    );
     expect(result).toHaveLength(1);
-    expect(result[0].conversation_id).toBe("conv-1");
+    expect(result[0].agent_a).toBe("be-dev-1");
+  });
+});
+
+describe("distinctA2AAgents", () => {
+  it("dedupes and sorts agent slugs across conversations and pairs", () => {
+    const conversations = [
+      buildConversation({ agent_a: "fe-qa", agent_b: "be-qa" }),
+    ];
+    const pairs = [buildPair({ agent_a: "be-dev-1", agent_b: "be-qa" })];
+    expect(distinctA2AAgents(conversations, pairs)).toEqual([
+      "be-dev-1",
+      "be-qa",
+      "fe-qa",
+    ]);
+  });
+});
+
+describe("activeA2AFilterCount", () => {
+  it("counts zero for the empty filter state", () => {
+    expect(activeA2AFilterCount(EMPTY_A2A_FILTERS)).toBe(0);
   });
 
-  it("matches search against agent display name (case-insensitive)", () => {
-    const pairs = [buildPair()];
-    expect(filterPairs(pairs, "all", "backend dev 1")).toHaveLength(1);
-    expect(filterPairs(pairs, "all", "nope")).toHaveLength(0);
+  it("counts one entry per active chip", () => {
+    expect(
+      activeA2AFilterCount(
+        filters({
+          agents: ["be-dev-1", "be-qa"],
+          statuses: ["active"],
+          dateFrom: "2026-07-01",
+        }),
+      ),
+    ).toBe(4);
   });
 });

--- a/panel/src/components/a2a/a2a-filter-bar.tsx
+++ b/panel/src/components/a2a/a2a-filter-bar.tsx
@@ -2,62 +2,301 @@
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Search } from "lucide-react";
-import type { A2AStatusFilter } from "./a2a-filter-utils";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { SlidersHorizontal, X } from "lucide-react";
+import { getAgentDisplayName } from "@/lib/agent-utils";
+import {
+  EMPTY_A2A_FILTERS,
+  activeA2AFilterCount,
+  type A2AConversationStatus,
+  type A2AFilters,
+} from "./a2a-filter-utils";
+
+const STATUS_OPTIONS: { value: A2AConversationStatus; label: string }[] = [
+  { value: "active", label: "Active" },
+  { value: "archived", label: "Archived" },
+];
 
 interface A2AFilterBarProps {
-  status: A2AStatusFilter;
-  onStatusChange: (status: A2AStatusFilter) => void;
-  search: string;
-  onSearchChange: (value: string) => void;
+  filters: A2AFilters;
+  onFiltersChange: (filters: A2AFilters) => void;
+  /** Distinct agent slugs to list as checkboxes (already deduped+sorted —
+   * see `distinctA2AAgents`). */
+  agentOptions: string[];
+  /** Task/Status/Date only narrow the List view — Switchboard pairs have no
+   * conversation to filter those dimensions on (design doc §1). */
+  view: "switchboard" | "list";
+}
+
+interface FilterChip {
+  key: string;
+  label: string;
+  onRemove: () => void;
 }
 
 /**
- * Filter bar above the switchboard/list content: free-text search (agent
- * name or topic) plus an active/all status toggle. Both narrow the
- * switchboard's pairs and the classic list's conversations identically —
- * see a2a-filter-utils.ts.
+ * Popover-triggered filter panel above the switchboard/list content: Agent
+ * (multi-select), Task (id fragment + "No linked task"), Status (toggle
+ * buttons) and a date range — plus the active-filter chip row and
+ * Clear-all. See docs/ux_ui/design/conversations-filter-control.md.
  */
 export function A2AFilterBar({
-  status,
-  onStatusChange,
-  search,
-  onSearchChange,
+  filters,
+  onFiltersChange,
+  agentOptions,
+  view,
 }: A2AFilterBarProps) {
+  const toggleAgent = (agent: string) => {
+    onFiltersChange({
+      ...filters,
+      agents: filters.agents.includes(agent)
+        ? filters.agents.filter((a) => a !== agent)
+        : [...filters.agents, agent],
+    });
+  };
+
+  const toggleStatus = (status: A2AConversationStatus) => {
+    onFiltersChange({
+      ...filters,
+      statuses: filters.statuses.includes(status)
+        ? filters.statuses.filter((s) => s !== status)
+        : [...filters.statuses, status],
+    });
+  };
+
+  const clearAll = () => onFiltersChange(EMPTY_A2A_FILTERS);
+
+  const chips: FilterChip[] = [
+    ...filters.agents.map((agent) => ({
+      key: `agent-${agent}`,
+      label: getAgentDisplayName(agent),
+      onRemove: () => toggleAgent(agent),
+    })),
+    ...(filters.taskIdFragment
+      ? [
+          {
+            key: "task-fragment",
+            label: `Task: ${filters.taskIdFragment}`,
+            onRemove: () => onFiltersChange({ ...filters, taskIdFragment: "" }),
+          },
+        ]
+      : []),
+    ...(filters.noLinkedTask
+      ? [
+          {
+            key: "no-linked-task",
+            label: "No linked task",
+            onRemove: () =>
+              onFiltersChange({ ...filters, noLinkedTask: false }),
+          },
+        ]
+      : []),
+    ...filters.statuses.map((status) => ({
+      key: `status-${status}`,
+      label: STATUS_OPTIONS.find((o) => o.value === status)?.label ?? status,
+      onRemove: () => toggleStatus(status),
+    })),
+    ...(filters.dateFrom
+      ? [
+          {
+            key: "date-from",
+            label: `From ${filters.dateFrom}`,
+            onRemove: () => onFiltersChange({ ...filters, dateFrom: "" }),
+          },
+        ]
+      : []),
+    ...(filters.dateTo
+      ? [
+          {
+            key: "date-to",
+            label: `To ${filters.dateTo}`,
+            onRemove: () => onFiltersChange({ ...filters, dateTo: "" }),
+          },
+        ]
+      : []),
+  ];
+
+  const count = activeA2AFilterCount(filters);
+
   return (
-    <div className="flex items-center gap-2 mb-2 shrink-0">
-      <div className="relative flex-1 min-w-0">
-        <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-        <Input
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-          placeholder="Search agent or topic..."
-          className="h-7 pl-7 text-xs"
-          aria-label="Search agent or topic"
-        />
+    <div className="mb-2 shrink-0">
+      <div className="flex items-center justify-end">
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 px-2 text-xs"
+            >
+              <SlidersHorizontal className="h-3.5 w-3.5" />
+              {count > 0 ? `Filters · ${count}` : "Filters"}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="end"
+            className="w-72 max-h-[70vh] space-y-3 overflow-y-auto"
+          >
+            {view === "switchboard" && (
+              <p className="text-xs text-muted-foreground">
+                Task, Status, and Date filters apply to the Conversation List
+                view.
+              </p>
+            )}
+
+            <div>
+              <div className="mb-1 flex items-center justify-between">
+                <span className="text-sm font-medium">Agent</span>
+                {filters.agents.length > 0 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs"
+                    onClick={() => onFiltersChange({ ...filters, agents: [] })}
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+              <div className="max-h-40 space-y-1 overflow-y-auto">
+                {agentOptions.map((agent) => (
+                  <label
+                    key={agent}
+                    className="flex cursor-pointer items-center gap-2 rounded px-1 py-1 hover:bg-muted"
+                  >
+                    <Checkbox
+                      checked={filters.agents.includes(agent)}
+                      onCheckedChange={() => toggleAgent(agent)}
+                    />
+                    <span className="text-sm">
+                      {getAgentDisplayName(agent)}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="border-t pt-2">
+              <span className="text-sm font-medium">Task</span>
+              <Input
+                value={filters.taskIdFragment}
+                onChange={(e) =>
+                  onFiltersChange({
+                    ...filters,
+                    taskIdFragment: e.target.value,
+                  })
+                }
+                placeholder="Task id fragment..."
+                className="mt-1 h-7 text-xs"
+                aria-label="Task id fragment"
+              />
+              <label className="mt-2 flex cursor-pointer items-center gap-2">
+                <Checkbox
+                  checked={filters.noLinkedTask}
+                  onCheckedChange={(checked) =>
+                    onFiltersChange({
+                      ...filters,
+                      noLinkedTask: checked === true,
+                    })
+                  }
+                />
+                <span className="text-sm">No linked task</span>
+              </label>
+            </div>
+
+            <div className="border-t pt-2">
+              <span className="text-sm font-medium">Status</span>
+              <div className="mt-1 flex items-center gap-1">
+                {STATUS_OPTIONS.map((opt) => (
+                  <Button
+                    key={opt.value}
+                    type="button"
+                    variant={
+                      filters.statuses.includes(opt.value)
+                        ? "secondary"
+                        : "outline"
+                    }
+                    size="sm"
+                    className="h-7 px-2 text-xs"
+                    aria-pressed={filters.statuses.includes(opt.value)}
+                    onClick={() => toggleStatus(opt.value)}
+                  >
+                    {opt.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            <div className="border-t pt-2">
+              <span className="text-sm font-medium">Date range</span>
+              <div className="mt-1 flex items-center gap-2">
+                <Input
+                  type="date"
+                  value={filters.dateFrom}
+                  onChange={(e) =>
+                    onFiltersChange({ ...filters, dateFrom: e.target.value })
+                  }
+                  className="h-7 text-xs"
+                  aria-label="From date"
+                />
+                <Input
+                  type="date"
+                  value={filters.dateTo}
+                  onChange={(e) =>
+                    onFiltersChange({ ...filters, dateTo: e.target.value })
+                  }
+                  className="h-7 text-xs"
+                  aria-label="To date"
+                />
+              </div>
+            </div>
+
+            {count > 0 && (
+              <div className="flex justify-end border-t pt-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={clearAll}
+                >
+                  Clear all
+                </Button>
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
       </div>
-      <div className="flex items-center gap-1 shrink-0">
-        <Button
-          type="button"
-          variant={status === "active" ? "secondary" : "ghost"}
-          size="sm"
-          className="h-7 px-2 text-xs"
-          aria-pressed={status === "active"}
-          onClick={() => onStatusChange("active")}
-        >
-          Active
-        </Button>
-        <Button
-          type="button"
-          variant={status === "all" ? "secondary" : "ghost"}
-          size="sm"
-          className="h-7 px-2 text-xs"
-          aria-pressed={status === "all"}
-          onClick={() => onStatusChange("all")}
-        >
-          All
-        </Button>
-      </div>
+
+      {chips.length > 0 && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {chips.map((chip) => (
+            <Badge key={chip.key} variant="secondary" className="gap-1">
+              {chip.label}
+              <button
+                type="button"
+                aria-label={`Remove ${chip.label} filter`}
+                onClick={chip.onRemove}
+              >
+                <X className="h-3 w-3 cursor-pointer hover:text-destructive" />
+              </button>
+            </Badge>
+          ))}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={clearAll}
+          >
+            Clear all
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/panel/src/components/a2a/a2a-filter-utils.ts
+++ b/panel/src/components/a2a/a2a-filter-utils.ts
@@ -1,67 +1,166 @@
 /**
- * Pure filter helpers for the A2A page's filter bar — shared by both the
- * switchboard (pairs) and the classic list (conversations) so the same two
- * inputs narrow both views to the matching subset.
+ * Pure filter helpers for the A2A page's filter control — shared by both the
+ * switchboard (pairs) and the classic list (conversations) so the same
+ * filter state narrows both views (per the per-view rules in
+ * docs/ux_ui/design/conversations-filter-control.md §1).
+ *
+ * All four dimensions filter client-side over the already-fetched page
+ * (there are no backend query params for them yet — see the design doc's
+ * "Future work" note).
  */
 
 import type { AdminConversationSummary, AdminPairSummary } from "@/lib/api/a2a";
-import { getAgentDisplayName } from "@/lib/agent-utils";
 
-/** "active" narrows to items with a live/talked conversation; "all" is no
- * status narrowing. */
-export type A2AStatusFilter = "active" | "all";
+/** The two known `AdminConversationSummary.status` values. */
+export type A2AConversationStatus = "active" | "archived";
 
-function matchesSearch(
-  query: string,
-  ...fields: Array<string | null | undefined>
-): boolean {
-  if (!query) return true;
-  const haystack = fields
-    .filter((field): field is string => !!field)
-    .join(" ")
-    .toLowerCase();
-  return haystack.includes(query);
+export interface A2AFilters {
+  /** Selected agent slugs — a conversation/pair matches if either
+   * participant is selected (empty = no agent filter). */
+  agents: string[];
+  /** Free-text fragment matched against `task_id` (case-insensitive). */
+  taskIdFragment: string;
+  /** When true, also match conversations with `task_id === null`. */
+  noLinkedTask: boolean;
+  /** Selected statuses (empty = no status filter). List-view only. */
+  statuses: A2AConversationStatus[];
+  /** Inclusive lower bound, `YYYY-MM-DD` (native `<input type="date">`
+   * value) or `""` for unset. List-view only. */
+  dateFrom: string;
+  /** Inclusive upper bound, `YYYY-MM-DD` or `""` for unset. List-view
+   * only. */
+  dateTo: string;
 }
 
-/** Narrow conversations to the active/all status (conversation.status)
- * and free-text search over both agents' slugs/display names and the
- * topic. */
+export const EMPTY_A2A_FILTERS: A2AFilters = {
+  agents: [],
+  taskIdFragment: "",
+  noLinkedTask: false,
+  statuses: [],
+  dateFrom: "",
+  dateTo: "",
+};
+
+/** Total count of active filter values, one per chip — drives the
+ * trigger's `Filters · N` badge. */
+export function activeA2AFilterCount(filters: A2AFilters): number {
+  return (
+    filters.agents.length +
+    (filters.taskIdFragment.trim() ? 1 : 0) +
+    (filters.noLinkedTask ? 1 : 0) +
+    filters.statuses.length +
+    (filters.dateFrom ? 1 : 0) +
+    (filters.dateTo ? 1 : 0)
+  );
+}
+
+function matchesAgent(
+  agentA: string,
+  agentB: string,
+  agents: ReadonlyArray<string>,
+): boolean {
+  if (agents.length === 0) return true;
+  return agents.includes(agentA) || agents.includes(agentB);
+}
+
+function matchesTask(
+  taskId: string | null,
+  fragment: string,
+  noLinkedTask: boolean,
+): boolean {
+  const frag = fragment.trim().toLowerCase();
+  if (!frag && !noLinkedTask) return true;
+  const fragmentMatch = frag
+    ? !!taskId && taskId.toLowerCase().includes(frag)
+    : false;
+  const noLinkedMatch = noLinkedTask ? taskId === null : false;
+  return fragmentMatch || noLinkedMatch;
+}
+
+function matchesStatus(
+  status: string,
+  statuses: ReadonlyArray<A2AConversationStatus>,
+): boolean {
+  if (statuses.length === 0) return true;
+  return statuses.includes(status as A2AConversationStatus);
+}
+
+/** Day-granularity local-timezone `YYYY-MM-DD`, comparable against a native
+ * `<input type="date">` value. */
+function localDateOnly(iso: string): string {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function matchesDateRange(
+  timestamp: string | null,
+  dateFrom: string,
+  dateTo: string,
+): boolean {
+  if (!dateFrom && !dateTo) return true;
+  if (!timestamp) return false;
+  const day = localDateOnly(timestamp);
+  if (dateFrom && day < dateFrom) return false;
+  if (dateTo && day > dateTo) return false;
+  return true;
+}
+
+/** Narrow conversations by all four dimensions — the classic List view. */
 export function filterConversations(
   conversations: ReadonlyArray<AdminConversationSummary>,
-  status: A2AStatusFilter,
-  search: string,
+  filters: A2AFilters,
 ): AdminConversationSummary[] {
-  const query = search.trim().toLowerCase();
-  return conversations.filter((conversation) => {
-    if (status === "active" && conversation.status !== "active") return false;
-    return matchesSearch(
-      query,
-      conversation.agent_a,
-      conversation.agent_b,
-      getAgentDisplayName(conversation.agent_a),
-      getAgentDisplayName(conversation.agent_b),
-      conversation.topic,
-    );
-  });
+  return conversations.filter(
+    (conversation) =>
+      matchesAgent(
+        conversation.agent_a,
+        conversation.agent_b,
+        filters.agents,
+      ) &&
+      matchesTask(
+        conversation.task_id,
+        filters.taskIdFragment,
+        filters.noLinkedTask,
+      ) &&
+      matchesStatus(conversation.status, filters.statuses) &&
+      matchesDateRange(
+        conversation.last_message_at ?? conversation.created_at,
+        filters.dateFrom,
+        filters.dateTo,
+      ),
+  );
 }
 
-/** Narrow switchboard pairs to the active/all status (active = the pair has
- * a representative conversation, i.e. has actually A2A'd) and free-text
- * search over both agents' slugs/display names. */
+/** Narrow switchboard pairs — Agent only (design doc §1 "Per-view
+ * applicability"): a pair with no conversation has no task/status/date to
+ * filter on. */
 export function filterPairs(
   pairs: ReadonlyArray<AdminPairSummary>,
-  status: A2AStatusFilter,
-  search: string,
+  filters: A2AFilters,
 ): AdminPairSummary[] {
-  const query = search.trim().toLowerCase();
-  return pairs.filter((pair) => {
-    if (status === "active" && !pair.conversation_id) return false;
-    return matchesSearch(
-      query,
-      pair.agent_a,
-      pair.agent_b,
-      getAgentDisplayName(pair.agent_a),
-      getAgentDisplayName(pair.agent_b),
-    );
-  });
+  return pairs.filter((pair) =>
+    matchesAgent(pair.agent_a, pair.agent_b, filters.agents),
+  );
+}
+
+/** Distinct agent slugs present across the currently loaded pairs +
+ * conversations, deduplicated and sorted — the Agent checkbox list's
+ * option set (design doc §1, dimension 1). */
+export function distinctA2AAgents(
+  conversations: ReadonlyArray<AdminConversationSummary>,
+  pairs: ReadonlyArray<AdminPairSummary>,
+): string[] {
+  const slugs = new Set<string>();
+  for (const pair of pairs) {
+    slugs.add(pair.agent_a);
+    slugs.add(pair.agent_b);
+  }
+  for (const conversation of conversations) {
+    slugs.add(conversation.agent_a);
+    slugs.add(conversation.agent_b);
+  }
+  return Array.from(slugs).sort();
 }


### PR DESCRIPTION
Build the 4-dimension filter control for the A2A conversations page exactly per the approved design spec docs/ux_ui/design/conversations-filter-control.md. Create a2a-filter-bar.tsx (or a dedicated filter component if the spec names one) that renders a Popover-triggered filter panel containing: an Agent checkbox list for multi-select filtering, a Task id-fragment text input with a "No linked task" toggle, Status toggle buttons, and two date-range inputs. Add an active-filter chip row above/below the trigger showing each applied filter with a per-chip remove affordance, plus a "Clear all" action. Wire the filters into both a2a-switchboard.tsx and a2a-conversation-list.tsx per the spec's per-view rules (read the spec doc for exactly which filters apply to which view — do not assume all four apply everywhere). Cross-check any new query param names against the backend's conversations query schema before wiring, since TypeScript won't catch a param-name mismatch.