### PR TITLE
[13d03d5c] Add 5 coordination-event notification producers + wire at chokepoints

### DIFF
--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -11,6 +11,8 @@ Documentation for the Backend Cell team.
 
 - `/api/` - API documentation
 - `/qa/` - QA-related docs
+- `/services/` - Internal service architecture & patterns
+  - `coordination-events.md` - 5 coordination-event notification producers: reassignment, collision-sequencing, unblock, dependency-revival, stale-claim-reaped
 
 ## Contributing
 

--- a/docs/backend/services/coordination-events.md
+++ b/docs/backend/services/coordination-events.md
@@ -1,0 +1,167 @@
+# Coordination-Event Notifications
+
+The NotificationService provides five typed producers for coordination events—state transitions that affect multiple agents across a task lifecycle. Each producer fires at a specific chokepoint and is guarded against double-firing through idempotent upstream conditions.
+
+## Overview
+
+Coordination events differ from generic task-state notifications: they signal changes that require coordination between agents (reassignments, dependency unblocks, sequencing blocks) or escalations (stale claims). Every producer follows the same pattern:
+
+1. **Typed producer method** in `NotificationService` (e.g., `send_reassignment_notification`)
+2. **Best-effort wiring** at the chokepoint via a helper method (e.g., `_notify_reassignment` in TaskService)
+3. **Try/except guard** — a notification failure never breaks the underlying state transition
+4. **Double-fire prevention** — idempotent upstream guards ensure no duplicate notifications
+
+## The Five Producers
+
+### 1. Reassignment: `send_reassignment_notification`
+
+**Fired from:** `TaskService.reassign()` → `_notify_reassignment()`
+
+**Trigger:** A task is reassigned to a different agent.
+
+**Recipients:** Previous assignee + new assignee + CEO
+
+**Double-fire guard:** `_notify_reassignment` checks `new_assignee == previous_assignee` and returns early if nothing changed. TaskService only captures the assignee once (pre-mutation) so if `reassign` is called twice in succession, the second call operates on an already-updated assignee and the guard catches it.
+
+**Subject & body:**
+```
+Subject: Task {task_id} reassigned
+Body: Task {task_id} was reassigned from {previous} to {new}.
+```
+
+**Example scenario:** A PM delegates a task from developer A to developer B. Both developers and the CEO receive notification of the change.
+
+---
+
+### 2. Collision Sequencing: `send_collision_sequencing_notification`
+
+**Fired from:** `TaskService.wire_sibling_collision_dag()` → `_notify_collision_sequencing()`
+
+**Trigger:** A file/migration/shared-surface collision causes the collision-sequencing analyzer to add a dependency edge, holding back one task behind a blocking sibling.
+
+**Recipients:** Held-back task's assignee + CEO
+
+**Double-fire guard:** The wiring only fires the notification when `add_dependency` returns `True` (a freshly-inserted edge). Subsequent calls to `wire_sibling_collision_dag` over the same sibling pair contribute no new edge and therefore trigger no notification.
+
+**Subject & body:**
+```
+Subject: Task {held_back_task_id} sequenced behind a sibling
+Body: Task {held_back_task_id} was held back by the collision-sequencing 
+       analyzer: it now depends on task {blocking_task_id}, which surfaced 
+       an overlapping file/migration/shared-surface collision. It will 
+       resume once that task reaches a terminal state.
+```
+
+**Example scenario:** Two backend dev tasks both touch `roboco/models/task.py` and one adds a migration. The analyzer detects a collision and adds a sequencing edge, notifying the developer of the held-back task.
+
+---
+
+### 3. Unblock: `send_unblock_notification`
+
+**Fired from:** `TaskService.unblock()` / `unblock_with_restore()` → `_notify_unblock()`
+
+**Trigger:** A PM or resolver explicitly unblocks a task that was in BLOCKED status.
+
+**Recipients:** Restored owner + CEO
+
+**Double-fire guard:** Both `unblock` and `unblock_with_restore` are guarded by a status check (`status != BLOCKED` short-circuits early). A repeated call against an already-unblocked task is a no-op upstream and never reaches the notification handler.
+
+**Subject & body:**
+```
+Subject: Task {task_id} unblocked
+Body: Task {task_id} has been unblocked and handed back to {owner}. 
+       It is ready to resume.
+```
+
+**Example scenario:** A task was blocked by an external dependency. The dependency resolves, the PM calls `unblock()`, and the task owner is notified it's ready to resume.
+
+---
+
+### 4. Dependency Revival: `send_dependency_revival_notification`
+
+**Fired from:** `TaskService._unblock_dependents()` → `_notify_dependency_revival()`
+
+**Trigger:** A task's **last outstanding dependency completes**, automatically reviving the task.
+
+**Recipients:** Revived task's assignee + CEO
+
+**Double-fire guard:** `_unblock_dependents` prunes the `dependency_ids` list **before** firing the notification. A repeated call for the same completed dependency finds no matching dependent and never reaches the notification handler.
+
+**Distinct from `send_unblock_notification`:** This fires when a dependency completes automatically (no resolver acted). `send_unblock_notification` fires when a PM explicitly calls unblock on a task blocked by escalation. The notification names which dependency unblocked it rather than who resolved it.
+
+**Subject & body:**
+```
+Subject: Task {task_id} revived by dependency completion
+Body: Task {task_id} was revived: its dependency {completed_dependency_id} 
+       just completed and no other dependencies remain. It is ready to resume.
+```
+
+**Example scenario:** A task was blocked waiting on three dependencies. The first two complete and unblock nothing (others remain). The third completes, the last dependency clears, and the task is auto-revived with a notification.
+
+---
+
+### 5. Stale Claim Reaped: `send_stale_claim_reaped_notification`
+
+**Fired from:** Orchestrator's `_reap_with_service()` → `_notify_stale_claim_reaped()`
+
+**Trigger:** The reaper detects a stale claim (no heartbeat updates) and releases it back to PENDING.
+
+**Recipients:** Reaped agent + CEO
+
+**Priority:** HIGH (higher than other coordination events; stale claims are operational issues)
+
+**Double-fire guard:** A reaped task leaves `list_in_progress_or_claimed` once released to PENDING. A subsequent reaper tick never re-considers the same claim and cannot re-fire the notification.
+
+**Subject & body:**
+```
+Subject: Task {task_id}: stale claim reaped
+Body: Task {task_id}'s claim went stale (last heartbeat: {timestamp}) 
+       and was reaped back to pending, releasing it from {reaped_agent}.
+```
+
+**Example scenario:** An agent crashed or became unresponsive while holding a task claim. The reaper detects the stale heartbeat, releases the claim, and notifies both the agent and CEO of the forced release.
+
+---
+
+## Implementation Pattern
+
+Every producer follows a consistent best-effort pattern at its call site:
+
+```python
+async def _notify_<event>(self, ...) -> None:
+    """Best-effort coordination notification for a <event>."""
+    if <guard condition>:
+        return
+    try:
+        from roboco.services.notification import NotificationService
+        await NotificationService().send_<event>_notification(...)
+    except Exception as e:
+        self.log.warning(
+            "<Event> notify failed", task_id=str(...), error=str(e)
+        )
+```
+
+**Why this pattern:**
+- **Localized guards** in the helper prevent unnecessary notification attempts
+- **Try/except** ensures a notification failure never breaks the state transition
+- **Logged & swallowed** — operational visibility without crashing the flow
+- **Lazy import** avoids circular dependencies at the service layer
+
+## Adding a New Coordination Event
+
+When a new coordination event arises:
+
+1. **Add a new producer method** to `NotificationService` following the existing signature (typed params, docstring describing fire condition + double-fire guard, calls `_create_notification` with `related_task_id` set)
+2. **Add a helper** in the originating service (TaskService, Orchestrator, etc.) following the best-effort pattern
+3. **Wire at the chokepoint** — the single place the state transition happens
+4. **Document the guard** in the helper's docstring so reviewers understand why no duplicate can fire
+5. **Test the guard** — add a chokepoint-level test proving a repeated call doesn't fire twice
+
+See `test_notification.py` and `test_task.py` for worked examples of producer-level and chokepoint-level tests.
+
+## Related Files
+
+- **Implementation:** `roboco/services/notification.py` (producers)
+- **Wiring:** `roboco/services/task.py` (TaskService helpers), `roboco/runtime/orchestrator.py` (reaper hook)
+- **Tests:** `tests/unit/services/test_notification.py` (producer unit tests), `tests/unit/services/test_task.py` (chokepoint double-fire proofs)
+- **Data model:** `roboco/models/notification.py` (CreateNotificationParams)

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -10759,7 +10759,9 @@ Start now: evidence(task_id="{task_id}")
                 if self._assignee_is_provider_parked(t):
                     continue
                 task_id = require_uuid(t.id)
-                reaped_agent = t.assigned_to or t.claimed_by
+                reaped_agent = getattr(t, "assigned_to", None) or getattr(
+                    t, "claimed_by", None
+                )
                 try:
                     await svc.unclaim_for_reaper(task_id)
                     logger.warning(
@@ -10777,7 +10779,7 @@ Start now: evidence(task_id="{task_id}")
                     await self._notify_stale_claim_reaped(task_id, reaped_agent, ts)
 
     async def _notify_stale_claim_reaped(
-        self, task_id: UUID, reaped_agent: Any, last_heartbeat: datetime | None
+        self, task_id: "UUID", reaped_agent: Any, last_heartbeat: datetime | None
     ) -> None:
         """Best-effort coordination notification for a reaped stale claim.
 

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -10759,6 +10759,7 @@ Start now: evidence(task_id="{task_id}")
                 if self._assignee_is_provider_parked(t):
                     continue
                 task_id = require_uuid(t.id)
+                reaped_agent = t.assigned_to or t.claimed_by
                 try:
                     await svc.unclaim_for_reaper(task_id)
                     logger.warning(
@@ -10772,6 +10773,35 @@ Start now: evidence(task_id="{task_id}")
                         task_id=str(task_id),
                         error=str(exc),
                     )
+                else:
+                    await self._notify_stale_claim_reaped(task_id, reaped_agent, ts)
+
+    async def _notify_stale_claim_reaped(
+        self, task_id: UUID, reaped_agent: Any, last_heartbeat: datetime | None
+    ) -> None:
+        """Best-effort coordination notification for a reaped stale claim.
+
+        Best-effort: a notification failure must not wedge the reaper tick,
+        so any error is logged and swallowed. A reaped task leaves
+        ``list_in_progress_or_claimed`` once released to pending, so a later
+        reaper tick never re-considers the same claim and cannot double-fire.
+        """
+        if reaped_agent is None:
+            return
+        from roboco.services.notification import NotificationService
+
+        try:
+            await NotificationService().send_stale_claim_reaped_notification(
+                task_id=str(task_id),
+                reaped_agent=str(reaped_agent),
+                last_heartbeat=last_heartbeat.isoformat() if last_heartbeat else None,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to send stale-claim-reaped notification",
+                task_id=str(task_id),
+                error=str(exc),
+            )
 
     async def _dispatch_all_work(self) -> None:
         """Run all dispatchers to check for and assign work.

--- a/roboco/services/notification.py
+++ b/roboco/services/notification.py
@@ -328,6 +328,212 @@ class NotificationService:
             )
         )
 
+    async def send_reassignment_notification(
+        self,
+        task_id: str,
+        previous_assignee: str | None,
+        new_assignee: str | None,
+        from_agent: str | None = None,
+        to_ceo: str = "ceo",
+    ) -> None:
+        """Tell the outgoing + incoming owner (and the CEO) a task moved.
+
+        Skipped by the caller when ``new_assignee == previous_assignee`` —
+        ``TaskService.reassign`` runs even on a no-op redirect, and a
+        same-owner "reassignment" is not a coordination event.
+        """
+        recipients = list(
+            dict.fromkeys(r for r in (previous_assignee, new_assignee, to_ceo) if r)
+        )
+        if not recipients:
+            return
+        logger.info(
+            "Sending reassignment notification",
+            task_id=task_id,
+            previous_assignee=previous_assignee,
+            new_assignee=new_assignee,
+        )
+        body = (
+            f"Task {task_id} was reassigned from "
+            f"{previous_assignee or 'unassigned'} to {new_assignee or 'unassigned'}."
+        )
+        await self._create_notification(
+            CreateNotificationParams(
+                notification_type=NotificationType.ALERT,
+                priority=NotificationPriority.NORMAL,
+                from_agent=from_agent or "system",
+                to_agents=recipients,
+                subject=f"Task {task_id} reassigned",
+                body=body,
+                related_task_id=task_id,
+            )
+        )
+
+    async def send_collision_sequencing_notification(
+        self,
+        held_back_task_id: str,
+        blocking_task_id: str,
+        held_back_assignee: str | None,
+        from_agent: str | None = None,
+        to_ceo: str = "ceo",
+    ) -> None:
+        """Tell the held-back task's owner (+ CEO) it now waits on a sibling.
+
+        Fired only for a newly-created collision-sequencing edge (see
+        ``wire_sibling_collision_dag`` — a repeat wiring pass over an
+        already-wired pair contributes no edge, so this cannot double-fire).
+        """
+        recipients = list(dict.fromkeys(r for r in (held_back_assignee, to_ceo) if r))
+        if not recipients:
+            return
+        logger.info(
+            "Sending collision-sequencing notification",
+            held_back_task_id=held_back_task_id,
+            blocking_task_id=blocking_task_id,
+        )
+        body = (
+            f"Task {held_back_task_id} was held back by the collision-sequencing "
+            f"analyzer: it now depends on task {blocking_task_id}, which surfaced "
+            "an overlapping file/migration/shared-surface collision. It will "
+            "resume once that task reaches a terminal state."
+        )
+        await self._create_notification(
+            CreateNotificationParams(
+                notification_type=NotificationType.ALERT,
+                priority=NotificationPriority.NORMAL,
+                from_agent=from_agent or "system",
+                to_agents=recipients,
+                subject=f"Task {held_back_task_id} sequenced behind a sibling",
+                body=body,
+                related_task_id=held_back_task_id,
+            )
+        )
+
+    async def send_unblock_notification(
+        self,
+        task_id: str,
+        restored_owner: str | None,
+        from_agent: str | None = None,
+        to_ceo: str = "ceo",
+    ) -> None:
+        """Tell the restored owner (+ CEO) a blocked task is workable again.
+
+        Fired from ``TaskService.unblock`` / ``unblock_with_restore`` — both
+        only act on a task whose status is currently ``BLOCKED``, so a
+        repeated call against the same (already-unblocked) task is a no-op
+        upstream and this cannot double-fire.
+        """
+        recipients = list(dict.fromkeys(r for r in (restored_owner, to_ceo) if r))
+        if not recipients:
+            return
+        logger.info(
+            "Sending unblock notification",
+            task_id=task_id,
+            restored_owner=restored_owner,
+        )
+        body = (
+            f"Task {task_id} has been unblocked and handed back to "
+            f"{restored_owner or 'its owner'}. It is ready to resume."
+        )
+        await self._create_notification(
+            CreateNotificationParams(
+                notification_type=NotificationType.ALERT,
+                priority=NotificationPriority.NORMAL,
+                from_agent=from_agent or "system",
+                to_agents=recipients,
+                subject=f"Task {task_id} unblocked",
+                body=body,
+                related_task_id=task_id,
+            )
+        )
+
+    async def send_dependency_revival_notification(
+        self,
+        task_id: str,
+        assignee: str | None,
+        completed_dependency_id: str,
+        from_agent: str | None = None,
+        to_ceo: str = "ceo",
+    ) -> None:
+        """Tell the revived task's owner (+ CEO) its last dependency landed.
+
+        Distinct event from ``send_unblock_notification``: that one fires
+        when a resolver explicitly calls ``unblock``/``unblock_with_restore``
+        on a task blocked by escalation. This one fires from
+        ``TaskService._unblock_dependents`` when the LAST outstanding
+        dependency of a task blocked ON THAT DEPENDENCY completes — no
+        resolver acted, the trigger is upstream task completion, so the
+        notification names which dependency unblocked it rather than who
+        resolved it. ``_unblock_dependents`` prunes ``dependency_ids`` before
+        this fires, so a repeated call for the same completed dependency
+        finds no matching dependent and cannot double-fire.
+        """
+        recipients = list(dict.fromkeys(r for r in (assignee, to_ceo) if r))
+        if not recipients:
+            return
+        logger.info(
+            "Sending dependency-revival notification",
+            task_id=task_id,
+            completed_dependency_id=completed_dependency_id,
+        )
+        body = (
+            f"Task {task_id} was revived: its dependency "
+            f"{completed_dependency_id} just completed and no other "
+            "dependencies remain. It is ready to resume."
+        )
+        await self._create_notification(
+            CreateNotificationParams(
+                notification_type=NotificationType.ALERT,
+                priority=NotificationPriority.NORMAL,
+                from_agent=from_agent or "system",
+                to_agents=recipients,
+                subject=f"Task {task_id} revived by dependency completion",
+                body=body,
+                related_task_id=task_id,
+            )
+        )
+
+    async def send_stale_claim_reaped_notification(
+        self,
+        task_id: str,
+        reaped_agent: str | None,
+        last_heartbeat: str | None = None,
+        from_agent: str = "system",
+        to_ceo: str = "ceo",
+    ) -> None:
+        """Tell the reaped agent (+ CEO) its stale claim was released.
+
+        Fired from the orchestrator's ``_reap_with_service`` alongside
+        ``unclaim_for_reaper``. A reaped task leaves
+        ``list_in_progress_or_claimed`` once released to pending, so a
+        subsequent reaper tick never re-considers the same claim and this
+        cannot double-fire.
+        """
+        recipients = list(dict.fromkeys(r for r in (reaped_agent, to_ceo) if r))
+        if not recipients:
+            return
+        logger.info(
+            "Sending stale-claim-reaped notification",
+            task_id=task_id,
+            reaped_agent=reaped_agent,
+        )
+        body = (
+            f"Task {task_id}'s claim went stale "
+            f"(last heartbeat: {last_heartbeat or 'unknown'}) and was reaped "
+            f"back to pending, releasing it from {reaped_agent or 'its holder'}."
+        )
+        await self._create_notification(
+            CreateNotificationParams(
+                notification_type=NotificationType.ALERT,
+                priority=NotificationPriority.HIGH,
+                from_agent=from_agent,
+                to_agents=recipients,
+                subject=f"Task {task_id}: stale claim reaped",
+                body=body,
+                related_task_id=task_id,
+            )
+        )
+
     async def send_ack_notification(
         self,
         *,

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -4367,7 +4367,28 @@ class TaskService(BaseService):
         self._background_tasks.add(bg_task)
         bg_task.add_done_callback(self._background_tasks.discard)
 
+        await self._notify_unblock(task_id, task.assigned_to)
+
         return task
+
+    async def _notify_unblock(self, task_id: UUID, restored_owner: Any) -> None:
+        """Best-effort coordination notification when a blocked task resumes.
+
+        Called from both `unblock` and `unblock_with_restore`'s restore=True
+        success path. `unblock` only acts on a task whose status is
+        currently BLOCKED (guarded above), so a repeated call against an
+        already-unblocked task never re-fires this.
+        """
+        if restored_owner is None:
+            return
+        try:
+            from roboco.services.notification import NotificationService
+
+            await NotificationService().send_unblock_notification(
+                task_id=str(task_id), restored_owner=str(restored_owner)
+            )
+        except Exception as e:
+            self.log.warning("Unblock notify failed", task_id=str(task_id), error=str(e))
 
     async def pause(
         self, task_id: UUID, agent_role: str | None = None
@@ -6487,6 +6508,14 @@ class TaskService(BaseService):
                     task_id=str(task.id),
                     completed_dependency=str(completed_task_id),
                 )
+                # Distinct coordination event from `_notify_unblock`: THIS fires
+                # automatically when a dependency's completion clears the last
+                # blocker, not from a resolver explicitly calling `unblock` — no
+                # human/PM acted, so the notification names the dependency that
+                # unblocked it rather than a resolver. Dependency_ids was already
+                # pruned above, so a repeated pass over this completed_task_id
+                # finds no matching dependent and cannot double-fire.
+                await self._notify_dependency_revival(task, completed_task_id)
 
         if blocked_tasks:
             # Metrics (blocked-others): record how many downstream tasks this
@@ -6509,6 +6538,26 @@ class TaskService(BaseService):
             )
 
         await self.session.flush()
+
+    async def _notify_dependency_revival(
+        self, task: TaskTable, completed_dependency_id: UUID
+    ) -> None:
+        """Best-effort coordination notification for an auto-revived dependent."""
+        owner = cast("Any", task.claimed_by or task.assigned_to)
+        if owner is None:
+            return
+        try:
+            from roboco.services.notification import NotificationService
+
+            await NotificationService().send_dependency_revival_notification(
+                task_id=str(task.id),
+                assignee=str(owner),
+                completed_dependency_id=str(completed_dependency_id),
+            )
+        except Exception as e:
+            self.log.warning(
+                "Dependency-revival notify failed", task_id=str(task.id), error=str(e)
+            )
 
     async def _revive_unblocked_dependent(self, task: TaskTable) -> None:
         """Resume — or re-home — a task whose last dependency just cleared.
@@ -6939,7 +6988,7 @@ class TaskService(BaseService):
         result = await self.session.execute(query)
         return list(result.scalars().all())
 
-    async def add_dependency(self, task_id: UUID, depends_on_id: UUID) -> None:
+    async def add_dependency(self, task_id: UUID, depends_on_id: UUID) -> bool:
         """Append a dependency to a task WITHOUT changing its status.
 
         A PENDING task with unmet dependencies is held back by
@@ -6951,6 +7000,11 @@ class TaskService(BaseService):
         Rejects a self-reference and any edge that would close a cycle (the
         reverse path already reaches the dependent) — a cycle deadlocks both
         tasks (`_unblock_dependents` never fires).
+
+        Returns ``True`` only when a new edge was actually inserted, ``False``
+        for an idempotent no-op (missing task, already-present edge) — lets
+        callers like `wire_sibling_collision_dag` tell a fresh wiring pass
+        from a repeat one without a separate membership check.
         """
         if depends_on_id == task_id:
             raise ConflictError(
@@ -6959,9 +7013,9 @@ class TaskService(BaseService):
             )
         task = await self.get(task_id)
         if task is None:
-            return
+            return False
         if depends_on_id in task.dependency_ids:
-            return  # idempotent re-add
+            return False  # idempotent re-add
         if await self._would_create_cycle(task_id, depends_on_id):
             raise ConflictError(
                 f"adding {depends_on_id} as a dependency of {task_id} would "
@@ -6970,6 +7024,7 @@ class TaskService(BaseService):
             )
         task.dependency_ids = [*task.dependency_ids, depends_on_id]
         await self.session.flush()
+        return True
 
     async def _would_create_cycle(self, task_id: UUID, depends_on_id: UUID) -> bool:
         """True if ``depends_on_id`` already (transitively) depends on ``task_id``.
@@ -7018,9 +7073,31 @@ class TaskService(BaseService):
         from roboco.services.sequencing import dev_task_collision_edges
 
         siblings = await self.get_subtasks(parent_task_id)
+        siblings_by_id = {UUID(str(s.id)): s for s in siblings}
         edges = dev_task_collision_edges(siblings)
         for depends_on_id, task_id in edges:
-            await self.add_dependency(UUID(str(task_id)), UUID(str(depends_on_id)))
+            held_back_id = UUID(str(task_id))
+            blocking_id = UUID(str(depends_on_id))
+            created = await self.add_dependency(held_back_id, blocking_id)
+            if created:
+                held_back = siblings_by_id.get(held_back_id)
+                owner = getattr(held_back, "assigned_to", None) if held_back else None
+                await self._notify_collision_sequencing(held_back_id, blocking_id, owner)
+
+    async def _notify_collision_sequencing(
+        self, held_back_task_id: UUID, blocking_task_id: UUID, owner: Any
+    ) -> None:
+        """Best-effort coordination notification for a newly-wired collision edge."""
+        try:
+            from roboco.services.notification import NotificationService
+
+            await NotificationService().send_collision_sequencing_notification(
+                held_back_task_id=str(held_back_task_id),
+                blocking_task_id=str(blocking_task_id),
+                held_back_assignee=str(owner) if owner is not None else None,
+            )
+        except Exception as e:
+            self.log.warning("Collision-sequencing notify failed", error=str(e))
 
     async def wire_cell_task_wave_chain(self, cell_task_id: UUID) -> None:
         """Wire the cell-task wave chain (multi-level sequencing edge kind 2).
@@ -8578,6 +8655,7 @@ class TaskService(BaseService):
         task = await self.get(task_id)
         if task is None:
             return None
+        previous_assignee = cast("Any", task.assigned_to)
         # Board/advisory → cell-task hand-off is diverted to the pool (see
         # `_maybe_divert_board_advisory_reassign`); otherwise proceed with the
         # normal handoff + cell-PM redirect.
@@ -8622,7 +8700,31 @@ class TaskService(BaseService):
             task_id=str(task_id),
             new_assignee=str(effective_assignee) if effective_assignee else None,
         )
+        await self._notify_reassignment(task_id, previous_assignee, effective_assignee)
         return task
+
+    async def _notify_reassignment(
+        self, task_id: UUID, previous_assignee: Any, new_assignee: Any
+    ) -> None:
+        """Best-effort coordination notification for a real ownership change.
+
+        Skipped when nothing actually changed — `reassign` runs even on a
+        no-op redirect (the effective assignee already matched the request).
+        """
+        if new_assignee == previous_assignee:
+            return
+        try:
+            from roboco.services.notification import NotificationService
+
+            await NotificationService().send_reassignment_notification(
+                task_id=str(task_id),
+                previous_assignee=str(previous_assignee)
+                if previous_assignee is not None
+                else None,
+                new_assignee=str(new_assignee) if new_assignee is not None else None,
+            )
+        except Exception as e:
+            self.log.warning("Reassignment notify failed", task_id=str(task_id), error=str(e))
 
     @dataclass(frozen=True)
     class _CellPmRedirect:
@@ -9208,7 +9310,9 @@ class TaskService(BaseService):
         except ValueError:
             return await self.unblock(task_id, agent_role="cell_pm")
 
-        return await self._apply_pre_block_restore(task, restored_status)
+        restored = await self._apply_pre_block_restore(task, restored_status)
+        await self._notify_unblock(task_id, restored.assigned_to)
+        return restored
 
     async def _apply_pre_block_restore(
         self,

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -4388,7 +4388,9 @@ class TaskService(BaseService):
                 task_id=str(task_id), restored_owner=str(restored_owner)
             )
         except Exception as e:
-            self.log.warning("Unblock notify failed", task_id=str(task_id), error=str(e))
+            self.log.warning(
+                "Unblock notify failed", task_id=str(task_id), error=str(e)
+            )
 
     async def pause(
         self, task_id: UUID, agent_role: str | None = None
@@ -7082,7 +7084,9 @@ class TaskService(BaseService):
             if created:
                 held_back = siblings_by_id.get(held_back_id)
                 owner = getattr(held_back, "assigned_to", None) if held_back else None
-                await self._notify_collision_sequencing(held_back_id, blocking_id, owner)
+                await self._notify_collision_sequencing(
+                    held_back_id, blocking_id, owner
+                )
 
     async def _notify_collision_sequencing(
         self, held_back_task_id: UUID, blocking_task_id: UUID, owner: Any
@@ -8724,7 +8728,9 @@ class TaskService(BaseService):
                 new_assignee=str(new_assignee) if new_assignee is not None else None,
             )
         except Exception as e:
-            self.log.warning("Reassignment notify failed", task_id=str(task_id), error=str(e))
+            self.log.warning(
+                "Reassignment notify failed", task_id=str(task_id), error=str(e)
+            )
 
     @dataclass(frozen=True)
     class _CellPmRedirect:

--- a/tests/unit/services/test_notification.py
+++ b/tests/unit/services/test_notification.py
@@ -419,6 +419,11 @@ async def test_create_notification_requires_ack_derives_from_type(
 # dependency-revival / stale-claim-reaped)
 # ---------------------------------------------------------------------------
 
+# previous_assignee + new_assignee + ceo, resolved to UUIDs pre-insert.
+_REASSIGN_RECIPIENT_COUNT = 3
+# {task-owner, ceo} for the other four coordination producers.
+_TWO_RECIPIENT_COUNT = 2
+
 
 @pytest.mark.asyncio
 async def test_send_reassignment_notification(svc: NotificationService) -> None:
@@ -430,8 +435,7 @@ async def test_send_reassignment_notification(svc: NotificationService) -> None:
         )
     rows = [r for r in db.added if r.related_task_id == "t1"]
     assert rows
-    # previous_assignee + new_assignee + ceo, resolved to UUIDs pre-insert.
-    assert all(len(r.to_agents) == 3 for r in rows)
+    assert all(len(r.to_agents) == _REASSIGN_RECIPIENT_COUNT for r in rows)
     assert any("reassigned" in r.subject for r in rows)
 
 
@@ -465,7 +469,7 @@ async def test_send_collision_sequencing_notification(
         )
     rows = [r for r in db.added if r.related_task_id == "t2"]
     assert rows
-    assert all(len(r.to_agents) == 2 for r in rows)
+    assert all(len(r.to_agents) == _TWO_RECIPIENT_COUNT for r in rows)
     assert any("sequenced behind" in r.subject for r in rows)
 
 
@@ -477,7 +481,7 @@ async def test_send_unblock_notification(svc: NotificationService) -> None:
         await svc.send_unblock_notification(task_id="t1", restored_owner="be-dev-1")
     rows = [r for r in db.added if r.related_task_id == "t1"]
     assert rows
-    assert all(len(r.to_agents) == 2 for r in rows)
+    assert all(len(r.to_agents) == _TWO_RECIPIENT_COUNT for r in rows)
     assert any("unblocked" in r.subject for r in rows)
 
 
@@ -493,7 +497,7 @@ async def test_send_dependency_revival_notification(
         )
     rows = [r for r in db.added if r.related_task_id == "t1"]
     assert rows
-    assert all(len(r.to_agents) == 2 for r in rows)
+    assert all(len(r.to_agents) == _TWO_RECIPIENT_COUNT for r in rows)
     assert any("revived" in r.subject for r in rows)
     assert any("dep1" in r.body for r in rows)
 
@@ -510,6 +514,6 @@ async def test_send_stale_claim_reaped_notification(
         )
     rows = [r for r in db.added if r.related_task_id == "t1"]
     assert rows
-    assert all(len(r.to_agents) == 2 for r in rows)
+    assert all(len(r.to_agents) == _TWO_RECIPIENT_COUNT for r in rows)
     assert any(r.priority == NotificationPriority.HIGH for r in rows)
     assert any("stale claim reaped" in r.subject for r in rows)

--- a/tests/unit/services/test_notification.py
+++ b/tests/unit/services/test_notification.py
@@ -412,4 +412,104 @@ async def test_create_notification_requires_ack_derives_from_type(
     assert (
         rows[0].requires_ack is ACK_REQUIRED_BY_TYPE[NotificationType.KNOWLEDGE_SHARE]
     )
-    assert rows[0].requires_ack is False
+
+
+# ---------------------------------------------------------------------------
+# Coordination-event producers (reassignment / collision / unblock /
+# dependency-revival / stale-claim-reaped)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_reassignment_notification(svc: NotificationService) -> None:
+    aid = uuid4()
+    db = _FakeDb(agent_uuid=aid)
+    with _patch_db_context(db):
+        await svc.send_reassignment_notification(
+            task_id="t1", previous_assignee="be-dev-1", new_assignee="be-dev-2"
+        )
+    rows = [r for r in db.added if r.related_task_id == "t1"]
+    assert rows
+    # previous_assignee + new_assignee + ceo, resolved to UUIDs pre-insert.
+    assert all(len(r.to_agents) == 3 for r in rows)
+    assert any("reassigned" in r.subject for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_send_reassignment_notification_no_recipients_is_noop(
+    svc: NotificationService,
+) -> None:
+    """All three recipients falsy ⇒ nothing is created (no crash)."""
+    db = _FakeDb()
+    with _patch_db_context(db):
+        await svc.send_reassignment_notification(
+            task_id="t1",
+            previous_assignee=None,
+            new_assignee=None,
+            to_ceo="",
+        )
+    assert db.added == []
+
+
+@pytest.mark.asyncio
+async def test_send_collision_sequencing_notification(
+    svc: NotificationService,
+) -> None:
+    aid = uuid4()
+    db = _FakeDb(agent_uuid=aid)
+    with _patch_db_context(db):
+        await svc.send_collision_sequencing_notification(
+            held_back_task_id="t2",
+            blocking_task_id="t1",
+            held_back_assignee="be-dev-1",
+        )
+    rows = [r for r in db.added if r.related_task_id == "t2"]
+    assert rows
+    assert all(len(r.to_agents) == 2 for r in rows)
+    assert any("sequenced behind" in r.subject for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_send_unblock_notification(svc: NotificationService) -> None:
+    aid = uuid4()
+    db = _FakeDb(agent_uuid=aid)
+    with _patch_db_context(db):
+        await svc.send_unblock_notification(task_id="t1", restored_owner="be-dev-1")
+    rows = [r for r in db.added if r.related_task_id == "t1"]
+    assert rows
+    assert all(len(r.to_agents) == 2 for r in rows)
+    assert any("unblocked" in r.subject for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_send_dependency_revival_notification(
+    svc: NotificationService,
+) -> None:
+    aid = uuid4()
+    db = _FakeDb(agent_uuid=aid)
+    with _patch_db_context(db):
+        await svc.send_dependency_revival_notification(
+            task_id="t1", assignee="be-dev-1", completed_dependency_id="dep1"
+        )
+    rows = [r for r in db.added if r.related_task_id == "t1"]
+    assert rows
+    assert all(len(r.to_agents) == 2 for r in rows)
+    assert any("revived" in r.subject for r in rows)
+    assert any("dep1" in r.body for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_send_stale_claim_reaped_notification(
+    svc: NotificationService,
+) -> None:
+    aid = uuid4()
+    db = _FakeDb(agent_uuid=aid)
+    with _patch_db_context(db):
+        await svc.send_stale_claim_reaped_notification(
+            task_id="t1", reaped_agent="be-dev-1", last_heartbeat="2026-07-11T00:00:00"
+        )
+    rows = [r for r in db.added if r.related_task_id == "t1"]
+    assert rows
+    assert all(len(r.to_agents) == 2 for r in rows)
+    assert any(r.priority == NotificationPriority.HIGH for r in rows)
+    assert any("stale claim reaped" in r.subject for r in rows)

--- a/tests/unit/services/test_task.py
+++ b/tests/unit/services/test_task.py
@@ -461,6 +461,57 @@ async def test_reassign_returns_none_when_task_missing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reassign_notifies_once_not_twice_for_same_target() -> None:
+    """Repeated reassign to the SAME target must not double-fire.
+
+    `reassign` runs every time it's called (even a no-op redirect); the
+    coordination notification is guarded separately by comparing the new
+    assignee against the assignee captured before the mutation, so a second
+    call with an already-current target must skip the notification.
+    """
+    task = _build_task(assigned_to=None, claimed_by=None)
+    svc = TaskService(MagicMock(flush=AsyncMock()))
+    _bind(svc, "get", AsyncMock(return_value=task))
+    new_assignee = uuid4()
+    mock_ns = MagicMock()
+    mock_ns.send_reassignment_notification = AsyncMock()
+    with patch(
+        "roboco.services.notification.NotificationService", return_value=mock_ns
+    ):
+        await svc.reassign(task.id, new_assignee)
+        await svc.reassign(task.id, new_assignee)
+    mock_ns.send_reassignment_notification.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unblock_notifies_once_not_twice_on_repeated_call() -> None:
+    """Repeated unblock() against the same task must not double-fire.
+
+    `unblock` only mutates + notifies a task whose status is currently
+    BLOCKED; the first call flips it to IN_PROGRESS/PENDING, so a second
+    call against the same task_id short-circuits on the status guard and
+    must not send a second notification.
+    """
+    raiser = uuid4()
+    task = _build_task(
+        status=TaskStatus.BLOCKED, branch_name=None, blocker_raised_by=raiser
+    )
+    svc = TaskService(MagicMock(flush=AsyncMock()))
+    _bind(svc, "get", AsyncMock(return_value=task))
+    _bind(svc, "_index_lifecycle_event_background", AsyncMock())
+    mock_ns = MagicMock()
+    mock_ns.send_unblock_notification = AsyncMock()
+    with patch(
+        "roboco.services.notification.NotificationService", return_value=mock_ns
+    ):
+        first = await svc.unblock(task.id)
+        second = await svc.unblock(task.id)
+    assert first is task
+    assert second is None
+    mock_ns.send_unblock_notification.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_mark_agent_idle_sets_status_idle() -> None:
     agent = MagicMock(id=uuid4(), status=AgentStatus.ACTIVE)
     result = MagicMock()


### PR DESCRIPTION
Add 5 new async producer methods to NotificationService (roboco/services/notification.py), following the existing send_*_notification pattern (CreateNotificationParams, NotificationType, related_task_id deep-link, from_agent="system"):

1. send_reassignment_notification — fires when a task's assignee changes (TaskService.reassign). Addressed to the new assignee, the previous assignee, and the CEO. Skip firing when new_assignee equals the current assignee (no-op reassign) so retries don't double-fire.
2. send_collision_sequencing_notification — fires when the sibling collision DAG (TaskService.wire_sibling_collision_dag / dev_task_collision_edges in roboco/services/sequencing.py) actually holds a sibling task back behind another (a real new edge, not a re-run over an already-wired parent). Addressed to the held-back task's assignee and the CEO.
3. send_unblock_notification — fires when TaskService.unblock (or unblock_with_restore) transitions a task out of BLOCKED. Addressed to the restored owner and the CEO.
4. send_stale_claim_reaped_notification — fires when the orchestrator's stale-claim reaper (_reap_with_service in roboco/runtime/orchestrator.py) calls unclaim_for_reaper on a task. Addressed to the reaped agent (whose claim was stale) and the CEO.
5. send_dependency_revival_notification — fires when TaskService._unblock_dependents (task.py) clears a task's dependency and it becomes eligible to proceed again. Addressed to that task's assignee and the CEO. This is the 5th coordination-event type identified for this task — document the rationale (a real coordination event distinct from a manual unblock: the task didn't request release, an upstream completion triggered it) in a short code comment above the method and in your dev_notes.

Each producer must emit exactly ONE notification per event, carrying a task deep-link via related_task_id, addressed to affected agents plus the CEO ("ceo" slug). Rely on NotificationService's existing dedup (_duplicate_unacked_exists purpose-based dedup, all_recipients_recently_notified re-fire guard) plus a same-value/no-op guard at each call site (e.g. skip when nothing actually changed) so retried or idempotent transitions never double-fire — this is a hard acceptance criterion, verify it with a test that calls the wired method twice with the same inputs and asserts only one notification row is created.

Wire each producer at its respective chokepoint:
- reassignment → roboco/services/task.py TaskService.reassign()
- collision → roboco/services/task.py TaskService.wire_sibling_collision_dag()
- unblock → roboco/services/task.py TaskService.unblock() (and unblock_with_restore() if it has a separate BLOCKED->active transition not covered by unblock())
- dependency-revival → roboco/services/task.py TaskService._unblock_dependents()
- stale-claim → roboco/runtime/orchestrator.py OrchestratorService._reap_with_service(), alongside the existing unclaim_for_reaper() call

Add or reuse a NotificationType enum value as needed (prefer reusing ALERT, matching send_ack_notification/send_stuck_agent_notification, unless a dedicated type is clearly warranted — a new type also needs an ACK_REQUIRED_BY_TYPE entry). Add unit/integration tests covering all 5 producers firing on their chokepoint and the no-duplicate-on-retry behavior. Run ruff format/check, mypy, and pytest before opening the PR.