### PR TITLE
[d615f2e3] Fix stale CLAIM_RULES pinning test (F-735bfda1)

### DIFF
--- a/tests/foundation/test_lifecycle_spec.py
+++ b/tests/foundation/test_lifecycle_spec.py
@@ -500,10 +500,18 @@ def test_claim_rules_match_pre_gateway_table() -> None:
         {spec.Status.PENDING, spec.Status.AWAITING_DOCUMENTATION}
     )
     assert spec.CLAIM_RULES[spec.Role.CELL_PM] == frozenset(
-        {spec.Status.PENDING, spec.Status.NEEDS_REVISION}
+        {
+            spec.Status.PENDING,
+            spec.Status.NEEDS_REVISION,
+            spec.Status.AWAITING_PM_REVIEW,
+        }
     )
     assert spec.CLAIM_RULES[spec.Role.MAIN_PM] == frozenset(
-        {spec.Status.PENDING, spec.Status.NEEDS_REVISION}
+        {
+            spec.Status.PENDING,
+            spec.Status.NEEDS_REVISION,
+            spec.Status.AWAITING_PM_REVIEW,
+        }
     )
 
 


### PR DESCRIPTION
PR #634's gate review returned blocker F-735bfda1: tests/foundation/test_lifecycle_spec.py:502-507, function test_claim_rules_match_pre_gateway_table, still asserts CLAIM_RULES[CELL_PM] == frozenset({Status.PENDING, Status.NEEDS_REVISION}) and the same set for MAIN_PM. But roboco/foundation/policy/lifecycle.py's CLAIM_RULES dict (lines 763-768, added by the earlier "Task lifecycle state-machine exhaustiveness audit" subtask on this same branch) now grants CELL_PM and MAIN_PM claim rights on Status.AWAITING_PM_REVIEW too (needed so a cell/main PM can re-claim its own task after a pr_gate bounce, which is exactly the flow this fix enables). The pinning test was never updated to match, so it fails on the next run and violates AC #5 ("make quality passes clean with no new regressions").

Fix: update the two assertions in test_claim_rules_match_pre_gateway_table (lines 502-507) so both the CELL_PM and MAIN_PM expected sets include Status.AWAITING_PM_REVIEW alongside Status.PENDING and Status.NEEDS_REVISION, matching the actual CLAIM_RULES dict in lifecycle.py. Before committing, grep the repo for any other place that hardcodes the old frozenset({PENDING, NEEDS_REVISION}) claim-rule literal for CELL_PM/MAIN_PM to make sure no sibling pinning test has the same staleness. Do not touch lifecycle.py itself — it is already correct.