### PR TITLE
[467e263d] Diagnose CI run 29653535468 and fix the root cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Orchestrator API is no longer published on a routable host interface (GHSA-4f7g-w95g-5q2c).** Both deploy composes published the orchestrator's `:8000` on `0.0.0.0`, so anyone who could reach the host hit the control plane directly — bypassing nginx and, in the default header-trust posture (`ROBOCO_AGENT_AUTH_REQUIRED` unset, cloud auth off), reading/writing runtime settings and spoofing `X-Agent-Role: ceo` to spawn/stop agents with no credential. The publish is now bound to `127.0.0.1`; nginx reaches the API over the internal Docker network, so normal operation and on-host debugging are unchanged, while off-host access must go through nginx + cloud auth. The header-trust design itself is unchanged (it stays the deliberate local-no-login panel path); this closes the unintended off-host reachability that gave it teeth.
 
+### Fixed
+
+- **Python quality gate: restored green on roboco-api@slave (CI run 29653535468).** Two independent code-level bugs broke the 'Python quality gate' job, not a dependency pin (pydantic-settings was already correctly pinned at 2.14.2). ① `roboco/services/git.py`: `_delete_remote_branch_best_effort` was typed to return `bool` but its success path fell off the function end with no return statement, failing mypy's `missing-return-statement` check and silently returning `None` instead of the documented `True` — added the missing `return True`. ② `roboco/services/company_goals.py`: `CompanyGoalsService.upsert`'s six repetitive `if key in data: row.key = data[key]` branches pushed the module's average cyclomatic complexity past xenon's `--max-modules A` gate — refactored into a data-driven loop over a `_MUTABLE_FIELDS` tuple (behaviourally identical, now rank A). Verified by reproducing all three CI steps locally on the slave-branch worktree: `uv sync --extra dev`, `alembic upgrade head` (all 76 migrations apply cleanly), and `make quality` (13,510 tests, 94.56% coverage, all gates green).
+
 ## [0.25.0] - 2026-07-16
 
 ### Added

--- a/roboco/services/company_goals.py
+++ b/roboco/services/company_goals.py
@@ -24,6 +24,17 @@ if TYPE_CHECKING:
 # Canonical single-row marker — the charter is a singleton.
 SINGLETON_ID = UUID("00000000-0000-0000-0000-000000000000")
 
+# Charter fields ``upsert`` writes verbatim when present in the partial-update
+# payload (``updated_by`` is handled separately — it's not a charter field).
+_MUTABLE_FIELDS = (
+    "north_star",
+    "objectives",
+    "constraints",
+    "operating_policy",
+    "brand_voice",
+    "company_name",
+)
+
 _EMPTY: dict[str, Any] = {
     "north_star": "",
     "objectives": [],
@@ -57,18 +68,9 @@ class CompanyGoalsService(BaseService):
         if row is None:
             row = CompanyGoalsTable(id=SINGLETON_ID)
             self.session.add(row)
-        if "north_star" in data:
-            row.north_star = data["north_star"]
-        if "objectives" in data:
-            row.objectives = data["objectives"]
-        if "constraints" in data:
-            row.constraints = data["constraints"]
-        if "operating_policy" in data:
-            row.operating_policy = data["operating_policy"]
-        if "brand_voice" in data:
-            row.brand_voice = data["brand_voice"]
-        if "company_name" in data:
-            row.company_name = data["company_name"]
+        for field in _MUTABLE_FIELDS:
+            if field in data:
+                setattr(row, field, data[field])
         if updated_by is not None:
             row.updated_by = updated_by
         await self.session.flush()

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -3519,6 +3519,7 @@ class GitService(BaseService):
             await self._forge.delete_branch_ref(
                 RepoRef(owner, repo), git_token, branch, timeout=10.0
             )
+            return True
         except httpx.HTTPError:
             return False
 


### PR DESCRIPTION
The 'CI' GitHub Actions workflow on roboco-api@slave concluded 'failure' on run https://github.com/rennf93/roboco/actions/runs/29653535468. The workflow (.github/workflows/ci.yml) has one job, 'Python quality gate', which runs: `uv sync --extra dev`, then `alembic upgrade head`, then `make quality`. Path filters confine this entirely to backend surface (roboco/, agents/, alembic/, tests/, scripts/, docker/, docker-compose.yml, Makefile, pyproject.toml, uv.lock, alembic.ini, .github/workflows/ci.yml).

Context: commit 657018eb (2026-07-15, 'ci: run CI on slave pushes') recently wired this workflow to also run on pushes to the slave branch, which may be why the failure is newly surfacing there rather than on master. Institutional memory also records a prior, similarly-titled CI regression on this same project whose root cause was a broken pydantic-settings 2.14.1 patch release, fixed by bumping the pin to >=2.14.2 — check current dependency pins (pydantic-settings and any sibling packages) as a first-order hypothesis before assuming a code-level bug. Note: the be-pm workspace's own uv.lock already shows pydantic-settings==2.14.2, so this specific pin may already be fine on the branch you check out — don't assume the hypothesis is confirmed without verifying against the actual failing branch state.

Your job:
1. Pull the actual GitHub Actions log for run 29653535468 (or, if inaccessible, reproduce the three CI steps locally on the slave branch: `uv sync --extra dev`, `alembic upgrade head`, `make quality`) to identify the exact failing step — dependency install, alembic migration, or one of the checks inside `make quality` (ruff format/check, mypy, vulture, tests+coverage, xenon, bandit, audit).
2. Identify the precise root cause (a bad dependency pin, a migration issue, or a specific lint/type/test failure).
3. Apply the minimal fix for that root cause.
4. Record the identified root cause explicitly in this subtask's journal (a `note(scope='reflect', ...)` before `i_am_done` works well for this).
5. Ensure `make quality` passes locally before submitting for QA.