### PR TITLE
feat(vault): arm the Obsidian vault flags in both compose files

### DIFF
--- a/docker-compose.registry.yml
+++ b/docker-compose.registry.yml
@@ -318,6 +318,9 @@ services:
       # the signal to the real CI workflow (RoboCo has several workflows, so the
       # unscoped "latest run" would be unreliable).
       ROBOCO_SELF_HEAL_ENABLED: ${ROBOCO_SELF_HEAL_ENABLED:-false}
+      ROBOCO_OBSIDIAN_VAULT_ENABLED: ${ROBOCO_OBSIDIAN_VAULT_ENABLED:-true}
+      ROBOCO_VAULT_PATH: ${ROBOCO_VAULT_PATH:-/app/vault}
+      ROBOCO_VAULT_INTAKE_ENABLED: ${ROBOCO_VAULT_INTAKE_ENABLED:-true}
       ROBOCO_SELF_HEAL_ORIGINATE_ENABLED: ${ROBOCO_SELF_HEAL_ORIGINATE_ENABLED:-false}
       ROBOCO_SELF_HEAL_PROJECT_SLUG: ${ROBOCO_SELF_HEAL_PROJECT_SLUG:-roboco-api}
       ROBOCO_SELF_HEAL_CI_WORKFLOW: ${ROBOCO_SELF_HEAL_CI_WORKFLOW:-ci.yml}
@@ -342,6 +345,7 @@ services:
       # agents never mount a dead credential; the agent's own mount stays RO.
       - ${ROBOCO_HOST_GROK_DIR:-${HOME}/.grok}:${ROBOCO_HOST_GROK_DIR:-${HOME}/.grok}
       - ${ROBOCO_DATA_DIR:-./data}/mcp-configs:/app/mcp-configs
+      - ${ROBOCO_DATA_DIR:-./data}/vault:/app/vault
       - ${ROBOCO_DATA_DIR:-./data}/prompts-generated:/app/prompts-generated
       - ${ROBOCO_DATA_DIR:-./data}/agent-settings:/app/agent-settings
       - ${ROBOCO_DATA_DIR:-./data}/workspaces:/data/workspaces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -514,6 +514,9 @@ services:
       ROBOCO_RELEASE_MANAGER_ENABLED: ${ROBOCO_RELEASE_MANAGER_ENABLED:-true}
       ROBOCO_ORG_MEMORY_ENABLED: ${ROBOCO_ORG_MEMORY_ENABLED:-true}
       ROBOCO_X_ENGINE_ENABLED: ${ROBOCO_X_ENGINE_ENABLED:-true}
+      ROBOCO_OBSIDIAN_VAULT_ENABLED: ${ROBOCO_OBSIDIAN_VAULT_ENABLED:-true}
+      ROBOCO_VAULT_PATH: ${ROBOCO_VAULT_PATH:-/app/vault}
+      ROBOCO_VAULT_INTAKE_ENABLED: ${ROBOCO_VAULT_INTAKE_ENABLED:-true}
       #   - Board roadmap engine: weekly, opens ONE held exploration task for
       #     the Product Owner, who proposes a themed cycle of roadmap items;
       #     the CEO approves each item individually into the backlog.
@@ -603,6 +606,7 @@ services:
       - ${ROBOCO_HOST_GROK_DIR:-/home/renzof/.grok}:${ROBOCO_HOST_GROK_DIR:-/home/renzof/.grok}
       # Shared config directory for MCP configs (writable)
       - ${ROBOCO_DATA_DIR:-./data}/mcp-configs:/app/mcp-configs
+      - ${ROBOCO_DATA_DIR:-./data}/vault:/app/vault
       # Generated prompts directory - composed at runtime from layers
       - ${ROBOCO_DATA_DIR:-./data}/prompts-generated:/app/prompts-generated
       # Per-agent Claude settings (generated at spawn time)


### PR DESCRIPTION
Arms `ROBOCO_OBSIDIAN_VAULT_ENABLED`, `ROBOCO_VAULT_PATH` (`/app/vault`, bind-mounted from `${ROBOCO_DATA_DIR:-./data}/vault`), and `ROBOCO_VAULT_INTAKE_ENABLED` on the orchestrator in both compose files — step 3 of the CEO's list. Env-overridable as usual; nothing runs until the next deploy. Both composes `config -q` clean. Post-deploy: `python -m roboco.vault rebuild` materializes the tree, Syncthing to the Mac vault per the ops pattern.