### PR TITLE
[f0f9bec4] CI-watch: fix the CI regression on roboco-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 - **Orchestrator API is no longer published on a routable host interface (GHSA-4f7g-w95g-5q2c).** Both deploy composes published the orchestrator's `:8000` on `0.0.0.0`, so anyone who could reach the host hit the control plane directly — bypassing nginx and, in the default header-trust posture (`ROBOCO_AGENT_AUTH_REQUIRED` unset, cloud auth off), reading/writing runtime settings and spoofing `X-Agent-Role: ceo` to spawn/stop agents with no credential. The publish is now bound to `127.0.0.1`; nginx reaches the API over the internal Docker network, so normal operation and on-host debugging are unchanged, while off-host access must go through nginx + cloud auth. The header-trust design itself is unchanged (it stays the deliberate local-no-login panel path); this closes the unintended off-host reachability that gave it teeth.
 
+### Fixed
+
+- **Python quality gate: restored green on roboco-api@slave (CI run 29653535468).** Two independent code-level bugs broke the 'Python quality gate' job, not a dependency pin (pydantic-settings was already correctly pinned at 2.14.2). ① `roboco/services/git.py`: `_delete_remote_branch_best_effort` was typed to return `bool` but its success path fell off the function end with no return statement, failing mypy's `missing-return-statement` check and silently returning `None` instead of the documented `True` — added the missing `return True`. ② `roboco/services/company_goals.py`: `CompanyGoalsService.upsert`'s six repetitive `if key in data: row.key = data[key]` branches pushed the module's average cyclomatic complexity past xenon's `--max-modules A` gate — refactored into a data-driven loop over a `_MUTABLE_FIELDS` tuple (behaviourally identical, now rank A). Verified by reproducing all three CI steps locally on the slave-branch worktree: `uv sync --extra dev`, `alembic upgrade head` (all 76 migrations apply cleanly), and `make quality` (13,510 tests, 94.56% coverage, all gates green).
+
 ## [0.25.0] - 2026-07-16
 
 ### Added

--- a/roboco/services/company_goals.py
+++ b/roboco/services/company_goals.py
@@ -24,6 +24,17 @@ if TYPE_CHECKING:
 # Canonical single-row marker — the charter is a singleton.
 SINGLETON_ID = UUID("00000000-0000-0000-0000-000000000000")
 
+# Charter fields ``upsert`` writes verbatim when present in the partial-update
+# payload (``updated_by`` is handled separately — it's not a charter field).
+_MUTABLE_FIELDS = (
+    "north_star",
+    "objectives",
+    "constraints",
+    "operating_policy",
+    "brand_voice",
+    "company_name",
+)
+
 _EMPTY: dict[str, Any] = {
     "north_star": "",
     "objectives": [],
@@ -57,18 +68,9 @@ class CompanyGoalsService(BaseService):
         if row is None:
             row = CompanyGoalsTable(id=SINGLETON_ID)
             self.session.add(row)
-        if "north_star" in data:
-            row.north_star = data["north_star"]
-        if "objectives" in data:
-            row.objectives = data["objectives"]
-        if "constraints" in data:
-            row.constraints = data["constraints"]
-        if "operating_policy" in data:
-            row.operating_policy = data["operating_policy"]
-        if "brand_voice" in data:
-            row.brand_voice = data["brand_voice"]
-        if "company_name" in data:
-            row.company_name = data["company_name"]
+        for field in _MUTABLE_FIELDS:
+            if field in data:
+                setattr(row, field, data[field])
         if updated_by is not None:
             row.updated_by = updated_by
         await self.session.flush()

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -3519,6 +3519,7 @@ class GitService(BaseService):
             await self._forge.delete_branch_ref(
                 RepoRef(owner, repo), git_token, branch, timeout=10.0
             )
+            return True
         except httpx.HTTPError:
             return False
 


### PR DESCRIPTION
This project's CI is red on its default branch.

CI on roboco-api@slave concluded 'failure' (CI)

Evidence: https://github.com/rennf93/roboco/actions/runs/29653535468

This is a Main-PM coordination root: decompose the fix and delegate the code work to a cell dev — the Main PM does not write the fix itself. This task was opened automatically by the CI-watch loop and is READY TO START NOW — no approval needed; plan the fix and delegate it. It still ships through the normal gates (QA, PR review, and the CEO's merge).