### PR TITLE
[6f991331] Add aria-label + matching tooltip per tooltip-aria-label-spec.md

### DIFF
--- a/docs/frontend/components/accessible-icon-buttons.md
+++ b/docs/frontend/components/accessible-icon-buttons.md
@@ -1,0 +1,159 @@
+# Accessible Icon-Only Controls (aria-label + Tooltip)
+
+## Overview
+
+Icon-only controls—buttons without visible text—require two layers of accessibility to be usable by all:
+
+1. **aria-label** attribute for screen reader users  
+2. **Visible Tooltip** (matching text) for mouse, keyboard, and screen reader users
+
+Both layers must use identical text that describes the action or result.
+
+## Pattern
+
+All icon-only controls in the panel follow this structure:
+
+```typescript
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const LABEL = "Open settings";
+
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button
+        aria-label={LABEL}
+        title={LABEL}
+      >
+        <Settings className="h-5 w-5" />
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent>{LABEL}</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+### Why three attributes?
+
+- **aria-label**: The accessible name for screen readers
+- **title**: Browser native tooltip (fallback, appears on hover/focus)
+- **TooltipContent**: Radix UI tooltip for consistent visual feedback
+
+### Naming convention
+
+Label text uses **active verbs** describing what happens when the control is clicked:
+
+| Control | Label |
+|---------|-------|
+| Settings gear | "Open settings" |
+| Notification bell | "View notifications" |
+| Back arrow | "Go back to tasks list" |
+| Collapse toggle | "Collapse sidebar" / "Expand sidebar" |
+| Drag handle | "Drag to move task between columns" |
+| Menu trigger | "Open task actions menu" |
+
+Avoid passive voice ("Settings opened") or generic labels ("Button").
+
+## State-dependent labels
+
+When a control's action varies by state, compute the label dynamically:
+
+```typescript
+const toggleLabel = sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar";
+const moveLabel = isBacklog ? "PM must activate this task first" : "Move forward";
+
+<Button
+  aria-label={toggleLabel}
+  title={moveLabel}
+>
+  {/* ... */}
+</Button>
+```
+
+The label updates whenever state changes, keeping screen reader users informed.
+
+## Truncated content (avatars, badges)
+
+When an icon-only control displays shortened content (e.g., "FD1" for "Frontend Dev 1"), wrap in a tooltip showing the full value:
+
+```typescript
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Avatar>
+        <AvatarFallback>{initials}</AvatarFallback>
+      </Avatar>
+    </TooltipTrigger>
+    <TooltipContent>{fullName}</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+## When NOT to use this pattern
+
+**Do not** apply aria-label + tooltip to:
+
+- **Text-labeled buttons** — the text is the label
+- **Decorative icons** — non-interactive graphics (use `aria-hidden="true"` instead)
+- **Self-labeling badges** — content + styling conveys meaning
+- **Chart tooltips** — handled by the charting library (recharts, etc.)
+
+## Implemented controls
+
+The following 8 icon-only controls have been retrofitted:
+
+1. **notification-bell.tsx** — "View notifications"
+2. **task-header.tsx** (back button) — "Go back to tasks list"
+3. **task-actions.tsx** (menu) — "Open task actions menu"
+4. **sidebar.tsx** (collapse toggle) — "Collapse sidebar" / "Expand sidebar"
+5. **kanban-card.tsx** (drag handle) — "Drag to move task between columns"
+6. **kanban-card.tsx** (move-forward) — "Move forward" / "PM must activate this task first"
+7. **command-center.tsx** (settings) — "Open settings"
+8. **pr-review-queue.tsx** (details link) — "Review details"
+
+Plus one avatar tooltip:
+
+9. **assignee-avatar.tsx** — Shows full agent display name
+
+## Testing
+
+### Screen reader
+1. Tab to the icon-only control
+2. Verify the aria-label is announced
+3. Focus should be visible and clear
+
+### Mouse
+1. Hover over the control
+2. Tooltip appears with the same text as aria-label
+3. Click triggers the expected action
+
+### Keyboard
+1. Tab to focus the control
+2. title attribute provides a browser tooltip
+3. Verify the label is consistent
+
+### State changes
+1. For conditional labels, verify the label updates when state changes
+2. Tab away and back to re-announce the new label
+
+## TooltipProvider scope
+
+Each component wraps its controls in a local `<TooltipProvider>` (not a single app-root provider). This pattern:
+
+- Keeps tooltip state scoped to the component
+- Matches existing codebase patterns
+- Simplifies DOM structure and reduces global state
+
+If a future refactoring uses a root-level provider, the structure remains valid—only the wrapping changes, not the aria-label/title pattern.
+
+## Resources
+
+- [WCAG 2.1: Text Alternatives for Images](https://www.w3.org/WAI/WCAG21/Understanding/text-alternatives)
+- [ARIA Authoring Practices: Buttons](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+- [Radix UI Tooltip](https://www.radix-ui.com/docs/primitives/components/tooltip)
+- Local test files: See `kanban-card-aria.test.tsx`, `sidebar.test.tsx`, `assignee-avatar.test.tsx`

--- a/panel/src/components/dashboard/command-center.tsx
+++ b/panel/src/components/dashboard/command-center.tsx
@@ -25,8 +25,16 @@ import type { Activity } from "./activity-item";
 import { Button } from "@/components/ui/button";
 import { UsageOverviewPanel } from "./usage-overview-panel";
 import { ScorecardOverviewPanel } from "./scorecard-overview-panel";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Settings, AlertCircle } from "lucide-react";
 import Link from "next/link";
+
+const SETTINGS_LABEL = "Open settings";
 
 export function CommandCenter() {
   const {
@@ -103,11 +111,23 @@ export function CommandCenter() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Link href="/settings" prefetch={false}>
-            <Button variant="ghost" size="icon">
-              <Settings className="h-5 w-5" />
-            </Button>
-          </Link>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Link href="/settings" prefetch={false}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={SETTINGS_LABEL}
+                    title={SETTINGS_LABEL}
+                  >
+                    <Settings className="h-5 w-5" />
+                  </Button>
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent>{SETTINGS_LABEL}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
 

--- a/panel/src/components/dashboard/pr-review-queue.tsx
+++ b/panel/src/components/dashboard/pr-review-queue.tsx
@@ -22,6 +22,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   GitPullRequest,
   ExternalLink,
   Rocket,
@@ -203,15 +209,23 @@ export function PrReviewQueue({ className }: PrReviewQueueProps) {
                     )}
                   </div>
                   <div className="flex items-center gap-2 ml-4 flex-shrink-0">
-                    <Link
-                      href={`/tasks/${task.id}`}
-                      title="Review details"
-                      prefetch={false}
-                    >
-                      <Button variant="ghost" size="sm">
-                        <FileText className="h-4 w-4" />
-                      </Button>
-                    </Link>
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Link href={`/tasks/${task.id}`} prefetch={false}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              aria-label="Review details"
+                              title="Review details"
+                            >
+                              <FileText className="h-4 w-4" />
+                            </Button>
+                          </Link>
+                        </TooltipTrigger>
+                        <TooltipContent>Review details</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                     {awaiting && (
                       <>
                         <Button

--- a/panel/src/components/kanban/core/__tests__/kanban-card-aria.test.tsx
+++ b/panel/src/components/kanban/core/__tests__/kanban-card-aria.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaskStatus, Team, TaskType, type Task } from "@/types";
+
+// tooltip-aria-label-spec.md §1a: the move-forward button already carried a
+// conditional `title` (disabled-vs-enabled); it needs a matching aria-label
+// using the identical text, per §2's "same string for both" rule.
+
+vi.mock("@/hooks/use-tasks", () => ({
+  useUpdateTask: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+import { KanbanCard } from "../kanban-card";
+
+function buildTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    title: "A task",
+    description: "",
+    acceptance_criteria: [],
+    status: TaskStatus.IN_PROGRESS,
+    priority: 2,
+    sequence: null,
+    team: Team.BACKEND,
+    assigned_to: null,
+    task_type: TaskType.CODE,
+    ...overrides,
+  } as unknown as Task;
+}
+
+describe("KanbanCard — move-forward aria-label (tooltip-aria-label-spec §1a)", () => {
+  it("uses 'Move forward' as both aria-label and title when the task is actionable", () => {
+    render(
+      <KanbanCard
+        task={buildTask()}
+        onAction={vi.fn()}
+        showQaActions={false}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Move forward" });
+    expect(button).toHaveAttribute("title", "Move forward");
+    expect(button).not.toBeDisabled();
+  });
+
+  it("swaps to the disabled-reason text on both aria-label and title for a backlog task", () => {
+    render(
+      <KanbanCard
+        task={buildTask({ status: TaskStatus.BACKLOG })}
+        onAction={vi.fn()}
+        showQaActions={false}
+      />,
+    );
+
+    const button = screen.getByRole("button", {
+      name: "PM must activate this task first",
+    });
+    expect(button).toHaveAttribute("title", "PM must activate this task first");
+    expect(button).toBeDisabled();
+  });
+
+  it("gives the drag handle an accessible name", () => {
+    render(
+      <KanbanCard
+        task={buildTask()}
+        onAction={vi.fn()}
+        showQaActions={false}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Drag to move task between columns"),
+    ).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/kanban/core/kanban-card.tsx
+++ b/panel/src/components/kanban/core/kanban-card.tsx
@@ -67,6 +67,11 @@ export function KanbanCard({
 
   const isDragging = isDraggingProp || isDraggingDnd;
 
+  const dragHandleLabel = "Drag to move task between columns";
+  const moveForwardLabel = isBacklog
+    ? "PM must activate this task first"
+    : "Move forward";
+
   const style = transform
     ? {
         transform: CSS.Translate.toString(transform),
@@ -119,13 +124,22 @@ export function KanbanCard({
               </p>
             )}
           </div>
-          <div
-            {...attributes}
-            {...listeners}
-            className={`shrink-0 mt-0.5 ${isBacklog ? "cursor-not-allowed opacity-50" : "cursor-grab active:cursor-grabbing"}`}
-          >
-            <GripVertical className="h-4 w-4 text-muted-foreground" />
-          </div>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  {...attributes}
+                  {...listeners}
+                  aria-label={dragHandleLabel}
+                  title={dragHandleLabel}
+                  className={`shrink-0 mt-0.5 ${isBacklog ? "cursor-not-allowed opacity-50" : "cursor-grab active:cursor-grabbing"}`}
+                >
+                  <GripVertical className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>{dragHandleLabel}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
 
         <div className="flex items-center justify-between mt-2">
@@ -234,23 +248,27 @@ export function KanbanCard({
               ) : (
                 task.status !== TaskStatus.COMPLETED &&
                 task.status !== TaskStatus.CANCELLED && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-11 w-11"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAction("move-forward", task.id);
-                    }}
-                    disabled={isBacklog}
-                    title={
-                      isBacklog
-                        ? "PM must activate this task first"
-                        : "Move forward"
-                    }
-                  >
-                    <ArrowRight className="h-3 w-3" />
-                  </Button>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-11 w-11"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onAction("move-forward", task.id);
+                          }}
+                          disabled={isBacklog}
+                          aria-label={moveForwardLabel}
+                          title={moveForwardLabel}
+                        >
+                          <ArrowRight className="h-3 w-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{moveForwardLabel}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )
               )}
             </div>

--- a/panel/src/components/kanban/shared/__tests__/assignee-avatar.test.tsx
+++ b/panel/src/components/kanban/shared/__tests__/assignee-avatar.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AssigneeAvatar } from "../assignee-avatar";
+
+// tooltip-aria-label-spec.md §1b: truncated content (two-letter initials)
+// standing in for a full value needs a Tooltip disclosing that full value.
+
+describe("AssigneeAvatar — full-name tooltip (tooltip-aria-label-spec §1b)", () => {
+  it("shows the full agent display name in the tooltip once hovered", async () => {
+    const user = userEvent.setup();
+    render(<AssigneeAvatar agentId="fe-dev-1" />);
+
+    // Radix mounts TooltipContent only once the trigger is hovered/focused.
+    await user.hover(screen.getByText("FD1"));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Frontend Dev 1",
+    );
+  });
+
+  it("renders nothing for an unassigned task", () => {
+    const { container } = render(<AssigneeAvatar agentId={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/panel/src/components/kanban/shared/assignee-avatar.tsx
+++ b/panel/src/components/kanban/shared/assignee-avatar.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import { getAgentInitials } from "@/lib/agent-utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { getAgentInitials, getAgentDisplayName } from "@/lib/agent-utils";
 
 interface AssigneeAvatarProps {
   agentId: string | null;
@@ -12,13 +18,21 @@ export function AssigneeAvatar({ agentId, size = "sm" }: AssigneeAvatarProps) {
   if (!agentId) return null;
 
   const initials = getAgentInitials(agentId);
+  const displayName = getAgentDisplayName(agentId);
   const sizeClasses = size === "sm" ? "h-6 w-6 text-xs" : "h-8 w-8 text-sm";
 
   return (
-    <Avatar className={sizeClasses}>
-      <AvatarFallback className="bg-primary/10 text-primary">
-        {initials}
-      </AvatarFallback>
-    </Avatar>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Avatar className={sizeClasses}>
+            <AvatarFallback className="bg-primary/10 text-primary">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </TooltipTrigger>
+        <TooltipContent>{displayName}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/panel/src/components/layout/__tests__/sidebar.test.tsx
+++ b/panel/src/components/layout/__tests__/sidebar.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useUIStore } from "@/store";
+
+// tooltip-aria-label-spec.md §1a: the collapse-rail toggle previously had no
+// accessible name at all. The label must track the current action (collapse
+// vs. expand), not a static string, so a screen reader announces what will
+// happen next.
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/overview",
+}));
+
+import { Sidebar } from "../sidebar";
+
+describe("Sidebar — collapse toggle aria-label (tooltip-aria-label-spec §1a)", () => {
+  it("labels the toggle 'Collapse sidebar' when expanded", () => {
+    useUIStore.setState({ sidebarCollapsed: false });
+    render(<Sidebar />);
+
+    const toggle = screen.getByRole("button", { name: "Collapse sidebar" });
+    expect(toggle).toHaveAttribute("title", "Collapse sidebar");
+  });
+
+  it("flips to 'Expand sidebar' once collapsed", () => {
+    useUIStore.setState({ sidebarCollapsed: false });
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse sidebar" }));
+
+    expect(
+      screen.getByRole("button", { name: "Expand sidebar" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/panel/src/components/layout/sidebar.tsx
+++ b/panel/src/components/layout/sidebar.tsx
@@ -27,6 +27,12 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useUIStore } from "@/store";
 
 export const navItems = [
@@ -137,6 +143,7 @@ export function SidebarFooter({
 
 export function Sidebar() {
   const { sidebarCollapsed, setSidebarCollapsed } = useUIStore();
+  const toggleLabel = sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar";
 
   return (
     <aside
@@ -167,19 +174,28 @@ export function Sidebar() {
             <span className="font-semibold text-lg">RoboCo</span>
           </Link>
         )}
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-          className={cn(sidebarCollapsed && "mx-auto")}
-        >
-          <ChevronLeft
-            className={cn(
-              "h-4 w-4 transition-transform",
-              sidebarCollapsed && "rotate-180",
-            )}
-          />
-        </Button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+                className={cn(sidebarCollapsed && "mx-auto")}
+                aria-label={toggleLabel}
+                title={toggleLabel}
+              >
+                <ChevronLeft
+                  className={cn(
+                    "h-4 w-4 transition-transform",
+                    sidebarCollapsed && "rotate-180",
+                  )}
+                />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{toggleLabel}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {/* Navigation */}

--- a/panel/src/components/notifications/notification-bell.tsx
+++ b/panel/src/components/notifications/notification-bell.tsx
@@ -10,7 +10,15 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { Bell, Wifi, WifiOff } from "lucide-react";
+
+const BELL_LABEL = "View notifications";
 
 export function NotificationBell() {
   const [open, setOpen] = useState(false);
@@ -20,16 +28,29 @@ export function NotificationBell() {
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="ghost" size="icon" className="relative">
-          <Bell className="h-5 w-5" />
-          {unreadCount > 0 && (
-            <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 text-xs bg-red-500">
-              {unreadCount > 9 ? "9+" : unreadCount}
-            </Badge>
-          )}
-        </Button>
-      </PopoverTrigger>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="relative"
+                aria-label={BELL_LABEL}
+                title={BELL_LABEL}
+              >
+                <Bell className="h-5 w-5" />
+                {unreadCount > 0 && (
+                  <Badge className="absolute -top-1 -right-1 h-5 w-5 flex items-center justify-center p-0 text-xs bg-red-500">
+                    {unreadCount > 9 ? "9+" : unreadCount}
+                  </Badge>
+                )}
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>{BELL_LABEL}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
       <PopoverContent className="w-80" align="end">
         <div className="space-y-4">
           <div className="flex items-center justify-between">

--- a/panel/src/components/tasks/task-actions.tsx
+++ b/panel/src/components/tasks/task-actions.tsx
@@ -23,6 +23,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   MoreHorizontal,
   Play,
   Pause,
@@ -138,14 +144,28 @@ export function TaskActions({
   // Check if task is in backlog (needs PM activation)
   const isBacklog = task.status === TaskStatus.BACKLOG;
 
+  const actionsLabel = "Open task actions menu";
+
   return (
     <>
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon">
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={actionsLabel}
+                  title={actionsLabel}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{actionsLabel}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <DropdownMenuContent align="end">
           {/* Edit option */}
           {showEdit && canEdit && (

--- a/panel/src/components/tasks/task-detail/task-header.tsx
+++ b/panel/src/components/tasks/task-detail/task-header.tsx
@@ -55,6 +55,14 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { TaskTypeBadge } from "../task-type-badge";
 import { CopyButton } from "@/components/ui/copy-button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const BACK_LABEL = "Go back to tasks list";
 
 // Status badge colors
 const statusColors: Record<TaskStatus, string> = {
@@ -472,11 +480,24 @@ export function TaskHeader({ task, onAction }: TaskHeaderProps) {
             title truncates, so a long title never pushes the controls or the
             Actions menu out of place. */}
         <div className="flex items-start gap-3 min-w-0 flex-1">
-          <Link href="/tasks" prefetch={false}>
-            <Button variant="ghost" size="icon" className="shrink-0">
-              <ArrowLeft className="h-5 w-5" />
-            </Button>
-          </Link>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Link href="/tasks" prefetch={false}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="shrink-0"
+                    aria-label={BACK_LABEL}
+                    title={BACK_LABEL}
+                  >
+                    <ArrowLeft className="h-5 w-5" />
+                  </Button>
+                </Link>
+              </TooltipTrigger>
+              <TooltipContent>{BACK_LABEL}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <div className="min-w-0 flex-1">
             {/* Row 1: title only — editable, no UUID. Truncates on overflow. */}
             {editingTitle ? (


### PR DESCRIPTION
Implement docs/ux_ui/design/tooltip-aria-label-spec.md's §1a/§1b punch-list. For each of the 8 icon-only controls the spec names — notification-bell.tsx:24 (Bell button), task-header.tsx:476 (back-arrow button), task-actions.tsx:145 (overflow-menu trigger), sidebar.tsx:170 (collapse-rail toggle), kanban-card.tsx:122-128 (drag handle) and :237-253 (move-forward button), command-center.tsx:107 (Settings gear), pr-review-queue.tsx:206-214 (review-details button) — add a mandatory `aria-label` using the spec's verb-phrase copy rule (e.g. "Refresh only the current page" style, not "Bell icon"), and also add a matching visible Tooltip (existing `ui/tooltip.tsx` Radix wrapper) using the IDENTICAL string as the aria-label, per §2's one-source-of-truth rule — following the reference pattern already correct at header.tsx:59-68 and copy-button.tsx:64-74. Separately, wrap assignee-avatar.tsx's two-letter initials in a Tooltip showing the full agent slug/name, matching the pattern kanban-card.tsx:137-151 already uses for its sequence-number badge. Do NOT add any tooltip or aria-label to controls the spec's §1c lists as needing neither (text-labeled buttons like "Assign"/"Pass"/"Fail", self-labeling badges like priority-indicator.tsx, decorative icons next to a heading, or recharts' own chart tooltip). This is copy/markup only — no layout, motion, or dependency changes.