### PR TITLE
[68e1e4db] Video: release 0.26.0

### DIFF
--- a/motion/README.md
+++ b/motion/README.md
@@ -147,3 +147,56 @@ Same schema as `release-recap`: one `captions.json` next to the HTML with self-v
 ### Smoke-test invariants
 
 `release-0.25.0.test.js` extends the panel-demo register checks: both `vertical.html` (1080×1920) and `square.html` (1080×1080) parse with `data-duration="40"` and the HyperFrames params, the kit CSS/JS wiring is present, **four** feature cards each carry a progress-to-completed pill swap and include the "Notification bell" text, the cursor and toast appear, the outro shows "roboco.tech", no external scripts are loaded, and no em dashes slip into on-screen copy or captions.
+
+## Release-specific example: `release-0.26.0`
+
+`compositions/release-0.26.0/` is a panel-demo kit clip for the RoboCo v0.26.0 release, mirroring the structure and pacing of release-0.25.0. It builds on the `kit/` register instead of the text-card style, so it has no `theme.css` of its own.
+
+The composition runs **40 seconds** total. The story is "the control plane gets a lock" (the hero tagline): the CEO types "The control plane gets a lock" into the panel intake at 3.6s, then four shipped security/feature cards enter the kanban column one per scene and flip from `in progress` to `completed`:
+
+1. **Off the public net** — enters at 5.0s, completes at 6.6s ("127.0.0.1 only, nginx does the rest."). The orchestrator API is now bound to localhost; public internet access is closed.
+2. **3 forges, 1 API** — enters at 10.0s, completes at 11.6s ("GitHub, Gitea, GitLab. Pick your forge."). Three forge providers (GitHub, Gitea, GitLab) are now first-class citizens behind one unified REST API.
+3. **Telegram cockpit** — enters at 15.0s, completes at 16.6s ("Today brief, approvals, chat. One socket."). The Telegram Mini App V4 becomes a real client with live task dashboard, actionable approvals, and multi-channel communication over a single WebSocket.
+4. **Guard mode: active** — enters at 20.0s, completes at 21.6s ("fastapi-guard stops watching, starts blocking."). The content-security guard flips from passive monitoring to active enforcement on request payloads.
+
+Each card gets roughly five seconds of fully visible time before the next card enters. A cursor clicks the intake at 4.8s (submit), then witnesses each card completing without further clicks (the agents do the work), then a second click at 30.8s (acknowledge the toast). The stats overlay shows "1 release / 3 forges / 0 leaks" from 24.0s to 32.0s, the toast "v0.26.0 shipped / I approved once. 25 agents shipped it." runs from 30.0s to 38.0s, and the "roboco.tech" outro lands at 36.0s and holds through the end.
+
+The composition reuses the same `pk-frame` chrome, `pk-column`/`pk-card`, `pk-pill`, `pk-cursor`, `pk-toast`, and `pk-outro` pieces from `kit/`, plus the typing reveal wired through `props.js`. Each feature card uses the `pk-pill--swap-out` / `pk-pill--swap-in` pattern to replace the `in progress` pill with `completed` on the same beat. The stats overlay uses display typography (Share Tech Mono) and the accent color to emphasize the "3 forges" metric, reinforcing the release's security + multi-provider focus.
+
+### Preview / test this composition
+
+```bash
+pnpm preview
+pnpm test   # release-0.26.0.test.js is picked up by vitest
+```
+
+### `props.js` shape
+
+```js
+{
+  introText: string,   // text that types into the panel intake field
+  toastTitle: string, // headline inside the shipping toast
+  toastBody: string,   // sub-line inside the shipping toast
+}
+```
+
+`window.__ORIENTATION__` is set for local preview only; the sidecar overwrites both globals at render time.
+
+### `captions.json`
+
+Same schema as prior releases: one `captions.json` next to the HTML with self-verified X and TikTok captions. The X caption totals **182 characters** (within the 280 limit); the TikTok caption **419 characters** (within the 2200 limit):
+
+```json
+{
+  "composition_id": "release-0.26.0",
+  "occasion": "release: RoboCo v0.26.0",
+  "platforms": {
+    "x":      { "caption": "v0.26.0 is out.\nOrchestrator API is off the public internet now.\nGitHub, Gitea, GitLab: one API.\nTelegram cockpit is a real client.\nI approved once. 25 agents shipped it.\nroboco.tech", "char_count": 182, "limit": 280,  "within_limit": true },
+    "tiktok": { "caption": "v0.26.0 is out.\n\nThe orchestrator API is off the public internet. No more raw access to the control plane.\n\nThree forges are first class now: GitHub, Gitea, GitLab. One API, one review flow, pick your forge.\n\nThe Telegram Mini App is a real client now: today brief, approvals, chat, all live off one socket.\n\nfastapi-guard is active enforcement. Not passive anymore.\n\nI approved once. 25 agents shipped it.\n\nroboco.tech", "char_count": 419, "limit": 2200, "within_limit": true }
+  }
+}
+```
+
+### Smoke-test invariants
+
+`release-0.26.0.test.js` extends the panel-demo register checks: both `vertical.html` (1080×1920) and `square.html` (1080×1080) parse with `data-duration="40"` and the HyperFrames params, the kit CSS/JS wiring is present, **four** feature cards each carry a progress-to-completed pill swap and include the exact titles ("Off the public net", "3 forges, 1 API", "Telegram cockpit", "Guard mode: active"), the stats overlay renders the three-line receipt (1 release / 3 forges / 0 leaks), the cursor and toast appear, the outro shows "roboco.tech", no external scripts are loaded, and no em dashes slip into on-screen copy or captions.

--- a/motion/compositions/release-0.26.0/captions.json
+++ b/motion/compositions/release-0.26.0/captions.json
@@ -1,0 +1,18 @@
+{
+  "composition_id": "release-0.26.0",
+  "occasion": "release: RoboCo v0.26.0",
+  "platforms": {
+    "x": {
+      "caption": "v0.26.0 is out.\nOrchestrator API is off the public internet now.\nGitHub, Gitea, GitLab: one API.\nTelegram cockpit is a real client.\nI approved once. 25 agents shipped it.\nroboco.tech",
+      "char_count": 182,
+      "limit": 280,
+      "within_limit": true
+    },
+    "tiktok": {
+      "caption": "v0.26.0 is out.\n\nThe orchestrator API is off the public internet. No more raw access to the control plane.\n\nThree forges are first class now: GitHub, Gitea, GitLab. One API, one review flow, pick your forge.\n\nThe Telegram Mini App is a real client now: today brief, approvals, chat, all live off one socket.\n\nfastapi-guard is active enforcement. Not passive anymore.\n\nI approved once. 25 agents shipped it.\n\nroboco.tech",
+      "char_count": 419,
+      "limit": 2200,
+      "within_limit": true
+    }
+  }
+}

--- a/motion/compositions/release-0.26.0/props.js
+++ b/motion/compositions/release-0.26.0/props.js
@@ -1,0 +1,9 @@
+// Default sample props for local preview of the RoboCo v0.26.0 release clip.
+// The video-renderer sidecar OVERWRITES this file at render time with the
+// real per-request values + window.__ORIENTATION__.
+window.__PROPS__ = {
+  introText: "The control plane gets a lock",
+  toastTitle: "v0.26.0 shipped",
+  toastBody: "I approved once. 25 agents shipped it.",
+};
+window.__ORIENTATION__ = "vertical";

--- a/motion/compositions/release-0.26.0/release-0.26.0.test.js
+++ b/motion/compositions/release-0.26.0/release-0.26.0.test.js
@@ -1,0 +1,115 @@
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// HTML-structure smoke test for the RoboCo v0.26.0 release composition.
+// Extends the panel-demo register: panel chrome, typing reveal, four feature cards
+// with progress -> completed pill flips, cursor, stats overlay, toast,
+// outro, offline constraint, and the captions.json schema/limits.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dir = here;
+const read = (name) => readFileSync(join(dir, name), "utf8");
+
+const orientations = [
+  { file: "vertical.html", height: "1920" },
+  { file: "square.html", height: "1080" },
+];
+
+describe("release-0.26.0 composition", () => {
+  it("ships props.js (default preview values, sidecar overwrites at render)", () => {
+    expect(existsSync(join(dir, "props.js"))).toBe(true);
+    const src = read("props.js");
+    expect(src).toContain("window.__PROPS__");
+    expect(src).toContain("window.__ORIENTATION__");
+    expect(src).toContain("introText");
+    expect(src).toContain("toastTitle");
+    expect(src).toContain("toastBody");
+    expect(src).not.toMatch(/—/);
+  });
+
+  it.each(orientations)("$file parses with correct dimensions and wiring", ({ file, height }) => {
+    const html = read(file);
+
+    expect(html).toContain('data-width="1080"');
+    expect(html).toContain(`data-height="${height}"`);
+    expect(html).toMatch(/data-duration="40"/);
+    expect(html).toMatch(/data-fps="30"/);
+
+    const propsIdx = html.indexOf('<script src="props.js"></script>');
+    const kitJsIdx = html.indexOf('<script src="../../kit/kit.js"></script>');
+    const inlineIdx = html.indexOf("window.__timelines");
+    expect(propsIdx).toBeGreaterThan(-1);
+    expect(kitJsIdx).toBeGreaterThan(propsIdx);
+    expect(inlineIdx).toBeGreaterThan(kitJsIdx);
+
+    expect(html).toContain('href="../../kit/kit.css"');
+    expect(html).toMatch(/class="[^"]*clip[^"]*"/);
+
+    expect(html).toContain("pk-frame");
+    expect(html).toContain("pk-frame__sidebar");
+    expect(html).toContain("pk-frame__topbar");
+
+    expect(html).toContain('id="typeIntro"');
+    expect(html).toContain("pk-caret");
+    expect(html).toContain("typeReveal");
+
+    const cardCount = (html.match(/class="pk-card"/g) || []).length;
+    const progressCount = (html.match(/pk-pill--progress/g) || []).length;
+    const completedCount = (html.match(/pk-pill--completed/g) || []).length;
+    expect(cardCount).toBe(4);
+    expect(progressCount).toBe(4);
+    expect(completedCount).toBe(4);
+
+    expect(html).toContain("v0.26.0");
+    expect(html).toContain("Off the public net");
+    expect(html).toContain("3 forges, 1 API");
+    expect(html).toContain("Telegram cockpit");
+    expect(html).toContain("Guard mode: active");
+
+    // Choreographed cursor: multi-waypoint path with at least one click
+    // beat (rings are generated at runtime by kit.js, not static HTML),
+    // and a camera that moves — a locked-off frame is an automatic bounce.
+    expect(html).toContain("pk-cursor");
+    const waypoints = html.match(/data-waypoints="([^"]+)"/);
+    expect(waypoints).not.toBeNull();
+    expect(waypoints[1].split(";").length).toBeGreaterThanOrEqual(6);
+    expect(waypoints[1]).toContain("click");
+    const shots = html.match(/data-shots="([^"]+)"/);
+    expect(shots).not.toBeNull();
+    expect(shots[1].split(";").length).toBeGreaterThanOrEqual(4);
+    expect(html).toContain("choreographAllCursors");
+    expect(html).toContain("choreographAllCameras");
+
+    expect(html).toContain("pk-toast");
+    expect(html).toContain('id="toastTitle"');
+    expect(html).toContain('id="toastBody"');
+
+    expect(html).toContain("pk-outro");
+    expect(html).toContain("roboco.tech");
+
+    expect(html).not.toMatch(/<script[^>]+src="https?:\/\//);
+    expect(html).not.toMatch(/href="https?:\/\//);
+    // on-screen copy only; the document <title> may carry an em dash as
+    // metadata (matches release-0.25.0's precedent) — it never renders.
+    const body = html.slice(html.indexOf("<body"));
+    expect(body).not.toMatch(/—/);
+  });
+
+  it("ships captions.json within X and TikTok platform limits", () => {
+    expect(existsSync(join(dir, "captions.json"))).toBe(true);
+    const captions = JSON.parse(read("captions.json"));
+
+    expect(captions.composition_id).toBe("release-0.26.0");
+    expect(captions.platforms.x.char_count).toBe(captions.platforms.x.caption.length);
+    expect(captions.platforms.x.char_count).toBeLessThanOrEqual(captions.platforms.x.limit);
+    expect(captions.platforms.x.within_limit).toBe(true);
+    expect(captions.platforms.tiktok.char_count).toBe(captions.platforms.tiktok.caption.length);
+    expect(captions.platforms.tiktok.char_count).toBeLessThanOrEqual(captions.platforms.tiktok.limit);
+    expect(captions.platforms.tiktok.within_limit).toBe(true);
+
+    expect(captions.platforms.x.caption).not.toMatch(/—/);
+    expect(captions.platforms.tiktok.caption).not.toMatch(/—/);
+  });
+});

--- a/motion/compositions/release-0.26.0/square.html
+++ b/motion/compositions/release-0.26.0/square.html
@@ -1,0 +1,351 @@
+<!doctype html>
+<html lang="en" data-composition-id="release-0.26.0" data-composition-duration="40" data-fps="30">
+  <head>
+    <meta charset="utf-8" />
+    <title>RoboCo v0.26.0 Release - square (1080×1080)</title>
+    <link rel="stylesheet" href="../../kit/kit.css" />
+    <script src="props.js"></script>
+    <script src="../../kit/kit.js"></script>
+    <style>
+      /* Square cut of the v0.26.0 release clip. Tighter spacing, smaller
+         hero, and the stats overlay covers the full frame for readability.
+         Total 40s. */
+
+      .r26-hero {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 28px;
+        background: var(--pk-bg);
+        z-index: 30;
+        animation: r26-hero-out 0.6s var(--pk-ease) 2.6s forwards;
+      }
+      @keyframes r26-hero-out { to { opacity: 0; visibility: hidden; } }
+
+      .r26-hero__markwrap { position: relative; width: 400px; height: 400px; }
+      .r26-hero__mark {
+        width: 400px;
+        height: 400px;
+        transform: scale(0.82);
+        opacity: 0;
+        filter: drop-shadow(0 12px 60px rgba(255, 90, 31, 0.18));
+        animation: r26-mark-in 1s var(--pk-ease) 0.2s forwards;
+      }
+      @keyframes r26-mark-in { to { transform: scale(1); opacity: 1; } }
+
+      .r26-hero__ring {
+        position: absolute;
+        inset: 6px;
+        border-radius: 50%;
+        padding: 3px;
+        background: conic-gradient(from 0deg, transparent 0 78%, var(--pk-accent) 92%, transparent 100%);
+        -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+        -webkit-mask-composite: xor;
+        mask-composite: exclude;
+        opacity: 0;
+        animation: r26-ring-in 0.3s linear 0.9s forwards, r26-ring-spin 1.4s cubic-bezier(0.5, 0, 0.3, 1) 0.9s forwards;
+      }
+      @keyframes r26-ring-in { to { opacity: 1; } }
+      @keyframes r26-ring-spin { to { transform: rotate(360deg); opacity: 0; } }
+
+      .r26-hero__version {
+        font-family: var(--pk-font-display);
+        font-size: 96px;
+        color: var(--pk-text);
+        opacity: 0;
+        transform: translateY(18px);
+        animation: pk-enter-rise 0.7s var(--pk-ease) 1.2s forwards;
+      }
+      .r26-hero__tag {
+        font-size: 26px;
+        color: var(--pk-text-muted);
+        opacity: 0;
+        transform: translateY(14px);
+        animation: pk-enter-rise 0.7s var(--pk-ease) 1.5s forwards;
+      }
+
+      .pk-frame { animation-delay: 2.6s; }
+      .pk-frame__sidebar {
+        width: 220px;
+        align-items: stretch;
+        gap: 6px;
+        padding: 24px 16px 0 16px;
+        transform: translateX(-40px);
+        opacity: 0;
+        animation: r26-side-in 0.7s var(--pk-ease) 2.8s forwards;
+      }
+      @keyframes r26-side-in { to { transform: translateX(0); opacity: 1; } }
+
+      .r26-side__logo {
+        width: 40px;
+        height: 40px;
+        border-radius: 12px;
+        background: #f4f6f8;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 0 18px 4px;
+      }
+      .r26-side__logo img { width: 30px; height: 30px; }
+
+      .r26-nav {
+        display: flex;
+        align-items: center;
+        height: 44px;
+        padding: 0 14px;
+        border-radius: 10px;
+        font-size: 18px;
+        color: var(--pk-text-muted);
+      }
+      .r26-nav--active { background: var(--pk-active-bg); color: var(--pk-active-fg); font-weight: 600; }
+
+      .pk-frame__topbar { left: 220px; height: 84px; padding: 0 32px; }
+      .pk-frame__content { left: 220px; top: 84px; }
+      .r26-user { font-size: 18px; }
+      .r26-user__chip { padding: 6px 14px; }
+
+      .pk-frame__search { width: 280px; height: 42px; font-size: 18px; }
+
+      .pk-intake { --pk-intake-top: 18px; }
+      .pk-intake__field { height: 60px; font-size: 28px; }
+      .pk-column { --pk-column-top: 130px; width: 560px; }
+      .pk-column .pk-card {
+        position: static;
+        margin-bottom: 12px;
+        padding: 18px 24px;
+        /* Springy entrance (see vertical.html); flat fades read as slides. */
+        animation-duration: 0.55s;
+        animation-timing-function: cubic-bezier(0.34, 1.4, 0.64, 1);
+      }
+      .pk-card__title { font-size: 28px; }
+      .r26-sub { font-size: 18px; }
+
+      .r26-stats {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        text-align: center;
+        background: rgba(10, 10, 10, 0.88);
+        z-index: 20;
+        font-family: var(--pk-font-display);
+        opacity: 0;
+        animation: r26-stats-in 0.4s var(--pk-ease) 24.0s forwards, r26-stats-out 0.5s var(--pk-ease) 32.0s forwards;
+      }
+      @keyframes r26-stats-in { to { opacity: 1; } }
+      .r26-stats__line {
+        font-size: 80px;
+        line-height: 1.25;
+        color: var(--pk-text);
+        opacity: 0;
+        transform: translateY(24px) scale(0.96);
+        animation: pk-enter-rise-scale 0.55s var(--pk-ease) forwards;
+      }
+      .r26-stats__line--accent { color: var(--pk-accent); }
+      @keyframes r26-stats-out { to { opacity: 0; } }
+
+      .pk-toast { --pk-toast-bottom: 84px; width: 480px; }
+
+      .pk-outro { --pk-outro-bottom: 28px; }
+      .r26-outro__logo {
+        width: 48px;
+        height: 48px;
+        border-radius: 14px;
+        background: #f4f6f8;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .r26-outro__logo img { width: 36px; height: 36px; }
+
+      #typeIntro { display: inline-block; overflow: hidden; white-space: pre; vertical-align: bottom; width: 0; }
+      @keyframes type-reveal { to { width: var(--type-ch, 20ch); } }
+    </style>
+  </head>
+  <body>
+    <div id="stage" data-composition-id="release-0.26.0" data-width="1080" data-height="1080" data-start="0" data-duration="40" data-fps="30">
+
+      <div class="r26-hero clip" data-start="0" data-duration="3.2" data-track-index="16">
+        <div class="r26-hero__markwrap">
+          <img class="r26-hero__mark" src="../../public/roboco-logo-darkmode.png" alt="RoboCo" />
+          <div class="r26-hero__ring"></div>
+        </div>
+        <div class="r26-hero__version">v0.26.0</div>
+        <div class="r26-hero__tag">the control plane gets a lock</div>
+      </div>
+
+      <!-- Camera: tight open, push per card beat, dead-wide before the
+           full-screen stats overlay, gentle push for the toast, settle. -->
+      <div class="pk-camera"
+           data-shots="2.6 0 10 1.03; 4.8 0 6 1.035;
+                       6.4 30 62 1.055; 9.2 26 56 1.05;
+                       10.4 28 8 1.06; 13.6 24 4 1.055;
+                       15.4 30 -46 1.06; 18.6 26 -50 1.055;
+                       20.4 28 -96 1.06; 22.4 22 -98 1.05;
+                       23.8 0 0 1.0; 32.6 0 0 1.0;
+                       33.8 -20 -60 1.03; 35.6 -18 -58 1.028;
+                       37.4 0 0 1.0; 39.6 0 4 1.004">
+      <div class="pk-frame clip" data-start="2.6" data-duration="37.4" data-track-index="1">
+        <aside class="pk-frame__sidebar">
+          <div class="r26-side__logo"><img src="../../public/roboco-logo.png" alt="" /></div>
+          <div class="r26-nav">Overview</div>
+          <div class="r26-nav">Business</div>
+          <div class="r26-nav">Social</div>
+          <div class="r26-nav r26-nav--active">Tasks</div>
+          <div class="r26-nav">Kanban</div>
+          <div class="r26-nav">Git</div>
+          <div class="r26-nav">Agents</div>
+          <div class="r26-nav">Metrics</div>
+        </aside>
+
+        <header class="pk-frame__topbar">
+          <div class="pk-frame__search">Search tasks, agents...</div>
+          <div class="r26-user">
+            <div class="pk-frame__status clip" data-start="2.6" data-duration="37.4" data-track-index="0">
+              <span class="pk-frame__statusdot"></span>
+              <span>Live</span>
+            </div>
+            <span class="r26-user__chip">CEO · Renzo</span>
+          </div>
+        </header>
+
+        <div class="pk-frame__content">
+          <div class="pk-intake" style="animation-delay: 3.6s;">
+            <div class="pk-intake__label">New task</div>
+            <div class="pk-intake__field"><span id="typeIntro">The control plane gets a lock</span><span class="pk-caret"></span></div>
+          </div>
+
+          <div class="pk-column">
+            <div class="pk-column__header">Shipped in v0.26.0</div>
+
+            <div class="pk-card" style="animation-delay: 5.0s;">
+              <div class="pk-card__title">Off the public net</div>
+              <div class="r26-sub">127.0.0.1 only, nginx does the rest.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">orchestrator :8000</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 5.0s; --pk-pill-exit-delay: 6.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 6.6s;">completed</span>
+              </div>
+            </div>
+
+            <div class="pk-card" style="animation-delay: 10.0s;">
+              <div class="pk-card__title">3 forges, 1 API</div>
+              <div class="r26-sub">GitHub, Gitea, GitLab. Pick your forge.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">git settings</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 10.0s; --pk-pill-exit-delay: 11.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 11.6s;">completed</span>
+              </div>
+            </div>
+
+            <div class="pk-card" style="animation-delay: 15.0s;">
+              <div class="pk-card__title">Telegram cockpit</div>
+              <div class="r26-sub">Today brief, approvals, chat. One socket.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">telegram</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 15.0s; --pk-pill-exit-delay: 16.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 16.6s;">completed</span>
+              </div>
+            </div>
+
+            <div class="pk-card" style="animation-delay: 20.0s;">
+              <div class="pk-card__title">Guard mode: active</div>
+              <div class="r26-sub">fastapi-guard stops watching, starts blocking.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">fastapi-guard</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 20.0s; --pk-pill-exit-delay: 21.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 21.6s;">completed</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- Same hand as the vertical cut: submit click, witness each
+               card, exit right BEFORE the full-screen stats overlay lands
+               at 24s (the cursor sits under its backdrop). -->
+          <div class="pk-cursor"
+               data-waypoints="4.0 520 130; 4.5 452 80; 4.8 445 76 click;
+                               5.6 250 185; 6.4 138 250; 7.6 152 262;
+                               9.6 220 340; 10.4 148 412; 12.0 134 424;
+                               14.6 215 505; 15.4 140 576; 17.0 155 588;
+                               19.6 220 668; 20.4 150 740; 22.0 136 752;
+                               23.0 480 780; 23.9 920 820">
+            <div class="pk-cursor__glyph"></div>
+          </div>
+
+          <div class="r26-stats">
+            <div class="r26-stats__line" style="animation-delay: 24.0s;">1 release</div>
+            <div class="r26-stats__line r26-stats__line--accent" style="animation-delay: 24.3s;">3 forges</div>
+            <div class="r26-stats__line" style="animation-delay: 24.6s;">0 leaks</div>
+          </div>
+
+          <div class="pk-toast" style="animation-delay: 30.0s;">
+            <div class="pk-toast__icon"></div>
+            <div class="pk-toast__body">
+              <div class="pk-toast__title" id="toastTitle">v0.26.0 shipped</div>
+              <div class="pk-toast__text" id="toastBody">I approved once. 25 agents shipped it.</div>
+            </div>
+          </div>
+
+          <div class="pk-outro" style="animation-delay: 36.0s;">
+            <span class="r26-outro__logo"><img src="../../public/roboco-logo.png" alt="" /></span>
+            <span>roboco.tech</span>
+          </div>
+        </div>
+      </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["release-0.26.0"] = {
+        id: "release-0.26.0",
+        duration: 40,
+        fps: 30,
+        animations: []
+      };
+
+      (function () {
+        var props = (window.__PROPS__ && typeof window.__PROPS__ === "object") ? window.__PROPS__ : {};
+
+        function setText(id, value) {
+          if (typeof value !== "string" || !value) return;
+          var el = document.getElementById(id);
+          if (el) el.textContent = value;
+        }
+
+        setText("toastTitle", props.toastTitle);
+        setText("toastBody", props.toastBody);
+
+        function typeReveal(el) {
+          var n = (el.textContent || "").length || 1;
+          el.style.setProperty("--type-ch", (n + 1) + "ch");
+          el.style.animation = "type-reveal " + (n * 0.07).toFixed(2) + "s steps(" + n + ", end) 4.0s forwards";
+        }
+        var typeEl = document.getElementById("typeIntro");
+        if (typeEl) {
+          if (typeof props.introText === "string" && props.introText) {
+            typeEl.textContent = props.introText;
+          }
+          typeReveal(typeEl);
+        }
+
+        window.PanelKit.choreographAllCursors();
+        window.PanelKit.choreographAllCameras();
+      })();
+    </script>
+  </body>
+</html>

--- a/motion/compositions/release-0.26.0/square.html
+++ b/motion/compositions/release-0.26.0/square.html
@@ -191,7 +191,7 @@
                        23.8 0 0 1.0; 32.6 0 0 1.0;
                        33.8 -20 -60 1.03; 35.6 -18 -58 1.028;
                        37.4 0 0 1.0; 39.6 0 4 1.004">
-      <div class="pk-frame clip" data-start="2.6" data-duration="37.4" data-track-index="1">
+      <div class="pk-frame clip" data-start="0" data-duration="40" data-track-index="1">
         <aside class="pk-frame__sidebar">
           <div class="r26-side__logo"><img src="../../public/roboco-logo.png" alt="" /></div>
           <div class="r26-nav">Overview</div>
@@ -207,7 +207,7 @@
         <header class="pk-frame__topbar">
           <div class="pk-frame__search">Search tasks, agents...</div>
           <div class="r26-user">
-            <div class="pk-frame__status clip" data-start="2.6" data-duration="37.4" data-track-index="0">
+            <div class="pk-frame__status clip" data-start="0" data-duration="40" data-track-index="0">
               <span class="pk-frame__statusdot"></span>
               <span>Live</span>
             </div>

--- a/motion/compositions/release-0.26.0/vertical.html
+++ b/motion/compositions/release-0.26.0/vertical.html
@@ -209,7 +209,7 @@
                        25.0 0 0 1.0; 29.2 0 0 1.0;
                        30.8 -26 -120 1.035; 33.4 -22 -116 1.03;
                        37.0 0 0 1.0; 39.6 0 6 1.005">
-      <div class="pk-frame clip" data-start="2.6" data-duration="37.4" data-track-index="1">
+      <div class="pk-frame clip" data-start="0" data-duration="40" data-track-index="1">
         <aside class="pk-frame__sidebar">
           <div class="r26-side__logo"><img src="../../public/roboco-logo.png" alt="" /></div>
           <div class="r26-nav">Overview</div>
@@ -225,7 +225,7 @@
         <header class="pk-frame__topbar">
           <div class="pk-frame__search">Search tasks, agents...</div>
           <div class="r26-user">
-            <div class="pk-frame__status clip" data-start="2.6" data-duration="37.4" data-track-index="0">
+            <div class="pk-frame__status clip" data-start="0" data-duration="40" data-track-index="0">
               <span class="pk-frame__statusdot"></span>
               <span>Live</span>
             </div>

--- a/motion/compositions/release-0.26.0/vertical.html
+++ b/motion/compositions/release-0.26.0/vertical.html
@@ -1,0 +1,377 @@
+<!doctype html>
+<html lang="en" data-composition-id="release-0.26.0" data-composition-duration="40" data-fps="30">
+  <head>
+    <meta charset="utf-8" />
+    <title>RoboCo v0.26.0 Release - vertical (1080×1920)</title>
+    <link rel="stylesheet" href="../../kit/kit.css" />
+    <script src="props.js"></script>
+    <script src="../../kit/kit.js"></script>
+    <style>
+      /* v0.26.0 release clip - panel-demo register, same shape as
+         release-0.25.0: identity cold open, panel assembles, four feature
+         cards flip to completed one per scene, cursor click, receipt
+         stats, toast, lockup. Total 40s. */
+
+      /* ---- Identity cold open -------------------------------------------- */
+      .r26-hero {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 38px;
+        background: var(--pk-bg);
+        z-index: 30;
+        animation: r26-hero-out 0.6s var(--pk-ease) 2.6s forwards;
+      }
+      @keyframes r26-hero-out { to { opacity: 0; visibility: hidden; } }
+
+      .r26-hero__markwrap { position: relative; width: 520px; height: 520px; }
+      .r26-hero__mark {
+        width: 520px;
+        height: 520px;
+        transform: scale(0.82);
+        opacity: 0;
+        filter: drop-shadow(0 12px 60px rgba(255, 90, 31, 0.18));
+        animation: r26-mark-in 1s var(--pk-ease) 0.2s forwards;
+      }
+      @keyframes r26-mark-in { to { transform: scale(1); opacity: 1; } }
+
+      .r26-hero__ring {
+        position: absolute;
+        inset: 6px;
+        border-radius: 50%;
+        padding: 3px;
+        background: conic-gradient(from 0deg, transparent 0 78%, var(--pk-accent) 92%, transparent 100%);
+        -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+        -webkit-mask-composite: xor;
+        mask-composite: exclude;
+        opacity: 0;
+        animation: r26-ring-in 0.3s linear 0.9s forwards, r26-ring-spin 1.4s cubic-bezier(0.5, 0, 0.3, 1) 0.9s forwards;
+      }
+      @keyframes r26-ring-in { to { opacity: 1; } }
+      @keyframes r26-ring-spin { to { transform: rotate(360deg); opacity: 0; } }
+
+      .r26-hero__version {
+        font-family: var(--pk-font-display);
+        font-size: 120px;
+        color: var(--pk-text);
+        opacity: 0;
+        transform: translateY(18px);
+        animation: pk-enter-rise 0.7s var(--pk-ease) 1.2s forwards;
+      }
+      .r26-hero__tag {
+        font-size: 30px;
+        color: var(--pk-text-muted);
+        opacity: 0;
+        transform: translateY(14px);
+        animation: pk-enter-rise 0.7s var(--pk-ease) 1.5s forwards;
+      }
+
+      /* ---- Panel chrome --------------------------------------------------- */
+      .pk-frame { animation-delay: 2.6s; }
+      .pk-frame__sidebar {
+        width: 250px;
+        align-items: stretch;
+        gap: 6px;
+        padding: 28px 18px 0 18px;
+        transform: translateX(-40px);
+        opacity: 0;
+        animation: r26-side-in 0.7s var(--pk-ease) 2.8s forwards;
+      }
+      @keyframes r26-side-in { to { transform: translateX(0); opacity: 1; } }
+
+      .r26-side__logo {
+        width: 44px;
+        height: 44px;
+        border-radius: 12px;
+        background: #f4f6f8;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin: 0 0 22px 4px;
+      }
+      .r26-side__logo img { width: 34px; height: 34px; }
+
+      .r26-nav {
+        display: flex;
+        align-items: center;
+        height: 52px;
+        padding: 0 16px;
+        border-radius: 10px;
+        font-size: 21px;
+        color: var(--pk-text-muted);
+      }
+      .r26-nav--active { background: var(--pk-active-bg); color: var(--pk-active-fg); font-weight: 600; }
+
+      .pk-frame__topbar { left: 250px; }
+      .pk-frame__content { left: 250px; }
+      .r26-user {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        color: var(--pk-text-muted);
+        font-size: 20px;
+      }
+      .r26-user__chip {
+        background: var(--pk-surface-raised);
+        border: 1px solid var(--pk-border);
+        border-radius: 999px;
+        padding: 8px 18px;
+        color: var(--pk-text);
+      }
+
+      /* ---- Content placement --------------------------------------------- */
+      .pk-intake { --pk-intake-top: 32px; }
+      .pk-column { --pk-column-top: 220px; width: 720px; }
+      .pk-column .pk-card {
+        position: static;
+        margin-bottom: 20px;
+        /* Springy entrance with a hint of overshoot; a flat fade on every
+           card is the metronome that makes the cut feel like a slideshow. */
+        animation-duration: 0.55s;
+        animation-timing-function: cubic-bezier(0.34, 1.4, 0.64, 1);
+      }
+      .r26-sub {
+        margin-top: 10px;
+        font-size: 22px;
+        line-height: 1.35;
+        color: var(--pk-text-muted);
+      }
+
+      /* Receipt stats overlay. */
+      .r26-stats {
+        position: absolute;
+        right: 64px;
+        bottom: 320px;
+        text-align: right;
+        font-family: var(--pk-font-display);
+      }
+      .r26-stats__line {
+        font-size: 64px;
+        line-height: 1.22;
+        color: var(--pk-text);
+        opacity: 0;
+        transform: translateY(24px) scale(0.96);
+        animation: pk-enter-rise-scale 0.55s var(--pk-ease) forwards;
+      }
+      .r26-stats__line--accent { color: var(--pk-accent); }
+      .r26-stats { animation: r26-stats-out 0.5s var(--pk-ease) 32.0s forwards; }
+      @keyframes r26-stats-out { to { opacity: 0; } }
+
+      .pk-toast { --pk-toast-bottom: 140px; }
+
+      /* Closing lockup. */
+      .pk-outro {
+        --pk-outro-bottom: 56px;
+        display: flex;
+        align-items: center;
+        gap: 20px;
+      }
+      .r26-outro__logo {
+        width: 52px;
+        height: 52px;
+        border-radius: 14px;
+        background: #f4f6f8;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .r26-outro__logo img { width: 40px; height: 40px; }
+
+      #typeIntro { display: inline-block; overflow: hidden; white-space: pre; vertical-align: bottom; width: 0; }
+      @keyframes type-reveal { to { width: var(--type-ch, 20ch); } }
+    </style>
+  </head>
+  <body>
+    <div id="stage" data-composition-id="release-0.26.0" data-width="1080" data-height="1920" data-start="0" data-duration="40" data-fps="30">
+
+      <!-- Beat 1: identity cold open. -->
+      <div class="r26-hero clip" data-start="0" data-duration="3.2" data-track-index="16">
+        <div class="r26-hero__markwrap">
+          <img class="r26-hero__mark" src="../../public/roboco-logo-darkmode.png" alt="RoboCo" />
+          <div class="r26-hero__ring"></div>
+        </div>
+        <div class="r26-hero__version">v0.26.0</div>
+        <div class="r26-hero__tag">the control plane gets a lock</div>
+      </div>
+
+      <!-- Beat 2: the panel assembles, and the camera lives on it: start a
+           touch tight, push toward each card as it completes, pull wide for
+           the receipt, ease onto the toast, settle for the lockup. -->
+      <div class="pk-camera"
+           data-shots="2.6 0 14 1.025; 4.8 0 8 1.03;
+                       6.4 34 96 1.055; 9.2 30 88 1.05;
+                       10.4 30 30 1.06; 13.6 26 24 1.055;
+                       15.4 32 -52 1.065; 18.6 28 -58 1.06;
+                       20.4 30 -150 1.065; 22.6 26 -156 1.06;
+                       25.0 0 0 1.0; 29.2 0 0 1.0;
+                       30.8 -26 -120 1.035; 33.4 -22 -116 1.03;
+                       37.0 0 0 1.0; 39.6 0 6 1.005">
+      <div class="pk-frame clip" data-start="2.6" data-duration="37.4" data-track-index="1">
+        <aside class="pk-frame__sidebar">
+          <div class="r26-side__logo"><img src="../../public/roboco-logo.png" alt="" /></div>
+          <div class="r26-nav">Overview</div>
+          <div class="r26-nav">Business</div>
+          <div class="r26-nav">Social</div>
+          <div class="r26-nav r26-nav--active">Tasks</div>
+          <div class="r26-nav">Kanban</div>
+          <div class="r26-nav">Git</div>
+          <div class="r26-nav">Agents</div>
+          <div class="r26-nav">Metrics</div>
+        </aside>
+
+        <header class="pk-frame__topbar">
+          <div class="pk-frame__search">Search tasks, agents...</div>
+          <div class="r26-user">
+            <div class="pk-frame__status clip" data-start="2.6" data-duration="37.4" data-track-index="0">
+              <span class="pk-frame__statusdot"></span>
+              <span>Live</span>
+            </div>
+            <span class="r26-user__chip">CEO · Renzo</span>
+          </div>
+        </header>
+
+        <div class="pk-frame__content">
+          <!-- Beat 3: the hook types into intake. -->
+          <div class="pk-intake" style="animation-delay: 3.6s;">
+            <div class="pk-intake__label">New task</div>
+            <div class="pk-intake__field"><span id="typeIntro">The control plane gets a lock</span><span class="pk-caret"></span></div>
+          </div>
+
+          <!-- Beat 4: four feature cards, one per ~5s scene, each fully visible before the next enters. -->
+          <div class="pk-column">
+            <div class="pk-column__header">Shipped in v0.26.0</div>
+
+            <div class="pk-card" style="animation-delay: 5.0s;">
+              <div class="pk-card__title">Off the public net</div>
+              <div class="r26-sub">127.0.0.1 only, nginx does the rest.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">orchestrator :8000</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 5.0s; --pk-pill-exit-delay: 6.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 6.6s;">completed</span>
+              </div>
+            </div>
+
+            <div class="pk-card" style="animation-delay: 10.0s;">
+              <div class="pk-card__title">3 forges, 1 API</div>
+              <div class="r26-sub">GitHub, Gitea, GitLab. Pick your forge.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">git settings</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 10.0s; --pk-pill-exit-delay: 11.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 11.6s;">completed</span>
+              </div>
+            </div>
+
+            <div class="pk-card" style="animation-delay: 15.0s;">
+              <div class="pk-card__title">Telegram cockpit</div>
+              <div class="r26-sub">Today brief, approvals, chat. One socket.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">telegram</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 15.0s; --pk-pill-exit-delay: 16.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 16.6s;">completed</span>
+              </div>
+            </div>
+
+            <div class="pk-card" style="animation-delay: 20.0s;">
+              <div class="pk-card__title">Guard mode: active</div>
+              <div class="r26-sub">fastapi-guard stops watching, starts blocking.</div>
+              <div class="pk-card__meta">
+                <span class="pk-chip pk-chip--gray">fastapi-guard</span>
+              </div>
+              <div class="pk-card__status">
+                <span class="pk-pill pk-pill--progress pk-pill--swap-out" style="--pk-pill-enter-delay: 20.0s; --pk-pill-exit-delay: 21.4s;">in progress</span>
+                <span class="pk-pill pk-pill--completed pk-pill--swap-in" style="--pk-pill-enter-delay: 21.6s;">completed</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- The cursor is the CEO's hand: settle on the intake while it
+               types, ONE submit click just before the org takes over, then
+               travel to witness each card completing (the agents do the
+               clicking-free work), drift to the receipt, acknowledge the
+               toast, and leave the frame; never freeze, never blink out. -->
+          <div class="pk-cursor"
+               data-waypoints="4.0 640 210; 4.5 552 152; 4.8 545 148 click;
+                               5.6 300 330; 6.4 160 405; 7.6 178 420;
+                               9.6 260 520; 10.4 190 628; 12.0 172 642;
+                               14.6 250 760; 15.4 162 848; 17.0 180 862;
+                               19.6 255 985; 20.4 190 1068; 22.0 174 1082;
+                               23.6 420 1180; 24.8 560 1250; 28.6 585 1268;
+                               29.6 615 1420; 30.8 612 1462 click;
+                               33.2 700 1520; 35.0 940 1660">
+            <div class="pk-cursor__glyph"></div>
+          </div>
+
+          <!-- Beat 5: receipt stats. -->
+          <div class="r26-stats">
+            <div class="r26-stats__line" style="animation-delay: 24.0s;">1 release</div>
+            <div class="r26-stats__line r26-stats__line--accent" style="animation-delay: 24.3s;">3 forges</div>
+            <div class="r26-stats__line" style="animation-delay: 24.6s;">0 leaks</div>
+          </div>
+
+          <!-- Beat 6: confirmation toast, then lockup. -->
+          <div class="pk-toast" style="animation-delay: 30.0s;">
+            <div class="pk-toast__icon"></div>
+            <div class="pk-toast__body">
+              <div class="pk-toast__title" id="toastTitle">v0.26.0 shipped</div>
+              <div class="pk-toast__text" id="toastBody">I approved once. 25 agents shipped it.</div>
+            </div>
+          </div>
+
+          <div class="pk-outro" style="animation-delay: 36.0s;">
+            <span class="r26-outro__logo"><img src="../../public/roboco-logo.png" alt="" /></span>
+            <span>roboco.tech</span>
+          </div>
+        </div>
+      </div>
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      window.__timelines["release-0.26.0"] = {
+        id: "release-0.26.0",
+        duration: 40,
+        fps: 30,
+        animations: []
+      };
+
+      (function () {
+        var props = (window.__PROPS__ && typeof window.__PROPS__ === "object") ? window.__PROPS__ : {};
+
+        function setText(id, value) {
+          if (typeof value !== "string" || !value) return;
+          var el = document.getElementById(id);
+          if (el) el.textContent = value;
+        }
+
+        setText("toastTitle", props.toastTitle);
+        setText("toastBody", props.toastBody);
+
+        function typeReveal(el) {
+          var n = (el.textContent || "").length || 1;
+          el.style.setProperty("--type-ch", (n + 1) + "ch");
+          el.style.animation = "type-reveal " + (n * 0.07).toFixed(2) + "s steps(" + n + ", end) 4.0s forwards";
+        }
+        var typeEl = document.getElementById("typeIntro");
+        if (typeEl) {
+          if (typeof props.introText === "string" && props.introText) {
+            typeEl.textContent = props.introText;
+          }
+          typeReveal(typeEl);
+        }
+
+        window.PanelKit.choreographAllCursors();
+        window.PanelKit.choreographAllCameras();
+      })();
+    </script>
+  </body>
+</html>

--- a/motion/node_modules
+++ b/motion/node_modules
@@ -1,0 +1,1 @@
+/data/workspaces/roboco-api/ux_ui/ux-dev-1/motion/node_modules


### PR DESCRIPTION
RoboCo API v0.26.0 release notes:

## [0.26.0] - 2026-07-20

### Security

- **Orchestrator API is no longer published on a routable host interface (GHSA-4f7g-w95g-5q2c).** Both deploy composes published the orchestrator's `:8000` on `0.0.0.0`, so anyone who could reach the host hit the control plane directly — bypassing nginx and, in the default header-trust posture (`ROBOCO_AGENT_AUTH_REQUIRED` unset, cloud auth off), reading/writing runtime settings and spoofing `X-Agent-Role: ceo` to spawn/stop agents with no credential. The publish is now bound to `127.0.0.1`; nginx reaches the API over the internal Docker network, so normal operation and on-host debugging are unchanged, while off-host access must go through nginx + cloud auth. The header-trust design itself is unchanged (it stays the deliberate local-no-login panel path); this closes the unintended off-host reachability that gave it teeth.
- **fastapi-guard flipped to active enforcement, with its prose validators calibrated and HTTPS enforcement removed from the app layer.** `ROBOCO_GUARD_PASSIVE_MODE`'s default flips from `true` to `false` in `docker-compose.yml`/`.yaml` (the registry compose already omits the guard trio and stays off) — the deliberately deferred step from the original guard build, now that cloud auth + Tailscale are armed. Activation exposed two calibration defects, both fixed before this ships: `enforce_https` was keyed off `environment == "production"`, but TLS is nginx's layer (the single entry point — the app only ever sees proxy-HTTP), so the check blocked a plain-HTTP-behind-Tailscale production deploy's entire request stream and is now hardcoded off at the guard config; and the two custom content validators were never calibrated against RoboCo's own vocabulary — the secret-exfil env-key pattern now requires a real base64-shaped value (the documented `ROBOCO_ENCRYPTION_KEY=<your-fernet-key>` placeholder no longer blocks a commit/note) and the prompt-injection override pattern requires the second-person "your" (neutral engineering prose about the guard subsystem passes; real injections still block).
- **`can_a2a_direct` refuses a CEO DM to a no-comms-role target.** The CEO's asymmetric "may DM any agent" branch returned `True, None` unconditionally, bypassing the non-DM-role exclusion (auditor, pr_reviewer, prompter, secretary — none carry `dm`/`read_a2a` on their manifest) that the panel's New-DM dialog only enforced client-side. A conversation to one of these roles is now refused at `get_or_create_conversation` with a clear reason instead of silently creating an unreadable/unackable thread. The refusal set (`NO_COMMS_ROLES`) is now canonical in `roboco/foundation/policy/communications.py`, reused by both this check and the `dm()` sender-side guard in `content_actions.py` so the two can't drift apart.

- **adm-zip overridden to >=0.6.0 in the motion toolchain (Dependabot alert 88).** The transitive `adm-zip <0.6.0` allowed a crafted ZIP to trigger a 4GB memory allocation; a pnpm override pins the patched version without unpinning the deliberately-held producer.
- **Registry compose fails closed on missing auth and arms registry authentication by default.** A registry deployment with unset credentials now refuses to come up in production instead of silently serving unauthenticated.

### Added

- **Telegram Mini App V4 — the phone cockpit becomes a real client (#576, #582).** The `/tg` surface opens on a Today brief served by one DB-only round trip (`GET /telegram/today`): needs-you items, held-draft counts, fleet with per-agent task titles, day-rollup spend with a live sparkline, weekly shipped-task velocity, and ship state. The Approvals tab is a native card stack over all four held-draft queues riding Telegram's MainButton/BackButton/haptics (with visible fallbacks), including X-draft editing with a 280 counter, a blob-fetched video player, and a per-AC release view; Chat and Today refresh live off the shared `/ws/system` socket with a poll fallback; the shell adopts the user's T

Highlights:
- **Orchestrator API is no longer published on a routable host interface (GHSA-4f7g-w95g-5q2c).** Both deploy composes published the orchestrator's `:8000` on `0.0.0.0`, so anyone who could reach the host hit the control plane directly — bypassing nginx and, in the default header-trust posture (`ROBOCO_AGENT_AUTH_REQUIRED` unset, cloud auth off), reading/writing runtime settings and spoofing `X-Agent-Role: ceo` to spawn/stop agents with no credential. The publish is now bound to `127.0.0.1`; nginx reaches the API over the internal Docker network, so normal operation and on-host debugging are unchanged, while off-host access must go through nginx + cloud auth. The header-trust design itself is unchanged (it stays the deliberate local-no-login panel path); this closes the unintended off-host reachability that gave it teeth.
- **fastapi-guard flipped to active enforcement, with its prose validators calibrated and HTTPS enforcement removed from the app layer.** `ROBOCO_GUARD_PASSIVE_MODE`'s default flips from `true` to `false` in `docker-compose.yml`/`.yaml` (the registry compose already omits the guard trio and stays off) — the deliberately deferred step from the original guard build, now that cloud auth + Tailscale are armed. Activation exposed two calibration defects, both fixed before this ships: `enforce_https` was keyed off `environment == "production"`, but TLS is nginx's layer (the single entry point — the app only ever sees proxy-HTTP), so the check blocked a plain-HTTP-behind-Tailscale production deploy's entire request stream and is now hardcoded off at the guard config; and the two custom content validators were never calibrated against RoboCo's own vocabulary — the secret-exfil env-key pattern now requires a real base64-shaped value (the documented `ROBOCO_ENCRYPTION_KEY=<your-fernet-key>` placeholder no longer blocks a commit/note) and the prompt-injection override pattern requires the second-person "your" (neutral engineering prose about the guard subsystem passes; real injections still block).
- **`can_a2a_direct` refuses a CEO DM to a no-comms-role target.** The CEO's asymmetric "may DM any agent" branch returned `True, None` unconditionally, bypassing the non-DM-role exclusion (auditor, pr_reviewer, prompter, secretary — none carry `dm`/`read_a2a` on their manifest) that the panel's New-DM dialog only enforced client-side. A conversation to one of these roles is now refused at `get_or_create_conversation` with a clear reason instead of silently creating an unreadable/unackable thread. The refusal set (`NO_COMMS_ROLES`) is now canonical in `roboco/foundation/policy/communications.py`, reused by both this check and the `dm()` sender-side guard in `content_actions.py` so the two can't drift apart.
- **adm-zip overridden to >=0.6.0 in the motion toolchain (Dependabot alert 88).** The transitive `adm-zip <0.6.0` allowed a crafted ZIP to trigger a 4GB memory allocation; a pnpm override pins the patched version without unpinning the deliberately-held producer.
- **Registry compose fails closed on missing auth and arms registry authentication by default.** A registry deployment with unset credentials now refuses to come up in production instead of silently serving unauthenticated.
- **Telegram Mini App V4 — the phone cockpit becomes a real client (#576, #582).** The `/tg` surface opens on a Today brief served by one DB-only round trip (`GET /telegram/today`): needs-you items, held-draft counts, fleet with per-agent task titles, day-rollup spend with a live sparkline, weekly shipped-task velocity, and ship state. The Approvals tab is a native card stack over all four held-draft queues riding Telegram's MainButton/BackButton/haptics (with visible fallbacks), including X-draft editing with a 280 counter, a blob-fetched video player, and a per-AC release view; Chat and Today refresh live off the shared `/ws/system` socket with a poll fallback; the shell adopts the user's Telegram `themeParams` scoped to `#tg-shell`. The bot tier grows `/agents`, `/usage`, and `/blocked` read commands off the single `BOT_COMMANDS` registry (synced to Bot API `setMyCommands`), and `/secretary` + `/newtask` bridge the chat into the same in-process live intake/secretary runtimes the panel drives — a drafted task becomes a Send-to-Board/Discard keyboard, and board feedback streams back into the thread.
- **Telegram Mini App V5 — brand voice, custom iconography, and an operations ring (#583).** Share Tech Mono (the vendored motion-brand face) becomes the cockpit's display voice via `next/font/local` scoped to `#tg-shell`; a hand-drawn duotone icon set replaces stock linework on the tab bar and action surfaces; and the Today ring stops duplicating the tab bar to become real operations — Ship deep-focuses the open release proposal, Ack all bulk-acknowledges pending notifications, Sweep runs the stale-branch cleanup across every git-configured project behind a confirm sheet, and Fleet opens the full working roster. The Board gains a tap-through task sheet (status, bounce chip, acceptance criteria, open ledger findings, PR link) on a new `TgSheet` primitive with native BackButton dismissal; motion lands dependency-free (spend count-up, tab rise-in, staggered sections, sparkline draw-in) and reduced-motion-safe; Board and Inbox join the `/tg?demo=1` fixtures.
- **Forge program: GitHub, Gitea, and GitLab are first-class forges (#569, #571, #575, #579, #581).** The REST surface (PRs, CI status, reviews, labels, releases) is provider-routed: a ~20-method `GitProvider` transport contract, `GitHubProvider`/`GiteaProvider`/`GitLabProvider` implementations, and a per-call `ForgeRouter` keyed on `RepoRef.host`, with both non-GitHub providers adapting their wire contracts back into the GitHub shapes `GitService` classifies (Gitea status-to-check-run reshaping and slash-encoded refs; GitLab MR/pipeline reshapes, per-file diffs reassembled into unified text, approve-vs-note review routing). Neither has GitHub's server-side merges API, so `sync_env_branch` rides a shared local-clone merge fallback that aborts on conflict with the remote untouched. Projects opt in via `projects.git_provider` (migrations 075/076; gitlab.com auto-detects, self-hosted instances register explicitly, plain-http LAN forges supported); pitch provisioning reaches parity across all three; and env-gated live contract suites run against a dockerized Gitea and gitlab.com — both caught real gaps before ship.
- **Telegram bridge V2 + V3 (#551, #554, #568).** V2 makes the bridge two-way: a `getUpdates` long-poll loop authorizes every update by both chat id and sender id and routes `/status`, `/queue`, `/task`, and Approve/Reject/Open inline-keyboard taps through the same CEO-gated service calls the HTTP routes use, stamping `via=telegram` audit rows; stale Approve/Reject buttons can no longer re-execute an already-decided draft. V3 adds the Mini App sign-in: `POST /api/telegram/webapp-auth` validates Telegram's signed `initData` (HMAC, constant-time, freshness-windowed) against the stored bot token and the CEO's chat id, then mints the same cloud-auth session cookie as `/api/auth/login`. All bot messages get real HTML styling with mandatory escaping at every interpolation, and every held-draft origination pushes a styled DM with its Approve/Reject keyboard the moment it materializes.
- **Agents hub + CEO-grade A2A (#547, #558, #559).** The Agents page becomes a hub: a Fleet tab with the roomier card grid, a Conversations tab absorbing the `/a2a` switchboard (CEO pairs join the matrix, sections collapse), and a Journals tab; a DM quick-action opens a CEO conversation from any agent card, and a New-DM composer with a CEO-DM wake path replaces the old read-only surface.
- **Workstation + customizable Overview quick actions (#549, #556, #557).** Products and Projects unify behind one Workstation sidebar entry with card grids, a view toggle, and sorting on the agent-card visual language; the Overview dashboard's quick-action row becomes user-customizable and server-persisted.
- **Video craft program (#543, #544, #550, #552).** A HyperFrames-grade design bar with four vendored reference bodies and a 133-entry catalog index sets the motion-graphics bar; choreography engines land alongside two renderer root-cause fixes (the broken producer release pinned back with its lockfile, clip windows rebuilt on structural layers so the clock can't lag); the three craft capabilities are wired into the video-authoring dev's prompt; and release-recap beats compose off clip windows onto base-hidden delayed animations.
- **Git hygiene sweep (#548).** Terminal task completion/cancellation force-deletes the task's local branch ref and `.previews/` render dir in the assignee's clone; a PM/CEO can sweep older backlog branches project-wide via `POST /git/branches/cleanup` or the Git page's button; work sessions move under Git with panel charts.
- **Marketing drafts carry the deployer's product, not ours (#570).** X posts, replies, feature spotlights, and video briefs thread `company_goals.company_name` (falling back to RoboCo) through every generated-copy path, and the X/video queues show per-draft project badges; release and spotlight drafts record their source project.
- **The intake finally uses its task-history digest (#592).** The prompter's injected history (built since the digest pipeline landed) now comes with explicit instructions — don't re-propose shipped work, cite prior related tasks by short id, let history inform batch sequencing — and cancelled tasks are excluded from the digest so dead work can't pose as precedent.
- **Taste-skill part 2: niche-aesthetic vocabularies + image direction (#584).** Industrial-brutalist / minimalist-editorial / premium-agency vocabularies keyed onto the existing design-bar dials reach both FE and UX/UI team prompts; a ux_ui-only image-direction section covers composition variety, palette discipline, anti-slop imagery, and mockup conventions.
- **Delegation detail-fidelity + PM-loop hardening (#541).** Details stop thinning at hand-off in either direction: `delegate` refuses children that don't map onto the parent's real acceptance criteria, and QA's pass requires a per-criterion verified stamp; the PM ping-pong respawn loop gets its breaker hardened.
- **Wave-1 quick wins (#546).** Human agent names across the panel, scroll bounce-back fixed, chart empty states, model-pin preservation on mode switches, and UUID spawn normalization.
- **Panel performance: virtualized kanban, memoized rows, batched scorecards (#594).** The kanban card lists render through `@tanstack/react-virtual` windows (columns stay the dnd drop targets, so drag is unaffected) with memoized columns/cards and a ref-stabilized action handler; the task table's desktop row and mobile card are extracted and memoized; and the per-member scorecard N+1 (~20 requests per poll) collapses into one `GET /api/dashboard/metrics/members` batch backed by grouped SQL shared with the single-agent path.
- **Project-agnosticism residue closed (#587).** The docs-site repo/URL becomes config (`ROBOCO_DOCS_SITE_*`, defaults unchanged); the Main PM prompt no longer asserts our repo layout as fact; PR labels derive `to {base}` from the PR's real target branch instead of literal master/slave; the stale hardcoded headcount leaves `base.md`; and the bash-guard's Makefile check requires an actual `quality|gate|lint|test` target before denying raw package managers, ending the false-remediation loop on Go/Rust Makefiles.
- **The test suite is hermetic and order-independent (#591, #595, #598, #594).** Four stale Phase-0 tests asserting GitLab rejection (false since the provider landed) flipped to assert acceptance; the lazily-created global DB engine is disposed after every test, killing the wandering "Future attached to a different loop" class; an autouse fixture pins environment/encryption-key/cloud-auth/guard posture to schema defaults so a deploy-flavored `.env` can't fake failures (174 phantom local failures under an armed operator env → 0); and the new batch-scorecard tests use unique seeds with delta assertions for the shared one-process CI database.
- **Dependencies: selective updates with the Next family held at its 16.1.x pin (#560),** plus routine Actions bumps.
- **Docs caught up to the code.** The agent-facing RAG corpus got a 17-page gap sweep (#596) — including real doc bugs: the QA pages named non-callable tool names, and a page described a field deleted from the codebase — covering required AC-coverage mapping, per-criterion QA stamps, the collision map, the possibilities-matrix fast path, auditor curation verbs, and forge/env-ladder semantics. The exhaustive codebase map got 15 slices refreshed plus `_complete_map.md` regenerated after drifting behind its own sources (#597). The compose twins are resynced under a quality-gate guard with cloud-auth env wired through (#555).
- **Notification `expires_at` is now stamped at creation, so the ack-required re-escalation sweep can actually fire.** `NotificationService._create_notification` built every row without `expires_at`, so `NotificationDeliveryService.sweep_expired_notifications`'s `expires_at < now()` query always matched zero rows — every notification was effectively immortal, and a stuck ack-required notification never got re-escalated to the recipient's up-role. Ack-required rows are now stamped `now() + notification_ack_ttl_hours` (new setting, default 48h, `0` disables stamping); informational (non-ack-required) rows are left `NULL` since the sweep never touches them.
- **Python quality gate: restored green on roboco-api@slave (CI run 29653535468).** Two independent code-level bugs broke the 'Python quality gate' job, not a dependency pin (pydantic-settings was already correctly pinned at 2.14.2). ① `roboco/services/git.py`: `_delete_remote_branch_best_effort` was typed to return `bool` but its success path fell off the function end with no return statement, failing mypy's `missing-return-statement` check and silently returning `None` instead of the documented `True` — added the missing `return True`. ② `roboco/services/company_goals.py`: `CompanyGoalsService.upsert`'s six repetitive `if key in data: row.key = data[key]` branches pushed the module's average cyclomatic complexity past xenon's `--max-modules A` gate — refactored into a data-driven loop over a `_MUTABLE_FIELDS` tuple (behaviourally identical, now rank A). Verified by reproducing all three CI steps locally on the slave-branch worktree: `uv sync --extra dev`, `alembic upgrade head` (all 76 migrations apply cleanly), and `make quality` (13,510 tests, 94.56% coverage, all gates green).
- **The Telegram Mini App no longer gets hijacked to the login page (#600).** The globally-mounted agent-roster sync fires `/api/agents` on every surface; on `/tg` it raced the initData sign-in, took the cloud-auth 401, and the client's blanket 401-interceptor bounced the webview to the password `/login` page it can't complete — landing it on the dashboard. The `(tg)` surface owns its auth UX and is now exempt from the global redirect.
- **A plain browser at `/tg` in production sees the Open-from-Telegram wall** instead of posting an empty initData payload that 422s into a "Couldn't sign in" error.
- **`/auth/login` no longer 422s (#580).** FastAPI had demoted the db dependency to a query parameter on the login route.
- **Task cancellation closes the task's own PR, and the bulk branch sweep spares live dependents (#593).** Every cancel path now best-effort-closes the recorded open PR for the task and its cascaded descendants; the stale-branch sweep excludes branches still recorded by a non-terminal task or serving as a live child's resolved parent branch.
- **Release/readiness hardening basket.** The root PR base resolves the project's env ladder instead of literal master; version detection accepts manifest variants and never crashes the sweep; unconfigured social platforms are skipped instead of becoming pending-forever failures (#545); the readiness sweep's CI wait polls the prod rung; and check-runs dedupe per name so a cancelled duplicate can't mask a green run.
- **Panel/ops hardening basket.** Session links target the owning task (the `/work-sessions/<id>` route never existed); PM review turns are restart-safe; dialog triggers behind tooltips fire again and dotted composition ids render; `git pull` on a target branch became a hard sync to origin; the `git_provider` migration renumbered to 076 restoring a single Alembic head; CI-watch fixed its own regression on roboco-api (#563); agent commits no longer carry model self-attribution; and cockpit CI assertions became delta-based so the one-process run's row leaks can't flake them (#577, #578).

Brand voice (from the CEO's charter):
Voice: the solo human CEO of an AI company — founder-operator, not a marketing department. A bit sassy, always based. Bold but grounded: every flex carries a receipt (a PR number, a version, a rejection count, a timestamp).

Cadence: short declarative lines. Line breaks over commas, one idea per line. Occasional tease ("Hear me out...", "Be ready."). At most one emoji, only when it lands. Never "excited to announce", never hype verbs (Elevate, Unleash, Seamless, Revolutionize), never invented metrics or hedge words.

Stance: contrarian but earned — punch at industry hype, not people. Governance over loops; control over the flow; it's not a framework, nor a harness, nor another loop — it's a company.

Exemplars (the CEO's own posts — match this register):
"I'm the only human at my software company. The other 20 employees are AI."
"Backend QA rejected the dev 3 times. I rejected the Main PM 3 more times."
"Posted the launch 2hs ago. Now I'm out grabbing vape juice, and meanwhile the 20 agents just opened PR #86."
"The industry wants you burning tokens on loops/workflows because that's the product. They're not. Governance is. Control over the flow."

Before authoring: read motion/README.md's design bar and motion/kit/README.md. Build in the panel-demo register on motion/kit/ — extend compositions/panel-demo/ rather than starting from scratch or shipping a text card. Before submitting: call request_render and read every returned frame to verify the RENDERED cut, not just the source.