### PR TITLE
[3bc47cdc] Fix _fresh_orchestrator state for auditor trigger e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - **Restored five coordination-event notification producers with double-fire guards.** Reassignment, collision-sequencing, unblock, dependency-revival, and stale-claim-reaped notifications are now wired at their lifecycle chokepoints in `TaskService` and the orchestrator reaper, each with an idempotent upstream guard preventing duplicate ALERT rows. The duplicate route-level `notify_assignee_of_unblock` call in `POST /api/tasks/{id}/unblock` was removed so unblock fires exactly one notification. Added `docs/backend/services/coordination-events.md` and `tests/e2e_smoke/test_notification_coordination_events.py` covering the restored producers.
+- **`_fresh_orchestrator` test helper initializes orchestrator state.** `tests/e2e_smoke/test_auditor_triggers.py` constructs a bare `AgentOrchestrator` via `__new__` so it can patch `spawn_agent`, but that bypasses `__init__`. The helper now explicitly sets `_instances = {}` and `_last_audit_spawn_at = None` so `_is_agent_active` and `_dispatch_audit_work` no longer raise `AttributeError` during the auditor trigger e2e tests.
 
 ## [0.23.0] - 2026-07-11
 

--- a/tests/e2e_smoke/test_auditor_triggers.py
+++ b/tests/e2e_smoke/test_auditor_triggers.py
@@ -111,6 +111,10 @@ def _fresh_orchestrator(stack: E2EStack, monkeypatch: pytest.MonkeyPatch) -> Any
     """Return a bare orchestrator whose internal API points at the e2e app."""
     monkeypatch.setattr(settings, "internal_api_url", f"{stack.base_url}/api")
     orch: Any = AgentOrchestrator.__new__(AgentOrchestrator)
+    # __new__ bypasses __init__, so the instance attributes that
+    # _is_agent_active and _dispatch_audit_work read must be initialized here.
+    orch._instances = {}
+    orch._last_audit_spawn_at = None
     orch.spawn_agent = AsyncMock()
     return orch
 


### PR DESCRIPTION
Initialize orchestrator state (at minimum orch._instances = {}, plus any additional attributes required for _is_agent_active and _dispatch_audit_work) in the _fresh_orchestrator helper in tests/e2e_smoke/test_auditor_triggers.py. Run pytest on tests/e2e_smoke/test_auditor_triggers.py to verify test_scheduled_audit_trigger_spawns_auditor and test_reactive_alert_producer_spawns_auditor both complete and assert the auditor spawn. Keep changes confined to the test harness; do not alter production orchestrator or task service behavior. The PR gate findings F-fc2f4e23 and F-7191c251 both trace to this helper leaving _instances unset when AgentOrchestrator is constructed via __new__ and spawn_agent is patched.