### PR TITLE
[a26c18b9] E2E smoke test for auditor triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Added
 
 - **Scheduled auditor sweeps.** `ROBOCO_AUDIT_INTERVAL_SECONDS` (default 21600s / 6h, `audit_interval_seconds` in `roboco/config.py`) drives a periodic auditor spawn. `_dispatch_audit_work` now spawns the auditor on a scheduled sweep when the interval has elapsed, the auditor is not already active, and recent delivery activity exists (active delivery states or a task completed within the window). Reactive alert spawns also stamp `_last_audit_spawn_at` so the interval gate is shared. A one-tick notification sentinel and the existing active-agent breaker prevent auditor spawn storms; `0` disables scheduled sweeps. The auditor identity prompt and `_build_audit_prompt(scheduled=True)` support sweep-based reviews.
+- **E2E smoke test for auditor triggers.** `tests/e2e_smoke/test_auditor_triggers.py` exercises both auditor spawn paths end-to-end against the real orchestrator dispatcher: a scheduled sweep that sees recent delivery activity and a reactive `ALERT` created by `POST /api/tasks/{id}/fail-qa`. `spawn_agent` is stubbed so the test asserts the dispatch decision without running an auditor container. The e2e harness now mounts `/api/notifications` so `_dispatch_audit_work` can poll alert rows.
 
 ### Fixed
 

--- a/docs/map/tests.md
+++ b/docs/map/tests.md
@@ -24,6 +24,7 @@ The pytest test suite for RoboCo: 571 test_*.py files across tests/foundation, t
 | tests/unit/gateway/ | 105 Choreographer/verb-runner unit tests — the largest single cluster: every intent verb's guards, envelopes, evidence, claim locks, lane barrier, pr gate, conventions gate, content actions |  |
 | tests/unit/runtime/ | 64 orchestrator unit tests: spawn/manifest/cwd/worktree, reaper, respawn persistence, rate-limit/overload sweeps, ci_watch/dep_update/release/self_heal loops, no_spawn_human_roles, per_dev_lane_queue, readopt_running_agents |  |
 | tests/unit/services/ | 120 service unit tests: task, git (+worktree), workspace, work_session, release_executor/readiness/manager, sequencing, conventions, playbook, notification, rate_limit_tracker, optimal_brain/ (10) |  |
+| tests/e2e_smoke/ | Scripted-agent lifecycle smoke tests: real routers + middleware over ephemeral Postgres + bare git origin + fake GitHub REST layer; no LLM. Env-gated (`ROBOCO_E2E_SMOKE=1`) via `make e2e-smoke`. |  |
 
 ## Key Symbols
 
@@ -107,6 +108,18 @@ tests/
 ├── property/  (2 — deterministic, no hypothesis)
 │   ├── test_state_machine_invariants.py  [6 invariants: orphan/terminal/reachability/random-walk/self-loop]
 │   └── test_tracing_completeness.py  [6-bullet tracing contract over smoke_test_batch]
+├── e2e_smoke/  (scripted-agent lifecycle smoke — env-gated)
+│   ├── conftest.py  [collection gate: skips unless ROBOCO_E2E_SMOKE=1]
+│   ├── harness.py  [in-process API, ephemeral Postgres, bare git origin, fake GitHub REST]
+│   ├── arcs.py  [canonical-company seeding + dev/qa/pm/reviewer lifecycle helpers]
+│   ├── test_dev_lifecycle.py  [scenario 1: leaf dev arc → awaiting_pm_review]
+│   ├── test_pm_merge_chain.py  [scenarios 2/2b: PR-gate turn cut + serial root merges]
+│   ├── test_root_ceo_chain.py  [scenario 3: pr_fail → rework → real approve-and-merge]
+│   ├── test_megatask_umbrella.py  [scenario 4: MegaTask sequencing + umbrella closure]
+│   ├── test_notification_coordination_events.py  [DB-truth checks for restored coordination-event ALERTs]
+│   ├── test_auditor_triggers.py  [scheduled sweep + reactive QA-fail alert paths spawn auditor]
+│   ├── test_auth_gate_coverage.py, test_background_engines.py, test_data_integrity.py, test_feature_spotlight.py, test_flow_verb_timeout.py, test_git_workflow.py, test_sandbox_image_tags.py, test_sandbox_on_demand.py, test_state_machine.py, test_video_pipeline.py  [other e2e smoke scenarios]
+│   └── test_bash_guard_message.sh / test_stop_hook_verb_names.sh  [NOT here — these live in tests/integration/]
 └── unit/  (~430 — mirrors roboco/)
     ├── test_* (11 top-level: agents_config, bootstrap, config_properties, enum_migration_parity, exceptions, logging, no_deleted_tool_names, notification_dedup, notification_dedup_refire, notification_delivery_refire, toolchain_flag)
     ├── agent_sdk/ (11) — grok_cli/intake/secretary/manifest/prompt_guard/usage_sync/verb_circuit_breaker
@@ -141,6 +154,7 @@ tests/
 |---|---|---|
 | make quality | Makefile | developer/CI merge gate — runs ruff format-check + ruff check + mypy roboco/ tests/ + pytest -q --cov=roboco --cov-report=term-missing --cov-fail-under=80 + xenon + vulture |
 | make quality-fast | Makefile | pre-submit fast gate — ruff + mypy + pytest -q -x --no-cov (no coverage threshold) |
+| make e2e-smoke | Makefile | scripted-agent lifecycle smoke — `ROBOCO_E2E_SMOKE=1 uv run pytest tests/e2e_smoke -q --no-cov`; needs test Postgres + git on PATH |
 | make gate (panel-gate) | Makefile | panel pnpm lint + typecheck + vitest |
 | make test/test-3.10..3.14/test-all | Makefile | docker compose run roboco pytest -v --cov=. across Python versions |
 | uv run pytest | pyproject.toml | direct invocation — auto-applies addopts (--cov=roboco --cov-report=term-missing), testpaths=tests, asyncio_mode=auto |
@@ -205,6 +219,7 @@ tests/
 > - **49526f55** test-suite quality gate unblock: fixed 12 mypy errors across 5 test files + 2 behavior corrections (child task state for cascade-cancel assertion; test_a2a_message_auth mocked to DB-free path).
 > - **76ce53e3** chat MESSAGE_SENT fix: test_websocket_bridge.py gained 3 new test functions for `_handle_message_event` (skips missing ids, skips invalid uuid, broadcasts to session+channel).
 > - **77958c1e** chat session/group/message read IDOR fix: test_messaging_service.py extended with `_make_agent` helper + IDOR access-control test coverage for get_session/get_group/list_messages.
+> - **1f129199** auditor-trigger e2e smoke test: added `tests/e2e_smoke/test_auditor_triggers.py` exercising scheduled sweep and reactive QA-fail alert paths end-to-end, plus harness mount of `/api/notifications` so `_dispatch_audit_work` can poll ALERT rows.
 
 ## Regression Risks
 

--- a/tests/e2e_smoke/harness.py
+++ b/tests/e2e_smoke/harness.py
@@ -322,6 +322,7 @@ def _make_admin_clone(root: Path, origin: Path) -> Path:
 def _build_app(gh: _FakeGitHub) -> FastAPI:
     from roboco.api.middleware import setup_middleware
     from roboco.api.routes.health import router as health_router
+    from roboco.api.routes.notifications import router as notifications_router
     from roboco.api.routes.orchestrator import router as orchestrator_router
     from roboco.api.routes.settings import router as settings_router
     from roboco.api.routes.tasks import router as tasks_router
@@ -344,6 +345,9 @@ def _build_app(gh: _FakeGitHub) -> FastAPI:
     # The REST task surface — scenario 3 drives the real CEO
     # approve-and-merge endpoint (the human gate) through it.
     app.include_router(tasks_router, prefix="/api/tasks")
+    # Notifications surface — exercised by orchestrator dispatchers such as
+    # _dispatch_audit_work, which poll ALERT notifications to spawn the auditor.
+    app.include_router(notifications_router, prefix="/api/notifications")
     # Cloud-auth gate coverage smoke exercises the real _require_ceo and
     # require_panel_token dep paths on these routers.
     app.include_router(orchestrator_router, prefix="/api/orchestrator")

--- a/tests/e2e_smoke/test_auditor_triggers.py
+++ b/tests/e2e_smoke/test_auditor_triggers.py
@@ -1,0 +1,215 @@
+"""e2e smoke test for auditor triggers.
+
+Exercises both the scheduled audit trigger path and the reactive alert producer
+path end-to-end, verifying they result in auditor-targeted work.
+
+- Scheduled path: an in-process orchestrator instance polls the real e2e API,
+  sees recent delivery activity, and calls ``spawn_agent(agent_id="auditor")``
+  with the scheduled sweep prompt.
+- Reactive path: a real QA-fail POST creates an ``ALERT`` notification addressed
+  to the auditor in the DB; the orchestrator's audit dispatcher fetches that
+  alert and calls ``spawn_agent(agent_id="auditor")`` with the quality-alert
+  prompt.
+
+No real auditor container is spawned — ``spawn_agent`` is stubbed so the test
+asserts on the dispatch decision, not the LLM runtime.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from roboco.config import settings
+from roboco.models.base import TaskStatus
+from roboco.runtime.orchestrator import AgentOrchestrator
+from tests.e2e_smoke.arcs import seed_company, seed_project, seed_task
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+    from tests.e2e_smoke.harness import E2EStack
+
+
+def _agent_headers(agent_id: Any, role: str) -> dict[str, str]:
+    return {"X-Agent-ID": str(agent_id), "X-Agent-Role": role}
+
+
+def _seed_auditor_agent(stack: E2EStack) -> UUID:
+    """Seed the canonical auditor agent at its fixed foundation UUID.
+
+    ``_resolve_agent_slug`` maps this UUID to ``"auditor"`` so the orchestrator
+    recognises auditor-targeted notifications and spawns the right role.
+    """
+    from roboco.db.tables import AgentTable
+    from roboco.foundation import identity as _foundation
+    from roboco.models import AgentRole, AgentStatus
+
+    async def _run(session: AsyncSession) -> UUID:
+        auditor_id = _foundation.AGENTS["auditor"].uuid
+        session.add(
+            AgentTable(
+                id=auditor_id,
+                name="auditor",
+                slug="auditor",
+                role=AgentRole.AUDITOR,
+                team=None,
+                status=AgentStatus.ACTIVE,
+                model_config={},
+                system_prompt="auditor",
+                capabilities=[],
+                permissions={},
+                metrics={},
+            )
+        )
+        await session.flush()
+        return auditor_id
+
+    auditor_id: UUID = stack.run_db(_run)
+    return auditor_id
+
+
+def _notifications_for_task(
+    stack: E2EStack, task_id: Any, notification_type: Any
+) -> list[dict[str, Any]]:
+    from roboco.db.tables import NotificationTable
+    from sqlalchemy import select
+
+    async def _run(session: AsyncSession) -> list[dict[str, Any]]:
+        rows = (
+            (
+                await session.execute(
+                    select(NotificationTable).where(
+                        NotificationTable.related_task_id == task_id,
+                        NotificationTable.type == notification_type,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return [
+            {
+                "type": str(r.type),
+                "related_task_id": r.related_task_id,
+                "subject": r.subject,
+                "priority": str(r.priority),
+                "to_agents": list(r.to_agents),
+            }
+            for r in rows
+        ]
+
+    rows: list[dict[str, Any]] = stack.run_db(_run)
+    return rows
+
+
+def _fresh_orchestrator(stack: E2EStack, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Return a bare orchestrator whose internal API points at the e2e app."""
+    monkeypatch.setattr(settings, "internal_api_url", f"{stack.base_url}/api")
+    orch: Any = AgentOrchestrator.__new__(AgentOrchestrator)
+    orch.spawn_agent = AsyncMock()
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_scheduled_audit_trigger_spawns_auditor(
+    e2e_stack: E2EStack, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The scheduled sweep spawns the auditor when delivery activity is recent."""
+    stack = e2e_stack
+    company = seed_company(stack)
+    project_id, _project_slug = seed_project(stack, company)
+    auditor_id = _seed_auditor_agent(stack)
+
+    # Any active delivery task counts as "recent activity" for the sweep gate.
+    task_id = seed_task(
+        stack,
+        title="Scheduled audit smoke task",
+        description="An in-progress task so the scheduled sweep has work to audit.",
+        acceptance_criteria=["the scheduled path sees recent activity"],
+        project_id=project_id,
+        created_by=company.cell_pm_id,
+        assigned_to=company.dev_id,
+        claimed_by=company.dev_id,
+        active_claimant_id=company.dev_id,
+        status=TaskStatus.IN_PROGRESS,
+        branch_name="feature/backend/e2e-scheduled-audit",
+    )
+
+    orch = _fresh_orchestrator(stack, monkeypatch)
+    monkeypatch.setattr(settings, "audit_interval_seconds", 60)
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        await orch._dispatch_audit_work(client)
+
+    orch.spawn_agent.assert_awaited_once()
+    call = orch.spawn_agent.await_args
+    assert call is not None
+    assert call.kwargs["agent_id"] == "auditor"
+    assert call.kwargs["spawned_by"] == "_dispatch_audit_work"
+    prompt = call.kwargs["initial_prompt"]
+    assert "SCHEDULED AUDIT SWEEP" in prompt
+
+    # No reactive alert should have been created for this path.
+    assert _notifications_for_task(stack, task_id, "ALERT") == []
+    assert auditor_id is not None  # auditor was seeded and resolved
+
+
+@pytest.mark.asyncio
+async def test_reactive_alert_producer_spawns_auditor(
+    e2e_stack: E2EStack, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """QA-fail emits an auditor-targeted ALERT; the dispatcher spawns the auditor."""
+    stack = e2e_stack
+    company = seed_company(stack)
+    project_id, _project_slug = seed_project(stack, company)
+    auditor_id = _seed_auditor_agent(stack)
+
+    task_id = seed_task(
+        stack,
+        title="Reactive alert smoke task",
+        description="A task awaiting QA so fail_qa can emit an auditor alert.",
+        acceptance_criteria=["the reactive path emits an auditor alert"],
+        project_id=project_id,
+        created_by=company.cell_pm_id,
+        assigned_to=company.dev_id,
+        claimed_by=company.dev_id,
+        active_claimant_id=company.dev_id,
+        status=TaskStatus.AWAITING_QA,
+        branch_name="feature/backend/e2e-reactive-alert",
+    )
+
+    resp = httpx.post(
+        f"{stack.base_url}/api/tasks/{task_id}/fail-qa",
+        json={"notes": "missing edge-case coverage"},
+        headers=_agent_headers(company.qa_id, "qa"),
+        timeout=30,
+    )
+    assert resp.status_code == HTTPStatus.OK, (
+        f"fail-qa: {resp.status_code} {resp.text[:1500]}"
+    )
+
+    alerts = _notifications_for_task(stack, task_id, "ALERT")
+    assert len(alerts) == 1, alerts
+    alert = alerts[0]
+    assert "rework alert" in alert["subject"].lower(), alert
+    assert auditor_id in alert["to_agents"], alert
+
+    orch = _fresh_orchestrator(stack, monkeypatch)
+    monkeypatch.setattr(settings, "audit_interval_seconds", 60)
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        await orch._dispatch_audit_work(client)
+
+    orch.spawn_agent.assert_awaited_once()
+    call = orch.spawn_agent.await_args
+    assert call is not None
+    assert call.kwargs["agent_id"] == "auditor"
+    assert call.kwargs["spawned_by"] == "_dispatch_audit_work"
+    prompt = call.kwargs["initial_prompt"]
+    assert "QUALITY ALERT" in prompt
+    assert "missing edge-case coverage" in prompt


### PR DESCRIPTION
Add an e2e smoke test that exercises both the scheduled audit trigger path and the reactive alert producer path end-to-end, verifying they result in auditor-targeted work. This subtask must wait until the scheduled trigger/config/prompt leaf and the reactive alert producer leaf have landed, then build the smoke test on top of those changes. Run the full backend quality suite (ruff, mypy, pytest) on the aggregate cell branch.