### PR TITLE
[ddc8121f] Diagnose and fix Python quality gate failure on PR #634 (head e6eb2a63)

### DIFF
--- a/docs/rag/lifecycle/status-transitions.md
+++ b/docs/rag/lifecycle/status-transitions.md
@@ -11,6 +11,7 @@
 | awaiting_documentation | claimed | claim | documenter |
 | awaiting_pm_review | awaiting_ceo_approval | escalate_to_ceo | head_marketing, main_pm, product_owner |
 | awaiting_pm_review | cancelled | cancel | cell_pm, ceo, main_pm |
+| awaiting_pm_review | claimed | claim | cell_pm, main_pm |
 | awaiting_pm_review | completed | complete | cell_pm, main_pm |
 | awaiting_pm_review | needs_revision | request_changes | cell_pm, main_pm |
 | awaiting_pr_review | awaiting_pm_review | pr_pass | pr_reviewer |

--- a/panel/lib/lifecycle.json
+++ b/panel/lib/lifecycle.json
@@ -2,6 +2,7 @@
   "claim_rules": {
     "auditor": [],
     "cell_pm": [
+      "awaiting_pm_review",
       "needs_revision",
       "pending"
     ],
@@ -16,6 +17,7 @@
     ],
     "head_marketing": [],
     "main_pm": [
+      "awaiting_pm_review",
       "needs_revision",
       "pending"
     ],
@@ -528,6 +530,15 @@
       ],
       "source": "awaiting_pm_review",
       "target": "cancelled"
+    },
+    {
+      "action": "claim",
+      "roles": [
+        "cell_pm",
+        "main_pm"
+      ],
+      "source": "awaiting_pm_review",
+      "target": "claimed"
     },
     {
       "action": "complete",


### PR DESCRIPTION
PR #634 (branch feature/backend/6788ce7f--4534c71a) has all four backend audit units already merged, but the assembled PR's Python quality gate CI check is red on the current head commit e6eb2a636d632ca25221bfbd838e2e5b7210f605. This is the third CI-red bounce on this PR: the first (head 296d105e) and second (a stale CLAIM_RULES pinning test, F-735bfda1) were each resolved by a dedicated fix, but the branch has since moved forward and CI is failing again on the new head — do NOT assume the prior fixes still apply; pull the current branch state fresh and diagnose against e6eb2a63 specifically.

Steps: sync your branch to the current PR head, run `make quality` locally to reproduce the exact failing check (lint/mypy/test/coverage/xenon/bandit), identify the root cause, fix it on this branch. If the failure is a genuine code/test regression (e.g. introduced by one of the merged sibling fixes — the CLAIM_RULES/lifecycle changes, the Redis mutex changes, or the sequencing.py changes), fix the actual defect and add/adjust a regression test as needed. If the failure is purely a stale assertion pinning old behavior that a merged sibling intentionally changed, update the assertion to match the new, correct behavior — do not revert the sibling's intended fix. Confirm `make quality` passes clean before pushing.

`Lifecycle artifacts are out of date. Run 'make lifecycle' and commit the diff.
make[1]: *** [Makefile:566: foundation-check] Error 1
make[1]: Leaving directory '/home/runner/work/roboco/roboco'
make: *** [Makefile:312: quality] Error 2
Error: Process completed with exit code 2`