### PR TITLE
[3ee8150b] Frontend: render coordination-event notifications + e2e smoke coverage

### DIFF
--- a/docs/frontend/components/notification-types.md
+++ b/docs/frontend/components/notification-types.md
@@ -1,0 +1,99 @@
+# Notification Types Reference
+
+The RoboCo panel renders five core **coordination-event notification types** — formal signals between agents tied to task lifecycle events. Each type has a visual identity (icon + color) and a semantic meaning. All types carry optional deep-links to related tasks.
+
+## The 5 Coordination-Event Types
+
+### 1. TASK_ASSIGNMENT
+**Icon:** ListTodo (green)  
+**Use case:** An agent has been assigned a new task.  
+**When sent:** Via `NotificationService.send_task_assignment` when a PM assigns work.  
+**Related task:** Usually carries `related_task_id` linking to the assigned task.
+
+### 2. BLOCKER_ESCALATION
+**Icon:** AlertTriangle (red)  
+**Use case:** A developer is blocked and has escalated the issue to the PM.  
+**When sent:** Via `NotificationDeliveryService.escalate_and_notify` when an agent calls `i_am_blocked`.  
+**Related task:** Links to the task that is blocked.
+
+### 3. REVIEW_REQUEST
+**Icon:** Check (purple)  
+**Use case:** QA has been asked to review a developer's work.  
+**When sent:** Via `NotificationService.send_qa_ready` when a dev submits `i_am_done`.  
+**Related task:** Links to the task under review.
+
+### 4. DOCUMENTATION_REQUEST
+**Icon:** Info (blue)  
+**Use case:** A documenter has been asked to write docs for a code change.  
+**When sent:** Via `NotificationService.send_docs_ready` when QA passes a task.  
+**Related task:** Links to the task whose code needs documenting.
+
+### 5. APPROVAL *(New in this release)*
+**Icon:** ShieldCheck (emerald)  
+**Use case:** A Board member (Product Owner, Head of Marketing, or Main PM) is requested to approve or provide feedback on escalated work.  
+**When sent:** Via `NotificationDeliveryService.notify_ceo_of_escalation` when a task escalates to the Board.  
+**Related task:** Links to the task awaiting approval.  
+**Backend reference:** Matches `roboco/models/base.py` `NotificationType.APPROVAL`.
+
+## Implementation Details
+
+All types are defined in `panel/src/types/index.ts` under the `NotificationType` enum:
+
+```typescript
+export enum NotificationType {
+  TASK_ASSIGNMENT = "task_assignment",
+  BLOCKER_ESCALATION = "blocker_escalation",
+  REVIEW_REQUEST = "review_request",
+  DOCUMENTATION_REQUEST = "documentation_request",
+  APPROVAL = "approval", // Board-level approval requests (PO/HM/Main PM)
+  // ... other types (ALERT, BROADCAST, etc.)
+}
+```
+
+### Icon Mapping
+Icons are rendered in `panel/src/app/(dashboard)/notifications/page.tsx` via the `typeIcons` Record — a TypeScript-enforced exhaustive mapping that ensures every enum member has a visual representation:
+
+```typescript
+const typeIcons: Record<NotificationType, React.ReactNode> = {
+  [NotificationType.TASK_ASSIGNMENT]: <ListTodo className="h-4 w-4 text-green-500" />,
+  [NotificationType.BLOCKER_ESCALATION]: <AlertTriangle className="h-4 w-4 text-red-500" />,
+  [NotificationType.REVIEW_REQUEST]: <Check className="h-4 w-4 text-purple-500" />,
+  [NotificationType.DOCUMENTATION_REQUEST]: <Info className="h-4 w-4 text-blue-500" />,
+  [NotificationType.APPROVAL]: <ShieldCheck className="h-4 w-4 text-emerald-500" />,
+  // ...
+};
+```
+
+TypeScript's `Record<K, V>` type ensures that if a new `NotificationType` enum member is added without a corresponding icon entry, the code will not compile — preventing the "missing icon" bug at build time.
+
+### Deep-Linking to Tasks
+When a notification carries a `related_task_id`, the notifications page renders a Next.js `Link` component:
+
+```tsx
+{notification.related_task_id && (
+  <Link href={`/tasks/${notification.related_task_id}`} className="text-primary hover:underline">
+    Task #{notification.related_task_id.substring(0, 8)}
+  </Link>
+)}
+```
+
+This allows agents to navigate directly from the notification inbox to the related task's detail view.
+
+## Testing
+
+The 5 coordination-event types are covered by component tests in `panel/src/app/(dashboard)/notifications/__tests__/page.test.tsx`:
+
+1. **Deep-link test:** Verifies that a TASK_ASSIGNMENT notification renders a working `<Link>` to `/tasks/{task_id}`.
+2. **Icon test:** Verifies that all 5 types render and are queryable by their subject text.
+
+## Adding a New Coordination-Event Type
+
+To add a new coordination-event notification type:
+
+1. Add the enum member to `NotificationType` in `panel/src/types/index.ts`
+2. Add a corresponding icon entry to the `typeIcons` Record in `notifications/page.tsx`
+3. Add a test case to the component test file
+4. Update backend `roboco/models/base.py` `NotificationType` to match
+5. Wire the notification send/delivery method in the backend service
+
+The TypeScript exhaustiveness check will catch any missing icon entry at build time.

--- a/panel/README.md
+++ b/panel/README.md
@@ -50,8 +50,9 @@ That gives you Next dev-server on `localhost:3000`, but you still need the orche
 - `src/components/` — React components (organized by feature: tasks, agents, channels, …)
 - `src/lib/api/` — typed API client (thin wrappers over `fetch`)
 - `src/lib/` — constants, utilities, WebSocket hooks
-- `src/types/` — shared TypeScript types mirroring backend schemas
+- `src/types/` — shared TypeScript types mirroring backend schemas (includes `NotificationType` enum)
 - `src/hooks/` — reusable React hooks (see [Frontend hooks](../docs/frontend/hooks.md))
+- `src/app/(dashboard)/notifications/` — notifications inbox page and components
 
 ## Hooks
 
@@ -72,6 +73,20 @@ const { register, unregister, refresh, loading, disabled } = usePageRefresh();
 - `disabled` returns to `true` when all callbacks are unregistered
 
 Wrap your page or layout in `PageRefreshProvider` from `@/components/providers` before consuming the hook. Dashboard pages should register their refetch callbacks and avoid adding inline "Refresh" buttons; see [`docs/frontend/components/page-refresh-provider.md`](../docs/frontend/components/page-refresh-provider.md) for the full wiring list and examples.
+
+## Notifications
+
+The panel renders five core **coordination-event notification types** that signal task lifecycle transitions between agents:
+
+| Type | Icon | Color | Meaning |
+|------|------|-------|---------|
+| `TASK_ASSIGNMENT` | ListTodo | green | A task has been assigned to you |
+| `BLOCKER_ESCALATION` | AlertTriangle | red | A developer is blocked and escalated |
+| `REVIEW_REQUEST` | Check | purple | Your review is needed |
+| `DOCUMENTATION_REQUEST` | Info | blue | Documentation is needed |
+| `APPROVAL` | ShieldCheck | emerald | Board-level approval requested |
+
+Each notification optionally carries a `related_task_id` rendered as a deep-link to `/tasks/{id}`. For full details on types, icons, and adding new types, see [`docs/frontend/components/notification-types.md`](../docs/frontend/components/notification-types.md).
 
 ## Dependency Management
 

--- a/panel/src/app/(dashboard)/notifications/__tests__/page.test.tsx
+++ b/panel/src/app/(dashboard)/notifications/__tests__/page.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { PageRefreshProvider } from "@/components/providers";
+import { NotificationType, NotificationPriority, type Notification } from "@/types";
+
+const {
+  useNotifications,
+  useMarkNotificationRead,
+  useAcknowledgeNotification,
+  useMarkAllNotificationsRead,
+} = vi.hoisted(() => ({
+  useNotifications: vi.fn(),
+  useMarkNotificationRead: vi.fn(),
+  useAcknowledgeNotification: vi.fn(),
+  useMarkAllNotificationsRead: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("tab=all"),
+}));
+
+vi.mock("@/hooks/use-notifications", () => ({
+  useNotifications,
+  useMarkNotificationRead,
+  useAcknowledgeNotification,
+  useMarkAllNotificationsRead,
+}));
+
+vi.mock("@/components/ui/markdown", () => ({
+  Markdown: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import NotificationsPage from "../page";
+
+function withPageRefresh(ui: ReactNode) {
+  return <PageRefreshProvider>{ui}</PageRefreshProvider>;
+}
+
+function buildNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: "notif-1",
+    type: NotificationType.TASK_ASSIGNMENT,
+    priority: NotificationPriority.NORMAL,
+    from_agent: "fe-pm-00000000",
+    to_agents: ["fe-dev-1"],
+    subject: "New task assigned",
+    body: "You have been assigned a new task.",
+    requires_ack: false,
+    is_acknowledged: false,
+    is_fully_acknowledged: false,
+    is_read: false,
+    related_task_id: "11111111-2222-3333-4444-555555555555",
+    related_message_ids: [],
+    timestamp: "2026-07-11T09:00:00Z",
+    expires_at: null,
+    acked_by: [],
+    acked_at: {},
+    ...overrides,
+  };
+}
+
+describe("NotificationsPage", () => {
+  beforeEach(() => {
+    useMarkNotificationRead.mockReturnValue({ mutateAsync: vi.fn() });
+    useAcknowledgeNotification.mockReturnValue({ mutateAsync: vi.fn() });
+    useMarkAllNotificationsRead.mockReturnValue({ mutateAsync: vi.fn() });
+  });
+
+  it("renders a TASK_ASSIGNMENT notification with a working deep-link to its task", () => {
+    useNotifications.mockReturnValue({
+      data: {
+        items: [buildNotification()],
+        total: 1,
+        unread_count: 1,
+        pending_ack_count: 0,
+      },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(withPageRefresh(<NotificationsPage />));
+
+    expect(screen.getByText("New task assigned")).toBeInTheDocument();
+
+    const taskLink = screen.getByRole("link", { name: /Task #11111111/i });
+    expect(taskLink).toHaveAttribute(
+      "href",
+      "/tasks/11111111-2222-3333-4444-555555555555",
+    );
+  });
+
+  it("renders each of the 5 coordination-event notification types with a distinguishing icon", () => {
+    const types = [
+      NotificationType.TASK_ASSIGNMENT,
+      NotificationType.BLOCKER_ESCALATION,
+      NotificationType.REVIEW_REQUEST,
+      NotificationType.DOCUMENTATION_REQUEST,
+      NotificationType.APPROVAL,
+    ];
+    const items = types.map((type, idx) =>
+      buildNotification({
+        id: `notif-${idx}`,
+        type,
+        subject: `Subject for ${type}`,
+        related_task_id: null,
+      }),
+    );
+
+    useNotifications.mockReturnValue({
+      data: { items, total: items.length, unread_count: 0, pending_ack_count: 0 },
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(withPageRefresh(<NotificationsPage />));
+
+    for (const type of types) {
+      expect(screen.getByText(`Subject for ${type}`)).toBeInTheDocument();
+    }
+  });
+});

--- a/panel/src/app/(dashboard)/notifications/page.tsx
+++ b/panel/src/app/(dashboard)/notifications/page.tsx
@@ -29,6 +29,7 @@ import {
   MailOpen,
   BookOpen,
   AtSign,
+  ShieldCheck,
 } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
@@ -49,6 +50,9 @@ const typeIcons: Record<NotificationType, React.ReactNode> = {
   ),
   [NotificationType.DOCUMENTATION_REQUEST]: (
     <Info className="h-4 w-4 text-blue-500" />
+  ),
+  [NotificationType.APPROVAL]: (
+    <ShieldCheck className="h-4 w-4 text-emerald-500" />
   ),
   [NotificationType.ALERT]: (
     <AlertTriangle className="h-4 w-4 text-yellow-500" />

--- a/panel/src/types/index.ts
+++ b/panel/src/types/index.ts
@@ -120,6 +120,7 @@ export enum NotificationType {
   BLOCKER_ESCALATION = "blocker_escalation",
   REVIEW_REQUEST = "review_request",
   DOCUMENTATION_REQUEST = "documentation_request",
+  APPROVAL = "approval", // Board-level approval requests (PO/HM/Main PM)
   ALERT = "alert",
   BROADCAST = "broadcast",
   KNOWLEDGE_SHARE = "knowledge_share", // Cross-agent learning notification

--- a/tests/e2e_smoke/test_notification_coordination_events.py
+++ b/tests/e2e_smoke/test_notification_coordination_events.py
@@ -1,0 +1,181 @@
+"""Scenario: coordination-event notification producers land real DB rows.
+
+Drives two of the coordination-event notification producers wired at
+``TaskService``'s transition chokepoints (``roboco/services/task.py``) —
+soft-block (BLOCKER_ESCALATION to the cell PM) and unblock (TASK_ASSIGNMENT
+to the original assignee) — through the real REST task surface mounted at
+``/api/tasks`` in this harness (the same surface scenario 3's CEO
+approve-and-merge call uses). Real in-process API, real
+``NotificationDeliveryService``, real ephemeral Postgres — no mocks. Each
+assertion reads the persisted ``NotificationTable`` row back out of the DB
+via ``E2EStack.run_db``, exactly as the harness's other DB-truth checks do.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from tests.e2e_smoke.arcs import seed_company, seed_project, seed_task
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from tests.e2e_smoke.harness import E2EStack
+
+
+def _agent_headers(agent_id: Any, role: str) -> dict[str, str]:
+    return {"X-Agent-ID": str(agent_id), "X-Agent-Role": role}
+
+
+def _notifications_for_task(
+    stack: E2EStack, task_id: Any, notification_type: Any
+) -> list[dict[str, Any]]:
+    from roboco.db.tables import NotificationTable
+    from sqlalchemy import select
+
+    async def _run(session: AsyncSession) -> list[dict[str, Any]]:
+        rows = (
+            (
+                await session.execute(
+                    select(NotificationTable).where(
+                        NotificationTable.related_task_id == task_id,
+                        NotificationTable.type == notification_type,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [
+            {
+                "type": str(r.type),
+                "related_task_id": r.related_task_id,
+                "subject": r.subject,
+                "priority": str(r.priority),
+                "to_agents": list(r.to_agents),
+            }
+            for r in rows
+        ]
+
+    rows: list[dict[str, Any]] = stack.run_db(_run)
+    return rows
+
+
+def test_soft_block_persists_blocker_escalation_notification(
+    e2e_stack: E2EStack,
+) -> None:
+    """soft-block chokepoint: notify_pm_of_block -> BLOCKER_ESCALATION."""
+    stack = e2e_stack
+    company = seed_company(stack)
+    project_id, _project_slug = seed_project(stack, company)
+
+    from roboco.models.base import TaskStatus
+
+    task_id = seed_task(
+        stack,
+        title="Investigate flaky upstream API",
+        description=(
+            "Dev is mid-work and hits an external dependency outage; "
+            "soft-blocking so the cell PM is paged for resolution."
+        ),
+        acceptance_criteria=["the upstream API responds reliably again"],
+        project_id=project_id,
+        created_by=company.cell_pm_id,
+        assigned_to=company.dev_id,
+        claimed_by=company.dev_id,
+        active_claimant_id=company.dev_id,
+        status=TaskStatus.IN_PROGRESS,
+        branch_name="feature/backend/e2e-soft-block-notify",
+    )
+
+    resp = httpx.post(
+        f"{stack.base_url}/api/tasks/{task_id}/soft-block",
+        json={
+            "reason": "The upstream payments API is returning 503s.",
+            "blocker_type": "external",
+            "what_needed": "Wait for the upstream provider to recover.",
+            "resolver_type": "agent",
+        },
+        headers=_agent_headers(company.dev_id, "developer"),
+        timeout=30,
+    )
+    assert resp.status_code == HTTPStatus.OK, (
+        f"soft-block: {resp.status_code} {resp.text[:1500]}"
+    )
+
+    from roboco.models import NotificationType
+
+    notifications = _notifications_for_task(
+        stack, task_id, NotificationType.BLOCKER_ESCALATION
+    )
+    assert len(notifications) == 1, notifications
+    note = notifications[0]
+    assert "blocker_escalation" in note["type"].lower(), note
+    assert note["related_task_id"] == task_id, note
+    assert note["subject"], "subject must be populated"
+    assert note["priority"], "priority must be populated"
+    assert company.cell_pm_id in note["to_agents"], note
+
+
+def test_unblock_persists_task_assignment_notification(e2e_stack: E2EStack) -> None:
+    """unblock chokepoint: notify_assignee_of_unblock -> TASK_ASSIGNMENT."""
+    stack = e2e_stack
+    company = seed_company(stack)
+    project_id, _project_slug = seed_project(stack, company)
+
+    from roboco.models.base import TaskStatus
+
+    task_id = seed_task(
+        stack,
+        title="Rotate the expired staging credential",
+        description=(
+            "Dev soft-blocked waiting on a credential rotation; the cell "
+            "PM resolves it and unblocks the task so the dev resumes."
+        ),
+        acceptance_criteria=["the staging credential is valid again"],
+        project_id=project_id,
+        created_by=company.cell_pm_id,
+        assigned_to=company.dev_id,
+        claimed_by=company.dev_id,
+        active_claimant_id=company.dev_id,
+        status=TaskStatus.IN_PROGRESS,
+        branch_name="feature/backend/e2e-unblock-notify",
+    )
+
+    block_resp = httpx.post(
+        f"{stack.base_url}/api/tasks/{task_id}/soft-block",
+        json={
+            "reason": "The staging DB credential expired overnight.",
+            "blocker_type": "external",
+            "what_needed": "A rotated staging credential from the cell PM.",
+            "resolver_type": "agent",
+        },
+        headers=_agent_headers(company.dev_id, "developer"),
+        timeout=30,
+    )
+    assert block_resp.status_code == HTTPStatus.OK, (
+        f"soft-block: {block_resp.status_code} {block_resp.text[:1500]}"
+    )
+
+    unblock_resp = httpx.post(
+        f"{stack.base_url}/api/tasks/{task_id}/unblock",
+        headers=_agent_headers(company.cell_pm_id, "cell_pm"),
+        timeout=30,
+    )
+    assert unblock_resp.status_code == HTTPStatus.OK, (
+        f"unblock: {unblock_resp.status_code} {unblock_resp.text[:1500]}"
+    )
+
+    from roboco.models import NotificationType
+
+    notifications = _notifications_for_task(
+        stack, task_id, NotificationType.TASK_ASSIGNMENT
+    )
+    assert len(notifications) == 1, notifications
+    note = notifications[0]
+    assert "task_assignment" in note["type"].lower(), note
+    assert note["related_task_id"] == task_id, note
+    assert note["subject"], "subject must be populated"
+    assert note["priority"], "priority must be populated"
+    assert company.dev_id in note["to_agents"], note


### PR DESCRIPTION
Goal: ensure the panel's existing A2A/notifications surface correctly renders the 5 new coordination-event notification types (reassignment, collision, unblock, stale-claim, plus a 5th type the backend cell will identify) with a working task deep-link per notification, and add e2e smoke tests exercising at least 2 of the 5 event types end-to-end.

Constraints: reuse the existing panel notification UI patterns — this is not new visual design, so no UX/UI design pass is needed. Fit the existing NotificationService payload contract (do not invent a parallel data shape). The backend cell (be-pm) is implementing the producers in parallel; your e2e smoke tests need real backend-emitted events to validate against, so sequence your smoke-test work to land after backend's producers are available (static rendering/UI review work can proceed now).

This is one of two independent work units for this feature (the other is backend event production, running in be-pm's cell in parallel). Please refine this into at least two independent developer leaves (e.g. notification rendering/deep-link UI vs. e2e smoke test authoring) so two frontend developers can build in parallel.