### PR TITLE
[75fd7444] Wire content prop into EditableNoteCard's CollapsibleSection

### DIFF
--- a/docs/frontend/components/collapsible-section.md
+++ b/docs/frontend/components/collapsible-section.md
@@ -171,6 +171,33 @@ const [isEditing, setIsEditing] = useState(false);
 
 When `isEditing` is `true`, the section is forced open even if the user clicked to close it. This prevents an edit form from being hidden mid-interaction.
 
+### Combined: controlled mode + content-driven initialization
+
+For components that edit long content (like task notes), seed the initial collapsed/expanded state from content length, but use controlled mode to force-open during edit:
+
+```tsx
+const currentValue = task.dev_notes;
+const [isEditing, setIsEditing] = useState(false);
+const [sectionOpen, setSectionOpen] = useState(() =>
+  !exceedsReadabilityThreshold(currentValue ?? ""),
+);
+
+<CollapsibleSection
+  title="Developer Notes"
+  content={currentValue ?? undefined}  // Drives content-readability check
+  open={isEditing || sectionOpen}       // Controlled: force-open while editing
+  onOpenChange={setSectionOpen}
+>
+  {isEditing ? <textarea value={currentValue} /> : <p>{currentValue}</p>}
+</CollapsibleSection>
+```
+
+This pattern (used in `tab-notes.tsx`'s `EditableNoteCard`) ensures:
+- Long notes default collapsed with an expand affordance
+- Short notes default expanded (fully visible)
+- Edit forms are always visible when editing, even if the user had collapsed the section
+- User's collapse/expand choice persists across edit cycles (via `sectionOpen` state)
+
 ## Used in
 
 The component is now applied across task-detail pages:
@@ -178,7 +205,7 @@ The component is now applied across task-detail pages:
 | Page / Component | Sections wrapped | Notes |
 |---|---|---|
 | `task-description.tsx` | Description, Constraints | Constraints section styled with amber border/background + ShieldAlert icon for visual distinction from authored content. |
-| `tab-notes.tsx` | Each editable note field (Description, Notes, Plan) | Edit/preview toggle forced open while editing via `open={isEditing \|\| sectionOpen}`. |
+| `tab-notes.tsx` | Each editable note field (dev_notes, qa_notes, doc_notes, etc.) | `EditableNoteCard` seeds initial `sectionOpen` from content length via `exceedsReadabilityThreshold`, passes `content={currentValue}` to CollapsibleSection, and forces open while editing via controlled `open={isEditing \|\| sectionOpen}`. Long notes default collapsed with expand affordance; short notes default expanded. |
 | `tab-plan.tsx` | Approach, Sub-Tasks, Technical Considerations, Risks, Open Questions | Each sub-section independently collapsible. |
 | `acceptance-criteria.tsx` | Full acceptance criteria list | Wrapped in CollapsibleSection with `content={criteriaText}`, so a long AC list defaults collapsed per content-readability spec. Forced open while adding/editing via controlled `open` prop. |
 | `tab-progress.tsx` | Individual progress updates and checkpoints (via internal Radix Collapsible wrapper) | Each entry wrapped in a collapsible section; only the 2 most recent entries default open (gated by content length as well). Older entries default collapsed even if short, keeping task detail navigable without endless scrolling. |

--- a/panel/src/components/tasks/task-detail/__tests__/tab-notes-collapse.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/tab-notes-collapse.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+import { READABILITY_CHAR_THRESHOLD } from "@/lib/content-readability";
+
+// EditableNoteCard drives CollapsibleSection with a controlled `open`, so the
+// content-length-based default has to be computed at the card level (mirrors
+// the same content-readability spec CollapsibleSection itself uses).
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useUpdateTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { TabNotes } from "../tab-notes";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    title: "Task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    created_at: "2026-06-01T12:00:00+00:00",
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("notes tab content-driven collapse", () => {
+  it("renders a long dev_notes field collapsed by default", () => {
+    const task = buildTask({
+      dev_notes: "a".repeat(READABILITY_CHAR_THRESHOLD + 1),
+    });
+    render(<TabNotes task={task} />);
+    expect(
+      screen.getByRole("button", { name: /Developer Notes/ }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders a short dev_notes field expanded by default", () => {
+    const task = buildTask({ dev_notes: "Built the greeting module." });
+    render(<TabNotes task={task} />);
+    expect(
+      screen.getByRole("button", { name: /Developer Notes/ }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/panel/src/components/tasks/task-detail/tab-notes.tsx
+++ b/panel/src/components/tasks/task-detail/tab-notes.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Markdown } from "@/components/ui/markdown";
 import { CollapsibleSection } from "./collapsible-section";
+import { exceedsReadabilityThreshold } from "@/lib/content-readability";
 import {
   FileText,
   Code,
@@ -149,12 +150,14 @@ function EditableNoteCard({
   bgClass,
 }: NoteCardProps) {
   const updateTask = useUpdateTask();
+  const currentValue = task[field];
   const [isEditing, setIsEditing] = useState(false);
   const [localEditValue, setLocalEditValue] = useState("");
   const [editMode, setEditMode] = useState<"write" | "preview">("write");
-  const [sectionOpen, setSectionOpen] = useState(true);
-
-  const currentValue = task[field];
+  // Long content starts collapsed; short content starts expanded.
+  const [sectionOpen, setSectionOpen] = useState(() =>
+    !exceedsReadabilityThreshold(currentValue ?? ""),
+  );
 
   // Display prop value when not editing, local value when editing
   const editValue = isEditing ? localEditValue : (currentValue ?? "");
@@ -244,6 +247,7 @@ function EditableNoteCard({
       }
       open={isEditing || sectionOpen}
       onOpenChange={setSectionOpen}
+      content={currentValue ?? undefined}
       actions={
         isEditing ? (
           <>


### PR DESCRIPTION
EditableNoteCard in tab-notes.tsx renders its collapsible wrapper (CollapsibleSection, or whatever the current collapse mechanism is — locate it first, it may need to be introduced if it isn't already wired) without passing it the note field's content. As a result, long Notes/QA fields never auto-collapse per the panel's existing readability length thresholds (see other panel components using Collapsible/CollapsibleContent for the established pattern, e.g. social-history-section.tsx). Wire the actual note content into the collapsible section's content prop so long fields auto-collapse and short fields render fully, matching that established pattern. This depends on the written_at fallback leaf landing first since both touch tab-notes.tsx.