### PR TITLE
[c2e98fc0] Reflow all three hard-wrapped docs and verify quality gate

### DIFF
--- a/docs/backend/api/video-engine-endpoints.md
+++ b/docs/backend/api/video-engine-endpoints.md
@@ -27,7 +27,7 @@ CEO-only (401 if not CEO).
 ```json
 {
   "occasion": "string",      // Unique identifier; required, min 1 char
-  "brief": "string",         // Video brief description; required, min 1 char  
+  "brief": "string",         // Video brief description; required, min 1 char
   "platforms": ["string"],   // Target platforms: ["x", "tiktok"]; required, min 1
   "project_id": "UUID"       // Project to author against; required (NEW in v2)
 }


### PR DESCRIPTION
The cell PR (#439, branch feature/ux_ui/f7d0a61a--e4ed92d6--8e912c3e) has now failed the in-path PR review gate twice on the same issue: `make reflow-check` fails because three markdown docs present on this branch are hard-wrapped (manual mid-paragraph line breaks instead of one line per paragraph):
- docs/ux_ui/design/01-video-request-composition-controls.md (the task's own target doc)
- docs/backend/api/video-engine-endpoints.md
- docs/backend/migrations/video-project-scoping.md

A prior sibling subtask was supposed to fix the two backend docs but no reflow commit actually landed on this branch — re-running `python scripts/reflow_md.py --check` today still flags all three files.

Do this:
1. Run `make reflow-docs` (equivalent to `uv run python scripts/reflow_md.py --apply`) from repo root. This tool only joins hard-wrapped paragraph/list lines into single lines; it enforces a token-identical invariant and will refuse to touch anything it can't safely rewrite — so it will not change any actual content/wording.
2. Confirm `make reflow-check` now exits 0 (no hard-wrapped files reported).
3. Run `make quality` (or the project's full quality/lint suite) and confirm it is green.
4. Diff each of the three files against its prior version and confirm the change is whitespace/line-join only — no wording, no reordering, no removed/added content.
5. Commit and push; ensure the PR (#439) reflects the fix.

Do NOT hand-edit prose content in these files. Do NOT touch any other files.