### PR TITLE
fix(panel): exempt /tg from the global 401→login redirect

### DIFF
--- a/panel/src/lib/__tests__/client.test.ts
+++ b/panel/src/lib/__tests__/client.test.ts
@@ -30,7 +30,7 @@ vi.mock("@/store/rate-limit-store", () => ({
 // ---------------------------------------------------------------------------
 // Import the function under test AFTER mocks are in place
 // ---------------------------------------------------------------------------
-import { getErrorMessage } from "@/lib/api/client";
+import { getErrorMessage, isTgSurfacePath } from "@/lib/api/client";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -210,5 +210,19 @@ describe("getErrorMessage — non-Axios fallbacks", () => {
     expect(getErrorMessage({ code: "SOME_CODE" })).toBe(
       "An unexpected error occurred",
     );
+  });
+});
+
+describe("isTgSurfacePath — the /tg login-redirect exemption", () => {
+  it("matches the cockpit root and subpaths", () => {
+    expect(isTgSurfacePath("/tg")).toBe(true);
+    expect(isTgSurfacePath("/tg/")).toBe(true);
+  });
+
+  it("does not match the dashboard or lookalike segments", () => {
+    expect(isTgSurfacePath("/overview")).toBe(false);
+    expect(isTgSurfacePath("/tgsomething")).toBe(false);
+    expect(isTgSurfacePath("/login")).toBe(false);
+    expect(isTgSurfacePath("/")).toBe(false);
   });
 });

--- a/panel/src/lib/api/client.ts
+++ b/panel/src/lib/api/client.ts
@@ -61,6 +61,16 @@ api.interceptors.request.use(
   },
 );
 
+/**
+ * The Telegram Mini App owns its auth UX: /tg signs in via initData and
+ * renders its own wall. Global mounts (the agent-roster sync) can 401 there
+ * before that sign-in lands — bouncing the webview to the password /login
+ * page it cannot complete would hijack the cockpit.
+ */
+export function isTgSurfacePath(pathname: string): boolean {
+  return /^\/tg(\/|$)/.test(pathname);
+}
+
 // A 401 only means "log in" when cloud auth is actually on. In header-trust /
 // secure mode (cloud auth off) a 401 is a misconfigured agent token, not a
 // missing session — bouncing to /login would dead-end on a page whose backend
@@ -68,6 +78,9 @@ api.interceptors.request.use(
 // doesn't re-enter this interceptor) and only redirect when cloud auth is on.
 async function redirectToLoginIfCloudAuth(): Promise<void> {
   if (typeof window === "undefined" || window.location.pathname === "/login") {
+    return;
+  }
+  if (isTgSurfacePath(window.location.pathname)) {
     return;
   }
   try {


### PR DESCRIPTION
## What

Live-debugged on the NAS tonight: opening the Mini App landed on the dashboard instead of the cockpit. nginx + orchestrator logs pinned the chain — `GET /tg` 200 → the globally-mounted `AgentRosterSync` fires `GET /api/agents` pre-auth → cloud-auth 401 → `redirectToLoginIfCloudAuth` bounces the webview to `/login` (referer `/tg` in the log) → the existing session cookie lands it on `/overview`.

The `(tg)` surface owns its auth UX — initData sign-in plus its own open-from-Telegram wall — so the global 401→login redirect now exempts it via an exported `isTgSurfacePath` predicate (segment-anchored, per the proxy-matcher lesson). Roster queries that 401 pre-auth simply retry after the initData session lands.

## Verification

- `client.test.ts`: 20 passed (6 new predicate cases incl. `/tgsomething` non-match). `pnpm typecheck` clean, lint 0 errors.
- Root-cause evidence in the session log: three `/tg` webview loads with zero webapp-auth POSTs and `/api/agents` 401s at the same second, followed by `GET /login` with referer `/tg`.