### PR TITLE
feat(rag): auto-index docs/map into the KB (roboco_kb_search-able)

### DIFF
--- a/roboco/services/optimal.py
+++ b/roboco/services/optimal.py
@@ -361,8 +361,10 @@ class OptimalService:
             )
             return None
 
-        # Directories to auto-index (RAG-optimized docs only)
-        auto_index_dirs = ["rag"]
+        # Directories to auto-index (RAG-optimized docs only). docs/rag is the
+        # agent-facing RAG corpus; docs/map is the agent-facing exhaustive
+        # codebase map — indexing it makes the map roboco_kb_search-able.
+        auto_index_dirs = ["rag", "map"]
 
         for subdir in auto_index_dirs:
             target_dir = docs_root / subdir

--- a/tests/unit/services/test_optimal_auto_index_map.py
+++ b/tests/unit/services/test_optimal_auto_index_map.py
@@ -1,0 +1,32 @@
+"""docs/map is auto-indexed alongside docs/rag.
+
+docs/map is the agent-facing exhaustive codebase map (CLAUDE.md); folding it
+into OptimalService._auto_index_docs's auto_index_dirs makes it
+roboco_kb_search-able. _index_docs_directory is generic (rglob *.md, route
+only the ``standards`` subdir to the standards indexer), so no map-specific
+branch is needed — every docs/map/*.md rides index_documentation like docs/rag.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from roboco.services.optimal import IndexingReport, OptimalService
+
+
+@pytest.mark.asyncio
+async def test_auto_index_docs_includes_map_subdir() -> None:
+    """_auto_index_docs calls _index_docs_directory once per auto_index_dirs
+    entry that exists under the resolved docs root — and docs/map exists in
+    this repo, so the map call must fire. The subdir name is the 2nd positional
+    arg (target_dir, name, _force=force)."""
+    svc = object.__new__(OptimalService)
+    mock = AsyncMock(return_value=IndexingReport(index_type="docs/x"))
+
+    with patch.object(svc, "_index_docs_directory", new=mock):
+        await svc._auto_index_docs()
+
+    names = [c.args[1] for c in mock.call_args_list]
+    assert "rag" in names
+    assert "map" in names


### PR DESCRIPTION
## What

`docs/map/` is the agent-facing exhaustive codebase map (CLAUDE.md) but was never RAG-indexed — only `docs/rag/` was. Add it to `OptimalService._auto_index_docs`'s `auto_index_dirs` (optimal.py:365) so every `docs/map/*.md` rides `index_documentation` and becomes `roboco_kb_search`-able.

`_index_docs_directory` is generic (rglob `*.md`, route only the `standards` subdir to the standards indexer), so no map-specific branch is needed — map files index exactly like rag files, with `report.index_type = "docs/map"`.

## Tests

`tests/unit/services/test_optimal_auto_index_map.py` — `_auto_index_docs` calls `_index_docs_directory` for both `rag` and `map` subdirs under the resolved docs root.

## Gate

`ROBOCO_TEST_DB_PORT=55432 ROBOCO_TEST_DB_USER=renzof make quality` → all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)