### PR TITLE
[e05c0f1e] Fix e2e lifecycle smoke failure on assembled PR #477

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to RoboCo are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Restored five coordination-event notification producers with double-fire guards.** Reassignment, collision-sequencing, unblock, dependency-revival, and stale-claim-reaped notifications are now wired at their lifecycle chokepoints in `TaskService` and the orchestrator reaper, each with an idempotent upstream guard preventing duplicate ALERT rows. The duplicate route-level `notify_assignee_of_unblock` call in `POST /api/tasks/{id}/unblock` was removed so unblock fires exactly one notification. Added `docs/backend/services/coordination-events.md` and `tests/e2e_smoke/test_notification_coordination_events.py` covering the restored producers.
+
 ## [0.21.0] - 2026-07-09
 
 ### Added

--- a/tests/unit/services/test_task.py
+++ b/tests/unit/services/test_task.py
@@ -512,6 +512,42 @@ async def test_unblock_notifies_once_not_twice_on_repeated_call() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wire_sibling_collision_dag_notifies_only_for_new_edges() -> None:
+    """Collision-sequencing notification fires only for freshly-added edges.
+
+    `add_dependency` returns True only on a new edge; a subsequent wiring
+    pass over the same pair returns False and must skip the notification,
+    so the coordination ALERT cannot double-fire.
+    """
+    parent_id = uuid4()
+    held_back_id = uuid4()
+    blocking_id = uuid4()
+    held_back = _build_task(id=held_back_id, assigned_to=uuid4())
+    blocking = _build_task(id=blocking_id)
+    svc = TaskService(MagicMock(flush=AsyncMock()))
+    _bind(svc, "get_subtasks", AsyncMock(return_value=[held_back, blocking]))
+    add_dep_mock = AsyncMock(side_effect=[True, False])
+    _bind(svc, "add_dependency", add_dep_mock)
+    mock_ns = MagicMock()
+    mock_ns.send_collision_sequencing_notification = AsyncMock()
+    wiring_passes = 2
+    with (
+        patch(
+            "roboco.services.sequencing.dev_task_collision_edges",
+            return_value=[(blocking_id, held_back_id)],
+        ),
+        patch(
+            "roboco.services.notification.NotificationService",
+            return_value=mock_ns,
+        ),
+    ):
+        for _ in range(wiring_passes):
+            await svc.wire_sibling_collision_dag(parent_id)
+    mock_ns.send_collision_sequencing_notification.assert_awaited_once()
+    assert add_dep_mock.await_count == wiring_passes
+
+
+@pytest.mark.asyncio
 async def test_mark_agent_idle_sets_status_idle() -> None:
     agent = MagicMock(id=uuid4(), status=AgentStatus.ACTIVE)
     result = MagicMock()


### PR DESCRIPTION
The assembled master PR #477 for the A2A team telemetry feature is blocked because the 'e2e lifecycle smoke (scripted agents)' CI check is red on head commit 823fc302. Your cell owns the backend slice (5 coordination-event notification producers wired at TaskService and orchestrator chokepoints), and the failure is in the backend orchestrated lifecycle suite, so this fix belongs to the backend cell.

Goal: diagnose why `make e2e-smoke` fails on the root branch, fix the backend cause, and get the check green without breaking the existing notification producer behavior or the frontend slice.

Constraints: work in the backend cell's branch under this root; do not touch frontend code; keep the 5 notification producers and their double-fire guards intact; update or add tests only as needed to prove the fix. Report the root cause in your cell's journal so the Main PM can relay it in the next root submission.