### PR TITLE
Exempt roboco-app[bot] from the CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,4 +41,15 @@ jobs:
           # the emails map to no GitHub account, so CLA Assistant identifies
           # them by display name — allowlist those names, wildcarded per team
           # family, mirroring roboco/seeds/initial_data.py's roster.
-          allowlist: "dependabot[bot],rennf93,Backend *,Frontend *,UX/UI *,Main PM,Product Owner,Head of Marketing,Auditor,Intake,Secretary,PR Reviewer,RoboCo Agent"
+          #
+          # roboco-app[bot] is the GitHub App the fleet pushes and opens PRs
+          # under. It authors the sync/merge commits GitService creates when a
+          # task branch is brought up to date with its base, so it is a
+          # committer on essentially every fleet PR — and unlike the agent
+          # identities it DOES map to a real GitHub account, so CLA Assistant
+          # demands a signature it can never give: an App cannot post the
+          # sign-off comment as itself. Exempting it is also correct on the
+          # merits, since the CLA exists to obtain copyright assignment from
+          # human contributors and the App commits on the copyright holder's
+          # own behalf. Same form as dependabot[bot] above.
+          allowlist: "dependabot[bot],roboco-app[bot],rennf93,Backend *,Frontend *,UX/UI *,Main PM,Product Owner,Head of Marketing,Auditor,Intake,Secretary,PR Reviewer,RoboCo Agent"


### PR DESCRIPTION
`cla` is currently red on every fleet PR (#703, #704) and cannot be cleared by rework, so the PR reviewer keeps sending tasks round another revision loop with nothing to fix.

## Cause

The committers on those PRs are:

```
Backend Developer 1 <be-dev-1@roboco.tech>     -> matches allowlist "Backend *"
Backend Documenter  <be-doc@roboco.tech>       -> matches allowlist "Backend *"
Backend PM          <be-pm@roboco.tech>        -> matches allowlist "Backend *"
roboco-app[bot]     <...@users.noreply.github.com>  -> NOT allowlisted
```

The agent identities pass because their `roboco.tech` emails map to no GitHub account, so CLA Assistant matches them by display name against the wildcards already in the allowlist. `roboco-app[bot]` is different: it maps to a real GitHub account, so CLA Assistant demands a signature — and an App cannot post the sign-off comment as itself, so that signature can never be given. The signature ledger confirms nobody has signed on its behalf (`signatures/version1/cla.json` holds only the two external human contributors).

It is a committer on essentially every fleet PR because it authors the sync/merge commits `GitService` creates when a task branch is brought up to date with its base — both #703 and #704 carry exactly such a commit.

## Fix

Add `roboco-app[bot]` to the allowlist, in the same form as the existing `dependabot[bot]` entry.

Exempting it is correct on the merits as well as practically: the CLA exists to obtain copyright assignment from human contributors, and the App commits on the copyright holder's own behalf. The alternative — making the App "sign" — is not available, and would be meaningless if it were.

Merge this first; #703 and #704 then need only a re-run of the check (or any push) to go green. Both are otherwise clean — #703's Python quality gate passes since the stale test was fixed, and #704's panel tests pass (1041 tests, verified locally, since `panel-ci.yml` declares `pull_request: branches: [master]` and never runs on a PR targeting `slave`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)