### PR TITLE
[3c4e7a35] Diagnose and fix Python quality gate failure on PR #634 (head 296d105e)

### DIFF
--- a/CONCURRENCY_AUDIT.md
+++ b/CONCURRENCY_AUDIT.md
@@ -9,7 +9,7 @@ This PR audits the list-open-then-originate dedup pattern across six engines and
 1. **VideoEngine.open_video_task** — Race condition fixed
    - **Why it races:** Three concurrent call sites (release hook, spotlight hook, /video/request route)
    - **Fix:** Per-occasion HeartbeatMutex wraps the dedup check + insert atomically
-   - **Tests:** 
+   - **Tests:**
      - `test_open_video_task_lock_held` — locked calls return None
      - `test_open_video_task_concurrent_calls` — concurrent calls for same occasion create only one task
 
@@ -24,7 +24,7 @@ This PR audits the list-open-then-originate dedup pattern across six engines and
 ### Verified Correct (with regression tests documenting why)
 
 1. **RoadmapEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
-2. **XEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race  
+2. **XEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
 3. **DepUpdateEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
 4. **CIWatchEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race
 5. **SelfHealEngine.run_cycle** — Single sequential orchestrator-loop call site → no self-race

--- a/tests/integration/test_video_routes.py
+++ b/tests/integration/test_video_routes.py
@@ -265,15 +265,16 @@ async def test_request_video_opens_authoring_task(
     project = (
         await db_session.execute(select(ProjectTable).where(ProjectTable.slug == SLUG))
     ).scalar_one()
-    resp = await ceo_client.post(
-        "/api/video/request",
-        json={
-            "occasion": "CEO on-demand: launch teaser",
-            "brief": "A short teaser for the new dashboard",
-            "platforms": ["x", "tiktok"],
-            "project_id": str(project.id),
-        },
-    )
+    with _LOCKED[0], _LOCKED[1]:
+        resp = await ceo_client.post(
+            "/api/video/request",
+            json={
+                "occasion": "CEO on-demand: launch teaser",
+                "brief": "A short teaser for the new dashboard",
+                "platforms": ["x", "tiktok"],
+                "project_id": str(project.id),
+            },
+        )
     assert resp.status_code == HTTPStatus.OK
     body = resp.json()
     assert body["status"] == "opened"
@@ -396,12 +397,14 @@ async def test_request_video_not_opened_on_duplicate_occasion(
         "platforms": ["x"],
         "project_id": str(project.id),
     }
-    first = await ceo_client.post("/api/video/request", json=payload)
+    with _LOCKED[0], _LOCKED[1]:
+        first = await ceo_client.post("/api/video/request", json=payload)
     assert first.status_code == HTTPStatus.OK
     assert first.json()["status"] == "opened"
     task_id = first.json()["task_id"]
     try:
-        second = await ceo_client.post("/api/video/request", json=payload)
+        with _LOCKED[0], _LOCKED[1]:
+            second = await ceo_client.post("/api/video/request", json=payload)
         assert second.status_code == HTTPStatus.OK
         assert second.json()["status"] == "not_opened"
         assert second.json()["task_id"] is None

--- a/tests/unit/runtime/test_video_render_loop.py
+++ b/tests/unit/runtime/test_video_render_loop.py
@@ -28,6 +28,7 @@ from roboco.runtime.orchestrator import (
     _MAX_VIDEO_RENDER_ATTEMPTS,
     AgentOrchestrator,
 )
+from roboco.services import video_engine as video_engine_module
 from roboco.services.task import VIDEO_POST_SOURCE, get_task_service
 from roboco.services.video_engine import VideoEngine
 from sqlalchemy import select
@@ -47,6 +48,26 @@ FOUR = 4
 
 def _orch() -> Any:
     return AgentOrchestrator.__new__(AgentOrchestrator)
+
+
+class _AlwaysAcquiredMutex:
+    """Stand-in for ``HeartbeatMutex``: always acquires immediately, no live
+    Redis required (matches the project's ``_no_live_redis`` fixture and
+    mirrors ``test_video_engine.py``'s identical stub)."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    async def acquire(self) -> str | None:
+        return "tok"
+
+    async def release(self, _token: str) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _stub_occasion_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(video_engine_module, "HeartbeatMutex", _AlwaysAcquiredMutex)
 
 
 class _FakeRenderer:


### PR DESCRIPTION
Gate review returned blocker F-60a86796 on this cell's PR #634 (branch feature/backend/6788ce7f--4534c71a): "CI is failing on the assembled PR's head commit — the Python quality gate check is red. The diff itself is clean (all 5 acceptance criteria are satisfied, all fixes are correct with proper regression tests, architectural placement is proper), but the gate cannot pass on red CI." The four merged audit units on this branch are: (1) XPostService/VideoPostService/ReleaseProposal/HeartbeatMutex pre-lock-write fixes, (2) lifecycle.py CLAIM_RULES + task.py _ESCALATABLE_TO_BLOCKED / _REVIEW_QUEUE_STATES audit fixes, (3) quality_gate.py / release_executor.py subprocess reap fixes, (4) sequencing.py dev_task_collision_edges fix + engine dedup race audit.

Run `make quality` on this branch's current head to identify the exact failing check (lint/format/mypy/test/coverage/xenon/bandit/audit). Determine whether it is: (a) a real regression introduced by one of the four merged fixes above, (b) a genuinely flaky/non-deterministic test unrelated to this PR, or (c) a pre-existing issue on master that this branch needs rebasing onto latest master to pick up a fix for. Land the narrowest fix that makes `make quality` pass clean, or rebase onto master if the root cause is upstream and already fixed there. Do not touch scope outside what's needed to turn CI green — no new speculative fixes.

```
==> markdown prose (no hard-wrapping)
1 file(s) have hard-wrapped prose. Fix with:
   make reflow-docs
   CONCURRENCY_AUDIT.md
make: *** [Makefile:285: quality] Error 1
Error: Process completed with exit code 2.
```