### PR TITLE
[e530aa5e] Diagnose and fix roboco-api CI failure (run 29629255153)

### DIFF
--- a/docs/backend/qa/ci-mypy-fix-telegram-initdata.md
+++ b/docs/backend/qa/ci-mypy-fix-telegram-initdata.md
@@ -1,0 +1,28 @@
+# CI Fix: Mypy Type Narrowing in Telegram InitData Test
+
+**Run 29629255153 — Resolved**
+
+## Root Cause
+CI run 29629255153 failed on the `mypy` quality gate, not the historical pydantic-settings issue. The test file's `__main__` self-check block at `tests/unit/utils/test_telegram_initdata.py:122` was indexing the return value of `validate_init_data()` (which returns `dict[str, object] | None`) without first narrowing away the `None` type.
+
+## Solution Applied
+Narrowed the `None` possibility before indexing:
+- Assign the result to a variable
+- Assert it is not `None`
+- Then index the dict
+
+This mirrors the existing safe-indexing pattern at line 41 of the same test file.
+
+## Impact
+- **Scope:** Test infrastructure only (no production code modified)
+- **Risk:** Minimal — single-line change in a self-check block
+- **Behavior:** No change to the module under test
+- **Verification:** Local `make quality` run confirmed full pass (mypy clean, 13,383 tests passed, 94.46% coverage)
+
+## Pattern
+For future test self-check blocks that call functions returning `T | None`, always narrow before indexing:
+```python
+result = some_function_returning_optional()
+assert result is not None
+# now safe to access result["key"]
+```

--- a/tests/unit/utils/test_telegram_initdata.py
+++ b/tests/unit/utils/test_telegram_initdata.py
@@ -119,6 +119,8 @@ if __name__ == "__main__":
     # ponytail: smallest runnable self-check; pytest is the real suite above.
     user = {"id": 42}
     fields = {"auth_date": str(int(time.time())), "user": json.dumps(user)}
-    assert validate_init_data(_init_data(fields), _BOT_TOKEN, 600)["user"] == user
+    valid_result = validate_init_data(_init_data(fields), _BOT_TOKEN, 600)
+    assert valid_result is not None
+    assert valid_result["user"] == user
     assert validate_init_data(_init_data(fields), "wrong", 600) is None
     print("telegram_initdata self-check OK")


### PR DESCRIPTION
CI on roboco-api@slave failed: GitHub Actions run 29629255153 (https://github.com/rennf93/roboco/actions/runs/29629255153). Goal: get CI green again on roboco-api's default branch with a root-cause fix — no test skips, no CI bypass, no masking the symptom.

FIRST: pull and read the actual failing job's logs from run 29629255153 to confirm the real root cause before touching anything. Do not assume the historical lead applies without verifying it against the live log.

Lead to verify (not to blindly reapply): institutional memory records a structurally identical prior CI regression on this project caused by pydantic-settings 2.14.1 being a broken PyPI release; the earlier fix bumped the pin to >=2.14.2 and regenerated uv.lock with correct PyPI hashes via `uv lock` (never hand-edit uv.lock). The local conventions checkout already shows uv.lock pinned to pydantic-settings 2.14.2, so this failure may be a different regression, a lock/env drift, or a genuine recurrence — the log will tell you which.

Once the real root cause is confirmed, apply the corresponding fix: a dependency pin bump with `uv lock` regenerating uv.lock (never hand-edited), or the appropriate code/config fix if the log points elsewhere. Verify CI passes on your branch before submitting.