### PR TITLE
fix(dispatch): stop burning breaker strikes on dependency-held blocked tasks; collision notify rides the delegate transaction

### DIFF
--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -15485,6 +15485,15 @@ Never `commit`, never write code, never run `git`. PMs coordinate.
             if self._is_hitl_blocked(task):
                 continue
 
+            # A dependency-held blocked task can't be unblocked by any
+            # resolver until the dependency lands — spawn_agent's readiness
+            # gate would refuse anyway, and each refused attempt burned a
+            # respawn-breaker strike + a CEO escalation once tripped
+            # (2026-07-29). Skip quietly; this dispatcher re-checks every
+            # tick and proceeds once the dependency goes terminal.
+            if await self._check_dependencies_terminal(client, task):
+                continue
+
             agent_id = self._blocker_resolver_slug(task)
             if not agent_id:
                 continue

--- a/roboco/services/notification.py
+++ b/roboco/services/notification.py
@@ -524,12 +524,16 @@ class NotificationService:
         to_ceo: str = "ceo",
         held_back_title: str | None = None,
         blocking_title: str | None = None,
+        db_session: AsyncSession | None = None,
     ) -> None:
         """Tell the held-back task's owner (+ CEO) it now waits on a sibling.
 
         Fired only for a newly-created collision-sequencing edge (see
         ``wire_sibling_collision_dag`` — a repeat wiring pass over an
         already-wired pair contributes no edge, so this cannot double-fire).
+        ``db_session`` must be the edge-wiring transaction's own session: the
+        held-back task row may be uncommitted there, and the FK on
+        ``related_task_id`` fails on any other connection (2026-07-29).
         """
         recipients = list(dict.fromkeys(r for r in (held_back_assignee, to_ceo) if r))
         if not recipients:
@@ -556,7 +560,8 @@ class NotificationService:
                 subject=f"Task {held_back_display} sequenced behind a sibling",
                 body=body,
                 related_task_id=held_back_task_id,
-            )
+            ),
+            db_session,
         )
 
     async def send_unblock_notification(

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -8944,6 +8944,7 @@ class TaskService(BaseService):
                 held_back_assignee=str(owner) if owner is not None else None,
                 held_back_title=held_back_title,
                 blocking_title=blocking_title,
+                db_session=self.session,
             )
         except Exception as e:
             self.log.warning("Collision-sequencing notify failed", error=str(e))

--- a/tests/unit/runtime/test_blocker_and_claimed_dispatch.py
+++ b/tests/unit/runtime/test_blocker_and_claimed_dispatch.py
@@ -156,6 +156,40 @@ async def test_dispatch_blocker_work_spawns_non_hitl_blocked_task(
     spawn.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_dispatch_blocker_work_skips_dependency_held_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """2026-07-29: a blocked task waiting on a non-terminal dependency must
+    be skipped BEFORE the respawn gate — spawn_agent's readiness gate was
+    going to refuse anyway, and each refused attempt burned a breaker strike
+    plus, once tripped, a CEO escalation notification."""
+    orch = _orch()
+    task: dict[str, Any] = {
+        "id": "t1",
+        "status": "blocked",
+        "blocker_resolver_type": None,
+        "team": "backend",
+        "assigned_to": AGENT_UUIDS["be-pm"],
+        "dependency_ids": ["d1"],
+    }
+    monkeypatch.setattr(orch, "_fetch_tasks", AsyncMock(return_value=[task]))
+    monkeypatch.setattr(
+        orch,
+        "_check_dependencies_terminal",
+        AsyncMock(return_value="Task t1 waiting on non-terminal dependency d1"),
+    )
+    gate = AsyncMock(return_value=False)
+    monkeypatch.setattr(orch, "_pm_respawn_should_gate", gate)
+    spawn = AsyncMock()
+    monkeypatch.setattr(orch, "spawn_agent", spawn)
+
+    await orch._dispatch_blocker_work(client=MagicMock())
+
+    spawn.assert_not_awaited()
+    gate.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # _claimed_task_needs_agent — claimed-but-no-agent detection
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_notification.py
+++ b/tests/unit/services/test_notification.py
@@ -545,6 +545,25 @@ async def test_send_collision_sequencing_notification(
 
 
 @pytest.mark.asyncio
+async def test_send_collision_sequencing_notification_rides_caller_session(
+    svc: NotificationService,
+) -> None:
+    """2026-07-29: delegate wires collision edges inside a transaction whose
+    held-back task row is not yet committed — the notification INSERT must
+    ride that same session, or its related_task_id FK fails on any other
+    connection. No _patch_db_context here: opening a separate connection
+    would hit the real engine and fail the test."""
+    db = _FakeDb(agent_uuid=uuid4())
+    await svc.send_collision_sequencing_notification(
+        held_back_task_id="t2",
+        blocking_task_id="t1",
+        held_back_assignee="be-dev-1",
+        db_session=db,
+    )
+    assert [r for r in db.added if r.related_task_id == "t2"]
+
+
+@pytest.mark.asyncio
 async def test_send_unblock_notification(svc: NotificationService) -> None:
     aid = uuid4()
     db = _FakeDb(agent_uuid=aid)

--- a/tests/unit/services/test_notification.py
+++ b/tests/unit/services/test_notification.py
@@ -558,7 +558,7 @@ async def test_send_collision_sequencing_notification_rides_caller_session(
         held_back_task_id="t2",
         blocking_task_id="t1",
         held_back_assignee="be-dev-1",
-        db_session=db,
+        db_session=cast("Any", db),
     )
     assert [r for r in db.added if r.related_task_id == "t2"]
 

--- a/tests/unit/services/test_task.py
+++ b/tests/unit/services/test_task.py
@@ -619,6 +619,23 @@ async def test_wire_sibling_collision_dag_notifies_only_for_new_edges() -> None:
 
 
 @pytest.mark.asyncio
+async def test_collision_sequencing_notify_rides_task_service_session() -> None:
+    """2026-07-29: the held-back task row is uncommitted in this transaction —
+    the notification must ride the SAME session or its related_task_id FK
+    fails (ForeignKeyViolationError seen live in cell_pm/delegate)."""
+    session = MagicMock(flush=AsyncMock())
+    svc = TaskService(session)
+    mock_ns = MagicMock()
+    mock_ns.send_collision_sequencing_notification = AsyncMock()
+    with patch(
+        "roboco.services.notification.NotificationService", return_value=mock_ns
+    ):
+        await svc._notify_collision_sequencing(uuid4(), uuid4(), None)
+    kwargs = mock_ns.send_collision_sequencing_notification.await_args.kwargs
+    assert kwargs["db_session"] is session
+
+
+@pytest.mark.asyncio
 async def test_mark_agent_idle_sets_status_idle() -> None:
     agent = MagicMock(id=uuid4(), status=AgentStatus.ACTIVE, current_task_id=uuid4())
     result = MagicMock()


### PR DESCRIPTION
## Two follow-ups from the 2026-07-29 blocked-task wave

**1. `_dispatch_blocker_work` skips dependency-held blocked tasks before the respawn gate.** A blocked task waiting on a non-terminal dependency can't be unblocked by any resolver until the dependency lands — `spawn_agent`'s readiness gate refused every attempt anyway, but each refused attempt burned a respawn-breaker strike and, once tripped at 4, fired a duplicate CEO escalation notification every dispatch tick (seen live: the frontend eslint-audit task held behind a paused backend audit dependency). The dispatcher still re-checks every tick and proceeds the moment the dependency goes terminal — same resume path, minus the strike burn and notification spam.

**2. Collision-sequencing notification rides the delegate transaction.** `delegate` wires collision edges inside a transaction whose held-back child row is not yet committed; `send_collision_sequencing_notification` ran its INSERT on a separate auto-commit connection and died on the `related_task_id` FK (`ForeignKeyViolationError` seen live in `cell_pm/delegate`), silently losing the coordination alert. The sender now accepts the `db_session` threading its sibling senders (`send_unblock_notification`, `send_oscillation_blocked_notification`) already have, and `TaskService._notify_collision_sequencing` passes its own session — the row sees the uncommitted task and both commit atomically.

## Verification

- Three new regression tests; all three fail with the fixes stashed (`3 failed`) and pass with them: dispatcher skips the dependency-held task without touching the respawn gate; the sender forwards the caller's session; `TaskService` passes its own session.
- Full blocker-dispatch + notification suites + adjacent task tests: 63 passed.
- ruff / ruff format / mypy / xenon clean on all six touched files.