### PR TITLE
[5517a49c] Fix roboco-api CI regression on default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- **CEO agent lookup now tolerates multiple role rows in the database.** `NotificationDeliveryService._get_ceo_agent()` previously crashed with `MultipleResultsFound` when more than one CEO-role agent row existed — a rare edge case in production but routine in the shared test database where sibling test runs each commit their own CEO agent. The query now uses `.order_by(AgentTable.created_at).limit(1)` to select the earliest-created agent, mirroring the already-established pattern in `_get_auditor_agent()`. This relaxes an over-strict query (which crashed on >1 row) to gracefully select one deterministic result; no behavior change when exactly one CEO agent exists (the production expectation). Verified 13679 tests pass with 94.39% coverage.
+
 ## [0.26.0] - 2026-07-20
 
 ### Security

--- a/roboco/services/notification_delivery.py
+++ b/roboco/services/notification_delivery.py
@@ -1205,8 +1205,21 @@ class NotificationDeliveryService(BaseService):
         return result.scalar_one_or_none()
 
     async def _get_ceo_agent(self) -> AgentTable | None:
+        """Find the CEO agent (org-wide; earliest-created if many).
+
+        CEO is a singleton in the real system, but nothing enforces that at
+        the DB level (no unique constraint on ``role``), so a bare
+        ``scalar_one_or_none()`` raised ``MultipleResultsFound`` whenever more
+        than one CEO-role row existed — a real (if rare) production
+        possibility, and a routine occurrence in the shared test DB where
+        sibling tests each commit their own CEO agent. Mirrors
+        ``_get_auditor_agent``'s established earliest-wins tie-break.
+        """
         result = await self.session.execute(
-            select(AgentTable).where(AgentTable.role == AgentRole.CEO)
+            select(AgentTable)
+            .where(AgentTable.role == AgentRole.CEO)
+            .order_by(AgentTable.created_at)
+            .limit(1)
         )
         return result.scalar_one_or_none()
 

--- a/roboco/services/x_engine.py
+++ b/roboco/services/x_engine.py
@@ -497,9 +497,7 @@ class XEngine(BaseService):
                 break
             if open_count + len(originated) >= settings.x_max_open_posts:
                 break
-            if not mention.id or await self._already_seen(mention.id):
-                continue
-            if not _is_meaningful(mention, settings.x_mentions_min_engagement):
+            if not await self._mention_is_new_and_meaningful(mention):
                 continue
             if project is None or project.id is None:
                 self.log.warning(
@@ -517,6 +515,14 @@ class XEngine(BaseService):
             if reply_task is not None:
                 originated.append(reply_task)
         return originated
+
+    async def _mention_is_new_and_meaningful(self, mention: XMention) -> bool:
+        """True when a mention hasn't been seen yet and clears the engagement
+        floor — the combined skip/continue precondition `_process_mentions`
+        checks before marking a mention seen and drafting a reply."""
+        if not mention.id or await self._already_seen(mention.id):
+            return False
+        return _is_meaningful(mention, settings.x_mentions_min_engagement)
 
     async def _since_id_get(self) -> str | None:
         """Best-effort read of the persisted mentions cursor; None on miss or


### PR DESCRIPTION
roboco-api's CI is red on its default branch (slave). Evidence: GitHub Actions run https://github.com/rennf93/roboco/actions/runs/29770147784.

Goal: get CI green again on the default branch with a root-cause fix, merged through the normal gates (QA, PR review, CEO merge). This is a backend-only repo (roboco/api, roboco/models, roboco/services, roboco/utils) — no frontend/UX involvement needed.

Constraint / lead to check first: institutional memory shows a directly relevant precedent on this same repo — a prior CI regression was root-caused to a broken pydantic-settings 2.14.1 PyPI release (patch published 2026-06-19), fixed by pinning pydantic-settings to >=2.14.2 and regenerating uv.lock with correct hashes (no test skips, no CI bypass). Have your dev check whether this run's failure is the same class of dependency-pin issue before investigating a deeper code regression. I don't have direct access to the CI job logs from this seat (no web search provider configured, raw git/curl to GitHub denied at Main PM role) — your dev will need to pull the branch and read the actual failure output to confirm root cause, whatever it turns out to be.

Decompose into one dev leaf: diagnose + fix + verify CI green on the branch before it goes to QA/PR review.