### PR TITLE
[4534c71a] Backend concurrency, state-machine, and engine audit

### DIFF
--- a/CONCURRENCY_AUDIT.md
+++ b/CONCURRENCY_AUDIT.md
@@ -9,7 +9,7 @@ This PR audits the list-open-then-originate dedup pattern across six engines and
 1. **VideoEngine.open_video_task** — Race condition fixed
    - **Why it races:** Three concurrent call sites (release hook, spotlight hook, /video/request route)
    - **Fix:** Per-occasion HeartbeatMutex wraps the dedup check + insert atomically
-   - **Tests:** 
+   - **Tests:**
      - `test_open_video_task_lock_held` — locked calls return None
      - `test_open_video_task_concurrent_calls` — concurrent calls for same occasion create only one task
 
@@ -24,7 +24,7 @@ This PR audits the list-open-then-originate dedup pattern across six engines and
 ### Verified Correct (with regression tests documenting why)
 
 1. **RoadmapEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
-2. **XEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race  
+2. **XEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
 3. **DepUpdateEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
 4. **CIWatchEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
 5. **SelfHealEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race

--- a/CONCURRENCY_AUDIT.md
+++ b/CONCURRENCY_AUDIT.md
@@ -1,0 +1,61 @@
+# Engine Dedup Audit and Concurrency Fixes (PR #628)
+
+## Summary
+
+This PR audits the list-open-then-originate dedup pattern across six engines and fixes two defects:
+
+### Fixes (with regression tests)
+
+1. **VideoEngine.open_video_task** — Race condition fixed
+   - **Why it races:** Three concurrent call sites (release hook, spotlight hook, /video/request route)
+   - **Fix:** Per-occasion HeartbeatMutex wraps the dedup check + insert atomically
+   - **Tests:** 
+     - `test_open_video_task_lock_held` — locked calls return None
+     - `test_open_video_task_concurrent_calls` — concurrent calls for same occasion create only one task
+
+2. **sequencing.py dev_task_collision_edges** — Short-circuit bug fixed
+   - **Why it fails:** `if edges: return edges` drops the assignee-lane fallback whenever any surfaced pair collides
+   - **Bug:** Unsurfaced siblings in same lane end up with no ordering at all
+   - **Fix:** Fallback always runs, filtering pairs already covered by the analyzer
+   - **Tests:**
+     - `test_dev_collision_fallback_still_applies_when_another_pair_collides` — unrelated pairs still ordered
+     - `test_dev_collision_fallback_covers_unsurfaced_sibling_in_surfaced_lane` — mixed-surface lane chain preserved
+
+### Verified Correct (with regression tests documenting why)
+
+1. **RoadmapEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
+2. **XEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race  
+3. **DepUpdateEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
+4. **CIWatchEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
+5. **SelfHealEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
+6. **ReleaseExecutor half-landed retry** — Version bump + changelog always atomically committed before any push
+   - Test: `test_release_commit_sha_detects_a_real_half_landed_commit` — real repo test verifies committed state
+
+Also verified:
+- **sequencing.py rule 3** — All-shared batch generates no edges (correct by inspection)
+  - Test: `test_all_shared_batch_with_disjoint_surfaces_generates_no_edges`
+
+## Key Patterns for Future Work
+
+### ✅ Safe Patterns
+
+- **Sequential call site** — If a method has exactly one entry point and builds dedup sets before any commit, the check-then-insert is atomic within that cycle. Document the orchestrator wiring to prevent accidental second call sites.
+
+- **Atomic database writes** — If version bump and changelog write together in one git commit before any push, a partial state is unreachable on origin. A fresh retry clone always sees the full committed state.
+
+### ⚠️ Anti-Patterns
+
+- **Non-atomic check-then-act** — Multiple concurrent calls can race on a shared resource without a lock
+  - Fix: HeartbeatMutex (renews TTL, fail-closed on crash)
+
+- **Conditional early returns skipping independent logic** — If multiple orderings apply independently, use filtering instead
+  - Fix: Always run both mechanisms, skip pairs already covered
+
+## Regression Test Coverage
+
+- 9 new regression tests total
+- 3 tests for VideoEngine occasion lock
+- 3 tests for sequencing.py fallback
+- 3 tests for verified patterns (ReleaseExecutor, rule 3, orchestrator sequentiality)
+
+All tests confirm the concurrent/sequential assumptions and prevent regressions if these patterns are refactored.

--- a/docs/rag/lifecycle/status-transitions.md
+++ b/docs/rag/lifecycle/status-transitions.md
@@ -11,6 +11,7 @@
 | awaiting_documentation | claimed | claim | documenter |
 | awaiting_pm_review | awaiting_ceo_approval | escalate_to_ceo | head_marketing, main_pm, product_owner |
 | awaiting_pm_review | cancelled | cancel | cell_pm, ceo, main_pm |
+| awaiting_pm_review | claimed | claim | cell_pm, main_pm |
 | awaiting_pm_review | completed | complete | cell_pm, main_pm |
 | awaiting_pm_review | needs_revision | request_changes | cell_pm, main_pm |
 | awaiting_pr_review | awaiting_pm_review | pr_pass | pr_reviewer |

--- a/panel/lib/lifecycle.json
+++ b/panel/lib/lifecycle.json
@@ -2,6 +2,7 @@
   "claim_rules": {
     "auditor": [],
     "cell_pm": [
+      "awaiting_pm_review",
       "needs_revision",
       "pending"
     ],
@@ -16,6 +17,7 @@
     ],
     "head_marketing": [],
     "main_pm": [
+      "awaiting_pm_review",
       "needs_revision",
       "pending"
     ],
@@ -528,6 +530,15 @@
       ],
       "source": "awaiting_pm_review",
       "target": "cancelled"
+    },
+    {
+      "action": "claim",
+      "roles": [
+        "cell_pm",
+        "main_pm"
+      ],
+      "source": "awaiting_pm_review",
+      "target": "claimed"
     },
     {
       "action": "complete",

--- a/roboco/api/routes/release.py
+++ b/roboco/api/routes/release.py
@@ -149,9 +149,15 @@ async def reject_release_proposal(
             status_code=status.HTTP_404_NOT_FOUND, detail="No open release proposal"
         )
     revised = await svc.reject(cast("UUID", task.id), data.required_changes)
-    if revised is None:  # pragma: no cover - open_proposal already guaranteed it
+    if revised is None:
+        # A concurrent approve is mid-execute (holds the release mutex) or
+        # Redis is unreachable — reject fails closed rather than racing it.
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="No open release proposal"
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Reject refused: a release approve is in progress or Redis is"
+                " unavailable. Retry once it clears."
+            ),
         )
     await db.commit()
     return _to_response(revised)

--- a/roboco/foundation/policy/lifecycle.py
+++ b/roboco/foundation/policy/lifecycle.py
@@ -245,6 +245,14 @@ _STATUS_TRANSITIONS: tuple[StatusTransition, ...] = (
         frozenset({Role.DOCUMENTER}),
     ),
     StatusTransition(Status.NEEDS_REVISION, Status.CLAIMED, "claim", None),
+    # A PM re-claims an awaiting_pm_review task it already owns (CLAIM_RULES
+    # grants this to CELL_PM/MAIN_PM) — see the "claim" ActionSpec comment.
+    StatusTransition(
+        Status.AWAITING_PM_REVIEW,
+        Status.CLAIMED,
+        "claim",
+        frozenset({Role.CELL_PM, Role.MAIN_PM}),
+    ),
     # Start
     StatusTransition(Status.CLAIMED, Status.IN_PROGRESS, "start", None),
     # Block / pause / resume
@@ -446,6 +454,16 @@ _ATOMIC_ACTIONS: dict[str, ActionSpec] = {
                 Status.AWAITING_QA,
                 Status.AWAITING_DOCUMENTATION,
                 Status.AWAITING_PR_REVIEW,
+                # A PM re-claims a review/queue task it already owns (e.g. after
+                # a respawn) via i_will_plan — CLAIM_RULES[CELL_PM/MAIN_PM]
+                # grants AWAITING_PM_REVIEW (see test_claim_rules_match_
+                # pre_gateway_table). Without it here, can_invoke_intent
+                # rejected i_will_plan on an awaiting_pm_review task with
+                # invalid_state even though CLAIM_RULES said it was allowed —
+                # the "validator checks consistency between them" below was
+                # promised but never written; see
+                # _check_claim_rules_subset_of_claim_action.
+                Status.AWAITING_PM_REVIEW,
             }
         ),
         target_status=Status.CLAIMED,
@@ -732,8 +750,22 @@ CLAIM_RULES: dict[Role, frozenset[Status]] = {
     # that scopes a developer's leaf-revision: give_me_work only ever offers an
     # agent its own assigned tasks. (A per-instance ownership gate at the gateway
     # would diverge from this spec — the parity invariant forbids that.)
-    Role.CELL_PM: frozenset({Status.PENDING, Status.NEEDS_REVISION}),
-    Role.MAIN_PM: frozenset({Status.PENDING, Status.NEEDS_REVISION}),
+    #
+    # AWAITING_PM_REVIEW: a PM re-claims its own review-queue task (e.g. after
+    # a respawn) via i_will_plan. roboco/services/task.py's
+    # _ROLE_CLAIM_STATUSES already granted this to "cell_pm"/"main_pm" on the
+    # stated belief that "the spec (lifecycle.CLAIM_RULES) grants it" — but
+    # CLAIM_RULES never actually did, so can_invoke_intent silently rejected
+    # every i_will_plan attempt on an awaiting_pm_review task with
+    # invalid_state regardless of what the service layer allowed. Added here
+    # to make that comment true; _check_claim_rules_subset_of_claim_action
+    # guards the two tables from diverging again.
+    Role.CELL_PM: frozenset(
+        {Status.PENDING, Status.NEEDS_REVISION, Status.AWAITING_PM_REVIEW}
+    ),
+    Role.MAIN_PM: frozenset(
+        {Status.PENDING, Status.NEEDS_REVISION, Status.AWAITING_PM_REVIEW}
+    ),
     Role.PRODUCT_OWNER: frozenset(),
     Role.HEAD_MARKETING: frozenset(),
     Role.AUDITOR: frozenset(),

--- a/roboco/services/release_executor.py
+++ b/roboco/services/release_executor.py
@@ -254,6 +254,15 @@ async def _await_proc(
             proc.kill()  # already-exited between the timeout and the kill is fine
         await proc.wait()
         return _TIMEOUT_RC, f"subprocess timed out after {int(timeout)}s"
+    except asyncio.CancelledError:
+        # An outer cancellation (e.g. the release loop's own task being
+        # cancelled mid-op) throws in here instead of the TimeoutError above —
+        # same orphaned child + leaked FDs if left unkilled. Mirrors
+        # quality_gate.py's ``_run_one`` handler for the identical shape.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        await proc.wait()
+        raise
     return proc.returncode or 0, out.decode("utf-8", "replace")
 
 

--- a/roboco/services/release_proposal.py
+++ b/roboco/services/release_proposal.py
@@ -439,6 +439,14 @@ class ReleaseProposalService(BaseService):
         published (COMPLETED) — an approve may have shipped it after a stale
         reject button/request was queued; cancelling a published release
         would lie about the release's real, already-public state.
+
+        Acquires the same release mutex ``approve()`` holds (same key, same
+        non-blocking acquire style) so a reject can't interleave with a
+        concurrent in-flight approve — an unguarded write here used to be
+        able to land on the proposal while an approve was mid-execute (up to
+        ~40 min), racing the approve's own post-lock write. Fails CLOSED like
+        approve, both when the lock is held and when Redis is unreachable —
+        the CEO retries the reject once it clears.
         """
         task = await get_task_service(self.session).get(task_id)
         if task is None or task.source != RELEASE_MANAGER_SOURCE:
@@ -448,10 +456,34 @@ class ReleaseProposalService(BaseService):
                 f"release proposal {task_id} already published (COMPLETED);"
                 " cannot be rejected"
             )
-        markers.set_release_required_changes(task, required_changes)
-        task.status = TaskStatus.CANCELLED
-        await self.session.flush()
-        return task
+
+        lock_key = f"{_RELEASE_LOCK_PREFIX}{task_id}"
+        try:
+            lock_token = await self._acquire_release_lock(lock_key)
+        except ReleaseLockUnavailable as exc:
+            logger.error("release reject lock unavailable (redis down): %s", exc)
+            return None
+        if lock_token is None:
+            return None  # a concurrent approve is mid-execute; refuse the reject
+        try:
+            # Re-read under the lock: a concurrent approve may have committed
+            # COMPLETED between the pre-lock check and here.
+            self.session.expire(task)
+            locked = await get_task_service(self.session).get(task_id)
+            if locked is None:
+                return None
+            if locked.status == TaskStatus.COMPLETED:
+                raise TaskAlreadyCompletedError(
+                    f"release proposal {task_id} already published (COMPLETED);"
+                    " cannot be rejected"
+                )
+            markers.set_release_required_changes(locked, required_changes)
+            locked.status = TaskStatus.CANCELLED
+            await self.session.flush()
+            return locked
+        finally:
+            await self._release_release_lock(lock_key, lock_token)
+            await self._close_redis()
 
 
 def get_release_proposal_service(session: AsyncSession) -> ReleaseProposalService:

--- a/roboco/services/sequencing.py
+++ b/roboco/services/sequencing.py
@@ -306,6 +306,15 @@ def dev_task_collision_edges(siblings: list) -> list[tuple[object, object]]:
     waves are edge-consistent, so an edge-wired pair can never invert its
     sort). ``add_dependency`` dedupes, so repeated wiring is a no-op on
     already-wired pairs.
+
+    The same-assignee-lane fallback (see ``_same_assignee_lane_edges``) always
+    runs alongside the collision edges above, not only when the analyzer found
+    none: a collision between ONE pair of surfaced siblings must not silently
+    drop the lane-ordering of every OTHER same-assignee pair the analyzer never
+    saw (an unsurfaced sibling contributes no analyzer edge at all — it isn't
+    even in ``surfaced``). Any pair the analyzer already ordered is left alone
+    here (its fallback edge is skipped) so the two mechanisms can never assert
+    opposite directions for the same pair.
     """
     # Collision edges from DECLARED surfaces. Fewer than two surfaced siblings
     # -> no collision path (edges stays empty); the undeclared-surface fallback
@@ -337,13 +346,19 @@ def dev_task_collision_edges(siblings: list) -> list[tuple[object, object]]:
         # any warning attributable. Empty capacity -> no warnings emitted.
         plan = SequencingService().analyze(surfaces, lambda _idx: "", {})
         edges = [(surfaced[a].id, surfaced[b].id) for a, b in plan.edges]
-    if edges:
-        return edges
 
-    # Undeclared-surface fallback (zero collision edges): chain same-assignee
-    # same-repo lanes so they don't merge out-of-order. See
-    # ``_same_assignee_lane_edges`` for the rationale + re-run idempotency.
-    return _same_assignee_lane_edges(siblings)
+    # Same-assignee-lane fallback: runs over EVERY sibling (surfaced or not),
+    # regardless of whether the collision analyzer above produced edges
+    # elsewhere in the batch. A pair already ordered by the analyzer keeps
+    # that edge only — its fallback duplicate is dropped so the two sources
+    # can never disagree on direction for the same pair.
+    covered_pairs = {frozenset((a, b)) for a, b in edges}
+    fallback = [
+        pair
+        for pair in _same_assignee_lane_edges(siblings)
+        if frozenset(pair) not in covered_pairs
+    ]
+    return edges + fallback
 
 
 # ---------------------------------------------------------------------------

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -5484,6 +5484,17 @@ class TaskService(BaseService):
             )
             owning_pm = await self._resolve_pm_for_review(task)
             task.assigned_to = cast("Any", owning_pm) if owning_pm else None
+            # The documenter's claim ends here — unlike submit_for_qa/pass_qa/
+            # fail_qa (which all clear claimed_by + active_claimant_id on their
+            # own review-queue entry), this path pre-assigns a SPECIFIC owning
+            # PM rather than leaving assigned_to null. Without clearing the
+            # stale documenter claimant_id too, `_active_claim_violation`
+            # (content_actions.py) wrongly refuses the newly-assigned PM's own
+            # note()/commit() calls against this task_id before it formally
+            # claims — `assigned_to == agent_id` routes into the active-claim
+            # check, which still sees the documenter as claimant.
+            task.claimed_by = cast("Any", owning_pm) if owning_pm else None
+            task.active_claimant_id = cast("Any", owning_pm) if owning_pm else None
             self.log.info(
                 "Documentation complete, awaiting PM review",
                 task_id=str(task_id),

--- a/roboco/services/video_engine.py
+++ b/roboco/services/video_engine.py
@@ -29,6 +29,7 @@ from roboco.foundation.policy.content import markers
 from roboco.models.base import Complexity, TaskNature, TaskStatus, TaskType, Team
 from roboco.services.base import BaseService
 from roboco.services.company_goals import get_company_goals_service
+from roboco.services.heartbeat_mutex import HeartbeatLockUnavailable, HeartbeatMutex
 from roboco.services.notification_delivery import get_notification_delivery_service
 from roboco.services.project import get_project_service
 from roboco.services.task import (
@@ -72,6 +73,19 @@ _CHAT_TIMEOUT_SECONDS = 60.0
 # The whole CHANGELOG section for a release, not one bullet — capped so a
 # pathological entry can't blow up the task description.
 _CHANGELOG_BRIEF_CHARS = 4000
+
+# ``open_video_task``'s "no open task for this occasion yet" check and its
+# insert are NOT atomic on their own: unlike the other engines' `run_cycle`
+# (each driven by exactly one sequential orchestrator-loop task, so it can
+# never overlap itself), this method is reachable from several genuinely
+# concurrent callers — the release-publish hook, the feature-spotlight hook,
+# and the CEO's on-demand ``POST /video/request`` route (two overlapping
+# requests, e.g. a double-click, each get their own DB session/transaction).
+# A flat SET NX (mirrors XPostService's identical short-critical-section
+# lock) keyed by occasion closes that window instead of letting a duplicate
+# authoring task slip through.
+_OCCASION_LOCK_PREFIX = "roboco:video_engine:occasion:"
+_OCCASION_LOCK_TTL_SECONDS = 60  # the check+insert completes in ms; crash backstop
 
 # Shared by every open_video_task caller (release/spotlight/on-demand) so the
 # authoring dev always lands on the demo kit instead of a text card.
@@ -357,9 +371,65 @@ class VideoEngine(BaseService):
         ``fallback_acceptance_criterion`` (when supplied) is appended instead
         — ``reauthor_from_rejection`` uses this for its
         feedback-must-be-addressed criterion.
+
+        The dedup check + insert below run under a short-lived Redis mutex
+        keyed by ``occasion`` (see ``_OCCASION_LOCK_PREFIX``) — this method,
+        unlike the other engines' single-loop ``run_cycle``, is reachable
+        from several genuinely concurrent callers (the release/spotlight
+        hooks and the on-demand ``/video/request`` route), so the "no open
+        task yet" read and the create must be atomic against each other.
+        Fails closed: a Redis outage or a lock already held both no-op
+        (return None) rather than risk a duplicate authoring task.
         """
         if not settings.video_engine_enabled:
             return None
+        lock = HeartbeatMutex(
+            f"{_OCCASION_LOCK_PREFIX}{occasion}",
+            ttl_seconds=_OCCASION_LOCK_TTL_SECONDS,
+            heartbeat_seconds=_OCCASION_LOCK_TTL_SECONDS,
+        )
+        try:
+            token = await lock.acquire()
+        except HeartbeatLockUnavailable as exc:
+            self.log.warning(
+                "video-engine: occasion lock unavailable (redis down); "
+                "not opening authoring task",
+                occasion=occasion,
+                error=str(exc),
+            )
+            return None
+        if token is None:
+            self.log.info(
+                "video-engine: another call is already opening this occasion; skipping",
+                occasion=occasion,
+            )
+            return None
+        try:
+            return await self._open_video_task_locked(
+                occasion=occasion,
+                script=script,
+                platforms=platforms,
+                brief=brief,
+                suggested_input_props=suggested_input_props,
+                project_id=project_id,
+                fallback_acceptance_criterion=fallback_acceptance_criterion,
+            )
+        finally:
+            await lock.release(token)
+
+    async def _open_video_task_locked(
+        self,
+        *,
+        occasion: str,
+        script: str,
+        platforms: list[str],
+        brief: str,
+        suggested_input_props: dict[str, Any] | None,
+        project_id: UUID | None,
+        fallback_acceptance_criterion: str | None,
+    ) -> TaskTable | None:
+        """The dedup-check + insert body, run while ``open_video_task`` holds
+        the per-occasion lock."""
         task_svc = get_task_service(self.session)
         open_tasks = await task_svc.list_open_video_posts()
         for existing in open_tasks:

--- a/roboco/services/x_post_service.py
+++ b/roboco/services/x_post_service.py
@@ -253,7 +253,17 @@ class XPostService(BaseService):
             logger.warning("spotlight video draft failed (best-effort): %s", exc)
 
     async def reject(self, task_id: UUID, reason: str) -> TaskTable | None:
-        """Record the CEO's reason and cancel the draft (never posted)."""
+        """Record the CEO's reason and cancel the draft (never posted).
+
+        Acquires the same post-mutex ``approve()`` holds (same key, same
+        non-blocking acquire style) so a reject can't interleave with a
+        concurrent in-flight approve — an unguarded write here used to race a
+        locked approve() straight to CANCELLED even while the approve was
+        mid-post, and depending on commit ordering could clobber the
+        approve's own COMPLETED write right after it landed. Fails CLOSED
+        like approve, both when the lock is held (approve mid-post) and when
+        Redis is unreachable — the CEO retries the reject once it clears.
+        """
         task = await get_task_service(self.session).get(task_id)
         if task is None or task.source not in X_SOURCES:
             return None
@@ -261,10 +271,32 @@ class XPostService(BaseService):
             raise TaskAlreadyCompletedError(
                 f"X draft {task_id} already posted (COMPLETED); cannot be rejected"
             )
-        markers.set_x_reject_reason(task, reason)
-        task.status = TaskStatus.CANCELLED
-        await self.session.flush()
-        return task
+
+        lock_key = f"{_LOCK_PREFIX}{task_id}"
+        try:
+            token = await self._acquire_lock(lock_key)
+        except _LockUnavailable as exc:
+            logger.error("x-post reject lock unavailable (redis down): %s", exc)
+            return None
+        if token is None:
+            return None  # a concurrent approve is mid-post; refuse the reject
+        try:
+            # Re-read under the lock: a concurrent approve may have posted +
+            # committed COMPLETED between the pre-lock check and here.
+            self.session.expire(task)
+            locked = await get_task_service(self.session).get(task_id)
+            if locked is None:
+                return None
+            if locked.status == TaskStatus.COMPLETED:
+                raise TaskAlreadyCompletedError(
+                    f"X draft {task_id} already posted (COMPLETED); cannot be rejected"
+                )
+            markers.set_x_reject_reason(locked, reason)
+            locked.status = TaskStatus.CANCELLED
+            await self.session.flush()
+            return locked
+        finally:
+            await self._release_lock(lock_key, token)
 
     # ---- Redis single-flight lock (plain SET NX — no heartbeat needed) -----
 

--- a/tests/foundation/test_lifecycle_spec.py
+++ b/tests/foundation/test_lifecycle_spec.py
@@ -500,10 +500,18 @@ def test_claim_rules_match_pre_gateway_table() -> None:
         {spec.Status.PENDING, spec.Status.AWAITING_DOCUMENTATION}
     )
     assert spec.CLAIM_RULES[spec.Role.CELL_PM] == frozenset(
-        {spec.Status.PENDING, spec.Status.NEEDS_REVISION}
+        {
+            spec.Status.PENDING,
+            spec.Status.NEEDS_REVISION,
+            spec.Status.AWAITING_PM_REVIEW,
+        }
     )
     assert spec.CLAIM_RULES[spec.Role.MAIN_PM] == frozenset(
-        {spec.Status.PENDING, spec.Status.NEEDS_REVISION}
+        {
+            spec.Status.PENDING,
+            spec.Status.NEEDS_REVISION,
+            spec.Status.AWAITING_PM_REVIEW,
+        }
     )
 
 

--- a/tests/integration/test_release_routes.py
+++ b/tests/integration/test_release_routes.py
@@ -368,10 +368,22 @@ async def test_reject_records_changes_and_cancels_frees_dedup(
     frees and the release manager can re-assess next cycle. The required-changes
     marker stays on the cancelled row for history."""
     task = await _seed_proposal(db_session)
-    resp = await ceo_client.post(
-        "/api/release/proposal/reject",
-        json={"required_changes": "Tighten the CHANGELOG wording for the API change."},
-    )
+    with (
+        patch.object(
+            ReleaseProposalService, "_acquire_release_lock", AsyncMock(return_value="t")
+        ),
+        patch.object(
+            ReleaseProposalService,
+            "_release_release_lock",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        resp = await ceo_client.post(
+            "/api/release/proposal/reject",
+            json={
+                "required_changes": "Tighten the CHANGELOG wording for the API change."
+            },
+        )
     assert resp.status_code == HTTPStatus.OK
     assert "Tighten the CHANGELOG" in (resp.json()["required_changes"] or "")
     refreshed = await db_session.get(TaskTable, task.id)
@@ -380,6 +392,24 @@ async def test_reject_records_changes_and_cancels_frees_dedup(
     # The dedup no longer counts it as open — a fresh proposal can originate.
     open_proposals = await TaskService(db_session).list_open_release_proposals()
     assert task.id not in {t.id for t in open_proposals}
+
+
+@pytest.mark.asyncio
+async def test_reject_refused_while_approve_lock_held(
+    db_session: AsyncSession, ceo_client: AsyncClient
+) -> None:
+    """A concurrent approve holds the release mutex (mid ~40min execute);
+    reject must fail closed with 409 instead of racing an unguarded write
+    under it — previously reject() never even attempted the lock."""
+    await _seed_proposal(db_session)
+    with patch.object(
+        ReleaseProposalService, "_acquire_release_lock", AsyncMock(return_value=None)
+    ):
+        resp = await ceo_client.post(
+            "/api/release/proposal/reject",
+            json={"required_changes": "Tighten the CHANGELOG wording."},
+        )
+    assert resp.status_code == HTTPStatus.CONFLICT
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_task_service_transitions.py
+++ b/tests/integration/test_task_service_transitions.py
@@ -2112,6 +2112,59 @@ async def test_docs_complete_advances_when_pr_already_created(
     assert out.status == TaskStatus.AWAITING_PM_REVIEW
 
 
+@pytest.mark.asyncio
+async def test_docs_complete_advance_clears_stale_documenter_claim(
+    task_setup: dict, db_session: AsyncSession
+) -> None:
+    """F-audit: docs_complete's PM hand-off must not leave the outgoing
+    documenter as claimed_by/active_claimant_id once a specific owning PM is
+    assigned — unlike its siblings (qa_pass/fail_qa/submit_for_qa/pr_pass/
+    pr_fail/request_changes), which always reassign or clear both fields
+    together, _maybe_advance_to_pm_review used to only update assigned_to.
+    A stale active_claimant_id then makes content_actions.py's
+    `_active_claim_violation` wrongly reject the newly-assigned PM's own
+    explicit-task_id note()/commit() calls before it formally claims.
+    """
+    svc = task_setup["svc"]
+    pm_agent = AgentTable(
+        id=uuid4(),
+        name="PM",
+        slug=f"be-pm-{uuid4().hex[:8]}",
+        role=AgentRole.CELL_PM,
+        team=Team.BACKEND,
+        status=AgentStatus.ACTIVE,
+        model_config={},
+        system_prompt="pm",
+        capabilities=[],
+        permissions={},
+        metrics={},
+    )
+    db_session.add(pm_agent)
+    await db_session.flush()
+    parent = await svc.create(_req(task_setup, assigned_to=pm_agent.id))
+    task = await svc.create(_req(task_setup, parent_task_id=parent.id))
+    task.status = TaskStatus.AWAITING_DOCUMENTATION
+    documenter_id = task_setup["agent_id"]
+    task.assigned_to = documenter_id
+    task.claimed_by = documenter_id
+    task.active_claimant_id = documenter_id
+    task.pr_number = 1
+    task.pr_url = "u"
+    task.pr_created = True
+    await db_session.flush()
+
+    out = await svc.docs_complete(task.id, doc_notes="documented all flows")
+
+    assert out is not None
+    assert out.status == TaskStatus.AWAITING_PM_REVIEW
+    assert out.assigned_to == pm_agent.id
+    # The documenter's claim must not survive the hand-off.
+    assert out.claimed_by == pm_agent.id
+    assert out.active_claimant_id == pm_agent.id
+    assert out.claimed_by != documenter_id
+    assert out.active_claimant_id != documenter_id
+
+
 # ---------------------------------------------------------------------------
 # mark_pr_created edge cases
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_video_routes.py
+++ b/tests/integration/test_video_routes.py
@@ -265,15 +265,16 @@ async def test_request_video_opens_authoring_task(
     project = (
         await db_session.execute(select(ProjectTable).where(ProjectTable.slug == SLUG))
     ).scalar_one()
-    resp = await ceo_client.post(
-        "/api/video/request",
-        json={
-            "occasion": "CEO on-demand: launch teaser",
-            "brief": "A short teaser for the new dashboard",
-            "platforms": ["x", "tiktok"],
-            "project_id": str(project.id),
-        },
-    )
+    with _LOCKED[0], _LOCKED[1]:
+        resp = await ceo_client.post(
+            "/api/video/request",
+            json={
+                "occasion": "CEO on-demand: launch teaser",
+                "brief": "A short teaser for the new dashboard",
+                "platforms": ["x", "tiktok"],
+                "project_id": str(project.id),
+            },
+        )
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     assert body["status"] == "opened"
@@ -396,12 +397,14 @@ async def test_request_video_not_opened_on_duplicate_occasion(
         "platforms": ["x"],
         "project_id": str(project.id),
     }
-    first = await ceo_client.post("/api/video/request", json=payload)
+    with _LOCKED[0], _LOCKED[1]:
+        first = await ceo_client.post("/api/video/request", json=payload)
     assert first.status_code == HTTPStatus.OK
     assert first.json()["status"] == "opened"
     task_id = first.json()["task_id"]
     try:
-        second = await ceo_client.post("/api/video/request", json=payload)
+        with _LOCKED[0], _LOCKED[1]:
+            second = await ceo_client.post("/api/video/request", json=payload)
         assert second.status_code == HTTPStatus.OK
         assert second.json()["status"] == "not_opened"
         assert second.json()["task_id"] is None

--- a/tests/integration/test_x_routes.py
+++ b/tests/integration/test_x_routes.py
@@ -189,9 +189,13 @@ async def test_reject_cancels_and_records_reason(
     db_session: AsyncSession, ceo_client: AsyncClient
 ) -> None:
     task = await _seed_draft(db_session)
-    resp = await ceo_client.post(
-        f"/api/x/posts/{task.id}/reject", json={"reason": "Not our voice"}
-    )
+    with (
+        patch.object(XPostService, "_acquire_lock", AsyncMock(return_value="tok")),
+        patch.object(XPostService, "_release_lock", AsyncMock(return_value=None)),
+    ):
+        resp = await ceo_client.post(
+            f"/api/x/posts/{task.id}/reject", json={"reason": "Not our voice"}
+        )
     assert resp.status_code == HTTPStatus.OK
     assert resp.json()["reject_reason"] == "Not our voice"
     refreshed = await db_session.get(TaskTable, task.id)
@@ -204,9 +208,13 @@ async def test_history_returns_posted_and_rejected_newest_first(
     db_session: AsyncSession, ceo_client: AsyncClient
 ) -> None:
     rejected = await _seed_draft(db_session)
-    await ceo_client.post(
-        f"/api/x/posts/{rejected.id}/reject", json={"reason": "off-brand tone"}
-    )
+    with (
+        patch.object(XPostService, "_acquire_lock", AsyncMock(return_value="tok")),
+        patch.object(XPostService, "_release_lock", AsyncMock(return_value=None)),
+    ):
+        await ceo_client.post(
+            f"/api/x/posts/{rejected.id}/reject", json={"reason": "off-brand tone"}
+        )
     posted = await _seed_draft(db_session)
     posted_project = await db_session.get(ProjectTable, posted.project_id)
     with (
@@ -258,9 +266,13 @@ async def test_history_respects_limit(
 ) -> None:
     for _ in range(3):
         t = await _seed_draft(db_session)
-        await ceo_client.post(
-            f"/api/x/posts/{t.id}/reject", json={"reason": "not relevant"}
-        )
+        with (
+            patch.object(XPostService, "_acquire_lock", AsyncMock(return_value="tok")),
+            patch.object(XPostService, "_release_lock", AsyncMock(return_value=None)),
+        ):
+            await ceo_client.post(
+                f"/api/x/posts/{t.id}/reject", json={"reason": "not relevant"}
+            )
     resp = await ceo_client.get("/api/x/posts/history", params={"limit": HISTORY_LIMIT})
     assert resp.status_code == HTTPStatus.OK
     assert len(resp.json()) == HISTORY_LIMIT

--- a/tests/unit/runtime/test_video_render_loop.py
+++ b/tests/unit/runtime/test_video_render_loop.py
@@ -28,6 +28,7 @@ from roboco.runtime.orchestrator import (
     _MAX_VIDEO_RENDER_ATTEMPTS,
     AgentOrchestrator,
 )
+from roboco.services import video_engine as video_engine_module
 from roboco.services.task import VIDEO_POST_SOURCE, get_task_service
 from roboco.services.video_engine import VideoEngine
 from sqlalchemy import select
@@ -47,6 +48,26 @@ FOUR = 4
 
 def _orch() -> Any:
     return AgentOrchestrator.__new__(AgentOrchestrator)
+
+
+class _AlwaysAcquiredMutex:
+    """Stand-in for ``HeartbeatMutex``: always acquires immediately, no live
+    Redis required (matches the project's ``_no_live_redis`` fixture and
+    mirrors ``test_video_engine.py``'s identical stub)."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    async def acquire(self) -> str | None:
+        return "tok"
+
+    async def release(self, _token: str) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_occasion_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(video_engine_module, "HeartbeatMutex", _AlwaysAcquiredMutex)
 
 
 class _FakeRenderer:

--- a/tests/unit/services/test_release_executor.py
+++ b/tests/unit/services/test_release_executor.py
@@ -9,8 +9,9 @@ call sequence; the production git/gh ops is exercised live (CEO-gated).
 from __future__ import annotations
 
 import base64
+import subprocess
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -442,6 +443,108 @@ def test_release_ci_workflow_decoupled_from_self_heal_setting(
     # An empty release setting never falls through to None — always the default.
     monkeypatch.setattr(settings, "release_ci_workflow", "")
     assert _resolve_release_ci_workflow() == "ci.yml"
+
+
+# --------------------------------------------------------------------------- #
+# _GitReleaseOps.release_commit_sha — half-landed retry detection against a
+# REAL git repo (not the fake ops above): verifies the exact worry the task
+# named — that ``_current_version`` could return the bumped version while the
+# changelog hasn't actually been written yet. It can't: ``apply_version_bumps``
+# and ``write_changelog_entry`` both run as uncommitted working-tree edits
+# BEFORE ``commit_and_push``'s single ``git add -A`` + commit, so nothing ever
+# reaches origin (and therefore no fresh retry clone can ever observe it) with
+# one written but not the other.
+# --------------------------------------------------------------------------- #
+
+
+def _git_sync(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+    return result.stdout
+
+
+def _init_release_repo(repo: Path, *, initial_version: str = "0.12.0") -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git_sync(repo, "init", "-b", "master")
+    _git_sync(repo, "config", "user.email", "t@example.com")
+    _git_sync(repo, "config", "user.name", "T")
+    _git_sync(repo, "config", "commit.gpgsign", "false")
+    (repo / "pyproject.toml").write_text(f'[project]\nversion = "{initial_version}"\n')
+    (repo / "CHANGELOG.md").write_text("# Changelog\n")
+    _git_sync(repo, "add", "-A")
+    _git_sync(repo, "commit", "-m", "init")
+
+
+def _ops(session: object, root: Path) -> _GitReleaseOps:
+    ctx = _ReleaseContext(
+        slug="roboco-api",
+        prod_branch="master",
+        root=root,
+        git_url="x",
+        git_prefix=[],
+        ci_workflow="ci.yml",
+        env_chain=[],
+    )
+    return _GitReleaseOps(session=cast("Any", session), ctx=ctx)
+
+
+@pytest.mark.asyncio
+async def test_release_commit_sha_detects_a_real_half_landed_commit(
+    tmp_path: Path,
+) -> None:
+    """A genuine publish_failed retry: a prior execute already ran
+    ``apply_version_bumps`` + ``write_changelog_entry`` + committed (both
+    landed in the SAME commit, exactly as ``commit_and_push`` does with one
+    ``git add -A``). The fresh clone must detect that commit and its
+    changelog entry must already be present — never re-bump, never skip the
+    changelog."""
+    _init_release_repo(tmp_path)
+    ops = _ops(MagicMock(), tmp_path)
+    await ops.apply_version_bumps(["pyproject.toml"], "0.13.0")
+    await ops.write_changelog_entry(
+        "## [0.13.0] - 2026-07-21\n\n### Added\n- a thing\n"
+    )
+    _git_sync(tmp_path, "add", "-A")
+    _git_sync(tmp_path, "commit", "-m", "chore(release): 0.13.0")
+
+    sha = await ops.release_commit_sha("0.13.0")
+
+    assert sha is not None
+    assert sha == _git_sync(tmp_path, "rev-parse", "HEAD").strip()
+    # The changelog entry landed in the SAME commit as the bump — never split.
+    assert "0.13.0" in (tmp_path / "pyproject.toml").read_text()
+    assert "a thing" in (tmp_path / "CHANGELOG.md").read_text()
+
+
+@pytest.mark.asyncio
+async def test_release_commit_sha_none_for_uncommitted_bump_no_false_half_landed(
+    tmp_path: Path,
+) -> None:
+    """An uncommitted version bump (e.g. a crash between apply_version_bumps
+    and commit_and_push) must NOT be mistaken for a half-landed release —
+    only a matching COMMIT counts. A fresh retry clone starts from origin's
+    unchanged HEAD anyway (this isolates release_commit_sha's own check)."""
+    _init_release_repo(tmp_path)
+    ops = _ops(MagicMock(), tmp_path)
+    # Bump the working tree WITHOUT committing (write_changelog_entry never ran).
+    await ops.apply_version_bumps(["pyproject.toml"], "0.13.0")
+
+    sha = await ops.release_commit_sha("0.13.0")
+
+    assert sha is None  # falls through to the normal bump/changelog/gate/commit path
+
+
+@pytest.mark.asyncio
+async def test_release_commit_sha_none_when_version_not_yet_bumped(
+    tmp_path: Path,
+) -> None:
+    """No prior attempt at all: the clone is still at the old version, so
+    there is nothing half-landed to detect."""
+    _init_release_repo(tmp_path)
+    ops = _ops(MagicMock(), tmp_path)
+
+    assert await ops.release_commit_sha("0.13.0") is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/services/test_release_executor_subprocess_timeout.py
+++ b/tests/unit/services/test_release_executor_subprocess_timeout.py
@@ -10,9 +10,10 @@ under a second — never relying on real wall-clock timing of the defaults.
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, MagicMock
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -335,6 +336,42 @@ async def test_clone_run_times_out_and_kills_proc(
     assert rc == _TIMEOUT_RC
     assert "timed out" in out
     assert proc.killed
+
+
+@pytest.mark.asyncio
+async def test_await_proc_kills_child_on_outer_cancellation() -> None:
+    """Redis mutex pre-lock write audit sibling finding: an outer cancellation
+    (e.g. the release loop's own task being cancelled mid-op) throws
+    ``CancelledError`` into ``_await_proc``'s ``wait_for``, bypassing the
+    ``TimeoutError`` handler. Without a dedicated handler (which
+    ``quality_gate.py``'s ``_run_one`` already has) the child is orphaned and
+    keeps running past the cancelled release op. ``_await_proc`` must kill +
+    reap it and re-raise, mirroring the already-shipped ``quality_gate.py``
+    pattern exactly."""
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+    spawned: dict[str, asyncio.subprocess.Process] = {}
+
+    async def _capturing_create(*args: Any, **kwargs: Any) -> Any:
+        proc = await real_create_subprocess_exec(*args, **kwargs)
+        spawned["proc"] = proc
+        return proc
+
+    with patch(
+        "roboco.services.release_executor.asyncio.create_subprocess_exec",
+        _capturing_create,
+    ):
+        task = asyncio.ensure_future(_run(["sleep", "30"]))
+        while "proc" not in spawned:
+            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)  # let the child actually exec
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    proc = spawned["proc"]
+    assert proc.returncode is not None, "child was not reaped after cancellation"
+    with pytest.raises(ProcessLookupError):
+        os.kill(proc.pid, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_release_proposal_status_guards.py
+++ b/tests/unit/services/test_release_proposal_status_guards.py
@@ -12,6 +12,7 @@ do for their own seams.
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -19,6 +20,7 @@ from uuid import uuid4
 import pytest
 from roboco.db.tables import AgentTable, ProjectTable, TaskTable
 from roboco.foundation import identity as _foundation
+from roboco.foundation.policy.content import markers
 from roboco.models.base import AgentRole, AgentStatus, TaskNature, TaskStatus, TaskType
 from roboco.models.base import Team as T
 from roboco.services.release_proposal import (
@@ -26,12 +28,16 @@ from roboco.services.release_proposal import (
     TaskAlreadyCompletedError,
 )
 from roboco.services.release_readiness import ReleaseReadinessReport, report_to_dict
-from roboco.services.task import RELEASE_MANAGER_SOURCE
+from roboco.services.task import RELEASE_MANAGER_SOURCE, TaskService
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 if TYPE_CHECKING:
     from uuid import UUID
-
-    from sqlalchemy.ext.asyncio import AsyncSession
 
 _VERSION = "0.18.0"
 
@@ -170,3 +176,89 @@ async def test_reject_raises_when_already_published(db_session: AsyncSession) ->
         )
     await db_session.refresh(task)
     assert task.status == TaskStatus.COMPLETED  # untouched, never cancelled
+
+
+async def _fresh_session(url: str) -> tuple[AsyncSession, AsyncEngine]:
+    """A session on a brand-new engine/connection (caller disposes)."""
+    engine = create_async_engine(url, future=True)
+    factory = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+    return factory(), engine
+
+
+async def _dispose(session: AsyncSession, engine: AsyncEngine) -> None:
+    with contextlib.suppress(Exception):
+        await session.rollback()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reject_concurrent_approve_completes_during_lock_wait(
+    db_session: AsyncSession, _test_database_url: str
+) -> None:
+    """Redis mutex pre-lock write audit regression for ``reject()``: a
+    genuinely concurrent approve (a real second session/connection) publishes
+    + commits COMPLETED in the window between reject's pre-lock read and its
+    lock acquisition. The in-lock re-read must see that committed state and
+    refuse — the CANCELLED status write and required-changes marker must
+    never land on the just-published row, proving the fix holds across
+    sessions, not merely within one. Mirrors
+    ``test_x_post_service.test_reject_concurrent_approve_completes_during_lock_wait``.
+    """
+    task = await _seed_proposal(db_session)
+    task_id = cast("UUID", task.id)
+    await db_session.commit()
+
+    real_get = TaskService.get
+    injected = False
+
+    async def _get_then_inject_concurrent_publish(
+        self: TaskService, tid: UUID
+    ) -> TaskTable | None:
+        """Fires once, right after reject's pre-lock read — the exact window
+        between that read and reject's own (would-be) pre-lock write."""
+        nonlocal injected
+        result = await real_get(self, tid)
+        if not injected:
+            injected = True
+            other, other_engine = await _fresh_session(_test_database_url)
+            try:
+                other_task = await other.get(TaskTable, tid)
+                assert other_task is not None
+                other_task.status = TaskStatus.COMPLETED
+                await other.commit()
+            finally:
+                await _dispose(other, other_engine)
+        return result
+
+    with (
+        patch.object(TaskService, "get", _get_then_inject_concurrent_publish),
+        patch.object(
+            ReleaseProposalService,
+            "_acquire_release_lock",
+            AsyncMock(return_value="tok"),
+        ),
+        patch.object(
+            ReleaseProposalService,
+            "_release_release_lock",
+            AsyncMock(return_value=None),
+        ),
+        patch.object(
+            ReleaseProposalService, "_close_redis", AsyncMock(return_value=None)
+        ),
+        pytest.raises(TaskAlreadyCompletedError),
+    ):
+        await ReleaseProposalService(db_session).reject(
+            task_id, "needs another migration check"
+        )
+
+    fresh, fresh_engine = await _fresh_session(_test_database_url)
+    try:
+        final = await fresh.get(TaskTable, task_id)
+        assert final is not None
+        assert final.status == TaskStatus.COMPLETED
+        # The reject must never have landed on the just-published row.
+        assert markers.get_release_required_changes(final) is None
+    finally:
+        await _dispose(fresh, fresh_engine)

--- a/tests/unit/services/test_sequencing.py
+++ b/tests/unit/services/test_sequencing.py
@@ -83,6 +83,27 @@ def test_touches_shared_runs_last() -> None:
     assert plan.waves[-1] == [2]  # the shared task is the final wave
 
 
+def test_all_shared_batch_with_disjoint_surfaces_generates_no_edges() -> None:
+    # Verifying the claimed rule-3 property: when every draft in the batch
+    # touches_shared, ``_shared_last_edges`` skips every candidate pair (its
+    # inner loop continues on `other.touches_shared`), so it contributes no
+    # edges on its own. With disjoint file surfaces rule 1 (same-shared-status
+    # overlap) also contributes nothing, so the whole batch runs in one
+    # parallel wave — confirmed correct, no fix needed.
+    s = [
+        DraftSurface(0, 1, ["fe/app/a.tsx"], False, True),
+        DraftSurface(1, 1, ["fe/app/b.tsx"], False, True),
+        DraftSurface(2, 1, ["fe/app/c.tsx"], False, True),
+    ]
+    plan = SequencingService().analyze(s, _frontend, {"frontend": 3})
+    assert plan.edges == []
+    assert plan.waves == [[0, 1, 2]]
+    # And rule 3 in isolation truly contributes zero edges for an all-shared
+    # set, regardless of overlap — it is rule 1 (same-shared-status overlap),
+    # not rule 3, that would serialize two OVERLAPPING shared surfaces.
+    assert SequencingService()._shared_last_edges(s) == []
+
+
 def test_cycle_is_rejected() -> None:
     with pytest.raises(SequencingError):
         SequencingService()._toposort([(0, 1), (1, 0)], 2)
@@ -352,6 +373,44 @@ def test_dev_collision_fallback_idempotent_on_rerun() -> None:
     a = _Sib(uuid4(), sequence=0, assigned_to="be-dev-1")
     b = _Sib(uuid4(), sequence=1, assigned_to="be-dev-1")
     assert dev_task_collision_edges([a, b]) == dev_task_collision_edges([a, b])
+
+
+def test_dev_collision_fallback_still_applies_when_another_pair_collides() -> None:
+    # Regression: a `if edges: return edges` short-circuit used to drop the
+    # assignee-lane fallback ENTIRELY whenever ANY surfaced pair produced a
+    # collision edge, even for a totally unrelated same-assignee pair with no
+    # declared surface at all. (a, b) collide on a.py (different assignees, so
+    # no lane relationship between them); (c, d) share an assignee/project but
+    # declare no surface — they must still get lane-ordered.
+    a = _Sib(
+        uuid4(),
+        sequence=0,
+        intends_to_touch=["a.py"],
+        assigned_to="be-dev-1",
+    )
+    b = _Sib(
+        uuid4(),
+        sequence=1,
+        intends_to_touch=["a.py"],
+        assigned_to="be-dev-2",
+    )
+    c = _Sib(uuid4(), sequence=2, assigned_to="be-dev-3")
+    d = _Sib(uuid4(), sequence=3, assigned_to="be-dev-3")
+    edges = _edge_set(dev_task_collision_edges([a, b, c, d]))
+    assert edges == {(a.id, b.id), (c.id, d.id)}
+
+
+def test_dev_collision_fallback_covers_unsurfaced_sibling_in_surfaced_lane() -> None:
+    # Same assignee/project lane mixes a surfaced sibling (touches a.py) with
+    # an unsurfaced one (no declared surface) and a third surfaced sibling
+    # that doesn't overlap the first — the analyzer alone wires nothing for
+    # this lane (no pair overlaps), so the fallback must still chain all three
+    # by (priority, sequence).
+    first = _Sib(uuid4(), sequence=0, assigned_to="be-dev-1", intends_to_touch=["a.py"])
+    bare = _Sib(uuid4(), sequence=1, assigned_to="be-dev-1")
+    other = _Sib(uuid4(), sequence=2, assigned_to="be-dev-1", intends_to_touch=["b.py"])
+    edges = dev_task_collision_edges([first, bare, other])
+    assert edges == [(first.id, bare.id), (bare.id, other.id)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_video_engine.py
+++ b/tests/unit/services/test_video_engine.py
@@ -8,6 +8,7 @@ Secretary-owned and held for the CEO. Asserted against a real Postgres DB.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
@@ -21,6 +22,7 @@ from roboco.models.base import AgentRole, AgentStatus, Complexity, Team
 from roboco.models.base import TaskStatus as TS
 from roboco.services import video_engine as video_engine_module
 from roboco.services.company_goals import get_company_goals_service
+from roboco.services.heartbeat_mutex import HeartbeatLockUnavailable
 from roboco.services.task import VIDEO_POST_SOURCE, VIDEO_SOURCE, get_task_service
 from sqlalchemy import delete, select
 
@@ -97,6 +99,27 @@ def _mock_local_model(monkeypatch: pytest.MonkeyPatch, reply: str | None) -> Asy
     mock = AsyncMock(return_value=reply)
     monkeypatch.setattr(video_engine_module, "_chat", mock)
     return mock
+
+
+class _AlwaysAcquiredMutex:
+    """Stand-in for ``HeartbeatMutex``: always acquires immediately, no live
+    Redis required (matches the project's ``_no_live_redis`` fixture). Used
+    as the default so every scenario below that isn't specifically testing
+    the occasion-lock behavior is unaffected by its introduction."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    async def acquire(self) -> str | None:
+        return "tok"
+
+    async def release(self, _token: str) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_occasion_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(video_engine_module, "HeartbeatMutex", _AlwaysAcquiredMutex)
 
 
 # --------------------------------------------------------------------------- #
@@ -199,6 +222,109 @@ async def test_open_video_task_dedupes_same_occasion(
         occasion="release v1.0.0", script="s2", platforms=["x"], brief="b2"
     )
     assert second is None
+    open_tasks = await get_task_service(db_session).list_open_video_posts()
+    assert len(open_tasks) == ONE
+
+
+@pytest.mark.asyncio
+async def test_open_video_task_returns_none_when_occasion_lock_held(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A held per-occasion lock (another call already owns it) is a no-op,
+    not an error — it opens nothing and leaves the shared session usable."""
+    await _seed(db_session)
+    _enable(monkeypatch)
+
+    class _HeldMutex:
+        def __init__(self, *_a: object, **_kw: object) -> None:
+            pass
+
+        async def acquire(self) -> str | None:
+            return None  # another call already holds this occasion's lock
+
+        async def release(self, _token: str) -> None:
+            raise AssertionError("release must not be called when acquire failed")
+
+    monkeypatch.setattr(video_engine_module, "HeartbeatMutex", _HeldMutex)
+    engine = video_engine_module.VideoEngine(db_session)
+    task = await engine.open_video_task(
+        occasion="release v1.0.0", script="s", platforms=["x"], brief="b"
+    )
+    assert task is None
+    assert await get_task_service(db_session).list_open_video_posts() == []
+
+
+@pytest.mark.asyncio
+async def test_open_video_task_returns_none_when_lock_unavailable(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Redis outage on the occasion lock fails closed (no-op), not a crash."""
+    await _seed(db_session)
+    _enable(monkeypatch)
+
+    class _BrokenMutex:
+        def __init__(self, *_a: object, **_kw: object) -> None:
+            pass
+
+        async def acquire(self) -> str | None:
+            raise HeartbeatLockUnavailable("redis down")
+
+        async def release(self, _token: str) -> None:
+            raise AssertionError("release must not be called when acquire failed")
+
+    monkeypatch.setattr(video_engine_module, "HeartbeatMutex", _BrokenMutex)
+    engine = video_engine_module.VideoEngine(db_session)
+    task = await engine.open_video_task(
+        occasion="release v1.0.0", script="s", platforms=["x"], brief="b"
+    )
+    assert task is None
+    assert await get_task_service(db_session).list_open_video_posts() == []
+
+
+@pytest.mark.asyncio
+async def test_open_video_task_concurrent_same_occasion_creates_only_one(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression (engine dedup race): ``open_video_task`` is reachable from
+    several genuinely concurrent callers for the same occasion (a double-click
+    on ``/video/request``, or an on-demand call racing the release hook) —
+    unlike the other engines' single-loop ``run_cycle``, two overlapping calls
+    are NOT serialized by the orchestrator's own scheduling. A real
+    ``asyncio.Lock`` stands in for the Redis SET NX mutex's mutual exclusion
+    (no live Redis in tests): the first caller to reach the DB's genuinely
+    suspending await wins the lock and creates the task; the second finds it
+    held and returns None immediately — never both passing the dedup check."""
+    await _seed(db_session)
+    _enable(monkeypatch)
+    engine = video_engine_module.VideoEngine(db_session)
+
+    real_lock = asyncio.Lock()
+
+    class _RaceMutex:
+        def __init__(self, *_a: object, **_kw: object) -> None:
+            pass
+
+        async def acquire(self) -> str | None:
+            if real_lock.locked():
+                return None
+            await real_lock.acquire()
+            return "tok"
+
+        async def release(self, _token: str) -> None:
+            real_lock.release()
+
+    monkeypatch.setattr(video_engine_module, "HeartbeatMutex", _RaceMutex)
+
+    results = await asyncio.gather(
+        engine.open_video_task(
+            occasion="race me", script="s1", platforms=["x"], brief="b1"
+        ),
+        engine.open_video_task(
+            occasion="race me", script="s2", platforms=["x"], brief="b2"
+        ),
+    )
+    created = [r for r in results if r is not None]
+    assert len(created) == ONE
     open_tasks = await get_task_service(db_session).list_open_video_posts()
     assert len(open_tasks) == ONE
 

--- a/tests/unit/services/test_video_post_service.py
+++ b/tests/unit/services/test_video_post_service.py
@@ -274,7 +274,7 @@ async def test_approve_completes_when_unconfigured_platform_is_skipped(
     assert result.status == "posted"
     assert result.posted == {"x": "x-vid-1"}
     assert "skipped (unconfigured): tiktok" in result.detail
-    assert tiktok_poster.calls == []  # never attempted without credentials
+    assert tiktok_poster.calls == []
     await db_session.refresh(task)
     assert task.status == TS.COMPLETED
     draft = markers.get_video_draft(task)
@@ -967,7 +967,7 @@ async def test_approve_concurrent_caption_edit_does_not_erase_a_committed_posted
     commit — the retry re-posted the platform (a double-post)."""
     task = await _seed_video_post(db_session, platforms=["x", "tiktok"])
     task_id = _id(task)
-    await db_session.commit()  # externally visible to the "concurrent" session below
+    await db_session.commit()
 
     real_get = TaskService.get
     injected = False

--- a/tests/unit/services/test_x_post_service.py
+++ b/tests/unit/services/test_x_post_service.py
@@ -7,6 +7,8 @@ fixture) so approve exercises the real post + status-transition path.
 
 from __future__ import annotations
 
+import contextlib
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -25,7 +27,12 @@ from roboco.models.base import (
 from roboco.models.base import TaskNature as TN
 from roboco.models.base import TaskStatus as TS
 from roboco.models.base import TaskType as TT
-from roboco.services.task import X_FEATURE_SOURCE, X_POST_SOURCE, X_REPLY_SOURCE
+from roboco.services.task import (
+    X_FEATURE_SOURCE,
+    X_POST_SOURCE,
+    X_REPLY_SOURCE,
+    TaskService,
+)
 from roboco.services.x_client import XClient, XMention, XPostResult
 from roboco.services.x_post_service import (
     TaskAlreadyCompletedError,
@@ -34,16 +41,32 @@ from roboco.services.x_post_service import (
     XPostService,
     get_x_post_service,
 )
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from uuid import UUID
-
-    from sqlalchemy.ext.asyncio import AsyncSession
 
 SYSTEM_UUID = _foundation.AGENTS["system"].uuid
 SECRETARY_UUID = _foundation.AGENTS["secretary-1"].uuid
 ONE = 1
 TWO = 2
+
+
+@contextmanager
+def _lock_free() -> Iterator[None]:
+    """Patch XPostService's lock helpers so approve/reject exercise the real
+    post/cancel path without touching the (test-blocked) Redis."""
+    with (
+        patch.object(XPostService, "_acquire_lock", AsyncMock(return_value="tok")),
+        patch.object(XPostService, "_release_lock", AsyncMock(return_value=None)),
+    ):
+        yield
 
 
 class _StubClient(XClient):
@@ -268,7 +291,7 @@ async def test_approve_no_credentials_result(db_session: AsyncSession) -> None:
     assert result is not None
     assert result.status == "no_credentials"
     await db_session.refresh(task)
-    assert task.status == TS.PENDING  # never advanced without credentials
+    assert task.status == TS.PENDING
 
 
 @pytest.mark.asyncio
@@ -326,7 +349,8 @@ async def test_approve_refuses_already_rejected_draft(
     refuses and never calls the X client — the reproduced bug (a stale
     Approve after reject re-posting)."""
     task = await _seed_draft(db_session)
-    await _svc(db_session).reject(_id(task), "not on-brand")
+    with _lock_free():
+        await _svc(db_session).reject(_id(task), "not on-brand")
     client = _StubClient()
     with (
         patch("roboco.services.x_post_service.build_x_client", return_value=client),
@@ -387,17 +411,39 @@ async def test_approve_unknown_task_returns_none(db_session: AsyncSession) -> No
 @pytest.mark.asyncio
 async def test_reject_records_reason_and_cancels(db_session: AsyncSession) -> None:
     task = await _seed_draft(db_session, source=X_REPLY_SOURCE)
-    updated = await _svc(db_session).reject(_id(task), "Tone doesn't match our voice")
+    with _lock_free():
+        updated = await _svc(db_session).reject(
+            _id(task), "Tone doesn't match our voice"
+        )
     assert updated is not None
     assert updated.status == TS.CANCELLED
     assert markers.get_x_reject_reason(updated) == "Tone doesn't match our voice"
 
 
 @pytest.mark.asyncio
+async def test_reject_refused_while_lock_held_by_concurrent_approve(
+    db_session: AsyncSession,
+) -> None:
+    """A concurrent approve holds the post lock (mid-tweet-POST); reject must
+    fail closed instead of racing a CANCEL under it — previously reject()
+    never even attempted the lock, so it could commit CANCELLED to a draft a
+    concurrent approve was about to mark COMPLETED, or clobber the approve's
+    outcome depending on commit ordering."""
+    task = await _seed_draft(db_session)
+    with patch.object(XPostService, "_acquire_lock", AsyncMock(return_value=None)):
+        result = await _svc(db_session).reject(_id(task), "not relevant")
+    assert result is None
+    await db_session.refresh(task)
+    assert task.status == TS.PENDING
+    assert markers.get_x_reject_reason(task) is None
+
+
+@pytest.mark.asyncio
 async def test_list_open_posts_excludes_terminal(db_session: AsyncSession) -> None:
     open_task = await _seed_draft(db_session)
     rejected_task = await _seed_draft(db_session, source=X_REPLY_SOURCE)
-    await _svc(db_session).reject(_id(rejected_task), "not relevant")
+    with _lock_free():
+        await _svc(db_session).reject(_id(rejected_task), "not relevant")
     open_posts = await _svc(db_session).list_open_posts()
     ids = {t.id for t in open_posts}
     assert open_task.id in ids
@@ -451,12 +497,72 @@ async def test_reject_completed_raises(db_session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+async def test_reject_concurrent_approve_completes_during_lock_wait(
+    db_session: AsyncSession, _test_database_url: str
+) -> None:
+    """Redis mutex pre-lock write audit regression for ``reject()``: a
+    genuinely concurrent approve (a real second session/connection) posts +
+    commits COMPLETED in the window between reject's pre-lock read and its
+    lock acquisition. The in-lock re-read must see that committed state and
+    refuse — the CANCELLED status write and reject reason must never land on
+    the just-posted row, proving the fix holds across sessions, not merely
+    within one. Mirrors
+    ``test_approve_concurrent_edit_does_not_clobber_a_committed_post``."""
+    task = await _seed_draft(db_session)
+    task_id = _id(task)
+    await db_session.commit()
+
+    real_get = TaskService.get
+    injected = False
+
+    async def _get_then_inject_concurrent_post(
+        self: TaskService, tid: UUID
+    ) -> TaskTable | None:
+        """Fires once, right after reject's pre-lock read — the exact window
+        between that read and reject's own (would-be) pre-lock write."""
+        nonlocal injected
+        result = await real_get(self, tid)
+        if not injected:
+            injected = True
+            other, other_engine = await _fresh_session(_test_database_url)
+            try:
+                other_task = await other.get(TaskTable, tid)
+                assert other_task is not None
+                markers.set_x_posted_tweet_id(other_task, "concurrent-999")
+                other_task.status = TS.COMPLETED
+                await other.commit()
+            finally:
+                await _dispose(other, other_engine)
+        return result
+
+    with (
+        patch.object(TaskService, "get", _get_then_inject_concurrent_post),
+        patch.object(XPostService, "_acquire_lock", AsyncMock(return_value="tok")),
+        patch.object(XPostService, "_release_lock", AsyncMock(return_value=None)),
+        pytest.raises(TaskAlreadyCompletedError),
+    ):
+        await _svc(db_session).reject(task_id, "Tone doesn't match")
+
+    fresh, fresh_engine = await _fresh_session(_test_database_url)
+    try:
+        final = await fresh.get(TaskTable, task_id)
+        assert final is not None
+        assert final.status == TS.COMPLETED
+        assert markers.get_x_posted_tweet_id(final) == "concurrent-999"
+        # The reject must never have landed on the just-posted row.
+        assert markers.get_x_reject_reason(final) is None
+    finally:
+        await _dispose(fresh, fresh_engine)
+
+
+@pytest.mark.asyncio
 async def test_list_post_history_excludes_open_drafts(
     db_session: AsyncSession,
 ) -> None:
     open_task = await _seed_draft(db_session)
     rejected_task = await _seed_draft(db_session, source=X_REPLY_SOURCE)
-    await _svc(db_session).reject(_id(rejected_task), "not relevant")
+    with _lock_free():
+        await _svc(db_session).reject(_id(rejected_task), "not relevant")
     history = await _svc(db_session).list_post_history()
     ids = {t.id for t in history}
     assert rejected_task.id in ids
@@ -468,7 +574,8 @@ async def test_list_post_history_newest_acted_first(
     db_session: AsyncSession,
 ) -> None:
     rejected_task = await _seed_draft(db_session, source=X_REPLY_SOURCE)
-    await _svc(db_session).reject(_id(rejected_task), "not relevant")
+    with _lock_free():
+        await _svc(db_session).reject(_id(rejected_task), "not relevant")
     posted_task = await _seed_draft(db_session)
     client = _StubClient()
     with (
@@ -495,7 +602,8 @@ async def test_list_post_history_includes_marker_fields(
     ):
         await _svc(db_session).approve(_id(posted_task))
     rejected_task = await _seed_draft(db_session, source=X_REPLY_SOURCE)
-    await _svc(db_session).reject(_id(rejected_task), "off-brand tone")
+    with _lock_free():
+        await _svc(db_session).reject(_id(rejected_task), "off-brand tone")
 
     history = await _svc(db_session).list_post_history()
     by_id = {t.id: t for t in history}
@@ -508,7 +616,8 @@ async def test_list_post_history_respects_limit(db_session: AsyncSession) -> Non
     tasks = []
     for _ in range(3):
         t = await _seed_draft(db_session, source=X_REPLY_SOURCE)
-        await _svc(db_session).reject(_id(t), "not relevant")
+        with _lock_free():
+            await _svc(db_session).reject(_id(t), "not relevant")
         tasks.append(t)
     history = await _svc(db_session).list_post_history(limit=2)
     assert len(history) == TWO
@@ -548,6 +657,86 @@ async def test_approve_does_not_flush_edited_body_before_lock(
     assert result.status == "already_posted"
     await db_session.refresh(task)
     assert markers.get_x_draft_body(task) == original_body
+
+
+async def _fresh_session(url: str) -> tuple[AsyncSession, AsyncEngine]:
+    """A session on a brand-new engine/connection (caller disposes)."""
+    engine = create_async_engine(url, future=True)
+    factory = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+    return factory(), engine
+
+
+async def _dispose(session: AsyncSession, engine: AsyncEngine) -> None:
+    with contextlib.suppress(Exception):
+        await session.rollback()
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_approve_concurrent_edit_does_not_clobber_a_committed_post(
+    db_session: AsyncSession, _test_database_url: str
+) -> None:
+    """Redis mutex pre-lock write audit regression: a genuinely concurrent
+    approve (a real second session/connection, not an in-process mock) posts
+    + commits COMPLETED in the window between our pre-lock read and our lock
+    acquisition. The in-lock re-read must see that committed state and the
+    CEO's edited body must never land on the just-posted row — proving the
+    fix holds across sessions, not merely within one, mirroring
+    VideoPostService's identical cross-session regression test."""
+    task = await _seed_draft(db_session, body="Original")
+    task_id = _id(task)
+    await db_session.commit()
+
+    real_get = TaskService.get
+    injected = False
+
+    async def _get_then_inject_concurrent_post(
+        self: TaskService, tid: UUID
+    ) -> TaskTable | None:
+        """Fires once, right after the outer pre-lock read — the exact
+        window between our read and our own (would-be) pre-lock write."""
+        nonlocal injected
+        result = await real_get(self, tid)
+        if not injected:
+            injected = True
+            other, other_engine = await _fresh_session(_test_database_url)
+            try:
+                other_task = await other.get(TaskTable, tid)
+                assert other_task is not None
+                markers.set_x_posted_tweet_id(other_task, "concurrent-999")
+                other_task.status = TS.COMPLETED
+                await other.commit()
+            finally:
+                await _dispose(other, other_engine)
+        return result
+
+    client = _StubClient()
+    with (
+        patch("roboco.services.x_post_service.build_x_client", return_value=client),
+        patch.object(TaskService, "get", _get_then_inject_concurrent_post),
+        patch.object(XPostService, "_acquire_lock", AsyncMock(return_value="tok")),
+        patch.object(XPostService, "_release_lock", AsyncMock(return_value=None)),
+    ):
+        result = await _svc(db_session).approve(task_id, "Edited body")
+
+    assert result is not None
+    assert result.status == "already_posted"
+    assert result.tweet_id == "concurrent-999"
+    # No double-post: the concurrently-committed tweet wins, ours never fires.
+    assert client.calls == []
+
+    fresh, fresh_engine = await _fresh_session(_test_database_url)
+    try:
+        final = await fresh.get(TaskTable, task_id)
+        assert final is not None
+        assert final.status == TS.COMPLETED
+        assert markers.get_x_posted_tweet_id(final) == "concurrent-999"
+        # The edit must never have landed on the just-posted row.
+        assert markers.get_x_draft_body(final) == "Original"
+    finally:
+        await _dispose(fresh, fresh_engine)
 
 
 # --------------------------------------------------------------------------- #
@@ -684,9 +873,12 @@ async def test_reject_feature_spotlight_with_wants_video_opens_none(
     task = await _seed_feature_draft(db_session)
     video_engine = AsyncMock()
     video_engine.open_video_task = AsyncMock(return_value=None)
-    with patch(
-        "roboco.services.video_engine.get_video_engine",
-        return_value=video_engine,
+    with (
+        patch(
+            "roboco.services.video_engine.get_video_engine",
+            return_value=video_engine,
+        ),
+        _lock_free(),
     ):
         updated = await _svc(db_session).reject(_id(task), "not on-brand")
     assert updated is not None


### PR DESCRIPTION
Audit and fix four independent backend defect domains identified by the PO's analysis. Please break each of the four units below into its own developer leaf so both backend devs can work in parallel — they are explicitly independent of one another per the intake.

1. Redis mutex pattern audit (independent of #2): XPostService.approve at roboco/services/x_post_service.py:90-99 writes edited_body pre-lock (flush before SET NX) — a confirmed data-integrity bug. VideoPostService at roboco/services/video_post_service.py:197-201 already documents the correct fix pattern (validate-pure pre-lock, apply-under-lock) — mirror it. Audit every SET NX / HeartbeatMutex consumer (x_post_service.py, video_post_service.py, release_proposal.py, heartbeat_mutex.py) for the same pre-lock DB-write anti-pattern and fix each one found.

2. Task lifecycle state-machine exhaustiveness (independent of #1): audit roboco/foundation/policy/lifecycle.py and roboco/enforcement/task_lifecycle.py for unreachable states and missing edges (e.g. can a task get stuck in awaiting_pr_review if the reviewer crashes?), and audit every caller of the _ESCALATABLE_TO_BLOCKED bypass set at roboco/services/task.py:122-137 (a documented direct task.status= write bypassing the validator). Verify _REVIEW_QUEUE_STATES (task.py:144-152) clears stale assignees on every entry.

3. Orchestrator dispatch race + subprocess leak audit (runs alongside #1/#2/#4): in roboco/runtime/orchestrator.py, scope to _dispatch_all_work (line 10108) and its callees plus _reap_stale_claims — audit whether _tick_handled_tasks (line 10127) prevents cross-tick double-dispatch when a claim lands between the stale-claim reaper (line 9641) and the next dispatcher tick; check every _dispatch_* skip condition. Do NOT attempt to audit the entire 12K+ line file. Separately, audit subprocess resource leaks in quality_gate.py:75-100 and release_executor.py:208-224 — every exit path must kill+wait+close pipe transports.

4. Default-off engine dedup race sweep + MegaTask sequencing edge cases (runs alongside the above): audit the list-open-then-originate non-atomic dedup pattern in RoadmapEngine.run_cycle, XEngine.run_cycle, VideoEngine.open_video_task, DepUpdateEngine, CIWatchEngine, SelfHealEngine. Verify the ReleaseExecutor half-landed retry path (release_executor.py:98-103) when _current_version returns bumped but the changelog isn't yet written. In sequencing.py, fix dev_task_collision_edges (line 337-343): it returns collision edges for surfaced siblings, but `if edges: return edges` short-circuits the assignee-lane fallback, leaving unsurfaced siblings in the same assignee lane with no ordering at all. Also verify sequencing.py rule 3 (all-shared batch generates no edges) is correct.

For every unit: confirmed defects get a fix + a regression test. Speculative findings (no concrete repro) get documented in the PR description but are not required to be fixed — do not fabricate fixes for non-issues. make quality must pass clean with no new regressions before submitting up.