### PR TITLE
fix(orchestrator): stop auditor alert-spawn rotation — ack as auditor on dispatch

### DIFF
--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -13578,22 +13578,32 @@ Never `commit`, never write code, never run `git`. PMs coordinate.
         Monitors: quality alert notifications + scheduled periodic sweeps
         Spawns: auditor
         """
-        alerts = await self._fetch_notifications(client, "alert")
-
-        for alert in alerts:
-            targets = alert.get("to_agents", [])
-            # Resolve UUIDs to slugs and check if auditor is a target
-            target_slugs = [self._resolve_agent_slug(str(t)) for t in targets]
-            if "auditor" in target_slugs and not self._is_agent_active("auditor"):
-                if self._notification_spawn_cooled("auditor", alert.get("id")):
-                    continue
-                await self.spawn_agent(
-                    agent_id="auditor",
-                    initial_prompt=self._build_audit_prompt(alert),
-                    spawned_by="_dispatch_audit_work",
-                )
-                self._last_audit_spawn_at = datetime.now(UTC)
-                return
+        # Alert path: dispatch the auditor ONCE per alert targeting it that the
+        # auditor has not observed yet. The auditor is read-only (no ack verb)
+        # and auditor_triage never acks, so under the old system-wide fetch
+        # (every not-fully-acked alert) a stale rework alert stayed pending
+        # forever and the per-alert cooldown only paced a rotation that
+        # respawned the auditor every ~3 min. Fetching the auditor's own
+        # not-yet-acked-by-me view and acking on dispatch makes each alert a
+        # one-shot, DB-persistent — the rotation cannot restart on a tick.
+        if not self._is_agent_active("auditor"):
+            alert = await self._next_unobserved_audit_alert(client)
+            if alert is not None:
+                alert_id = str(alert["id"])
+                if not self._notification_spawn_cooled("auditor", alert_id):
+                    await self.spawn_agent(
+                        agent_id="auditor",
+                        initial_prompt=self._build_audit_prompt(
+                            {
+                                "subject": alert.get("subject", ""),
+                                "body": alert.get("body", ""),
+                            }
+                        ),
+                        spawned_by="_dispatch_audit_work",
+                    )
+                    await self._ack_alert_as_auditor(client, alert_id)
+                    self._last_audit_spawn_at = datetime.now(UTC)
+                    return
 
         # Scheduled periodic audit sweep. Reuse the notification cooldown
         # pattern with a sentinel key as a one-tick breaker so a single
@@ -13626,6 +13636,68 @@ Never `commit`, never write code, never run `git`. PMs coordinate.
         if last is None:
             return False
         return (datetime.now(UTC) - last).total_seconds() < interval
+
+    async def _next_unobserved_audit_alert(
+        self, client: httpx.AsyncClient
+    ) -> dict[str, Any] | None:
+        """Newest ALERT targeting the auditor that the auditor has not acked.
+
+        Fetches the auditor's OWN pending-ack view: ``GET /notifications`` authed
+        as the auditor routes through ``list_for_agent``, which filters
+        ``acked_by`` for the auditor — not the system-wide "not fully acked"
+        view ``list_system_notifications`` returns. The auditor is read-only (no
+        ack verb) and ``auditor_triage`` never acks, so under the system view a
+        stale rework alert stayed pending forever (the CEO hadn't acked either)
+        and the per-alert cooldown only paced a rotation that respawned the
+        auditor every ~3 min. The auditor's own view excludes alerts it has
+        already observed — even ones the CEO has not acked yet — so each alert
+        is a one-shot, not a rotation source. Authed as the auditor (not the
+        system identity) so the route selects the per-recipient view.
+        """
+        auditor_uuid = AGENT_UUIDS.get("auditor")
+        if not auditor_uuid:
+            return None
+        try:
+            resp = await client.get(
+                f"{self._api_url}/notifications",
+                params={"type_filter": "alert", "pending_ack_only": "true"},
+                headers=_agent_api_headers(auditor_uuid, "auditor"),
+            )
+            if resp.status_code == http_status.HTTP_200_OK:
+                items = resp.json().get("items", [])
+                return items[0] if items else None
+        except Exception as e:
+            logger.error("Fetch unobserved audit alert failed", error=str(e))
+        return None
+
+    async def _ack_alert_as_auditor(
+        self, client: httpx.AsyncClient, notification_id: str
+    ) -> None:
+        """Acknowledge an alert as the auditor on dispatch (HTTP, loop-safe).
+
+        The spawn IS the auditor's observation; the auditor has no ack verb
+        (read-only), so the orchestrator acks on its behalf via the API authed
+        as the auditor. This is the terminal one-shot response that clears the
+        alert from the auditor's pending view so the next tick cannot respawn
+        on the same alert. Best-effort: a failed ack degrades to the per-alert
+        cooldown guarding the next tick — it never blocks the dispatch.
+        """
+        auditor_uuid = AGENT_UUIDS.get("auditor")
+        if not auditor_uuid:
+            return
+        try:
+            resp = await client.post(
+                f"{self._api_url}/notifications/{notification_id}/ack",
+                headers=_agent_api_headers(auditor_uuid, "auditor"),
+            )
+            if resp.status_code != http_status.HTTP_200_OK:
+                logger.warning(
+                    "Ack audit alert as auditor failed",
+                    notification_id=notification_id,
+                    status=resp.status_code,
+                )
+        except Exception as e:
+            logger.warning("Ack audit alert as auditor failed", error=str(e))
 
     async def _has_recent_delivery_activity(
         self,

--- a/tests/e2e_smoke/test_auditor_triggers.py
+++ b/tests/e2e_smoke/test_auditor_triggers.py
@@ -228,3 +228,30 @@ def test_reactive_alert_producer_spawns_auditor(
     prompt = call.kwargs["initial_prompt"]
     assert "QUALITY ALERT" in prompt
     assert "missing edge-case coverage" in prompt
+
+    # Rotation-stopper: dispatch acks the alert as the auditor (the auditor is
+    # read-only, no ack verb), so the auditor's pending-ack view no longer
+    # returns it and the next tick cannot respawn on this same alert. Without
+    # this ack the per-alert cooldown only paced a rotation through every
+    # stale not-fully-acked alert — the loop being fixed.
+    async def _acked_by_auditor(session: AsyncSession) -> bool:
+        from roboco.db.tables import NotificationTable
+        from sqlalchemy import select
+
+        row = (
+            (
+                await session.execute(
+                    select(NotificationTable).where(
+                        NotificationTable.related_task_id == task_id,
+                        NotificationTable.type == NotificationType.ALERT,
+                    )
+                )
+            )
+            .scalars()
+            .one()
+        )
+        return auditor_id in row.acked_by
+
+    assert stack.run_db(_acked_by_auditor), (
+        "alert not acked as auditor after dispatch — rotation not stopped"
+    )

--- a/tests/e2e_smoke/test_vault_v2.py
+++ b/tests/e2e_smoke/test_vault_v2.py
@@ -47,7 +47,7 @@ from roboco.services.vault_kb_engine import VaultKBEngine
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
     from tests.e2e_smoke.harness import E2EStack
 
 _PROJECT_SLUG = "vault-e2e-proj"
@@ -116,13 +116,25 @@ def _arm_vault(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     return vault
 
 
-def _fresh_factory() -> async_sessionmaker[AsyncSession]:
-    """The app's lazy factory, rebound to THIS test's loop (M1 posture)."""
-    from roboco.db import base as db_base
+def _fresh_factory(
+    db_url: str,
+) -> tuple[async_sessionmaker[AsyncSession], AsyncEngine]:
+    """A PRIVATE engine bound to THIS test's loop — not the app's shared _DbHolder.
 
-    db_base._DbHolder.engine = None
-    db_base._DbHolder.session_factory = None
-    return db_base.get_session_factory()
+    The create/janitor seams use only the passed session (``assemble_task_note_data``
+    / ``get_project_service`` / ``VaultJanitor`` never call ``get_session_factory``),
+    so a private engine against the same e2e DB exercises the real wiring without
+    sharing a connection pool with the uvicorn server thread. A lingering app
+    handler on the server's loop checking out a connection from a shared engine
+    is what flaked this suite ~1/50 in CI: asyncpg's pool then handed a following
+    test a connection created on the server's loop, awaited on the test's loop →
+    ``RuntimeError: Future ... attached to a different loop``. A private engine
+    the app can't reach keeps its pool loop-pure. Caller disposes the engine.
+    """
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(db_url)
+    return async_sessionmaker(engine, expire_on_commit=False), engine
 
 
 # ---------------------------------------------------------------------------
@@ -139,10 +151,8 @@ async def test_create_seam_materializes_note_flag_on_and_off(
     """Real ``TaskService.create`` against the e2e DB: with the vault armed
     the note appears (status frontmatter + placeholder narrative); with the
     flag off a second create writes nothing new."""
-    from roboco.db import base as db_base
-
     vault = _arm_vault(monkeypatch, tmp_path)
-    factory = _fresh_factory()
+    factory, engine = _fresh_factory(e2e_stack.db_url)
     try:
         async with factory() as session:
             created_by = await _seed_system_agent(session)
@@ -168,7 +178,7 @@ async def test_create_seam_materializes_note_flag_on_and_off(
             await session.commit()
             assert len(list(vault.rglob("*.md"))) == 1  # nothing new
     finally:
-        await db_base.close_db()
+        await engine.dispose()
 
 
 # ---------------------------------------------------------------------------
@@ -226,12 +236,10 @@ async def test_janitor_cycle_reprojects_archives_and_persists_state(
     re-projects into Tasks/, the old terminal one lands in Archive/<year>/,
     the state file carries last_sweep + archive_watermark, and the returned
     counts match what was actually done. No vault code is mocked."""
-    from roboco.db import base as db_base
-
     vault = _arm_vault(monkeypatch, tmp_path)
     monkeypatch.setattr(settings, "vault_archive_days", 30)
     monkeypatch.setattr(settings, "vault_report_enabled", False)
-    factory = _fresh_factory()
+    factory, engine = _fresh_factory(e2e_stack.db_url)
     try:
         async with factory() as session:
             created_by = await _seed_system_agent(session)
@@ -266,7 +274,7 @@ async def test_janitor_cycle_reprojects_archives_and_persists_state(
         assert datetime.fromisoformat(state["last_sweep"]).tzinfo is not None
         assert datetime.fromisoformat(state["archive_watermark"]).tzinfo is not None
     finally:
-        await db_base.close_db()
+        await engine.dispose()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/runtime/test_scheduled_audit_trigger.py
+++ b/tests/unit/runtime/test_scheduled_audit_trigger.py
@@ -191,7 +191,9 @@ async def test_reactive_alert_acks_so_it_cannot_rotate(
     assert spawn_mock.await_count == 1  # not respawned on tick 2
     assert ack_mock.await_count == 1
     # acked as the auditor saw it: (client, alert_id)
-    assert ack_mock.await_args.args[1] == alert_id
+    ack_call = ack_mock.await_args
+    assert ack_call is not None
+    assert ack_call.args[1] == alert_id
 
 
 @pytest.mark.anyio

--- a/tests/unit/runtime/test_scheduled_audit_trigger.py
+++ b/tests/unit/runtime/test_scheduled_audit_trigger.py
@@ -26,10 +26,13 @@ def orch() -> AgentOrchestrator:
 async def _run_dispatch(
     orch: AgentOrchestrator, *, tasks: list[dict] | None = None
 ) -> MagicMock:
-    """Run _dispatch_audit_work with notifications empty and return the spawn mock."""
+    """Run _dispatch_audit_work with no unobserved alerts and return the spawn mock."""
     client = MagicMock()
     with (
-        patch.object(orch, "_fetch_notifications", new=AsyncMock(return_value=[])),
+        patch.object(
+            orch, "_next_unobserved_audit_alert", new=AsyncMock(return_value=None)
+        ),
+        patch.object(orch, "_ack_alert_as_auditor", new=AsyncMock()),
         patch.object(orch, "_fetch_tasks", new=AsyncMock(return_value=tasks or [])),
         patch.object(orch, "_is_agent_active", return_value=False),
         patch.object(orch, "spawn_agent", new=AsyncMock()) as spawn_mock,
@@ -111,7 +114,10 @@ async def test_breaker_skips_when_auditor_active(orch: AgentOrchestrator) -> Non
     with (
         patch.object(settings, "audit_interval_seconds", 21600),
         patch("roboco.runtime.orchestrator.datetime", wraps=datetime) as dt_mock,
-        patch.object(orch, "_fetch_notifications", new=AsyncMock(return_value=[])),
+        patch.object(
+            orch, "_next_unobserved_audit_alert", new=AsyncMock(return_value=None)
+        ),
+        patch.object(orch, "_ack_alert_as_auditor", new=AsyncMock()),
         patch.object(orch, "_fetch_tasks", new=AsyncMock(return_value=[])),
         patch.object(orch, "_is_agent_active", return_value=True),
         patch.object(orch, "spawn_agent", new=AsyncMock()) as spawn_mock,
@@ -129,8 +135,7 @@ async def test_reactive_alert_stamps_last_spawn_and_blocks_scheduled(
     """A reactive alert spawn records _last_audit_spawn_at and returns early."""
     client = MagicMock()
     alert = {
-        "id": "a1",
-        "to_agents": ["auditor"],
+        "id": "11111111-1111-1111-1111-111111111111",
         "subject": "Coverage gap",
         "body": "Test",
     }
@@ -138,7 +143,10 @@ async def test_reactive_alert_stamps_last_spawn_and_blocks_scheduled(
     with (
         patch.object(settings, "audit_interval_seconds", 21600),
         patch("roboco.runtime.orchestrator.datetime", wraps=datetime) as dt_mock,
-        patch.object(orch, "_fetch_notifications", new=AsyncMock(return_value=[alert])),
+        patch.object(
+            orch, "_next_unobserved_audit_alert", new=AsyncMock(return_value=alert)
+        ),
+        patch.object(orch, "_ack_alert_as_auditor", new=AsyncMock()),
         patch.object(orch, "_fetch_tasks", new=AsyncMock(return_value=[])),
         patch.object(orch, "_is_agent_active", return_value=False),
         patch.object(orch, "spawn_agent", new=AsyncMock()) as spawn_mock,
@@ -147,6 +155,43 @@ async def test_reactive_alert_stamps_last_spawn_and_blocks_scheduled(
         await orch._dispatch_audit_work(client)
     assert spawn_mock.await_count == 1
     assert orch._last_audit_spawn_at == now
+
+
+@pytest.mark.anyio
+async def test_reactive_alert_acks_so_it_cannot_rotate(
+    orch: AgentOrchestrator,
+) -> None:
+    """The alert is acked as the auditor on dispatch, so the next tick —
+    which would otherwise re-fetch the same stale alert and respawn — finds
+    no unobserved alert and falls through to the scheduled path (blocked by
+    the just-stamped _last_audit_spawn_at). This is the rotation-stopper.
+    """
+    client = MagicMock()
+    alert_id = "22222222-2222-2222-2222-222222222222"
+    alert = {
+        "id": alert_id,
+        "subject": "Rework alert",
+        "body": "Task entered needs_revision",
+    }
+    now = datetime.now(UTC)
+    ack_mock = AsyncMock()
+    fetch_mock = AsyncMock(side_effect=[alert, None])
+    with (
+        patch.object(settings, "audit_interval_seconds", 21600),
+        patch("roboco.runtime.orchestrator.datetime", wraps=datetime) as dt_mock,
+        patch.object(orch, "_next_unobserved_audit_alert", new=fetch_mock),
+        patch.object(orch, "_ack_alert_as_auditor", new=ack_mock),
+        patch.object(orch, "_fetch_tasks", new=AsyncMock(return_value=[])),
+        patch.object(orch, "_is_agent_active", return_value=False),
+        patch.object(orch, "spawn_agent", new=AsyncMock()) as spawn_mock,
+    ):
+        dt_mock.now.return_value = now
+        await orch._dispatch_audit_work(client)  # tick 1: alert -> spawn + ack
+        await orch._dispatch_audit_work(client)  # tick 2: no alert -> scheduled
+    assert spawn_mock.await_count == 1  # not respawned on tick 2
+    assert ack_mock.await_count == 1
+    # acked as the auditor saw it: (client, alert_id)
+    assert ack_mock.await_args.args[1] == alert_id
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Root cause

The auditor respawned every ~3 min on the same stale rework alerts. PR #499's per-alert cooldown was a **damper, not a fix**.

`_dispatch_audit_work`'s alert path fetched the **system-wide "not fully acked" view** (`list_system_notifications` via `GET /notifications` authed as the `system` identity). But:
- The auditor is **read-only** — its verb surface is `note(scope=reflect)` + `evidence` only, **no ack verb**.
- `auditor_triage` (the board triage path) never acks either.

So once a rework alert was created, the **CEO was the only party who could clear it from the system view**, and the CEO hadn't acked. The per-alert cooldown only paced a rotation through the N un-acked alerts — each tick a different stale alert passed the cooldown and respawned the auditor. Live evidence: 6 un-acked "Rework alert" rows targeting the auditor (from 2026-07-13 `needs_revision` transitions), all `acked_at = {}`.

## Fix

Fetch the **auditor's OWN pending-ack view** and **ack the alert as the auditor on dispatch**:

- `_next_unobserved_audit_alert` → `GET /notifications` **authed as the auditor** (not `system`), so the route selects `list_for_agent`, which filters `acked_by` for the auditor. An alert the auditor already observed — even one the CEO hasn't acked — is excluded.
- `_ack_alert_as_auditor` → `POST /notifications/{id}/ack` authed as the auditor, on dispatch. The spawn **IS** the auditor's observation; the orchestrator acks on its behalf (it has no ack verb). This clears the alert from the auditor's pending view, so the next tick cannot respawn on the same alert.

Each alert is now a **one-shot, DB-persistent** — the rotation cannot restart on a tick.

### Why HTTP, not DB-direct

DB-direct via `get_session_factory()` would reuse the app's event-loop-bound asyncpg engine. In **production** the orchestrator shares the app's loop so that's fine, but the **e2e harness** runs `_dispatch_audit_work` in its own `asyncio.run` loop, away from the uvicorn server's loop → cross-loop `Future attached to a different loop` error (the first attempt failed exactly this way). HTTP is loop-agnostic and reuses the existing `_agent_api_headers` pattern (same shape as the cell-PM auto-submit self-call).

## Tests

- `tests/unit/runtime/test_scheduled_audit_trigger.py`: updated the reactive tests to the new fetch/ack helper signatures; added `test_reactive_alert_acks_so_it_cannot_rotate` (tick 1 spawns+acks, tick 2 finds no unobserved alert → scheduled path blocked by the just-stamped `_last_audit_spawn_at` → no respawn).
- `tests/e2e_smoke/test_auditor_triggers.py`: added an assertion that the alert is in `acked_by` for the auditor **after dispatch** — the rotation-stopper itself, not just the spawn.

Gate: ruff format + check clean, mypy clean, 864 runtime/notification unit tests pass, both auditor e2e smokes pass.