### PR TITLE
[e6e23c1f] Enforce docs_sync_max_per_cycle cap in docs_sync_engine.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ ROBOCO_CONVENTIONS_ENABLED=false        # per-project architectural conventions 
 ROBOCO_TOOLCHAIN_MATCH_ENABLED=false    # build each target project under its own Python
 ROBOCO_OVERLOAD_BREAK_ENABLED=true      # park a provider on a persistent model-API overload
 ROBOCO_DOCS_SYNC_ENABLED=false          # docs-divergence sync (release → docs-update task). Default-off; when on, a successful release publish originates one bounded, deduped docs-update task against the roboco-website project.
+ROBOCO_DOCS_SYNC_MAX_OPEN_TASKS=3       # rolling cap on concurrently-open docs-sync tasks
+ROBOCO_DOCS_SYNC_MAX_PER_CYCLE=1        # max docs-sync tasks originated per publish invocation
 
 # Auditor scheduled sweeps (default 6 hours; 0 disables)
 ROBOCO_AUDIT_INTERVAL_SECONDS=21600

--- a/docs/map/engine-docs-sync.md
+++ b/docs/map/engine-docs-sync.md
@@ -10,7 +10,7 @@ A default-off, release-triggered task-origination engine that keeps the public d
 
 | Path | Role | LOC |
 |---|---|---|
-| `roboco/services/docs_sync_engine.py` | `DocsSyncEngine` and `get_docs_sync_engine` — release-triggered origination of one docs-update task per release tag | 171 |
+| `roboco/services/docs_sync_engine.py` | `DocsSyncEngine` and `get_docs_sync_engine` — release-triggered origination of one docs-update task per release tag | 188 |
 | `roboco/services/release_proposal.py` | Publish-success seam: `ReleaseProposalService._draft_docs_update` hands the release report to `DocsSyncEngine` best-effort | 18 |
 | `roboco/services/task.py` | `DOCS_SYNC_SOURCE` constant and `TaskService.list_open_docs_sync_tasks(version=None)` dedupe query | 31 |
 | `roboco/foundation/policy/content/markers.py` | `DOCS_SYNC_RELEASE_VERSION` marker + `get/set_docs_sync_release_version` accessors | 17 |
@@ -22,13 +22,15 @@ A default-off, release-triggered task-origination engine that keeps the public d
 
 | Name | Kind | File:Line | Responsibility |
 |---|---|---|---|
-| `_DOCS_PROJECT_SLUG` | constant | `roboco/services/docs_sync_engine.py:48` | The registered project slug that hosts the public docs (`roboco-website`). Engine no-ops with a warning when this project is missing. |
-| `_DIVERGENCE_CHECKLIST_POINTER` | constant | `roboco/services/docs_sync_engine.py:51` | Text pointer included in every originated task, telling the assignee to review the release-readiness `docs_drift` gaps. |
-| `DocsSyncEngine` | class | `roboco/services/docs_sync_engine.py:59` | Release-triggered docs-update task origination service. |
-| `DocsSyncEngine.originate_docs_update` | method | `roboco/services/docs_sync_engine.py:64` | Public entry point: returns the created `TaskTable` or `None` when disabled / missing project / cap reached / already open for this version. Flushes; caller commits. |
-| `DocsSyncEngine._already_open_for_version` | method | `roboco/services/docs_sync_engine.py:116` | Dedupe check using `TaskService.list_open_docs_sync_tasks(version=...)` filtered by the `docs_sync_release_version` marker. |
-| `DocsSyncEngine._open_task` | method | `roboco/services/docs_sync_engine.py:123` | Builds the `TaskCreateRequest` (Main-PM planning root, `confirmed_by_human=True`, source `docs_sync`) and stamps the release-version marker. |
-| `get_docs_sync_engine` | function | `roboco/services/docs_sync_engine.py:169` | Factory constructing a `DocsSyncEngine` bound to a session. |
+| `_DOCS_PROJECT_SLUG` | constant | `roboco/services/docs_sync_engine.py:50` | The registered project slug that hosts the public docs (`roboco-website`). Engine no-ops with a warning when this project is missing. |
+| `_DIVERGENCE_CHECKLIST_POINTER` | constant | `roboco/services/docs_sync_engine.py:53` | Text pointer included in every originated task, telling the assignee to review the release-readiness `docs_drift` gaps. |
+| `DocsSyncEngine` | class | `roboco/services/docs_sync_engine.py:61` | Release-triggered docs-update task origination service. |
+| `DocsSyncEngine.__init__` | method | `roboco/services/docs_sync_engine.py:66` | Initializes the per-instance `_per_cycle_originated` counter. Reset per engine instance because `release_proposal.py` constructs a fresh engine per publish invocation. |
+| `DocsSyncEngine.originate_docs_update` | method | `roboco/services/docs_sync_engine.py:72` | Public entry point: returns the created `TaskTable` or `None` when disabled / missing project / either cap reached / already open for this version. Flushes; caller commits. |
+| `DocsSyncEngine._per_cycle_originated` | attribute | `roboco/services/docs_sync_engine.py:70` | Instance counter tracking how many docs-sync tasks this engine has originated. Guarded against `settings.docs_sync_max_per_cycle`. |
+| `DocsSyncEngine._already_open_for_version` | method | `roboco/services/docs_sync_engine.py:132` | Dedupe check using `TaskService.list_open_docs_sync_tasks(version=...)` filtered by the `docs_sync_release_version` marker. |
+| `DocsSyncEngine._open_task` | method | `roboco/services/docs_sync_engine.py:139` | Builds the `TaskCreateRequest` (Main-PM planning root, `confirmed_by_human=True`, source `docs_sync`) and stamps the release-version marker. |
+| `get_docs_sync_engine` | function | `roboco/services/docs_sync_engine.py:185` | Factory constructing a `DocsSyncEngine` bound to a session. |
 | `DOCS_SYNC_SOURCE` | constant | `roboco/services/task.py:600` | Source tag value `"docs_sync"` used for dedupe queries and task creation. |
 | `list_open_docs_sync_tasks` | method | `roboco/services/task.py:1577` | Returns non-terminal `docs_sync` tasks, optionally scoped to one release version via JSONB marker filtering in SQL. |
 | `get_docs_sync_release_version` / `set_docs_sync_release_version` | functions | `roboco/foundation/policy/content/markers.py:412,417` | Read/write the `docs_sync_release_version` marker used for per-release dedupe. |
@@ -42,9 +44,10 @@ A default-off, release-triggered task-origination engine that keeps the public d
 1. **Flag gate**: returns `None` immediately if `settings.docs_sync_enabled` is `False`.
 2. **Project resolution**: looks up `roboco-website` via `ProjectService.get_by_slug`. If missing, logs a warning and returns `None`.
 3. **Rolling cap**: counts all non-terminal `docs_sync` tasks via `list_open_docs_sync_tasks()`; if the count is already at `docs_sync_max_open_tasks` (default 3), logs and returns `None`.
-4. **Per-release dedupe**: calls `list_open_docs_sync_tasks(version=version)` filtering on the `docs_sync_release_version` JSONB marker in SQL; if any row exists, logs and returns `None`.
-5. **Originate**: creates a `TaskCreateRequest` with `source=DOCS_SYNC_SOURCE`, `team=Team.MAIN_PM`, `assigned_to=AGENTS["main-pm"].uuid`, `created_by=AGENTS["system"].uuid`, `task_type=PLANNING`, `nature=TECHNICAL`, `complexity=MEDIUM`, `status=PENDING`, `confirmed_by_human=True`, `project_id=roboco-website.id`. The description includes the release version, the drafted CHANGELOG section, the divergence-checklist pointer, and a note that the task is a Main-PM coordination root ready to decompose and delegate.
-6. **Marker stamp**: calls `markers.set_docs_sync_release_version(task, version)` and flushes.
+4. **Per-cycle cap**: checks an instance-level counter (`_per_cycle_originated`) against `docs_sync_max_per_cycle` (default 1). If the counter is already at the cap, logs and returns `None`. The counter resets per engine instance; `release_proposal.py` constructs a fresh instance per publish invocation.
+5. **Per-release dedupe**: calls `list_open_docs_sync_tasks(version=version)` filtering on the `docs_sync_release_version` JSONB marker in SQL; if any row exists, logs and returns `None`.
+6. **Originate**: creates a `TaskCreateRequest` with `source=DOCS_SYNC_SOURCE`, `team=Team.MAIN_PM`, `assigned_to=AGENTS["main-pm"].uuid`, `created_by=AGENTS["system"].uuid`, `task_type=PLANNING`, `nature=TECHNICAL`, `complexity=MEDIUM`, `status=PENDING`, `confirmed_by_human=True`, `project_id=roboco-website.id`. The description includes the release version, the drafted CHANGELOG section, the divergence-checklist pointer, and a note that the task is a Main-PM coordination root ready to decompose and delegate.
+7. **Marker stamp**: calls `markers.set_docs_sync_release_version(task, version)` and flushes.
 
 The created task then rides the normal delivery lifecycle: Main PM decomposes it into per-cell subtasks, a dev/documenter implements the docs update, QA verifies, the PR reviewer passes it, and the CEO merges.
 
@@ -75,15 +78,21 @@ sequenceDiagram
             DSE->>TS: list_open_docs_sync_tasks()
             alt open_count >= max_open_tasks
                 DSE-->>RP: None
-            else under cap
-                DSE->>TS: list_open_docs_sync_tasks(version=report.proposed_version)
-                alt already open for version
+            else under rolling cap
+                DSE->>DSE: _per_cycle_originated >= max_per_cycle?
+                alt per-cycle cap reached
                     DSE-->>RP: None
-                else new version
-                    DSE->>TS: create(TaskCreateRequest, source=docs_sync)
-                    TS->>DB: INSERT PENDING Main-PM planning task
-                    DSE->>DB: set docs_sync_release_version marker
-                    DSE-->>RP: created task
+                else under per-cycle cap
+                    DSE->>TS: list_open_docs_sync_tasks(version=report.proposed_version)
+                    alt already open for version
+                        DSE-->>RP: None
+                    else new version
+                        DSE->>TS: create(TaskCreateRequest, source=docs_sync)
+                        TS->>DB: INSERT PENDING Main-PM planning task
+                        DSE->>DSE: _per_cycle_originated += 1
+                        DSE->>DB: set docs_sync_release_version marker
+                        DSE-->>RP: created task
+                    end
                 end
             end
         end
@@ -102,8 +111,10 @@ engine-docs-sync
       gate on docs_sync_enabled
       resolve roboco-website project
       check docs_sync_max_open_tasks rolling cap
+      check docs_sync_max_per_cycle instance counter
       dedupe per version via list_open_docs_sync_tasks(version)
       _open_task(project_id, version, changelog)
+      increment _per_cycle_originated
     _already_open_for_version(task_svc, version) -> bool
     _open_task(task_svc, project_id, version, changelog) -> TaskTable
       create TaskCreateRequest(source=docs_sync, team=MAIN_PM, ...)
@@ -138,7 +149,7 @@ engine-docs-sync
 | Name | File | Trigger |
 |---|---|---|
 | `ReleaseProposalService.approve` | `roboco/services/release_proposal.py:82` | CEO panel `POST /api/release/proposal/approve`; runs executor, then calls `_draft_docs_update(report)` on publish success |
-| `DocsSyncEngine.originate_docs_update` | `roboco/services/docs_sync_engine.py:64` | Called from `_draft_docs_update`; no background loop or public API route |
+| `DocsSyncEngine.originate_docs_update` | `roboco/services/docs_sync_engine.py:72` | Called from `_draft_docs_update`; no background loop or public API route |
 
 ## Config Flags
 
@@ -168,6 +179,7 @@ The flag is registered in `roboco/services/settings.py`'s `FEATURE_FLAGS` tuple,
 |---|---|---|
 | af2fb904 | `[687574d2] Add docs-sync engine and release-proposal publish seam` | Introduced `roboco/services/docs_sync_engine.py`, the `release_proposal.py` seam, `DOCS_SYNC_SOURCE`, `list_open_docs_sync_tasks`, the `docs_sync_release_version` marker, and `docs_sync_max_open_tasks` / `docs_sync_max_per_cycle` config caps. |
 | db919882 | `[687574d2] Restore task.py safeguards deleted by docs-sync engine commit and filter docs_sync version in SQL` | Restored unrelated `task.py` safeguards accidentally deleted by the first commit and moved the version predicate in `list_open_docs_sync_tasks` into SQL against the JSONB marker. |
+| d333dde7 | `[e6e23c1f] Enforce docs_sync_max_per_cycle cap in DocsSyncEngine` | Added a per-instance `_per_cycle_originated` counter and guard so `originate_docs_update` respects `docs_sync_max_per_cycle` in addition to the existing rolling cap. Added `test_per_cycle_cap_is_enforced`. |
 
 ## Regression Risks
 
@@ -175,7 +187,8 @@ The flag is registered in `roboco/services/settings.py`'s `FEATURE_FLAGS` tuple,
 |---|---|---|---|
 | Missing `roboco-website` project silently skips docs updates | `roboco/services/docs_sync_engine.py:80` | By design the engine logs a warning and no-ops; operators must register the docs project before enabling the flag. | low |
 | Broad exception catch in `_draft_docs_update` could mask persistent engine failures | `roboco/services/release_proposal.py:242` | Best-effort by design so publish success is never endangered, but a persistent failure would only surface as a log warning. | low |
-| Cap/dedupe ordering: open_count is checked before per-version dedupe | `roboco/services/docs_sync_engine.py:89` | Correct: a duplicate for the same version is rejected after the cap check, so the cap is not consumed by duplicates. | low |
+| Cap/dedupe ordering: open_count is checked before per-version dedupe | `roboco/services/docs_sync_engine.py:97` | Correct: a duplicate for the same version is rejected after the cap check, so the cap is not consumed by duplicates. | low |
+| Instance-level `_per_cycle_originated` counter persists across calls on a reused engine | `roboco/services/docs_sync_engine.py:66` | Safe today because `release_proposal.py` constructs a fresh `DocsSyncEngine` per publish invocation. A future refactor that reuses an instance must either create a fresh engine per publish or add an explicit reset. | low |
 
 ## Health
 

--- a/roboco/services/docs_sync_engine.py
+++ b/roboco/services/docs_sync_engine.py
@@ -9,7 +9,9 @@ divergence checklist. Conservative:
 * **Never self-deploys** — it only OPENS a task; the docs update still ships
   through the normal gates (dev -> QA -> PR review -> the CEO's merge).
 * **Bounded + deduped per release** — at most one open docs_sync task per
-  release version, plus a rolling open-task cap.
+  release version, a rolling open-task cap, and a per-invocation cap so a
+  single publish event cannot originate more than ``docs_sync_max_per_cycle``
+  tasks.
 
 The release-proposal service calls ``originate_docs_update`` from its publish-
 success path; the engine itself has no background loop.

--- a/roboco/services/docs_sync_engine.py
+++ b/roboco/services/docs_sync_engine.py
@@ -61,15 +61,21 @@ class DocsSyncEngine(BaseService):
 
     service_name = "docs_sync_engine"
 
+    def __init__(self, session: AsyncSession) -> None:
+        super().__init__(session)
+        # Tracks how many tasks this engine instance has originated. Reset per
+        # instance because release_proposal creates a fresh engine per publish.
+        self._per_cycle_originated = 0
+
     async def originate_docs_update(
         self, version: str, changelog: str
     ) -> TaskTable | None:
         """If enabled, open one docs-update task for this release.
 
         Returns the created task, or None when disabled, when roboco-website is
-        not registered, when the open-task cap is reached, or when a task for
-        this version is already open. Flushes; the caller (release_proposal)
-        owns the commit. Never starts / approves / merges.
+        not registered, when either cap is reached, or when a task for this
+        version is already open. Flushes; the caller (release_proposal) owns
+        the commit. Never starts / approves / merges.
         """
         if not settings.docs_sync_enabled:
             return None
@@ -95,6 +101,13 @@ class DocsSyncEngine(BaseService):
             )
             return None
 
+        if self._per_cycle_originated >= settings.docs_sync_max_per_cycle:
+            self.log.info(
+                "docs-sync per-cycle cap reached; not originating",
+                cap=settings.docs_sync_max_per_cycle,
+            )
+            return None
+
         if await self._already_open_for_version(task_svc, version):
             self.log.info(
                 "docs-sync task already open for version",
@@ -105,6 +118,7 @@ class DocsSyncEngine(BaseService):
         task = await self._open_task(
             task_svc, cast("UUID", project.id), version, changelog
         )
+        self._per_cycle_originated += 1
         self.log.info(
             "docs-sync task opened",
             task_id=str(task.id),

--- a/tests/integration/services/test_docs_sync_engine.py
+++ b/tests/integration/services/test_docs_sync_engine.py
@@ -222,3 +222,38 @@ async def test_open_task_cap_is_enforced(
 
     assert result is None
     task_svc.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_per_cycle_cap_is_enforced(
+    _enabled: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once the per-cycle cap is reached, further calls on the same engine no-op."""
+    monkeypatch.setattr(settings, "docs_sync_max_per_cycle", 1)
+    project_id = uuid4()
+    project = _project(
+        project_id, "roboco-website", "https://github.com/x/roboco-website.git"
+    )
+    first_task = _task(uuid4(), project_id, "0.23.0")
+    second_task = _task(uuid4(), project_id, "0.24.0")
+
+    project_svc = MagicMock()
+    project_svc.get_by_slug = AsyncMock(return_value=project)
+    task_svc = MagicMock()
+    task_svc.list_open_docs_sync_tasks = AsyncMock(
+        side_effect=lambda version=None: [first_task] if version is None else []
+    )
+    task_svc.create = AsyncMock(side_effect=[first_task, second_task])
+
+    engine, patchers = _make_engine(project_svc, task_svc)
+    try:
+        first = await engine.originate_docs_update(version="0.23.0", changelog="x")
+        second = await engine.originate_docs_update(version="0.24.0", changelog="y")
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert first is not None
+    assert first.id == first_task.id
+    assert second is None
+    task_svc.create.assert_awaited_once()


### PR DESCRIPTION
be-dev-1 edits roboco/services/docs_sync_engine.py so that DocsSyncEngine.originate_docs_update respects the docs_sync_max_per_cycle setting. The current code checks docs_sync_max_open_tasks but never docs_sync_max_per_cycle. Add a per-call counter that stops creating tasks after docs_sync_max_per_cycle originations in the current release-publish call, while keeping the existing rolling cap. Update tests to cover this path. Do not modify task.py, release_proposal.py, config, or compose files.