### PR TITLE
[d5315683] Approval-queue status-handling and optimistic-UI audit and fix

### DIFF
--- a/panel/src/components/dashboard/__tests__/release-proposal-card-status-feedback.test.tsx
+++ b/panel/src/components/dashboard/__tests__/release-proposal-card-status-feedback.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { ReleaseProposal } from "@/lib/api/release";
+import { PageRefreshProvider } from "@/components/providers";
+
+// Unlike release-proposal-card.test.tsx (which stubs useMutation entirely to
+// test the query-failure/execute-status surfacing paths), these tests
+// exercise the REAL useMutation onSuccess handler — mirrors the
+// x-post-queue/video-post-queue/roadmap-review-queue test pattern — so
+// approve()'s per-status toast copy is actually asserted.
+const { resolveApproveRef } = vi.hoisted(() => ({
+  resolveApproveRef: { current: null as null | ((v: unknown) => void) },
+}));
+
+const { getProposal, approve, reject } = vi.hoisted(() => ({
+  getProposal: vi.fn(
+    async (): Promise<ReleaseProposal> => ({
+      task_id: "t1",
+      title: "Cut v0.14.0",
+      status: "awaiting_ceo_approval",
+      required_changes: null,
+      report: {
+        proposed_version: "0.14.0",
+        bump_kind: "minor",
+        change_summary: ["feat: metrics"],
+        drafted_changelog: "## 0.14.0\n- metrics",
+        version_bump_plan: ["pyproject.toml"],
+        gaps: [],
+        migration_notes: [],
+        gate_state: "green",
+      },
+    }),
+  ),
+  // Deferred so the test can freeze the approve mid-flight.
+  approve: vi.fn(
+    () =>
+      new Promise((r) => {
+        resolveApproveRef.current = r as (v: unknown) => void;
+      }),
+  ),
+  reject: vi.fn(async () => ({})),
+}));
+
+vi.mock("@/lib/api", () => ({
+  releaseApi: { getProposal, approve, reject },
+}));
+
+const { toast } = vi.hoisted(() => ({
+  toast: { success: vi.fn(), warning: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast }));
+
+import { ReleaseProposalCard } from "../release-proposal-card";
+
+function withProviders(ui: ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <PageRefreshProvider>{ui}</PageRefreshProvider>
+    </QueryClientProvider>
+  );
+}
+
+async function clickApprove() {
+  render(withProviders(<ReleaseProposalCard />));
+  fireEvent.click(
+    await screen.findByRole("button", { name: /Approve & publish/i }),
+  );
+  // Radix marks the rest of the page inert/aria-hidden once the dialog opens
+  // — the main card's own button drops out of the accessible tree, so this
+  // now uniquely matches the dialog's confirm button.
+  await screen.findByRole("dialog");
+  fireEvent.click(
+    await screen.findByRole("button", { name: /Approve & publish/i }),
+  );
+  await waitFor(() => expect(approve).toHaveBeenCalled());
+}
+
+describe("ReleaseProposalCard — status feedback (silent-bug-sweep #c)", () => {
+  beforeEach(() => {
+    getProposal.mockClear();
+    approve.mockClear();
+    reject.mockClear();
+    toast.success.mockClear();
+    toast.warning.mockClear();
+    toast.info.mockClear();
+    toast.error.mockClear();
+    resolveApproveRef.current = null;
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [
+      "already_in_progress",
+      "A release execute is already in progress for this proposal.",
+    ],
+    [
+      "redis_unavailable",
+      "Redis is unavailable — can't acquire the release mutex.",
+    ],
+    ["lock_lost", "The release lock was lost mid-execute — retry the approve."],
+    ["gate_failed", "Release halted (gate_failed): the gate is red"],
+  ])("shows distinct feedback for the %s status", async (status, message) => {
+    await clickApprove();
+
+    resolveApproveRef.current?.({
+      status,
+      version: "0.14.0",
+      files_changed: [],
+      commit_sha: null,
+      release_url: null,
+      detail: "the gate is red",
+    });
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(message));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast for the published status", async () => {
+    await clickApprove();
+
+    resolveApproveRef.current?.({
+      status: "published",
+      version: "0.14.0",
+      files_changed: ["pyproject.toml"],
+      commit_sha: "abc123",
+      release_url: "https://github.com/example/example/releases/tag/v0.14.0",
+      detail: "published",
+    });
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Published v0.14.0"),
+    );
+  });
+
+  it("shows an info toast for the accepted (background-dispatched) status", async () => {
+    await clickApprove();
+
+    resolveApproveRef.current?.({
+      status: "accepted",
+      version: "0.14.0",
+      files_changed: [],
+      commit_sha: null,
+      release_url: null,
+      detail: "dispatched",
+    });
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "Release execute dispatched — running in the background. This card updates as it progresses.",
+      ),
+    );
+  });
+});

--- a/panel/src/components/dashboard/__tests__/roadmap-review-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/roadmap-review-queue.test.tsx
@@ -58,6 +58,11 @@ vi.mock("@/lib/api", () => ({
   roadmapApi: { listCycles, approveItem, rejectItem },
 }));
 
+const { toast } = vi.hoisted(() => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast }));
+
 import { RoadmapReviewQueue } from "../roadmap-review-queue";
 
 function withQueryClient(ui: ReactNode) {
@@ -72,6 +77,9 @@ describe("RoadmapReviewQueue", () => {
     listCycles.mockClear();
     approveItem.mockClear();
     rejectItem.mockClear();
+    toast.success.mockClear();
+    toast.warning.mockClear();
+    toast.error.mockClear();
     resolveApproveRef.current = null;
   });
   afterEach(() => {
@@ -140,4 +148,48 @@ describe("RoadmapReviewQueue", () => {
     await waitFor(() => expect(listCycles).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
   });
+
+  // F(silent-bug-sweep #c): RoadmapService uses its own disjoint status
+  // vocabulary (approved/already_approved/invalid_state/rejected/
+  // already_rejected) — none of the 7 named cross-queue statuses
+  // (already_in_progress, redis_unavailable, lock_lost, post_failed,
+  // posted_partial, no_platforms, no_credentials) ever reach this queue, so
+  // this locks in distinct feedback for roadmap's own statuses instead.
+  it.each([
+    [
+      "already_approved",
+      "this item was already approved",
+      "Item approved — added to the backlog",
+    ],
+    [
+      "invalid_state",
+      "item is 'rejected', not proposed — cannot approve",
+      "item is 'rejected', not proposed — cannot approve",
+    ],
+  ])(
+    "shows distinct feedback for the %s status",
+    async (status, detail, message) => {
+      render(withQueryClient(<RoadmapReviewQueue />));
+      const approveButtons = await screen.findAllByRole("button", {
+        name: /Approve/,
+      });
+      fireEvent.click(approveButtons[0]);
+      await waitFor(() => expect(approveItem).toHaveBeenCalled());
+
+      resolveApproveRef.current?.({
+        status,
+        item_id: "item-0",
+        materialized_task_id: null,
+        detail,
+      });
+
+      await waitFor(() => {
+        if (status === "already_approved") {
+          expect(toast.success).toHaveBeenCalledWith(message);
+        } else {
+          expect(toast.warning).toHaveBeenCalledWith(message);
+        }
+      });
+    },
+  );
 });

--- a/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/video-post-queue.test.tsx
@@ -102,6 +102,11 @@ vi.mock("@/components/projects/project-selector", () => ({
   ),
 }));
 
+const { toast } = vi.hoisted(() => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast }));
+
 import { VideoPostQueue } from "../video-post-queue";
 
 function withQueryClient(ui: ReactNode) {
@@ -119,6 +124,9 @@ describe("VideoPostQueue", () => {
     reject.mockClear();
     requestVideo.mockClear();
     getMediaBlob.mockClear();
+    toast.success.mockClear();
+    toast.warning.mockClear();
+    toast.error.mockClear();
     resolveApproveRef.current = null;
     // jsdom has no Blob URL implementation. Distinct URLs per call so a
     // revoke can be asserted against the specific (stale) one it replaced.
@@ -557,5 +565,69 @@ describe("VideoPostQueue", () => {
     render(withQueryClient(<VideoPostQueue />));
     await screen.findByText("release");
     expect(document.querySelector("iframe")).not.toBeInTheDocument();
+  });
+
+  // F(silent-bug-sweep #c): every VideoPostService.approve status must
+  // render a distinct, non-swallowed toast — regression guard, no code gap
+  // was found here (describeExecuteResult already branches every one of
+  // these).
+  it.each([
+    [
+      "posted_partial",
+      { status: "posted_partial", posted: { x: "1" }, detail: "tiktok: down" },
+      "Posted to some platforms — tiktok: down",
+    ],
+    [
+      "post_failed",
+      { status: "post_failed", posted: {}, detail: "both platforms down" },
+      "Posting failed: both platforms down",
+    ],
+    [
+      "already_in_progress",
+      { status: "already_in_progress", posted: {}, detail: "" },
+      "A post is already in progress for this draft.",
+    ],
+    [
+      "no_platforms",
+      { status: "no_platforms", posted: {}, detail: "" },
+      "This draft has no target platforms.",
+    ],
+    [
+      "lock_lost",
+      { status: "lock_lost", posted: {}, detail: "" },
+      "The post lock was lost mid-upload — retry the approve.",
+    ],
+    [
+      "redis_unavailable",
+      { status: "redis_unavailable", posted: {}, detail: "" },
+      "Redis is unavailable — can't acquire the post lock.",
+    ],
+  ])("shows distinct feedback for the %s status", async (_, result, message) => {
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+    fireEvent.click(screen.getByRole("button", { name: /Approve/ }));
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+
+    resolveApproveRef.current?.(result);
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(message));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast for the posted status", async () => {
+    render(withQueryClient(<VideoPostQueue />));
+    await screen.findByText("release");
+    fireEvent.click(screen.getByRole("button", { name: /Approve/ }));
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+
+    resolveApproveRef.current?.({
+      status: "posted",
+      posted: { x: "1", tiktok: "2" },
+      detail: "posted to all platforms",
+    });
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Posted to all platforms."),
+    );
   });
 });

--- a/panel/src/components/dashboard/__tests__/x-post-queue.test.tsx
+++ b/panel/src/components/dashboard/__tests__/x-post-queue.test.tsx
@@ -44,6 +44,11 @@ const { listPosts, approve, reject } = vi.hoisted(() => ({
 
 vi.mock("@/lib/api", () => ({ xApi: { listPosts, approve, reject } }));
 
+const { toast } = vi.hoisted(() => ({
+  toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+vi.mock("sonner", () => ({ toast }));
+
 import { XPostQueue } from "../x-post-queue";
 
 function withQueryClient(ui: ReactNode) {
@@ -58,6 +63,9 @@ describe("XPostQueue", () => {
     listPosts.mockClear();
     approve.mockClear();
     reject.mockClear();
+    toast.success.mockClear();
+    toast.warning.mockClear();
+    toast.error.mockClear();
     resolveApproveRef.current = null;
   });
   afterEach(() => {
@@ -177,5 +185,56 @@ describe("XPostQueue", () => {
     const { container } = render(withQueryClient(<XPostQueue />));
     await waitFor(() => expect(listPosts).toHaveBeenCalled());
     expect(container).toBeEmptyDOMElement();
+  });
+
+  // F(silent-bug-sweep #c): every XPostService.approve status must render a
+  // distinct, non-swallowed toast — not a blanket success/failure.
+  it.each([
+    ["already_in_progress", "A post is already in progress for this draft."],
+    [
+      "no_credentials",
+      "No X credentials configured — set them below first.",
+    ],
+    ["post_failed", "Posting failed: the X API rejected the tweet"],
+    [
+      "redis_unavailable",
+      "Redis is unavailable — can't acquire the post lock.",
+    ],
+    ["already_posted", "Already posted — no-op."],
+  ])("shows distinct feedback for the %s status", async (status, message) => {
+    render(withQueryClient(<XPostQueue />));
+    const approveButtons = await screen.findAllByRole("button", {
+      name: /Approve/,
+    });
+    fireEvent.click(approveButtons[0]);
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+
+    resolveApproveRef.current?.({
+      status,
+      tweet_id: null,
+      detail: "the X API rejected the tweet",
+    });
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(message));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast for the posted status", async () => {
+    render(withQueryClient(<XPostQueue />));
+    const approveButtons = await screen.findAllByRole("button", {
+      name: /Approve/,
+    });
+    fireEvent.click(approveButtons[0]);
+    await waitFor(() => expect(approve).toHaveBeenCalled());
+
+    resolveApproveRef.current?.({
+      status: "posted",
+      tweet_id: "1",
+      detail: "ok",
+    });
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Posted to X."),
+    );
   });
 });

--- a/panel/src/components/dashboard/release-proposal-card.tsx
+++ b/panel/src/components/dashboard/release-proposal-card.tsx
@@ -38,6 +38,20 @@ function gateBadgeVariant(
   return "secondary";
 }
 
+// Distinct copy for the concurrency/infra statuses a release execute can
+// come back with (already_in_progress / redis_unavailable / lock_lost) —
+// the rest (gate_failed, ci_failed, ...) fall through to the generic
+// "Release halted (status): detail" message, itself still status-specific.
+function describeHaltedStatus(result: ReleaseExecuteResult): string {
+  if (result.status === "already_in_progress")
+    return "A release execute is already in progress for this proposal.";
+  if (result.status === "redis_unavailable")
+    return "Redis is unavailable — can't acquire the release mutex.";
+  if (result.status === "lock_lost")
+    return "The release lock was lost mid-execute — retry the approve.";
+  return `Release halted (${result.status}): ${result.detail}`;
+}
+
 // A red gate / open gaps make publishing risky — the CEO should resolve them
 // first. Approval still runs the fail-closed executor, so it can't ship a bad
 // release; this only steers the CEO.
@@ -86,7 +100,7 @@ export function ReleaseProposalCard({ className }: { className?: string }) {
           "Release execute dispatched — running in the background. This card updates as it progresses.",
         );
       } else {
-        toast.warning(`Release halted (${result.status}): ${result.detail}`);
+        toast.warning(describeHaltedStatus(result));
       }
       closeDialog();
     },

--- a/panel/src/components/dashboard/x-post-queue.tsx
+++ b/panel/src/components/dashboard/x-post-queue.tsx
@@ -77,6 +77,10 @@ function describeExecuteResult(result: XPostExecuteResult): string {
     return "A post is already in progress for this draft.";
   if (result.status === "no_credentials")
     return "No X credentials configured — set them below first.";
+  if (result.status === "post_failed")
+    return `Posting failed: ${result.detail}`;
+  if (result.status === "redis_unavailable")
+    return "Redis is unavailable — can't acquire the post lock.";
   return `${result.status}: ${result.detail}`;
 }
 


### PR DESCRIPTION
## Summary

Audited x-post-queue.tsx, video-post-queue.tsx, release-proposal-card.tsx, and roadmap-review-queue.tsx for (a) failed mutations leaving the UI inconsistent, (b) optimistic drafts disappearing before the backend confirms, and (c) every one of 7 named backend result statuses (already_in_progress, redis_unavailable, lock_lost, post_failed, posted_partial, no_platforms, no_credentials) rendering distinct, user-visible feedback.

## Confirmed fixes (with regression tests)

- x-post-queue.tsx: describeExecuteResult() fell through to a generic status:detail string for post_failed and redis_unavailable (real XPostService.approve outcomes, roboco/services/x_post_service.py:118,201). Added explicit branches.
- release-proposal-card.tsx: the approve mutation's onSuccess collapsed already_in_progress/redis_unavailable/lock_lost (roboco/services/release_proposal.py:135,148,183) into one generic "Release halted" toast. Added a describeHaltedStatus() helper with explicit copy for these three; the generic fallback still covers release-specific statuses outside the named 7 (gate_failed, ci_failed, commit_failed, publish_failed, already_published, promotion_failed).

## Statuses confirmed NOT applicable (no fabricated handling added)

- video-post-queue.tsx already explicitly branches every status VideoPostService.approve can return. no_credentials is not a distinct status there - a missing credential is folded into post_failed/posted_partial's detail string. No code change; added regression tests locking in existing behavior.
- roadmap-review-queue.tsx talks to RoadmapService, a disjoint vocabulary (approved, already_approved, invalid_state, rejected, already_rejected) - none of the 7 named statuses are reachable there. Added regression tests for roadmap's own statuses instead.
- release-proposal-card.tsx cannot receive post_failed/posted_partial/no_platforms/no_credentials - those are X/video-posting concepts, not release-execute concepts.

## Audit items (a) and (b): no repro found

No component uses onMutate/setQueryData - invalidateQueries only runs inside onSuccess, so a draft never disappears before the backend confirms. Every approve/reject mutation pairs isPending-driven disabling with an onError toast; approve mutations additionally reset the local approving-id via onSettled.

## Test plan

- pnpm lint clean (0 errors)
- pnpm typecheck clean
- pnpm test clean - 137 test files / 836 tests passed
- New/updated regression tests across all 4 queue test files plus a new release-proposal-card-status-feedback.test.tsx
