### PR TITLE
[8323cd50] Fix e2e smoke regression on assembled cell PR #496

### DIFF
--- a/docs/map/tests.md
+++ b/docs/map/tests.md
@@ -24,7 +24,18 @@ The pytest test suite for RoboCo: 571 test_*.py files across tests/foundation, t
 | tests/unit/gateway/ | 105 Choreographer/verb-runner unit tests — the largest single cluster: every intent verb's guards, envelopes, evidence, claim locks, lane barrier, pr gate, conventions gate, content actions |  |
 | tests/unit/runtime/ | 64 orchestrator unit tests: spawn/manifest/cwd/worktree, reaper, respawn persistence, rate-limit/overload sweeps, ci_watch/dep_update/release/self_heal loops, no_spawn_human_roles, per_dev_lane_queue, readopt_running_agents |  |
 | tests/unit/services/ | 120 service unit tests: task, git (+worktree), workspace, work_session, release_executor/readiness/manager, sequencing, conventions, playbook, notification, rate_limit_tracker, optimal_brain/ (10) |  |
-| tests/e2e_smoke/ | Scripted-agent lifecycle smoke tests: real routers + middleware over ephemeral Postgres + bare git origin + fake GitHub REST layer; no LLM. Env-gated (`ROBOCO_E2E_SMOKE=1`) via `make e2e-smoke`. |  |
+| tests/e2e_smoke/ | Scripted-agent smoke tests against the live in-process orchestrator; separate from the default pytest collection (run by the PR/NAS smoke gate) |  |
+| tests/e2e_smoke/harness.py | E2E harness: E2EStack app + orchestrator client + per-test agent manifests; used by the e2e_smoke tier | ~520 |
+
+## E2E smoke harness
+
+The `tests/e2e_smoke/` tier runs scripted agents against a real in-process FastAPI app and orchestrator. It is **not** collected by the default `uv run pytest` invocation; it is exercised separately by the PR gate / NAS smoke run. The harness in `tests/e2e_smoke/harness.py` builds an `E2EStack`, mounts the orchestrator client, and gives each test a per-agent manifest.
+
+Recent harness hardening for the auditor-revival slice (PR #498, task `8323cd50`):
+
+- `tests/conftest.py` now catches a missing `pgvector` extension when creating the ephemeral test database and continues with a warning. The core schema does not require it and the e2e smoke suite does not exercise RAG, so lightweight Postgres sandboxes can run the suite without the pgvector package.
+- `tests/e2e_smoke/harness.py` clears any host-supplied `ROBOCO_AGENT_TOKEN` from the environment before a `ScriptedAgent` re-imports `roboco.mcp.flow_server`. The host agent may carry a real token for the test runner's identity; that token does not match the ephemeral test agent IDs and causes `401 Unauthorized` when flow_server forwards it.
+- `tests/e2e_smoke/test_auditor_triggers.py` exercises both scheduled and reactive auditor dispatch through a `_fresh_orchestrator` helper. Because the helper constructs `AgentOrchestrator` via `__new__` to bypass normal initialization, it must manually initialize the private attributes `_instances` and `_last_audit_spawn_at` that `_is_agent_active` and `_dispatch_audit_work` read. The two tests are intentionally **synchronous** (no `@pytest.mark.asyncio`) because the harness already enters an async loop via `run_db`; the test body uses `asyncio.run` on an inner coroutine. Internal API calls use the raw `_SYSTEM_API_HEADERS` (system identity only) rather than the production `_system_api_headers` helper, because dev mode rejects an `UNSIGNED` `X-Agent-Token`. Settings are patched at `api_url` (the input to the computed `internal_api_url` property), and notifications are matched with `NotificationType.ALERT` instead of the string `"ALERT"`.
 
 ## Key Symbols
 
@@ -86,6 +97,10 @@ tests/
 ├── conftest.py  [TOP-LEVEL — DB provisioning, db_session, smoke_test_batch, skip hook]
 ├── fixtures/
 │   └── 2026-05-08-smoke-trace.json  [11 synthesized bug records, replay_kind taxonomy]
+├── e2e_smoke/  (scripted-agent smoke tests against live orchestrator; not collected by default pytest run)
+│   ├── harness.py  [E2EStack + orchestrator client + per-test agent manifests]
+│   ├── arcs.py  [seed helpers for company/project/task]
+│   └── test_auditor_triggers.py  [scheduled + reactive auditor dispatch smoke tests]
 ├── foundation/  (21 tests — structural/parity gates)
 │   ├── test_lifecycle_smoke_replay.py  [consumes the JSON fixture, dispatch by replay_kind]
 │   ├── test_lifecycle_spec.py/test_lifecycle_generators.py/test_lifecycle_consumer_parity.py
@@ -194,6 +209,9 @@ tests/
 - The two .sh smoke scripts are NOT collected by pytest (no pytest collection of .sh); they must be invoked directly. They are not referenced in Makefile or .github/ workflows — likely run manually or in an unwired CI step.
 - _test_database_url is session-scoped with loop_scope=session; db_session is function-scoped with asyncio_default_fixture_loop_scope=function (pyproject). Mixing session+function loop scopes is supported but a session-scoped async fixture holds one event loop for the whole session.
 - conftest default port 15432 points at Docker's roboco-postgres (down on a bare-metal dev box). Per project memory the local-PG workflow is ROBOCO_TEST_DB_PORT=55432 ROBOCO_TEST_DB_USER=renzof ROBOCO_TEST_DB_PASSWORD= — without these env vars, ALL db_session tests silently skip on a non-Docker dev machine.
+- `tests/e2e_smoke/test_auditor_triggers.py` tests are sync wrappers around an async helper. The two auditor-trigger smoke tests are plain `def` tests that call `asyncio.run()` on an inner coroutine, because the harness already starts an async loop via `run_db`. Marking them with `@pytest.mark.asyncio` would conflict with that nested loop.
+- `tests/conftest.py` now tolerates a missing `pgvector` extension. `_test_database_url` catches `CREATE EXTENSION IF NOT EXISTS vector` failures and warns instead of failing. This lets the suite run in lightweight sandboxes, but it also means a sandbox with missing pgvector will pass with a warning rather than failing loudly.
+- `tests/e2e_smoke/harness.py` clears host `ROBOCO_AGENT_TOKEN` before scripted agents load `flow_server`. A `ScriptedAgent` pops `ROBOCO_AGENT_TOKEN` from `os.environ` before re-importing `roboco.mcp.flow_server`. Without this, a real host token is forwarded for an ephemeral test agent identity and causes 401s. Any new harness path that imports `flow_server` inside a scripted agent must do the same.
 
 
 ## Drift from CLAUDE.md
@@ -220,6 +238,7 @@ tests/
 > - **76ce53e3** chat MESSAGE_SENT fix: test_websocket_bridge.py gained 3 new test functions for `_handle_message_event` (skips missing ids, skips invalid uuid, broadcasts to session+channel).
 > - **77958c1e** chat session/group/message read IDOR fix: test_messaging_service.py extended with `_make_agent` helper + IDOR access-control test coverage for get_session/get_group/list_messages.
 > - **1f129199** auditor-trigger e2e smoke test: added `tests/e2e_smoke/test_auditor_triggers.py` exercising scheduled sweep and reactive QA-fail alert paths end-to-end, plus harness mount of `/api/notifications` so `_dispatch_audit_work` can poll ALERT rows.
+> - **babffe0a** fix(e2e_smoke): repair auditor-trigger smoke tests and harden harness (#498): fixed `tests/e2e_smoke/test_auditor_triggers.py` so scheduled/reactive auditor-trigger tests reach their spawn assertions, hardened `tests/conftest.py` to tolerate missing pgvector, and cleared leaked `ROBOCO_AGENT_TOKEN` in `tests/e2e_smoke/harness.py` before scripted agents load `flow_server`. See the E2E smoke harness section above for the exact patterns.
 
 ## Regression Risks
 
@@ -233,6 +252,9 @@ tests/
 | Property random-walk seed is not pinned — state-machine holes can hide | tests/property/test_state_machine_invariants.py:95 | test_random_walks_stay_within_declared_states uses stdlib random without an explicit seed. A state-machine transition added by the gap-fill commits that violates an invariant on a rarely-walked path could pass CI on most runs and fail intermittently. Without hypothesis and without a fixed seed, the walk coverage is non-deterministic. | low |
 | JSON smoke-trace fixture is a synthesis — skip-classified bugs are not re-asserted | tests/fixtures/2026-05-08-smoke-trace.json:1 | 3 of 11 records are *_skip (schema_only_skip, audit_only_skip, behavioral_skip) and are documented NOT re-asserted at the spec layer in test_lifecycle_smoke_replay. A regression in the bug those records document (e.g. delegate.task_type default, the audit-layer fix) would not be caught by the smoke-replay test; it relies on other tests covering those layers. If those other tests were removed, the regression window re-opens silently. | low |
 | Shell smoke scripts are not wired into any CI/Makefile target | tests/integration/test_stop_hook_verb_names.sh:1 | test_bash_guard_message.sh and test_stop_hook_verb_names.sh are not referenced in Makefile or .github/workflows. They guard against pre-gateway legacy verb names leaking back into stop-hook.sh/bash-guard-hook.sh and against denial-message bloat. A regression (re-introducing an old verb name, or an 8-line denial) would not be caught by make quality or pytest; the scripts must be run manually. | low |
+| Missing pgvector is now a warning, not a failure | tests/conftest.py:189 | `_test_database_url` catches `CREATE EXTENSION IF NOT EXISTS vector` failures. A sandbox that accidentally omits pgvector will green-run the e2e smoke suite with a warning, so a regression in pgvector-dependent code could pass locally and only fail in CI. | low |
+| Host `ROBOCO_AGENT_TOKEN` can leak into scripted-agent calls | tests/e2e_smoke/harness.py:476 | The harness clears the token before loading `flow_server`, but any new scripted-agent bootstrap path that forgets this step will forward the test runner's real token and get 401s for ephemeral agent IDs. | low |
+| `_fresh_orchestrator` bypasses `__init__` and must stay in sync with private attributes | tests/e2e_smoke/test_auditor_triggers.py:115 | The helper constructs `AgentOrchestrator` via `__new__` and manually sets `_instances` and `_last_audit_spawn_at`. A refactor of `AgentOrchestrator.__init__` that adds new instance attributes read by `_dispatch_audit_work` will break the smoke tests silently until the helper is updated. | low |
 
 ## Health
 The test slice is structurally healthy and well-tiered (foundation parity/integration real-DB/property invariants/unit mirror), with a single load-bearing conftest that honestly documents its own drift from the alembic chain. The 571-file suite is async-first and coverage-gated, but two architectural facts temper confidence: (1) the coverage omit list excludes the orchestrator, git, workspace, mcp, and agents surface from the 80% gate, so make quality green does NOT mean those hot paths are covered — their regressions are deferred to NAS smoke runs; (2) the conftest builds schema via Base.metadata.create_all, which is correct today but creates a standing trap for any future NOT NULL ORM-mapped migration column. The since-baseline gap-fill commits added substantial real coverage (worktree lifecycle, respawn persistence, lane barrier, sequencing, release executor fail-closed, rate-limit atomicity), and the conftest DB-default change (5432/$USER -> 15432/roboco) fixed a real out-of-the-box failure mode but introduced silent-skip behavior on non-Docker dev boxes. The property tests lack hypothesis and a pinned seed, and the JSON smoke fixture is a synthesis with 3/11 records not re-asserted — both are documented limitations, not defects. Overall the slice is solid for a merge gate but should be supplemented by the NAS smoke run before any deploy claim, and the shell smoke scripts need wiring into CI to actually guard what they assert.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,7 +189,16 @@ async def _test_database_url() -> AsyncIterator[str]:
     pgvector_engine = create_async_engine(test_url_async, future=True)
     try:
         async with pgvector_engine.begin() as conn:
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            try:
+                await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            except Exception:
+                # Dev/sandbox Postgres may lack pgvector; the core schema does
+                # not require it and the e2e smoke suite does not exercise RAG.
+                # Continue so tests can run in lightweight sandboxes.
+                warnings.warn(
+                    "pgvector extension unavailable - continuing without it",
+                    stacklevel=2,
+                )
     finally:
         await pgvector_engine.dispose()
 

--- a/tests/e2e_smoke/harness.py
+++ b/tests/e2e_smoke/harness.py
@@ -476,6 +476,12 @@ class ScriptedAgent:
         os.environ["ROBOCO_AGENT_ROLE"] = self.role
         os.environ["ROBOCO_ORCHESTRATOR_URL"] = self.stack.base_url
         os.environ["ROBOCO_TOOL_MANIFEST_PATH"] = str(self._manifest_path)
+        # The host agent environment may carry a real ROBOCO_AGENT_TOKEN issued
+        # for the test runner's identity. flow_server reads it at import time
+        # and forwards it on every call; the token won't match the ephemeral
+        # test agent IDs and causes 401s. Drop it so tests run in the same
+        # unsigned-token mode as CI.
+        os.environ.pop("ROBOCO_AGENT_TOKEN", None)
         module = importlib.import_module(name)
         if getattr(module, "AGENT_ID", None) != str(self.agent_id):
             module = importlib.reload(module)

--- a/tests/e2e_smoke/test_auditor_triggers.py
+++ b/tests/e2e_smoke/test_auditor_triggers.py
@@ -17,20 +17,22 @@ asserts on the dispatch decision, not the LLM runtime.
 
 from __future__ import annotations
 
+import asyncio
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
 import httpx
-import pytest
 from roboco.config import settings
+from roboco.models import NotificationType
 from roboco.models.base import TaskStatus
-from roboco.runtime.orchestrator import AgentOrchestrator
+from roboco.runtime.orchestrator import _SYSTEM_API_HEADERS, AgentOrchestrator
 from tests.e2e_smoke.arcs import seed_company, seed_project, seed_task
 
 if TYPE_CHECKING:
     from uuid import UUID
 
+    import pytest
     from sqlalchemy.ext.asyncio import AsyncSession
     from tests.e2e_smoke.harness import E2EStack
 
@@ -109,7 +111,8 @@ def _notifications_for_task(
 
 def _fresh_orchestrator(stack: E2EStack, monkeypatch: pytest.MonkeyPatch) -> Any:
     """Return a bare orchestrator whose internal API points at the e2e app."""
-    monkeypatch.setattr(settings, "internal_api_url", f"{stack.base_url}/api")
+    # internal_api_url is a computed property; patch its input api_url instead.
+    monkeypatch.setattr(settings, "api_url", stack.base_url)
     orch: Any = AgentOrchestrator.__new__(AgentOrchestrator)
     # __new__ bypasses __init__, so the instance attributes that
     # _is_agent_active and _dispatch_audit_work read must be initialized here.
@@ -119,8 +122,7 @@ def _fresh_orchestrator(stack: E2EStack, monkeypatch: pytest.MonkeyPatch) -> Any
     return orch
 
 
-@pytest.mark.asyncio
-async def test_scheduled_audit_trigger_spawns_auditor(
+def test_scheduled_audit_trigger_spawns_auditor(
     e2e_stack: E2EStack, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """The scheduled sweep spawns the auditor when delivery activity is recent."""
@@ -147,8 +149,13 @@ async def test_scheduled_audit_trigger_spawns_auditor(
     orch = _fresh_orchestrator(stack, monkeypatch)
     monkeypatch.setattr(settings, "audit_interval_seconds", 60)
 
-    async with httpx.AsyncClient(timeout=5.0) as client:
-        await orch._dispatch_audit_work(client)
+    async def _dispatch() -> None:
+        async with httpx.AsyncClient(
+            timeout=5.0, headers=_SYSTEM_API_HEADERS
+        ) as client:
+            await orch._dispatch_audit_work(client)
+
+    asyncio.run(_dispatch())
 
     orch.spawn_agent.assert_awaited_once()
     call = orch.spawn_agent.await_args
@@ -159,12 +166,11 @@ async def test_scheduled_audit_trigger_spawns_auditor(
     assert "SCHEDULED AUDIT SWEEP" in prompt
 
     # No reactive alert should have been created for this path.
-    assert _notifications_for_task(stack, task_id, "ALERT") == []
+    assert _notifications_for_task(stack, task_id, NotificationType.ALERT) == []
     assert auditor_id is not None  # auditor was seeded and resolved
 
 
-@pytest.mark.asyncio
-async def test_reactive_alert_producer_spawns_auditor(
+def test_reactive_alert_producer_spawns_auditor(
     e2e_stack: E2EStack, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """QA-fail emits an auditor-targeted ALERT; the dispatcher spawns the auditor."""
@@ -197,7 +203,7 @@ async def test_reactive_alert_producer_spawns_auditor(
         f"fail-qa: {resp.status_code} {resp.text[:1500]}"
     )
 
-    alerts = _notifications_for_task(stack, task_id, "ALERT")
+    alerts = _notifications_for_task(stack, task_id, NotificationType.ALERT)
     assert len(alerts) == 1, alerts
     alert = alerts[0]
     assert "rework alert" in alert["subject"].lower(), alert
@@ -206,8 +212,13 @@ async def test_reactive_alert_producer_spawns_auditor(
     orch = _fresh_orchestrator(stack, monkeypatch)
     monkeypatch.setattr(settings, "audit_interval_seconds", 60)
 
-    async with httpx.AsyncClient(timeout=5.0) as client:
-        await orch._dispatch_audit_work(client)
+    async def _dispatch() -> None:
+        async with httpx.AsyncClient(
+            timeout=5.0, headers=_SYSTEM_API_HEADERS
+        ) as client:
+            await orch._dispatch_audit_work(client)
+
+    asyncio.run(_dispatch())
 
     orch.spawn_agent.assert_awaited_once()
     call = orch.spawn_agent.await_args


### PR DESCRIPTION
Cell-level PR #496 (auditor-revival backend slice) was rejected by the PR gate with blocker [F-8c44a759] on tests/e2e_smoke: the assembled branch's head commit fails the e2e lifecycle smoke (scripted agents). The cell branch feature/backend/f7d0a61a--90c9474c--927e64d5 contains the auditor slice (scheduled trigger + reactive alert producers + e2e smoke test + _fresh_orchestrator fix) and also carries the coordination-events slice (#477) plus other MegaTask wave-2 backend work, so the regression could be in tests/e2e_smoke/test_auditor_triggers.py, tests/e2e_smoke/test_notification_coordination_events.py, or the shared harness (harness.py / conftest.py). Your job is to check out the cell branch, run the e2e smoke tests, reproduce the failure, identify the root cause, apply the smallest fix that makes the e2e smoke suite green, and re-run the full e2e smoke suite locally. If the fix must touch production code, document why in your handoff note and keep the change minimal. Open a leaf PR and leave it for PM review/merge.