### PR TITLE
fix: compose/.env drift — twin resync + guard, cloud-auth passthrough, registry reconciliation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,12 +5,20 @@
 #
 # NOTE: No API keys needed for agents - they use your Claude Code authentication.
 # Run `claude` on the host to authenticate before starting RoboCo.
+#
+# Covers all three deploy shapes: local dev (plain `uv run` / `make dev`),
+# docker-compose.yml / .yaml (build-from-source, the NAS deploy — the two
+# files are kept byte-identical, see Makefile's `compose-sync` gate), and
+# docker-compose.registry.yml (pre-built, pull-and-run). Every var a compose
+# file references is listed below; unreferenced vars have no effect on that
+# deploy shape even if set.
 
 # =============================================================================
-# Docker Deployment (NAS/Server)
+# Docker Deployment (NAS/Server) — host paths for Docker-in-Docker
 # =============================================================================
-# These are REQUIRED when running via docker compose on a NAS/server.
-# They tell the orchestrator container where to find files on the HOST.
+# These are REQUIRED when running via docker compose on a NAS/server. They
+# tell the orchestrator container where to find files on the HOST (must be
+# ABSOLUTE paths — the orchestrator bind-mounts them into spawned agents).
 
 # Path to the project on the host (absolute path)
 # ROBOCO_HOST_PROJECT_DIR=/volume1/roboco
@@ -20,6 +28,19 @@
 
 # Claude auth directory to mount into orchestrator
 # CLAUDE_AUTH_DIR=~/.claude
+
+# Host dir holding the SuperGrok auth (~/.grok) for Grok-CLI agents. Read-write:
+# the orchestrator auto-refreshes the ~6h token in place. Run `grok login` once
+# on the host first.
+# ROBOCO_HOST_GROK_DIR=/home/youruser/.grok
+
+# Host path mirroring ROBOCO_DATA_DIR (see below), used when the orchestrator
+# needs the HOST-side path for a bind mount it hands to a spawned container.
+# ROBOCO_HOST_DATA_DIR=/volume1/roboco/data
+
+# Public base URL for commit-trailer links (e.g. LAN IP or domain) — default
+# 127.0.0.1 produces unusable links in commit message bodies.
+# ROBOCO_PUBLIC_BASE_URL=http://localhost:8000
 
 # =============================================================================
 # Container Images (docker-compose.registry.yml — pre-built deployment)
@@ -83,6 +104,10 @@ ROBOCO_LOCAL_LLM_BASE_URL=http://localhost:11434/v1
 ROBOCO_LOCAL_LLM_MODEL=glm-5.2:cloud
 ROBOCO_DEFAULT_EMBEDDING_MODEL=qwen3-embedding:0.6b
 
+# Ollama Cloud API key (optional) — only needed if you point ROBOCO_LOCAL_LLM_MODEL
+# at a *:cloud model and Ollama's own local auth isn't already configured.
+# OLLAMA_API_KEY=
+
 # =============================================================================
 # Grok (xAI) Provider — optional
 # =============================================================================
@@ -90,11 +115,9 @@ ROBOCO_DEFAULT_EMBEDDING_MODEL=qwen3-embedding:0.6b
 # SuperGrok subscription, instead of Claude Code. No metered xAI API key is used:
 # the CLI authenticates from a mounted ~/.grok/auth.json — run `grok login` once
 # on the host (auth.json auto-refreshes). Every var below is optional.
-
-# Host dir holding the SuperGrok auth (one canonical var). The compose mounts it
-# into the orchestrator at the same path, and the orchestrator hands that path to
-# each Grok agent's auth.json bind — so it must be the real host ~/.grok.
-# ROBOCO_HOST_GROK_DIR=/home/youruser/.grok
+# (ROBOCO_HOST_GROK_DIR is set above, under Docker Deployment — same var, both
+# compose files mount it into the orchestrator AND hand the same host path to
+# each Grok agent's own bind.)
 
 # Image the orchestrator spawns for Grok agents, and the CLI model id.
 # ROBOCO_GROK_AGENT_IMAGE=roboco-agent-grok:latest
@@ -147,15 +170,24 @@ ROBOCO_AGENT_AUTH_REQUIRED=false
 # it is itself a valid CEO credential that would bypass the login page.
 ROBOCO_PANEL_AGENT_TOKEN=
 
+# DB network isolation: true when your compose topology puts postgres/redis on
+# a data-only network unreachable from agent containers (both docker-compose.yml
+# and docker-compose.registry.yml ship this true — it must always travel with
+# that networks: topology; flip false only if you removed the isolation).
+ROBOCO_DB_NETWORK_ISOLATED=true
+
 # =============================================================================
-# Cloud auth (panel login) — ARMED ON in the NAS compose (v0.17.0)
+# Cloud auth (panel login, FastAPI Users) — off by default in config;
+# ARMED ON by default in docker-compose.yaml/.yml (NAS build compose), OFF by
+# default in docker-compose.registry.yml
 # =============================================================================
-# ROBOCO_CLOUD_AUTH_ENABLED defaults ON in docker-compose.yaml. When on, the
-# orchestrator REFUSES TO START unless ROBOCO_CLOUD_AUTH_SECRET is set, the
-# panel requires a login, and the session cookie is secure-only (needs TLS).
+# When on, the orchestrator REFUSES TO START unless ROBOCO_CLOUD_AUTH_SECRET is
+# set, the panel requires a login, and the session cookie is secure-only (needs
+# TLS in front of nginx).
+# ROBOCO_CLOUD_AUTH_ENABLED=false
 #
-# To TEST-DEPLOY before you've set up creds + TLS, turn it off for that run:
-#   ROBOCO_CLOUD_AUTH_ENABLED=false
+# To TEST-DEPLOY the NAS compose before you've set up creds + TLS, turn it off
+# for that run:  ROBOCO_CLOUD_AUTH_ENABLED=false
 #
 # To ARM it: set all three below + terminate TLS in front of nginx + leave
 # ROBOCO_PANEL_AGENT_TOKEN unset.
@@ -165,39 +197,103 @@ ROBOCO_PANEL_AGENT_TOKEN=
 # ROBOCO_CLOUD_AUTH_SECRET=
 # ROBOCO_CLOUD_AUTH_EMAIL=
 # ROBOCO_CLOUD_AUTH_PASSWORD=
+# Session cookie lifetime in seconds (default 30 days, sliding — an active
+# session never expires, only genuine inactivity past this window logs out).
+# ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE=2592000
 
 # =============================================================================
-# Model routing strictness — ARMED ON in the NAS compose (v0.17.0)
+# Telegram notifications bridge — V1 (outbound DMs) / V2 (inbound commands) /
+# V3 (Mini App sign-in) — all default OFF; inert without stored bot-token +
+# chat-id credentials (set via the panel, not env) regardless of these flags.
+# =============================================================================
+# ROBOCO_TELEGRAM_ENABLED=false
+# V2: inbound commands + actionable approve/reject buttons. Sub-switch on top
+# of ROBOCO_TELEGRAM_ENABLED above — arming this alone does nothing.
+# ROBOCO_TELEGRAM_INBOUND_ENABLED=false
+# V3: Telegram Mini App sign-in — mints a cloud-auth session cookie for the
+# CEO's phone. Requires ROBOCO_CLOUD_AUTH_ENABLED=true (startup fails loud
+# otherwise) AND a public HTTPS origin (Mini Apps only open over https).
+# ROBOCO_TELEGRAM_MINIAPP_ENABLED=false
+
+# =============================================================================
+# Model routing strictness
 # =============================================================================
 # Fail-closed routing: a spawn whose configured provider is disabled RAISES
-# instead of degrading to the legacy Claude path. Audit the model_assignments
-# table first (a stale row pointing at a disabled provider crashes that spawn).
-# To restore graceful degradation: ROBOCO_ROUTING_STRICT=false
+# instead of degrading to the legacy Claude path. Off (default) => graceful
+# degradation with a warning. Audit the model_assignments table before arming
+# (a stale row pointing at a disabled provider crashes that spawn).
+# ROBOCO_ROUTING_STRICT=false
+
+# Spawn preflight: refuse a non-gateway delivery role that would respawn
+# forever. Inert in practice (every real delivery role is gateway-enabled).
+# ROBOCO_SPAWN_PREFLIGHT_ENABLED=false
 
 # =============================================================================
-# X (Twitter) engine — ARMED ON in the NAS compose (v0.17.0)
+# fastapi-guard HTTP security layer — v0.16.0
 # =============================================================================
-# The engine drafts release posts + mention replies HELD for per-post CEO
-# approval; it is INERT until you store the four OAuth 1.0a secrets. Those are
-# NOT env vars — enter them in the panel (Settings -> X credentials, stored
-# Fernet-encrypted): API key, API secret, access token, access token secret,
-# from an X developer app with read+write user-context access.
-# Optional: pin the account's numeric user id (else it's resolved via /users/me).
-# ROBOCO_X_ACCOUNT_USER_ID=
+# Master switch + calibration knobs. Off by default; the NAS build compose
+# arms it in PASSIVE (log-only) mode for false-positive review before
+# enforcing. Not exposed on the panel's Feature Flags card (still calibrating).
+# ROBOCO_GUARD_ENABLED=false
+# Detect-and-log without blocking.
+# ROBOCO_GUARD_PASSIVE_MODE=true
+# Fail CLOSED on an internal guard error (true) vs fail open (false).
+# ROBOCO_GUARD_FAIL_SECURE=true
 
 # =============================================================================
-# Web research — ARMED ON in the NAS compose (v0.17.0)
+# Architectural conventions standard + agent-runtime toolchain matching
 # =============================================================================
-# Gives Board/PM roles web_search + web_fetch. INERT (empty results) without a
-# provider key — set one to make it live (Tavily / Brave / Exa, per your config).
-# ROBOCO_RESEARCH_API_KEY=
+# Conventions: gates where code lives per-project via .roboco/conventions.yml.
+# ROBOCO_CONVENTIONS_ENABLED=false
+# Toolchain match: provisions each agent workspace with the TARGET project's
+# Python (uv resolves requires-python) and blocks delivery when the suite
+# can't be executed, instead of passing on a source-only read.
+# ROBOCO_TOOLCHAIN_MATCH_ENABLED=false
 
 # =============================================================================
-# Auditor scheduled sweeps
+# External / internal PR review
 # =============================================================================
-# The orchestrator spawns the auditor on a periodic delivery-process review when
-# the interval has elapsed AND recent delivery activity exists. 0 disables.
-# ROBOCO_AUDIT_INTERVAL_SECONDS=21600
+# External: discovers inbound external/fork PRs; the PR reviewer posts one
+# READ-ONLY change-request (never runs contributor code).
+# ROBOCO_EXTERNAL_PR_ENABLED=false
+ROBOCO_EXTERNAL_PR_REQUIRE_HUMAN_CONFIRM=true
+# ROBOCO_EXTERNAL_PR_POLL_INTERVAL_SECONDS=300
+# ROBOCO_EXTERNAL_PR_AUTHOR_ALLOWLIST=["corey"]   # empty = every external PR
+# Internal: proactive review pass over RoboCo's own internal PRs.
+# ROBOCO_INTERNAL_PR_ENABLED=false
+
+# =============================================================================
+# Self-healing CI loop (RoboCo watching its OWN repo)
+# =============================================================================
+# On red CI, notifies the CEO and (with originate on) opens a PENDING fix task
+# held for the CEO's Approve-&-Start — never self-deploys.
+# ROBOCO_SELF_HEAL_ENABLED=false
+# ROBOCO_SELF_HEAL_ORIGINATE_ENABLED=false
+# The registered project that IS RoboCo itself.
+# ROBOCO_SELF_HEAL_PROJECT_SLUG=roboco-api
+# Scopes the CI signal to one workflow file (RoboCo has several).
+# ROBOCO_SELF_HEAL_CI_WORKFLOW=ci.yml
+
+# =============================================================================
+# Multi-repo CI-watch / dependency-update bot / gated release manager /
+# organizational memory loop / board roadmap engine — all default OFF,
+# per-engine bounded + CEO-gated; toggle from Settings -> Feature Flags too.
+# =============================================================================
+# CI-watch: fan-out self-heal to every opted-in project (projects.ci_watch_enabled).
+# ROBOCO_CI_WATCH_ENABLED=false
+# Dep-update bot: weekly lockfile-diff probe -> "update dependencies" task, only
+# for projects with a dep_update_command set.
+# ROBOCO_DEP_UPDATE_ENABLED=false
+# Release manager: deterministic readiness sweep -> ONE release proposal HELD
+# for the CEO; the executor publishes only on CEO approval + green CI (reuses
+# ROBOCO_SELF_HEAL_PROJECT_SLUG as the RoboCo repo).
+# ROBOCO_RELEASE_MANAGER_ENABLED=false
+# Org-memory loop: distils a completion lesson + auto-injects relevant past
+# lessons/playbooks into each claim's briefing (local model only).
+# ROBOCO_ORG_MEMORY_ENABLED=false
+# Board roadmap engine: weekly, opens ONE held exploration task for the Product
+# Owner, who proposes a themed cycle of roadmap items for CEO per-item approval.
+# ROBOCO_ROADMAP_ENGINE_ENABLED=false
 
 # =============================================================================
 # Docs-divergence sync (release -> docs-update task)
@@ -210,6 +306,117 @@ ROBOCO_PANEL_AGENT_TOKEN=
 # ROBOCO_DOCS_SYNC_ENABLED=false
 # ROBOCO_DOCS_SYNC_MAX_OPEN_TASKS=3
 # ROBOCO_DOCS_SYNC_MAX_PER_CYCLE=1
+
+# =============================================================================
+# Sandboxed dev DB/Redis/Mongo (per-project opt-in via projects.sandbox_services)
+# =============================================================================
+# On-demand throwaway sibling containers per agent spawn, replacing the legacy
+# prod-creds gate-env injection for an opted-in project.
+# ROBOCO_SANDBOX_DB_ENABLED=false
+
+# =============================================================================
+# Strategy engine (proactive strategy signals)
+# =============================================================================
+# ROBOCO_STRATEGY_ENGINE_ENABLED=false
+
+# =============================================================================
+# Web research
+# =============================================================================
+# Gives Board/PM roles web_search + web_fetch. INERT (empty results) without a
+# provider key — set one to make it live (Tavily / Brave / Exa, per your config).
+# ROBOCO_RESEARCH_ENABLED=true
+# ROBOCO_RESEARCH_API_KEY=
+
+# =============================================================================
+# GitHub repository auto-provisioning (pitch -> approve -> auto-provision)
+# =============================================================================
+# The only place that CREATES GitHub repos. Inert without a stored token/org
+# regardless of this flag (set via the panel, not env).
+# ROBOCO_PROVISIONING_ENABLED=true
+
+# =============================================================================
+# Transcript pruning (retention maintenance)
+# =============================================================================
+# ROBOCO_TRANSCRIPT_PRUNE_ENABLED=true
+
+# =============================================================================
+# Auditor scheduled sweeps
+# =============================================================================
+# The orchestrator spawns the auditor on a periodic delivery-process review when
+# the interval has elapsed AND recent delivery activity exists. 0 disables.
+# ROBOCO_AUDIT_INTERVAL_SECONDS=21600
+
+# =============================================================================
+# Obsidian vault (org's human-readable memory palace, V1+V2)
+# =============================================================================
+# Both compose files default vault ON (ROBOCO_VAULT_PATH bind-mounted to
+# ${ROBOCO_DATA_DIR}/vault). Set false to disable materialization entirely.
+# ROBOCO_OBSIDIAN_VAULT_ENABLED=true
+# Root directory the vault materializes into INSIDE the container — must match
+# the compose bind mount target (/app/vault); do not change without also
+# editing the compose volume line.
+# ROBOCO_VAULT_PATH=/app/vault
+# Watches #roboco-tagged notes in the vault inbox -> board-review drafts.
+# ROBOCO_VAULT_INTAKE_ENABLED=true
+# Move old terminal tasks' notes into RoboCo/Archive/<year>/ during the weekly
+# drift-janitor sweep. 0 disables archival.
+# ROBOCO_VAULT_ARCHIVE_DAYS=30
+# Weekly org-report note (metrics/usage digest) + CEO notification.
+# ROBOCO_VAULT_REPORT_ENABLED=true
+# KB ingest: embeds the CEO's own RoboCo/Notes/ into the fleet-retrievable
+# corpus (roboco_kb_search, claim-time briefings). Off by default in the
+# registry compose; the NAS compose arms it true.
+# ROBOCO_VAULT_KB_ENABLED=false
+# Comma-separated vault-relative dirs to ingest (must not overlap a reserved
+# projection dir — Tasks/Journals/A2A/Agents/Archive/_meta/Reports/.obsidian).
+# ROBOCO_VAULT_KB_DIRS=RoboCo/Notes
+# Seconds between vault-KB ingest scan cycles.
+# ROBOCO_VAULT_KB_INTERVAL_SECONDS=900
+
+# =============================================================================
+# RoboCo video engine (bespoke motion-graphics videos)
+# =============================================================================
+# A UX/UI dev authors a HyperFrames video per release/spotlight/on-demand
+# trigger through the normal delivery lifecycle; nothing auto-posts — every
+# clip is held for CEO approval. Off by default; the NAS compose arms it.
+# ROBOCO_VIDEO_ENGINE_ENABLED=false
+# ROBOCO_VIDEO_ON_RELEASE=false
+# ROBOCO_VIDEO_ON_SPOTLIGHT=false
+
+# =============================================================================
+# MinIO object storage for rendered videos — NAS build compose only
+# =============================================================================
+# Decoupled, docker-managed durable copy of rendered MP4s alongside the local-
+# disk source of truth. Intentionally OMITTED from docker-compose.registry.yml
+# (NAS default-on, registry default-off — see minio-data volume + minio/
+# minio-init services in docker-compose.yml). Empty endpoint = disabled (the
+# media route falls back to local-disk FileResponse); the NAS compose hardcodes
+# the endpoint to the minio container, so only these four matter there:
+# ROBOCO_MINIO_ACCESS_KEY=minio
+# ROBOCO_MINIO_SECRET_KEY=minio123
+# ROBOCO_MINIO_BUCKET=roboco-video-renders
+# ROBOCO_MINIO_REGION=us-east-1
+
+# =============================================================================
+# Fable-mode (behavioral doctrine + turn-discipline/honesty/verification hooks)
+# =============================================================================
+# Off by default; the NAS compose arms it as the live test bed. Bundles the
+# ponytail build-laziness doctrine on the same flag.
+# ROBOCO_FABLE_MODE_ENABLED=false
+# lite | full | ultra — developer ladder intensity (bundled with fable-mode).
+# ROBOCO_PONYTAIL_INTENSITY=full
+
+# =============================================================================
+# X (Twitter) engine
+# =============================================================================
+# The engine drafts release posts + mention replies HELD for per-post CEO
+# approval; it is INERT until you store the four OAuth 1.0a secrets. Those are
+# NOT env vars — enter them in the panel (Settings -> X credentials, stored
+# Fernet-encrypted): API key, API secret, access token, access token secret,
+# from an X developer app with read+write user-context access.
+# ROBOCO_X_ENGINE_ENABLED=false
+# Optional: pin the account's numeric user id (else it's resolved via /users/me).
+# ROBOCO_X_ACCOUNT_USER_ID=
 
 # =============================================================================
 # CORS (comma-separated origins)

--- a/Makefile
+++ b/Makefile
@@ -264,9 +264,19 @@ security: bandit pip-audit
 # QUALITY GATES
 # =============================================================================
 
+# docker-compose.yaml and docker-compose.yml must stay byte-identical: Compose's
+# default file lookup prefers .yaml, so a bare `docker compose up` silently runs
+# whichever twin is stale. This has drifted before (see CHANGELOG's vault-mount
+# divergence) — this is the guard that catches it before it ships again.
+.PHONY: compose-sync
+compose-sync:
+	@cmp -s docker-compose.yml docker-compose.yaml || (echo "docker-compose.yaml has drifted from docker-compose.yml — copy .yml over .yaml" && exit 1)
+
 # Run every quality gate. Fails on any red. Use this as the merge gate.
 .PHONY: quality
 quality: sync
+	@echo "==> compose files in sync (.yaml == .yml)"
+	@$(MAKE) compose-sync
 	@echo "==> ruff format --check"
 	@uv run ruff format --check .
 	@echo "==> ruff check"

--- a/docker-compose.registry.yml
+++ b/docker-compose.registry.yml
@@ -22,6 +22,31 @@
 # NOTE: this file is the registry counterpart of docker-compose.yml — when you
 # add or change a service there, mirror it here. The infra services
 # (postgres/redis/ollama/nginx) are byte-identical to the build compose.
+#
+# Declared contract — intended deltas from docker-compose.yml (check drift
+# against THIS list, not against the build compose directly):
+#   - Image source: every roboco-built service pulls `image:` from
+#     ROBOCO_REGISTRY/ROBOCO_VERSION instead of `build:`-ing from source.
+#   - Agent image pre-pull one-shots + ROBOCO_AGENT_IMAGE_REGISTRY/_TAG exist
+#     only here — the build compose builds agent images on demand instead.
+#   - Feature-flag posture: every default-OFF subsystem is carried here at
+#     its OFF/config default (never omitted — an omitted var can't be armed
+#     via .env without hand-editing this file) so the published default
+#     stays conservative; the build compose arms most of them ON for the
+#     personal NAS deploy. ROBOCO_ROUTING_STRICT and the fastapi-guard trio
+#     (ROBOCO_GUARD_ENABLED/_PASSIVE_MODE/_FAIL_SECURE) are the exception:
+#     both are still mid-calibration on the personal deploy, so they're
+#     omitted entirely here rather than carried — their config defaults
+#     (graceful-degrade routing, guard off) are already the safe posture.
+#   - Host path defaults differ (/opt/roboco vs /volume1/roboco, ${HOME}
+#     instead of a hardcoded /home/renzof) — registry targets a generic host.
+#   - MinIO (object storage for rendered videos) is intentionally omitted —
+#     NAS default-on, registry default-off (see the comment near the
+#     orchestrator's MinIO env block below and docs/rag/architecture/
+#     minio-storage.md). No consumer requires it; the media route falls
+#     back to local-disk FileResponse when unconfigured.
+#   - The video-renders bind mount is commented out here (video engine ships
+#     OFF); uncomment alongside ROBOCO_VIDEO_ENGINE_ENABLED=true.
 # ============================================================================
 services:
   postgres:
@@ -346,6 +371,45 @@ services:
       ROBOCO_VIDEO_ENGINE_ENABLED: ${ROBOCO_VIDEO_ENGINE_ENABLED:-false}
       ROBOCO_VIDEO_ON_RELEASE: ${ROBOCO_VIDEO_ON_RELEASE:-false}
       ROBOCO_VIDEO_ON_SPOTLIGHT: ${ROBOCO_VIDEO_ON_SPOTLIGHT:-false}
+      # Toolchain matching + architectural conventions standard: default OFF
+      # in config; carried here at OFF (armed in the build compose) so a
+      # registry deploy can opt in via .env without hand-editing this file.
+      ROBOCO_TOOLCHAIN_MATCH_ENABLED: ${ROBOCO_TOOLCHAIN_MATCH_ENABLED:-false}
+      ROBOCO_CONVENTIONS_ENABLED: ${ROBOCO_CONVENTIONS_ENABLED:-false}
+      # Autonomy engines (CI-watch, dep-update bot, release manager, org-memory
+      # loop, X account, board roadmap engine) — default OFF, carried at OFF
+      # so the published default stays conservative; arm any via .env.
+      ROBOCO_CI_WATCH_ENABLED: ${ROBOCO_CI_WATCH_ENABLED:-false}
+      ROBOCO_DEP_UPDATE_ENABLED: ${ROBOCO_DEP_UPDATE_ENABLED:-false}
+      ROBOCO_RELEASE_MANAGER_ENABLED: ${ROBOCO_RELEASE_MANAGER_ENABLED:-false}
+      ROBOCO_ORG_MEMORY_ENABLED: ${ROBOCO_ORG_MEMORY_ENABLED:-false}
+      ROBOCO_X_ENGINE_ENABLED: ${ROBOCO_X_ENGINE_ENABLED:-false}
+      ROBOCO_ROADMAP_ENGINE_ENABLED: ${ROBOCO_ROADMAP_ENGINE_ENABLED:-false}
+      # Telegram notifications bridge V1/V2/V3 — default OFF; inert without
+      # stored bot-token + chat-id credentials regardless of these flags.
+      ROBOCO_TELEGRAM_ENABLED: ${ROBOCO_TELEGRAM_ENABLED:-false}
+      ROBOCO_TELEGRAM_INBOUND_ENABLED: ${ROBOCO_TELEGRAM_INBOUND_ENABLED:-false}
+      ROBOCO_TELEGRAM_MINIAPP_ENABLED: ${ROBOCO_TELEGRAM_MINIAPP_ENABLED:-false}
+      # Fable-mode (behavioral doctrine + turn-discipline hooks) and the
+      # sandboxed per-agent dev DB/Redis — both default OFF, conservative here.
+      ROBOCO_FABLE_MODE_ENABLED: ${ROBOCO_FABLE_MODE_ENABLED:-false}
+      ROBOCO_SANDBOX_DB_ENABLED: ${ROBOCO_SANDBOX_DB_ENABLED:-false}
+      # Strategy engine + internal PR review — both default OFF.
+      ROBOCO_STRATEGY_ENGINE_ENABLED: ${ROBOCO_STRATEGY_ENGINE_ENABLED:-false}
+      ROBOCO_INTERNAL_PR_ENABLED: ${ROBOCO_INTERNAL_PR_ENABLED:-false}
+      # Spawn preflight — inert in practice (every real delivery role is
+      # gateway-enabled); carried at OFF for parity with the build compose.
+      ROBOCO_SPAWN_PREFLIGHT_ENABLED: ${ROBOCO_SPAWN_PREFLIGHT_ENABLED:-false}
+      # Cloud auth (FastAPI Users): login-gates the panel/API when exposed
+      # beyond localhost. OFF by default (matches config default, unlike the
+      # build compose which arms it for the personal deploy). Set
+      # ROBOCO_CLOUD_AUTH_EMAIL/_PASSWORD/_SECRET in .env and terminate TLS
+      # before arming — startup fails loud if enabled without a secret.
+      ROBOCO_CLOUD_AUTH_ENABLED: ${ROBOCO_CLOUD_AUTH_ENABLED:-false}
+      ROBOCO_CLOUD_AUTH_EMAIL: ${ROBOCO_CLOUD_AUTH_EMAIL:-}
+      ROBOCO_CLOUD_AUTH_PASSWORD: ${ROBOCO_CLOUD_AUTH_PASSWORD:-}
+      ROBOCO_CLOUD_AUTH_SECRET: ${ROBOCO_CLOUD_AUTH_SECRET:-}
+      ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE: ${ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE:-2592000}
       # MinIO object storage for rendered videos is intentionally omitted from
       # this registry compose (NAS default-on, registry default-off — the
       # established pattern). The minio/minio-init services are absent here and

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
     container_name: roboco-ollama
     restart: unless-stopped
     environment:
-        OLLAMA_API_KEY: ${OLLAMA_API_KEY}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
     ports:
       - "11435:11434"
     volumes:
@@ -533,6 +533,19 @@ services:
       # + completion. Config default is OFF; not yet armed here (needs stored
       # bot-token + chat-id credentials regardless of this flag).
       ROBOCO_TELEGRAM_ENABLED: ${ROBOCO_TELEGRAM_ENABLED:-false}
+      # Telegram V2 — inbound commands + actionable approve/reject buttons.
+      # Armed here (sub-switch on top of the still-off ROBOCO_TELEGRAM_ENABLED
+      # above); the whole bridge stays inert until that flag AND credentials
+      # are both set, so arming this alone does nothing yet.
+      ROBOCO_TELEGRAM_INBOUND_ENABLED: ${ROBOCO_TELEGRAM_INBOUND_ENABLED:-true}
+      # Telegram Mini App sign-in: validates Telegram's signed WebApp initData
+      # and mints the same cloud-auth session cookie /api/auth/login issues,
+      # so the CEO's phone becomes an authenticated panel client. Requires
+      # ROBOCO_CLOUD_AUTH_ENABLED=true (startup fails loud otherwise) AND a
+      # public HTTPS origin (the cookie is secure-only, and Telegram itself
+      # only opens Mini Apps over https). Default OFF; not armed here — the
+      # operator flips it on once TLS + cloud-auth creds are both live.
+      ROBOCO_TELEGRAM_MINIAPP_ENABLED: ${ROBOCO_TELEGRAM_MINIAPP_ENABLED:-false}
       ROBOCO_OBSIDIAN_VAULT_ENABLED: ${ROBOCO_OBSIDIAN_VAULT_ENABLED:-true}
       ROBOCO_VAULT_PATH: ${ROBOCO_VAULT_PATH:-/app/vault}
       ROBOCO_VAULT_INTAKE_ENABLED: ${ROBOCO_VAULT_INTAKE_ENABLED:-true}
@@ -601,6 +614,13 @@ services:
       #     disabled RAISES instead of degrading. Audit model_assignments first
       #     (a stale row pointing at a disabled provider would crash that spawn).
       ROBOCO_CLOUD_AUTH_ENABLED: ${ROBOCO_CLOUD_AUTH_ENABLED:-true}
+      # .env values only reach the container when referenced here — without
+      # these lines the seeded login/secret never arrive and startup fails
+      # loud (ENABLED defaults true above).
+      ROBOCO_CLOUD_AUTH_EMAIL: ${ROBOCO_CLOUD_AUTH_EMAIL:-}
+      ROBOCO_CLOUD_AUTH_PASSWORD: ${ROBOCO_CLOUD_AUTH_PASSWORD:-}
+      ROBOCO_CLOUD_AUTH_SECRET: ${ROBOCO_CLOUD_AUTH_SECRET:-}
+      ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE: ${ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE:-2592000}
       ROBOCO_ROUTING_STRICT: ${ROBOCO_ROUTING_STRICT:-true}
       # Spawn preflight (token-opt Phase 3) — refuse a non-gateway delivery role
       # that would respawn forever. Default-OFF in config; ARMED here (inert in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
     container_name: roboco-ollama
     restart: unless-stopped
     environment:
-        OLLAMA_API_KEY: ${OLLAMA_API_KEY}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
     ports:
       - "11435:11434"
     volumes:
@@ -614,6 +614,13 @@ services:
       #     disabled RAISES instead of degrading. Audit model_assignments first
       #     (a stale row pointing at a disabled provider would crash that spawn).
       ROBOCO_CLOUD_AUTH_ENABLED: ${ROBOCO_CLOUD_AUTH_ENABLED:-true}
+      # .env values only reach the container when referenced here — without
+      # these lines the seeded login/secret never arrive and startup fails
+      # loud (ENABLED defaults true above).
+      ROBOCO_CLOUD_AUTH_EMAIL: ${ROBOCO_CLOUD_AUTH_EMAIL:-}
+      ROBOCO_CLOUD_AUTH_PASSWORD: ${ROBOCO_CLOUD_AUTH_PASSWORD:-}
+      ROBOCO_CLOUD_AUTH_SECRET: ${ROBOCO_CLOUD_AUTH_SECRET:-}
+      ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE: ${ROBOCO_CLOUD_AUTH_COOKIE_MAX_AGE:-2592000}
       ROBOCO_ROUTING_STRICT: ${ROBOCO_ROUTING_STRICT:-true}
       # Spawn preflight (token-opt Phase 3) — refuse a non-gateway delivery role
       # that would respawn forever. Default-OFF in config; ARMED here (inert in


### PR DESCRIPTION
CEO-reported drift, audited and fixed at the root. Four rots:

1. **The `.yaml` twin was stale and silently winning.** Docker Compose's lookup order prefers `docker-compose.yaml` over `.yml`, so a bare `docker compose up` ran the Jul-16 file — missing exactly the Telegram V2/V3 env wiring (13 lines). Resynced byte-identical, and `make quality` now opens with a `compose-sync` equality gate (verified it fires on injected drift) so this class — which previously broke the vault mount — cannot ship silently again.
2. **Cloud-auth env never reached the container** (latent boot-breaker): `docker-compose.yml` defaults `ROBOCO_CLOUD_AUTH_ENABLED=true` and its own comment tells operators to set EMAIL/PASSWORD/SECRET in `.env` — but none of those vars were referenced in the orchestrator's environment block, so `.env` values had zero effect and a fresh boot with documented defaults crashes on the fail-loud validator. All four vars wired through in both twins (+ registry with off-defaults).
3. **Registry compose reconciled against a declared contract.** Thirteen feature-flag families the `.yml` comments claim are "left OFF in registry" were entirely absent there (unarm-able via `.env` without editing the file) — all added with off/config defaults, incl. the Telegram trio. MinIO's absence verified INTENTIONAL (docs/rag/architecture/minio-storage.md documents NAS-on/registry-off; every consumer degrades gracefully) — the registry file now carries a header block enumerating every intended delta from `.yml`, so future drift is detectable against a stated contract.
4. **`.env.example` regenerated**: all 65 compose-referenced vars present (was missing ~50), grouped and commented per subsystem with secret-generation commands; still-accurate prose preserved. Grew 218 → ~330 lines.

Validation: `cmp` identical twins; `make compose-sync` green (and red on injected drift); all three compose files `config -q` clean with the two intentionally-required vars stubbed — zero errors, zero unset-variable warnings.

Follow-up flagged, not done here: CI's path triggers watch only `docker-compose.yml` — a change reaching only the twin/registry file wouldn't retrigger compose-relevant jobs.