### PR TITLE
fix(git): branch list classifies remote refs correctly and prunes stale ones

### DIFF
--- a/roboco/api/routes/git.py
+++ b/roboco/api/routes/git.py
@@ -290,6 +290,28 @@ async def get_git_log(
     )
 
 
+def _parse_branch_line(line: str) -> tuple[str, bool, str | None] | None:
+    """Classify one `%(refname)|%(objectname:short)` line as (name, is_remote,
+    last_commit), or None for skippable entries (blank, origin/HEAD, other ref
+    namespaces). Full refname, not `:short` — a remote-tracking ref shortens to
+    `origin/<branch>`, indistinguishable from a local branch literally named
+    that; classify on the `refs/heads/` vs `refs/remotes/` prefix instead.
+    """
+    if not line:
+        return None
+    parts = line.split("|")
+    ref = parts[0]
+    last_commit = parts[1] if len(parts) > 1 else None
+    if ref.startswith("refs/heads/"):
+        return ref.removeprefix("refs/heads/"), False, last_commit
+    if ref.startswith("refs/remotes/"):
+        _remote_name, _, name = ref.removeprefix("refs/remotes/").partition("/")
+        if not name or name == "HEAD":
+            return None  # origin/HEAD is a symbolic pointer, not a branch
+        return name, True, last_commit
+    return None
+
+
 @router.get("/branches", response_model=GitBranchListResponse)
 async def list_branches(
     db: DbSession,
@@ -310,10 +332,6 @@ async def list_branches(
             # upstream via the forge API) before listing them.
             await git_service.prune_remote_best_effort(workspace)
 
-        # Full refname, not `:short` — a remote-tracking ref shortens to
-        # `origin/<branch>`, indistinguishable from a local branch literally
-        # named that; classify on the `refs/heads/` vs `refs/remotes/`
-        # prefix instead.
         args = ["branch", "--format=%(refname)|%(objectname:short)"]
         if include_remote:
             args.append("-a")
@@ -324,23 +342,10 @@ async def list_branches(
 
     branches = []
     for line in branch_result.stdout.strip().split("\n"):
-        if not line:
+        parsed = _parse_branch_line(line)
+        if parsed is None:
             continue
-        parts = line.split("|")
-        ref = parts[0]
-        last_commit = parts[1] if len(parts) > 1 else None
-
-        if ref.startswith("refs/heads/"):
-            name = ref.removeprefix("refs/heads/")
-            is_remote = False
-        elif ref.startswith("refs/remotes/"):
-            _remote_name, _, name = ref.removeprefix("refs/remotes/").partition("/")
-            if not name or name == "HEAD":
-                continue  # origin/HEAD is a symbolic pointer, not a branch
-            is_remote = True
-        else:
-            continue
-
+        name, is_remote, last_commit = parsed
         branches.append(
             BranchInfo(
                 name=name,

--- a/roboco/api/routes/git.py
+++ b/roboco/api/routes/git.py
@@ -305,8 +305,16 @@ async def list_branches(
         workspace = await git_service.get_workspace(project_slug, agent.agent_id)
         current_branch = await git_service.get_current_branch(workspace)
 
-        # Get branches
-        args = ["branch", "--format=%(refname:short)|%(objectname:short)"]
+        if include_remote:
+            # Self-heal orphaned remote-tracking refs (branches deleted
+            # upstream via the forge API) before listing them.
+            await git_service.prune_remote_best_effort(workspace)
+
+        # Full refname, not `:short` — a remote-tracking ref shortens to
+        # `origin/<branch>`, indistinguishable from a local branch literally
+        # named that; classify on the `refs/heads/` vs `refs/remotes/`
+        # prefix instead.
+        args = ["branch", "--format=%(refname)|%(objectname:short)"]
         if include_remote:
             args.append("-a")
 
@@ -319,12 +327,19 @@ async def list_branches(
         if not line:
             continue
         parts = line.split("|")
-        name = parts[0]
+        ref = parts[0]
         last_commit = parts[1] if len(parts) > 1 else None
 
-        is_remote = name.startswith("remotes/")
-        if is_remote:
-            name = name.replace("remotes/origin/", "")
+        if ref.startswith("refs/heads/"):
+            name = ref.removeprefix("refs/heads/")
+            is_remote = False
+        elif ref.startswith("refs/remotes/"):
+            _remote_name, _, name = ref.removeprefix("refs/remotes/").partition("/")
+            if not name or name == "HEAD":
+                continue  # origin/HEAD is a symbolic pointer, not a branch
+            is_remote = True
+        else:
+            continue
 
         branches.append(
             BranchInfo(

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -648,6 +648,28 @@ class GitService(BaseService):
             return None
         return bool(result.stdout.strip())
 
+    async def prune_remote_best_effort(self, workspace: Path) -> None:
+        """Drop stale `origin/*` remote-tracking refs (ref-only, no object
+        transfer) so a branch deleted upstream stops showing in the viewing
+        clone's remote branch list. Never raises — a prune failure must not
+        break the caller's listing, mirroring `branch_exists_on_remote`.
+        """
+        try:
+            token = await self._token_for_workspace(workspace)
+            await self._run_git(
+                workspace,
+                ["remote", "prune", "origin"],
+                check=False,
+                token=token,
+                timeout=_network_git_timeout(),
+            )
+        except Exception as exc:
+            self.log.warning(
+                "remote prune failed; continuing with existing refs",
+                workspace=str(workspace),
+                error=str(exc),
+            )
+
     # =========================================================================
     # STATUS / INFO METHODS
     # =========================================================================
@@ -1842,6 +1864,10 @@ class GitService(BaseService):
     ) -> tuple[str, bool, list[str], list[str], list[str], int, int]:
         """Fetch changes from origin without merging and return post-fetch status.
 
+        `--prune` drops local remote-tracking refs for branches deleted
+        upstream, so the manual Fetch button self-heals the same staleness
+        `prune_remote_best_effort` targets for the branches-list route.
+
         Uses _network_git_timeout() because the operation talks to origin.
 
         Returns: (current_branch, has_changes, staged, unstaged, untracked,
@@ -1850,7 +1876,7 @@ class GitService(BaseService):
         token = await self._token_for_workspace(workspace)
         await self._run_git(
             workspace,
-            ["fetch", "origin"],
+            ["fetch", "origin", "--prune"],
             token=token,
             timeout=_network_git_timeout(),
         )

--- a/tests/integration/test_git_routes.py
+++ b/tests/integration/test_git_routes.py
@@ -324,7 +324,7 @@ async def test_log_service_error(git_client: dict) -> None:
 @pytest.mark.asyncio
 async def test_branches_local_only(git_client: dict) -> None:
     branch_result = MagicMock()
-    branch_result.stdout = "main|abc123\nfeature/x|def456\n"
+    branch_result.stdout = "refs/heads/main|abc123\nrefs/heads/feature/x|def456\n"
     with patch("roboco.api.routes.git.get_git_service") as mock_get:
         svc = AsyncMock()
         svc.get_workspace = AsyncMock(return_value="/tmp/ws")
@@ -336,12 +336,27 @@ async def test_branches_local_only(git_client: dict) -> None:
             headers=_HDR,
         )
     assert response.status_code == HTTPStatus.OK
+    names = {b["name"]: b for b in response.json()["branches"]}
+    assert names["main"]["is_remote"] is False
+    assert names["feature/x"]["is_remote"] is False
+    # include_remote=False (default) never prunes.
+    svc.prune_remote_best_effort.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_branches_with_remote(git_client: dict) -> None:
+    """Regression: `%(refname)` renders a remote-tracking ref as
+    `refs/remotes/origin/<branch>` (real git never emits the old stub's
+    `remotes/origin/<branch>` shape) — it must classify as remote with the
+    `refs/remotes/origin/` prefix stripped down to the bare branch name, and
+    the symbolic `origin/HEAD` ref must be dropped, not surfaced as a fake
+    branch named "HEAD"."""
     branch_result = MagicMock()
-    branch_result.stdout = "main|abc123\nremotes/origin/feature/y|def456\n"
+    branch_result.stdout = (
+        "refs/heads/main|abc123\n"
+        "refs/remotes/origin/feature/y|def456\n"
+        "refs/remotes/origin/HEAD|abc123\n"
+    )
     with patch("roboco.api.routes.git.get_git_service") as mock_get:
         svc = AsyncMock()
         svc.get_workspace = AsyncMock(return_value="/tmp/ws")
@@ -354,6 +369,11 @@ async def test_branches_with_remote(git_client: dict) -> None:
             headers=_HDR,
         )
     assert response.status_code == HTTPStatus.OK
+    names = {b["name"]: b for b in response.json()["branches"]}
+    assert names["feature/y"]["is_remote"] is True
+    assert "origin/feature/y" not in names
+    assert "HEAD" not in names
+    svc.prune_remote_best_effort.assert_awaited_once_with("/tmp/ws")
 
 
 @pytest.mark.asyncio
@@ -361,7 +381,7 @@ async def test_branches_skips_empty_lines(git_client: dict) -> None:
     """Line 246: empty line in branch output triggers continue."""
     branch_result = MagicMock()
     # Embed an empty line between two branches.
-    branch_result.stdout = "main|abc\n\nfeature/x|def\n"
+    branch_result.stdout = "refs/heads/main|abc\n\nrefs/heads/feature/x|def\n"
     with patch("roboco.api.routes.git.get_git_service") as mock_get:
         svc = AsyncMock()
         svc.get_workspace = AsyncMock(return_value="/tmp/ws")


### PR DESCRIPTION
## Problem
The Git page's "Clean Up Stale Branches" appeared to do nothing: after cleanup the branch list was unchanged, with `origin/*` entries listed under **LOCAL**.

Two independent bugs compounded:

1. **`is_remote` detection never fired.** `list_branches` ran `git branch --format=%(refname:short)` but classified remote refs via `name.startswith("remotes/")` — a shape `%(refname:short)` never emits (it renders `origin/<branch>`). Every remote-tracking ref was bucketed as local, and `origin/HEAD` surfaced as a fake branch. The integration test stubbed the same fictitious format, so it stayed green.
2. **The viewing clone was never pruned.** Cleanup's remote deletion genuinely fires, but the panel lists branches from the CEO-context clone, and no code path ever pruned it: `GitService.fetch()` ran a plain `fetch` (no `--prune`) and the workspace auto-refresh deliberately scopes out `feature/*` refs. Deleted branches persisted as orphaned remote-tracking refs forever.

## Fix
- List with full `%(refname)` and classify on `refs/heads/` vs `refs/remotes/`; skip the symbolic `origin/HEAD`.
- New `GitService.prune_remote_best_effort()` (`git remote prune origin`, token + network timeout, never raises) runs before listing when `include_remote=True`.
- `GitService.fetch()` now fetches with `--prune` so the manual Fetch button self-heals too.
- Test stubs corrected to real git output; regression test asserts remote classification, prefix stripping, `origin/HEAD` suppression, and prune invocation.

No changes to cleanup deletion semantics, response schema, or the panel (its invalidation + result toast were already correct).

## Gates
`ruff` clean, `mypy` clean, `tests/integration/test_git_routes.py` 47 passed, `tests/unit/services/test_git.py` 56 passed.