### PR TITLE
[bb0dadb4] Fix duplicate unblock notification + wrong e2e assertions on PR #477

### DIFF
--- a/docs/backend/services/coordination-events.md
+++ b/docs/backend/services/coordination-events.md
@@ -66,10 +66,12 @@ Body: Task {held_back_task_id} was held back by the collision-sequencing
 
 **Double-fire guard:** Both `unblock` and `unblock_with_restore` are guarded by a status check (`status != BLOCKED` short-circuits early). A repeated call against an already-unblocked task is a no-op upstream and never reaches the notification handler.
 
+**Route-layer duplicate removed:** The `POST /api/tasks/{id}/unblock` route previously called `NotificationDeliveryService.notify_assignee_of_unblock()` (a `TASK_ASSIGNMENT` notification) after `TaskService.unblock()` had already sent the ALERT above. That route-layer call and the now-dead delivery method have been removed, so the ALERT from the service chokepoint is the only notification fired for an unblock.
+
 **Subject & body:**
 ```
 Subject: Task {task_id} unblocked
-Body: Task {task_id} has been unblocked and handed back to {owner}. 
+Body: Task {task_id} has been unblocked and handed back to {owner}.
        It is ready to resume.
 ```
 
@@ -163,5 +165,7 @@ See `test_notification.py` and `test_task.py` for worked examples of producer-le
 
 - **Implementation:** `roboco/services/notification.py` (producers)
 - **Wiring:** `roboco/services/task.py` (TaskService helpers), `roboco/runtime/orchestrator.py` (reaper hook)
-- **Tests:** `tests/unit/services/test_notification.py` (producer unit tests), `tests/unit/services/test_task.py` (chokepoint double-fire proofs)
+- **Route:** `roboco/api/routes/tasks.py` (`unblock` endpoint; service-layer ALERT only, no route-level duplicate)
+- **Unit tests:** `tests/unit/services/test_notification.py` (producer unit tests), `tests/unit/services/test_task.py` (chokepoint double-fire proofs)
+- **Route/chokepoint integration tests:** `tests/integration/test_tasks_routes.py` (unblock returns 200 and leaves `blocked` with no duplicate notification), `tests/e2e_smoke/test_notification_coordination_events.py` (DB-truth checks for unblock and dependency-revival ALERT rows)
 - **Data model:** `roboco/models/notification.py` (CreateNotificationParams)

--- a/roboco/api/routes/tasks.py
+++ b/roboco/api/routes/tasks.py
@@ -1491,9 +1491,6 @@ async def unblock_task(
             detail="Not authorized to unblock this task",
         )
 
-    # Remember the assigned agent before unblocking
-    assigned_agent_id = task.assigned_to
-
     task = await service.unblock(task_id, agent.role)
     if not task:
         raise HTTPException(
@@ -1501,16 +1498,9 @@ async def unblock_task(
             detail="Cannot unblock task - not blocked",
         )
 
-    # Notify the assigned agent that the task is unblocked
-    if assigned_agent_id and assigned_agent_id != agent.agent_id:
-        delivery = get_notification_delivery_service(db)
-        await delivery.notify_assignee_of_unblock(
-            task=task,
-            task_id=task_id,
-            from_agent_id=agent.agent_id,
-            assignee_agent_id=require_uuid(assigned_agent_id),
-        )
-
+    # TaskService.unblock() already sends the ALERT unblock notification
+    # (send_unblock_notification) to the restored owner + CEO — do not
+    # duplicate it here.
     await db.commit()
     return task_to_response(task)
 

--- a/roboco/services/notification_delivery.py
+++ b/roboco/services/notification_delivery.py
@@ -794,30 +794,6 @@ class NotificationDeliveryService(BaseService):
         )
         await self._persist_and_deliver(notification)
 
-    async def notify_assignee_of_unblock(
-        self,
-        *,
-        task: TaskTable,
-        task_id: UUID,
-        from_agent_id: UUID,
-        assignee_agent_id: UUID,
-    ) -> None:
-        """Notify the task's assigned agent that their task is unblocked."""
-        notification = NotificationTable(
-            type=NotificationType.TASK_ASSIGNMENT,
-            priority=NotificationPriority.HIGH,
-            from_agent=from_agent_id,
-            to_agents=[assignee_agent_id],
-            subject=f"Task unblocked: {task.title or 'Unknown task'}",
-            body=(
-                f"Task {task_id} has been unblocked and is ready to resume.\n\n"
-                "Review the task details in your briefing and continue work."
-            ),
-            related_task_id=task_id,
-            requires_ack=ACK_REQUIRED_BY_TYPE[NotificationType.TASK_ASSIGNMENT],
-        )
-        await self._persist_and_deliver(notification)
-
     async def notify_assignee_of_ceo_rejection(
         self,
         *,

--- a/tests/e2e_smoke/test_notification_coordination_events.py
+++ b/tests/e2e_smoke/test_notification_coordination_events.py
@@ -1,14 +1,25 @@
 """Scenario: coordination-event notification producers land real DB rows.
 
-Drives two of the coordination-event notification producers wired at
+Drives three of the coordination-event notification producers wired at
 ``TaskService``'s transition chokepoints (``roboco/services/task.py``) —
-soft-block (BLOCKER_ESCALATION to the cell PM) and unblock (TASK_ASSIGNMENT
-to the original assignee) — through the real REST task surface mounted at
-``/api/tasks`` in this harness (the same surface scenario 3's CEO
-approve-and-merge call uses). Real in-process API, real
-``NotificationDeliveryService``, real ephemeral Postgres — no mocks. Each
-assertion reads the persisted ``NotificationTable`` row back out of the DB
-via ``E2EStack.run_db``, exactly as the harness's other DB-truth checks do.
+soft-block (BLOCKER_ESCALATION to the cell PM), unblock (ALERT to the
+restored owner + CEO, ``send_unblock_notification``), and dependency-revival
+(ALERT to the revived owner + CEO, ``send_dependency_revival_notification``)
+— through the real REST task surface mounted at ``/api/tasks`` in this
+harness (the same surface scenario 3's CEO approve-and-merge call uses), plus
+one direct ``TaskService`` chokepoint call for the dependency-revival
+producer (mirrors ``arcs.wire_dependency``'s pattern of driving
+``TaskService`` directly for setup that has no bespoke REST endpoint). Real
+in-process API, real ``NotificationService``/``NotificationDeliveryService``,
+real ephemeral Postgres — no mocks. Each assertion reads the persisted
+``NotificationTable`` row back out of the DB via ``E2EStack.run_db``, exactly
+as the harness's other DB-truth checks do.
+
+The unblock route (``POST /api/tasks/{id}/unblock``) used to ALSO send a
+second, duplicate TASK_ASSIGNMENT notification from the route handler
+itself (``notify_assignee_of_unblock``) on top of the ALERT
+``TaskService.unblock()`` already sends. That duplicate route-layer call has
+been removed — unblock fires exactly one notification now, the ALERT below.
 """
 
 from __future__ import annotations
@@ -118,8 +129,12 @@ def test_soft_block_persists_blocker_escalation_notification(
     assert company.cell_pm_id in note["to_agents"], note
 
 
-def test_unblock_persists_task_assignment_notification(e2e_stack: E2EStack) -> None:
-    """unblock chokepoint: notify_assignee_of_unblock -> TASK_ASSIGNMENT."""
+def test_unblock_persists_alert_notification(e2e_stack: E2EStack) -> None:
+    """unblock chokepoint: TaskService.unblock -> send_unblock_notification -> ALERT.
+
+    Exactly one notification fires for unblock (the route-layer
+    ``notify_assignee_of_unblock`` TASK_ASSIGNMENT duplicate was removed).
+    """
     stack = e2e_stack
     company = seed_company(stack)
     project_id, _project_slug = seed_project(stack, company)
@@ -169,13 +184,81 @@ def test_unblock_persists_task_assignment_notification(e2e_stack: E2EStack) -> N
 
     from roboco.models import NotificationType
 
-    notifications = _notifications_for_task(
-        stack, task_id, NotificationType.TASK_ASSIGNMENT
-    )
+    notifications = _notifications_for_task(stack, task_id, NotificationType.ALERT)
     assert len(notifications) == 1, notifications
     note = notifications[0]
-    assert "task_assignment" in note["type"].lower(), note
+    assert "alert" in note["type"].lower(), note
     assert note["related_task_id"] == task_id, note
-    assert note["subject"], "subject must be populated"
+    assert note["subject"] == f"Task {task_id} unblocked", note
+    assert note["priority"], "priority must be populated"
+    assert company.dev_id in note["to_agents"], note
+
+    # The deleted route-layer TASK_ASSIGNMENT duplicate must not reappear.
+    stale = _notifications_for_task(stack, task_id, NotificationType.TASK_ASSIGNMENT)
+    assert stale == [], stale
+
+
+def test_dependency_revival_persists_alert_notification(e2e_stack: E2EStack) -> None:
+    """dependency-revival chokepoint: _unblock_dependents ->
+    send_dependency_revival_notification -> ALERT.
+
+    No resolver calls unblock here — a dependent task blocked on another
+    task auto-resumes the moment that dependency's completion clears the
+    last outstanding dependency, at the same ``_unblock_dependents``
+    chokepoint ``TaskService.complete``/``ceo_approve`` call in production.
+    Driven directly against ``TaskService`` (mirrors
+    ``arcs.wire_dependency``'s pattern) since there is no bespoke REST
+    endpoint for "a dependency just completed".
+    """
+    stack = e2e_stack
+    company = seed_company(stack)
+    project_id, _project_slug = seed_project(stack, company)
+
+    from roboco.models.base import TaskStatus
+
+    dependency_id = seed_task(
+        stack,
+        title="Ship the shared auth helper",
+        description="Upstream task the dependent below is blocked on.",
+        acceptance_criteria=["the shared auth helper is merged"],
+        project_id=project_id,
+        created_by=company.cell_pm_id,
+        assigned_to=company.dev_id,
+        status=TaskStatus.IN_PROGRESS,
+    )
+    dependent_id = seed_task(
+        stack,
+        title="Wire the new endpoint to the shared auth helper",
+        description=(
+            "Blocked on the shared auth helper landing; should auto-resume "
+            "the moment that dependency completes, with no resolver acting."
+        ),
+        acceptance_criteria=["the endpoint uses the shared auth helper"],
+        project_id=project_id,
+        created_by=company.cell_pm_id,
+        assigned_to=company.dev_id,
+        claimed_by=company.dev_id,
+        status=TaskStatus.BLOCKED,
+        dependency_ids=[dependency_id],
+        branch_name="feature/backend/e2e-dependency-revival",
+    )
+
+    from roboco.services.task import get_task_service
+
+    async def _complete_dependency(session: AsyncSession) -> None:
+        await get_task_service(session)._unblock_dependents(dependency_id)
+
+    stack.run_db(_complete_dependency)
+
+    from roboco.models import NotificationType
+
+    notifications = _notifications_for_task(stack, dependent_id, NotificationType.ALERT)
+    assert len(notifications) == 1, notifications
+    note = notifications[0]
+    assert "alert" in note["type"].lower(), note
+    assert note["related_task_id"] == dependent_id, note
+    assert note["subject"] == f"Task {dependent_id} revived by dependency completion", (
+        note
+    )
     assert note["priority"], "priority must be populated"
     assert company.dev_id in note["to_agents"], note

--- a/tests/integration/test_tasks_routes.py
+++ b/tests/integration/test_tasks_routes.py
@@ -2023,15 +2023,21 @@ async def test_soft_block_task_success(task_client: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# unblock: success notifies assignee + commits
+# unblock: success leaves blocked status
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_unblock_task_success_notifies_assignee(
+async def test_unblock_task_success(
     task_client: dict,
 ) -> None:
-    """Unblock a blocked task assigned to a different agent → notification path."""
+    """Unblock a blocked task assigned to a different agent → 200, leaves BLOCKED.
+
+    The unblock notification (ALERT) is sent from TaskService.unblock() itself
+    (roboco/services/notification.py send_unblock_notification) — the route no
+    longer sends a second, duplicate notification, so there is nothing to mock
+    here.
+    """
     other = await _seed_agent(task_client)
     task = _seed_task(
         task_client,
@@ -2040,18 +2046,11 @@ async def test_unblock_task_success_notifies_assignee(
     )
     await task_client["db"].flush()
 
-    with patch(
-        "roboco.api.routes.tasks.get_notification_delivery_service"
-    ) as mock_delivery:
-        delivery_instance = AsyncMock()
-        delivery_instance.notify_assignee_of_unblock = AsyncMock(return_value=None)
-        mock_delivery.return_value = delivery_instance
-        response = await task_client["client"].post(
-            f"/api/tasks/{task.id}/unblock", headers=_HDR
-        )
+    response = await task_client["client"].post(
+        f"/api/tasks/{task.id}/unblock", headers=_HDR
+    )
     assert response.status_code == HTTPStatus.OK
     assert response.json()["status"] != "blocked"
-    delivery_instance.notify_assignee_of_unblock.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
pr-reviewer-1 requested changes on the assembled master PR #477 (head f0a0f74). Two concrete, backend-only findings to fix:

1. Double notification on unblock (AC #2 violation): the REST route POST /tasks/{task_id}/unblock at roboco/api/routes/tasks.py:1507 still calls the pre-existing delivery.notify_assignee_of_unblock() (creates a TASK_ASSIGNMENT notification, notification_delivery.py:807). This PR also added TaskService.unblock()'s new _notify_unblock() helper (roboco/services/task.py) which creates an ALERT notification via NotificationService.send_unblock_notification(). Both fire on a single unblock call today, producing two notifications instead of one. Remove the route-layer notify_assignee_of_unblock() call at routes/tasks.py:1507 since the new service-layer producer replaces it — a single unblock must fire exactly one notification (ALERT).

2. e2e smoke tests validate the wrong paths (AC #3 gap): in tests/e2e_smoke/test_notification_coordination_events.py, test_soft_block_persists_blocker_escalation_notification exercises the pre-existing notify_pm_of_block → BLOCKER_ESCALATION path (soft-block is NOT one of the 5 new event types: reassignment, collision-sequencing, unblock, dependency-revival, stale-claim-reaped). test_unblock_persists_task_assignment_notification queries NotificationType.TASK_ASSIGNMENT, which is the old route-layer notification being removed in fix #1 — the new send_unblock_notification produces NotificationType.ALERT. Rewrite both tests (or replace with two new ones) so the e2e smoke suite exercises 2 of the 5 new coordination-event producers and asserts on NotificationType.ALERT with the producers' actual subject strings (e.g. containing "reassigned" for reassignment, "unblocked" for unblock).

Both fixes are confined to roboco/api/routes/tasks.py, tests/e2e_smoke/test_notification_coordination_events.py, and any adjacent unit tests in tests/unit/services/test_task.py that assert on the old double-notification behavior. No frontend or ux_ui change is implicated — do not touch panel/.