### PR TITLE
[cfc53ec9] Diagnose and fix roboco-api CI regression (run 29770147784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **CEO agent lookup now tolerates multiple role rows in the database.** `NotificationDeliveryService._get_ceo_agent()` previously crashed with `MultipleResultsFound` when more than one CEO-role agent row existed — a rare edge case in production but routine in the shared test database where sibling test runs each commit their own CEO agent. The query now uses `.order_by(AgentTable.created_at).limit(1)` to select the earliest-created agent, mirroring the already-established pattern in `_get_auditor_agent()`. This relaxes an over-strict query (which crashed on >1 row) to gracefully select one deterministic result; no behavior change when exactly one CEO agent exists (the production expectation). Verified 13679 tests pass with 94.39% coverage.
+
 ## [0.26.0] - 2026-07-20
 
 ### Security

--- a/roboco/services/notification_delivery.py
+++ b/roboco/services/notification_delivery.py
@@ -1205,8 +1205,21 @@ class NotificationDeliveryService(BaseService):
         return result.scalar_one_or_none()
 
     async def _get_ceo_agent(self) -> AgentTable | None:
+        """Find the CEO agent (org-wide; earliest-created if many).
+
+        CEO is a singleton in the real system, but nothing enforces that at
+        the DB level (no unique constraint on ``role``), so a bare
+        ``scalar_one_or_none()`` raised ``MultipleResultsFound`` whenever more
+        than one CEO-role row existed — a real (if rare) production
+        possibility, and a routine occurrence in the shared test DB where
+        sibling tests each commit their own CEO agent. Mirrors
+        ``_get_auditor_agent``'s established earliest-wins tie-break.
+        """
         result = await self.session.execute(
-            select(AgentTable).where(AgentTable.role == AgentRole.CEO)
+            select(AgentTable)
+            .where(AgentTable.role == AgentRole.CEO)
+            .order_by(AgentTable.created_at)
+            .limit(1)
         )
         return result.scalar_one_or_none()
 

--- a/roboco/services/x_engine.py
+++ b/roboco/services/x_engine.py
@@ -497,9 +497,7 @@ class XEngine(BaseService):
                 break
             if open_count + len(originated) >= settings.x_max_open_posts:
                 break
-            if not mention.id or await self._already_seen(mention.id):
-                continue
-            if not _is_meaningful(mention, settings.x_mentions_min_engagement):
+            if not await self._mention_is_new_and_meaningful(mention):
                 continue
             if project is None or project.id is None:
                 self.log.warning(
@@ -517,6 +515,14 @@ class XEngine(BaseService):
             if reply_task is not None:
                 originated.append(reply_task)
         return originated
+
+    async def _mention_is_new_and_meaningful(self, mention: XMention) -> bool:
+        """True when a mention hasn't been seen yet and clears the engagement
+        floor — the combined skip/continue precondition `_process_mentions`
+        checks before marking a mention seen and drafting a reply."""
+        if not mention.id or await self._already_seen(mention.id):
+            return False
+        return _is_meaningful(mention, settings.x_mentions_min_engagement)
 
     async def _since_id_get(self) -> str | None:
         """Best-effort read of the persisted mentions cursor; None on miss or


### PR DESCRIPTION
roboco-api's CI is red on the default branch (slave). Evidence: GitHub Actions run https://github.com/rennf93/roboco/actions/runs/29770147784.

Pull the default branch and reproduce the failure locally via `make quality` (or the specific failing stage) to read the actual error output — do not guess from the run URL alone, since this seat has no direct access to GitHub Actions job logs.

Check first whether this matches a known precedent on this repo: a prior CI regression was root-caused to a broken pydantic-settings 2.14.1 PyPI release (patch published 2026-06-19), fixed by pinning pydantic-settings to >=2.14.2 in pyproject.toml and regenerating uv.lock with correct hashes. If the current failure is the same class of dependency-pin issue (e.g. pydantic-settings import/validation errors, or a similarly broken pinned dependency), apply the equivalent fix: bump the pin and regenerate the lockfile. If the actual error output shows a different root cause (a real code regression, test failure, lint/type violation, etc.), investigate and fix that instead — do not assume the precedent applies without confirming against the real failure text.

Constraints: no skipped tests, no CI config bypass (e.g. disabling a check, marking tests xfail without justification), no masking the symptom. The fix must address the actual root cause. Scope is backend-only: roboco/api, roboco/models, roboco/services, roboco/utils, and dependency files (pyproject.toml, uv.lock) if applicable.

Document the confirmed root cause in your journal (reflect note) and PR notes before submitting. Verify `make quality` (or CI-equivalent checks) passes locally before requesting QA.