### PR TITLE
[fc04d84a] Round-3 revision: fix 4 named gaps on task-detail overhaul, one dev leaf per fix

### DIFF
--- a/docs/frontend/components/collapsible-section.md
+++ b/docs/frontend/components/collapsible-section.md
@@ -171,6 +171,33 @@ const [isEditing, setIsEditing] = useState(false);
 
 When `isEditing` is `true`, the section is forced open even if the user clicked to close it. This prevents an edit form from being hidden mid-interaction.
 
+### Combined: controlled mode + content-driven initialization
+
+For components that edit long content (like task notes), seed the initial collapsed/expanded state from content length, but use controlled mode to force-open during edit:
+
+```tsx
+const currentValue = task.dev_notes;
+const [isEditing, setIsEditing] = useState(false);
+const [sectionOpen, setSectionOpen] = useState(() =>
+  !exceedsReadabilityThreshold(currentValue ?? ""),
+);
+
+<CollapsibleSection
+  title="Developer Notes"
+  content={currentValue ?? undefined}  // Drives content-readability check
+  open={isEditing || sectionOpen}       // Controlled: force-open while editing
+  onOpenChange={setSectionOpen}
+>
+  {isEditing ? <textarea value={currentValue} /> : <p>{currentValue}</p>}
+</CollapsibleSection>
+```
+
+This pattern (used in `tab-notes.tsx`'s `EditableNoteCard`) ensures:
+- Long notes default collapsed with an expand affordance
+- Short notes default expanded (fully visible)
+- Edit forms are always visible when editing, even if the user had collapsed the section
+- User's collapse/expand choice persists across edit cycles (via `sectionOpen` state)
+
 ## Used in
 
 The component is now applied across task-detail pages:
@@ -178,7 +205,7 @@ The component is now applied across task-detail pages:
 | Page / Component | Sections wrapped | Notes |
 |---|---|---|
 | `task-description.tsx` | Description, Constraints | Constraints section styled with amber border/background + ShieldAlert icon for visual distinction from authored content. |
-| `tab-notes.tsx` | Each editable note field (Description, Notes, Plan) | Edit/preview toggle forced open while editing via `open={isEditing \|\| sectionOpen}`. |
+| `tab-notes.tsx` | Each editable note field (dev_notes, qa_notes, doc_notes, etc.) | `EditableNoteCard` seeds initial `sectionOpen` from content length via `exceedsReadabilityThreshold`, passes `content={currentValue}` to CollapsibleSection, and forces open while editing via controlled `open={isEditing \|\| sectionOpen}`. Long notes default collapsed with expand affordance; short notes default expanded. |
 | `tab-plan.tsx` | Approach, Sub-Tasks, Technical Considerations, Risks, Open Questions | Each sub-section independently collapsible. |
 | `acceptance-criteria.tsx` | Full acceptance criteria list | Wrapped in CollapsibleSection with `content={criteriaText}`, so a long AC list defaults collapsed per content-readability spec. Forced open while adding/editing via controlled `open` prop. |
 | `tab-progress.tsx` | Individual progress updates and checkpoints (via internal Radix Collapsible wrapper) | Each entry wrapped in a collapsible section; only the 2 most recent entries default open (gated by content length as well). Older entries default collapsed even if short, keeping task detail navigable without endless scrolling. |

--- a/docs/ux_ui/design/task-navigation-structure.md
+++ b/docs/ux_ui/design/task-navigation-structure.md
@@ -1,6 +1,6 @@
 # Navigation/structure spec: breadcrumb, prev/next, constraints distinction
 
-Status: proposed
+Status: implemented (v0.21.0+)
 Owner: ux-dev-2
 Surface: task detail page (`panel/src/app/(dashboard)/tasks/[taskId]/page.tsx`)
 and its header (`panel/src/components/tasks/task-detail/task-header.tsx`) and
@@ -42,12 +42,13 @@ field (`parent_task_id`, `sequence`, and `project_id` already exist on `Task`;
 
 ## 1. Breadcrumb trail
 
-**Component:** new `TaskBreadcrumb` at
-`panel/src/components/tasks/task-detail/task-breadcrumb.tsx`, rendered inside
-`TaskHeader` as a new row **above** the existing title row (still inside the
-`<div className="border-b pb-4">` wrapper), replacing the standalone
-`ArrowLeft` button — the breadcrumb's leading "Tasks" crumb takes over that
-back-to-list function, so no control is lost.
+**Implementation status:** ✓ Complete (v0.21.0+). The standalone `ArrowLeft` back button has been removed from `task-header.tsx`. The breadcrumb component and prev/next navigation now provide all navigation affordances.
+
+**Component:** `TaskBreadcrumb` at
+`panel/src/components/tasks/task-detail/task-breadcrumb.tsx`, rendered in the
+task detail page (`[taskId]/page.tsx`) above the `TaskHeader` component,
+replacing the standalone `ArrowLeft` button — the breadcrumb's leading "Tasks"
+crumb takes over that back-to-list function, so no control is lost.
 
 **Data.** The chain is built client-side from data already available:
 `Project` (via the existing `useProject(task.project_id)` call `TaskMetadata`
@@ -100,14 +101,15 @@ preferable to introducing a new scroll container.
 **Accessibility.** Wrap the row in `<nav aria-label="Task breadcrumb">`; the
 current-task span carries `aria-current="page"`.
 
-## 2. Prev/next sibling navigation
+## 2. Prev/next list navigation
 
-**Component:** new `TaskPrevNext` at
-`panel/src/components/tasks/task-detail/task-prev-next.tsx`, rendered in the
-existing header's right-hand action area (`task-header.tsx`'s
-`<div className="shrink-0">` block, lines 598-649), immediately to the left
-of the "Actions" dropdown button — two icon buttons, not a full toolbar,
-so it doesn't compete with the primary Actions control for attention.
+**Implementation status:** ✓ Complete (v0.21.0+). List-context-aware navigation, documented separately in `docs/guide/task-detail-navigation.md`.
+
+**Component:** `TaskListNav` at
+`panel/src/components/tasks/task-detail/task-list-nav.tsx`, rendered in the
+task detail page (`[taskId]/page.tsx`) alongside the breadcrumb —  two chevron
+icon buttons that move to adjacent tasks within the current Tasks list
+filter/sort context, or disabled when viewed outside the list context.
 
 **Data & ordering.** "Sibling" means another task sharing the same
 `parent_task_id`. Fetch with the existing `useSubtasks(task.parent_task_id)`
@@ -150,8 +152,10 @@ predictable regardless of which task the reader is on.
 
 ## 3. Constraints visual distinction
 
-**File:** `panel/src/components/tasks/task-detail/task-description.tsx`,
-replacing the existing `constraints` block (lines 181-196).
+**Implementation status:** ✓ Complete (v0.21.0+). Constraints now render with distinctive amber styling and a ShieldAlert icon.
+
+**File:** `panel/src/components/tasks/task-detail/task-description.tsx`
+(lines 181-199).
 
 **Treatment — amber "read-only architectural" tint, matching the existing
 convention already used for the *same* concept elsewhere in the panel:** the

--- a/docs/ux_ui/design/task-navigation-structure.md
+++ b/docs/ux_ui/design/task-navigation-structure.md
@@ -111,43 +111,47 @@ task detail page (`[taskId]/page.tsx`) alongside the breadcrumb —  two chevron
 icon buttons that move to adjacent tasks within the current Tasks list
 filter/sort context, or disabled when viewed outside the list context.
 
-**Data & ordering.** "Sibling" means another task sharing the same
-`parent_task_id`. Fetch with the existing `useSubtasks(task.parent_task_id)`
-hook (already used by `SubtasksList` for the reverse direction — children —
-so this is the same hook pointed at the parent instead of at `task.id`), sort
-the result by `sequence` ascending (the field `TaskMetadata` already surfaces
-as a read-only "Sequence" card), and locate the current task's index in that
-sorted list.
+**Data & ordering.** This diverged from the original sibling-order proposal
+during implementation (see `docs/guide/task-detail-navigation.md` for the
+full writeup) — "adjacent" means the previous/next row in the **Tasks list's
+last-visited filter/sort order**, not a `parent_task_id` sibling. The Tasks
+list page (`tasks/page.tsx`) reports its currently visible, filtered/sorted
+task order to `useScrollRestorationStore.setTaskListNav({ items, queryString
+})` whenever it changes; `TaskListNav` reads that `taskListNav` context, finds
+`task.id`'s index in `items`, and derives the prev/next item from
+`index - 1` / `index + 1`. The context is session-scoped (`sessionStorage`
+via the existing Zustand `persist` middleware), so it survives navigation
+within a session but doesn't persist across sessions. `useSubtasks` /
+`parent_task_id` / `sequence` are not part of this feature — sibling-order
+navigation, as originally proposed below, was not what shipped.
 
-**Controls.** Two `Button variant="ghost" size="icon"` (matching the
-existing `ArrowLeft` button's exact styling in `task-header.tsx`) using
-`ChevronLeft` / `ChevronRight` (`lucide-react`):
+**Controls.** Two `Button variant="outline" size="icon"` using `ChevronLeft` /
+`ChevronRight` (`lucide-react`), each wrapped in a `Tooltip`:
 
-- **Prev** navigates (`router.push` or `Link href="/tasks/{id}"`) to the
-  sibling at `index - 1`; **disabled** (not hidden — a disabled control at
-  the boundary communicates "this is the first one," an absent control
-  reads as "there is no prev/next feature here") when the current task is
-  first in sequence, or when `task.parent_task_id` is null (no parent, so
-  no sibling set — every button in the pair is disabled in that case, not
-  removed, since the feature applies uniformly across the task tree).
-- **Next** mirrors this at `index + 1`, disabled when current is last.
-- Each button carries a `title` tooltip naming the target: `"Previous:
-  {sibling.title}"` / `"Next: {sibling.title}"` (truncated to ~40 chars),
-  or `"No previous task"` / `"No next task"` when disabled — so hovering a
-  disabled button still explains why, rather than looking broken.
+- **Prev** links (`Link href="/tasks/{id}{queryString}"`) to `items[index -
+  1]`; **disabled** (not hidden — a disabled control at the boundary
+  communicates "this is the first one," an absent control reads as "there is
+  no prev/next feature here") when the current task is first in the captured
+  list order, or when no list context exists for this session, or when the
+  current task isn't part of the captured order (opened via a direct link,
+  search, or notification instead of from the list).
+- **Next** mirrors this at `index + 1`, disabled when current is last (or the
+  same no-context/not-in-list cases as Prev).
+- Each button's tooltip shows the target item's `title` when enabled, or the
+  fixed explanation "Open this task from the Tasks list to enable prev/next
+  navigation within that list's filter/sort order." when disabled — so
+  hovering a disabled button still explains why, rather than looking broken.
+- The href carries the captured `queryString` (the Tasks list's filters/sort
+  at the time it was visited), so navigating there preserves that view.
 
-**Keyboard.** `Alt+ArrowLeft` / `Alt+ArrowRight` trigger the same navigation
-when focus is not inside a text input, `Textarea`, or `contenteditable`
-element (guard on `document.activeElement.tagName`) — a plain
-`useEffect` + `window.addEventListener("keydown", ...)` in `TaskPrevNext`,
-cleaned up on unmount. `Alt+Arrow` (not the bare arrow key) avoids colliding
-with normal text-field cursor movement anywhere else on the page, so no
-existing input behavior changes.
+**Keyboard.** Not implemented. `Alt+Arrow` shortcuts were part of the
+original proposal below but were not built; see `docs/guide/task-detail-
+navigation.md`'s "Future Extensions" for the deferred idea.
 
-**Empty state.** When `useSubtasks` resolves to a single-item list (no
-siblings) or `task.parent_task_id` is null, both buttons render disabled with
-the "No previous/next task" tooltip rather than being omitted — consistent
-with the boundary-disabled treatment above, so the control's presence is
+**Empty state.** When no list context has been captured this session, or the
+current task isn't found in the captured `items`, both buttons render
+disabled with the fallback tooltip above rather than being omitted —
+consistent with the boundary-disabled treatment, so the control's presence is
 predictable regardless of which task the reader is on.
 
 ## 3. Constraints visual distinction
@@ -216,12 +220,13 @@ project-wide rule) is preserved; only the visual weight changes.
 - No new shadcn/ui primitive (no `breadcrumb.tsx` added to `components/ui`)
   — the breadcrumb composes existing `Link`, `DropdownMenu`, and
   `lucide-react` icons already in the tree, per the "fewest files" bar.
-- No change to how siblings/ancestors are fetched server-side — this reuses
-  `useTask` and `useSubtasks` exactly as they exist today; no new endpoint,
-  no new query param.
+- No change to how ancestors are fetched server-side — the breadcrumb reuses
+  `useTask` exactly as it exists today; no new endpoint, no new query param.
+  Prev/next reuses the Tasks list's already-fetched page data instead of a
+  dedicated sibling endpoint.
 - No persisted "last visited sibling" or breadcrumb history — this is a
   point-in-time structural view of the current task's position, not a
   session/browsing-history feature.
-- No global keyboard-shortcut registry — the `Alt+Arrow` binding is local to
-  `TaskPrevNext` and unregisters on unmount; a cross-page shortcut system is
-  out of scope for this pass.
+- No keyboard shortcut for prev/next shipped in this pass (the `Alt+Arrow`
+  idea from the original proposal was deferred — see
+  `docs/guide/task-detail-navigation.md`'s "Future Extensions").

--- a/panel/src/components/tasks/task-detail/__tests__/tab-notes-collapse.test.tsx
+++ b/panel/src/components/tasks/task-detail/__tests__/tab-notes-collapse.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+import { READABILITY_CHAR_THRESHOLD } from "@/lib/content-readability";
+
+// EditableNoteCard drives CollapsibleSection with a controlled `open`, so the
+// content-length-based default has to be computed at the card level (mirrors
+// the same content-readability spec CollapsibleSection itself uses).
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useUpdateTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { TabNotes } from "../tab-notes";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    title: "Task",
+    description: "d",
+    status: TaskStatus.IN_PROGRESS,
+    team: Team.BACKEND,
+    task_type: TaskType.CODE,
+    acceptance_criteria: [],
+    created_at: "2026-06-01T12:00:00+00:00",
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("notes tab content-driven collapse", () => {
+  it("renders a long dev_notes field collapsed by default", () => {
+    const task = buildTask({
+      dev_notes: "a".repeat(READABILITY_CHAR_THRESHOLD + 1),
+    });
+    render(<TabNotes task={task} />);
+    expect(
+      screen.getByRole("button", { name: /Developer Notes/ }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("renders a short dev_notes field expanded by default", () => {
+    const task = buildTask({ dev_notes: "Built the greeting module." });
+    render(<TabNotes task={task} />);
+    expect(
+      screen.getByRole("button", { name: /Developer Notes/ }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/panel/src/components/tasks/task-detail/tab-notes.tsx
+++ b/panel/src/components/tasks/task-detail/tab-notes.tsx
@@ -96,13 +96,17 @@ const FIELD_TO_SECTION: Record<NoteField, string> = {
   doc_notes: "doc",
 };
 
-// When the section was last written (apply_structured_note stamps it).
+// When the section was last written (apply_structured_note stamps it). Falls
+// back to the task's creation time when content exists but predates the stamp
+// (older notes written before apply_structured_note started stamping) so a
+// populated field never renders with no timestamp at all.
 function writtenAt(task: Task, field: NoteField): string | null {
   const sections = task.notes_structured as
     | Record<string, { written_at?: string }>
     | null
     | undefined;
-  const stamp = sections?.[FIELD_TO_SECTION[field]]?.written_at;
+  const stamp =
+    sections?.[FIELD_TO_SECTION[field]]?.written_at ?? task.created_at;
   if (!stamp) return null;
   const date = new Date(stamp);
   if (Number.isNaN(date.getTime())) return null;

--- a/panel/src/components/tasks/task-detail/tab-notes.tsx
+++ b/panel/src/components/tasks/task-detail/tab-notes.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Markdown } from "@/components/ui/markdown";
 import { CollapsibleSection } from "./collapsible-section";
+import { exceedsReadabilityThreshold } from "@/lib/content-readability";
 import {
   FileText,
   Code,
@@ -149,12 +150,14 @@ function EditableNoteCard({
   bgClass,
 }: NoteCardProps) {
   const updateTask = useUpdateTask();
+  const currentValue = task[field];
   const [isEditing, setIsEditing] = useState(false);
   const [localEditValue, setLocalEditValue] = useState("");
   const [editMode, setEditMode] = useState<"write" | "preview">("write");
-  const [sectionOpen, setSectionOpen] = useState(true);
-
-  const currentValue = task[field];
+  // Long content starts collapsed; short content starts expanded.
+  const [sectionOpen, setSectionOpen] = useState(() =>
+    !exceedsReadabilityThreshold(currentValue ?? ""),
+  );
 
   // Display prop value when not editing, local value when editing
   const editValue = isEditing ? localEditValue : (currentValue ?? "");
@@ -244,6 +247,7 @@ function EditableNoteCard({
       }
       open={isEditing || sectionOpen}
       onOpenChange={setSectionOpen}
+      content={currentValue ?? undefined}
       actions={
         isEditing ? (
           <>

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -35,7 +35,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
-  ArrowLeft,
   MoreVertical,
   Play,
   Pause,
@@ -52,7 +51,6 @@ import {
   ThumbsDown,
 } from "lucide-react";
 import { toast } from "sonner";
-import Link from "next/link";
 import { TaskTypeBadge } from "../task-type-badge";
 import { CopyButton } from "@/components/ui/copy-button";
 
@@ -468,15 +466,10 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
   return (
     <div className="border-b pb-4">
       <div className="flex items-start justify-between gap-4">
-        {/* Left: back arrow + title + metadata. This column SHRINKS and the
-            title truncates, so a long title never pushes the controls or the
+        {/* Left: title + metadata. This column SHRINKS and the title
+            truncates, so a long title never pushes the controls or the
             Actions menu out of place. */}
         <div className="flex items-start gap-3 min-w-0 flex-1">
-          <Link href="/tasks" prefetch={false}>
-            <Button variant="ghost" size="icon" className="shrink-0">
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-          </Link>
           <div className="min-w-0 flex-1">
             {/* Row 1: title only — editable, no UUID. Truncates on overflow. */}
             {editingTitle ? (


### PR DESCRIPTION
The CEO has rejected this root's merge THREE times now. Round 3 names 4 specific items still missing or incomplete, one of which (item 1) was already named in round 1 and is still unfixed after two revision passes:

1. **WrittenAtStamp fallback (flagship bug, named twice, still broken)** — `panel/src/components/tasks/task-detail/tab-notes.tsx`, the `writtenAt()` helper (~lines 100-128), still `return null`s when `written_at` is missing on a note. Fall back to the note's creation time so every note shows a timestamp — this is what AC2 ("every note and progress entry shows its timestamp inline") actually requires and it fails on this path today.

2. **Notes/QA fields never auto-collapse** — `EditableNoteCard` renders `CollapsibleSection` with `open={isEditing || sectionOpen}`, `sectionOpen = useState(true)`, and never passes the `content` prop, so the length-based auto-collapse logic (`exceedsReadabilityThreshold`) never runs for Notes/QA fields. Wire the `content` prop (plain-text of the note body) into these CollapsibleSection calls, or default `sectionOpen` closed per the readability spec.

3. **Redundant back button** — `task-header.tsx` still renders an `ArrowLeft` back button even though `docs/ux_ui/design/task-navigation-structure.md` specifies the breadcrumb replaces it "so no control is lost." Remove the `ArrowLeft` button now that `TaskBreadcrumb` is shipped.

4. **Prev/next spec-vs-implementation contradiction** — the design spec (`docs/ux_ui/design/task-navigation-structure.md`) describes sibling navigation via `parent_task_id` + sequence; the shipped `TaskListNav` implements Tasks-list filter/sort-order navigation instead (session-scoped, sourced from the scroll-restoration store). These are two different behaviors. Either implement true sibling navigation per the spec, or update the spec doc so it accurately describes the shipped list-order behavior — pick one, document why, and make the spec and the code agree.

**Mandatory process requirement, not optional**: split this into 4 separate dev leaves, one per numbered item above — do NOT bundle them into a single implementation task. This root has already failed twice from bundled fixes hiding gaps (see org learning lrn-eedcbcc57ca1: "one dev leaf per fix forces individual QA verification and prevents bundling from hiding gaps"). Item 1 in particular must ship and pass QA on its own, since it is the single most-repeated miss on this task. Stay within the files already touched by the prior two revision passes; do not expand scope beyond these 4 items.