### PR TITLE
[cac9b603] Fix missing written_at timestamp fallback in tab-notes.tsx

### DIFF
--- a/panel/src/components/tasks/task-detail/tab-notes.tsx
+++ b/panel/src/components/tasks/task-detail/tab-notes.tsx
@@ -96,13 +96,17 @@ const FIELD_TO_SECTION: Record<NoteField, string> = {
   doc_notes: "doc",
 };
 
-// When the section was last written (apply_structured_note stamps it).
+// When the section was last written (apply_structured_note stamps it). Falls
+// back to the task's creation time when content exists but predates the stamp
+// (older notes written before apply_structured_note started stamping) so a
+// populated field never renders with no timestamp at all.
 function writtenAt(task: Task, field: NoteField): string | null {
   const sections = task.notes_structured as
     | Record<string, { written_at?: string }>
     | null
     | undefined;
-  const stamp = sections?.[FIELD_TO_SECTION[field]]?.written_at;
+  const stamp =
+    sections?.[FIELD_TO_SECTION[field]]?.written_at ?? task.created_at;
   if (!stamp) return null;
   const date = new Date(stamp);
   if (Number.isNaN(date.getTime())) return null;


### PR DESCRIPTION
tab-notes.tsx's writtenAt() helper reads task.notes_structured[section].written_at and returns null (rendering no timestamp) whenever that stamp is absent. Fix the helper so that when written_at is missing for a field that DOES have content, it falls back to displaying the note's creation-time timestamp (e.g. the task's created_at, or another already-available creation timestamp for that note) instead of showing nothing. Keep the same formatting (month/day/hour/minute via toLocaleString) used for the written_at path. Do not touch the CollapsibleSection/EditableNoteCard rendering — that is a separate leaf.