### PR TITLE
fix(gateway): route head-branch leaf merge to CEO approval (CEO_ONLY bounce)

### DIFF
--- a/roboco/services/gateway/choreographer/_impl.py
+++ b/roboco/services/gateway/choreographer/_impl.py
@@ -7696,6 +7696,67 @@ class Choreographer:
             )
         return None
 
+    async def _maybe_route_head_branch_to_ceo(
+        self,
+        pm_agent_id: UUID,
+        task_id: UUID,
+        t: Any,
+        target: str,
+    ) -> Envelope | None:
+        """Route a CEO-only head-branch leaf merge to CEO approval, or None.
+
+        A leaf whose parent is a branchless coordination root resolves its
+        merge target to the project's head env branch (slave/master, via
+        resolve_parent_branch's branchless-parent fallback). pr_merge is
+        CEO-only for the head branch: no agent may merge into it, so calling
+        it raises UnauthorizedError(CEO_ONLY) and the cell PM would
+        escalate_up -> main-pm (which also can't merge) and bounce BLOCKED
+        until the CEO intervenes by hand. Route such a leaf to
+        awaiting_ceo_approval (the CEO merge turn) instead; the closure
+        dispatcher skips awaiting_ceo_approval, so this is quiet, not a
+        re-spawn loop. Returns None when target is not the head branch (the
+        normal cell-PM merge proceeds). Live incidents this closes:
+        5612b225/PR 856 (blocked 3x), 5b780794/PR 840.
+        """
+        if not t.pr_number:
+            return None
+        head_branch = await self.task.project_default_branch_for_task(t)
+        if head_branch is None or target != head_branch:
+            return None
+        escalated = await self.task.escalate_to_ceo(
+            cast("UUID", t.id),
+            agent_role="cell_pm",
+            notes=(
+                f"Leaf PR #{t.pr_number} targets the CEO-only head branch"
+                f" '{target}' (parent is a branchless coordination root). The"
+                f" cell PM cannot merge into the head branch; routed to the"
+                f" CEO for approve-and-merge."
+            ),
+            actor_agent_id=pm_agent_id,
+            allow_subtask_ceo_merge=True,
+        )
+        if escalated is not None:
+            return Envelope.ok(
+                status=str(escalated.status),
+                task_id=str(task_id),
+                next=(
+                    "routed to CEO approval (PR targets the CEO-only head"
+                    " branch); idle until the CEO approves and merges"
+                ),
+                context_briefing=await self._briefing_for(pm_agent_id, task_id),
+            ).with_introspection(task=escalated, role="cell_pm")
+        return Envelope.invalid_state(
+            message=(
+                f"could not route PR #{t.pr_number} to CEO approval for the"
+                f" CEO-only head branch '{target}'"
+            ),
+            remediate=(
+                "the CEO must approve-and-merge this PR into the head branch"
+                f" '{target}' manually"
+            ),
+            context_briefing=await self._briefing_for(pm_agent_id, task_id),
+        ).with_introspection(task=t, role="cell_pm")
+
     async def cell_pm_complete(
         self, pm_agent_id: UUID, task_id: UUID, notes: str
     ) -> Envelope:
@@ -7746,6 +7807,11 @@ class Choreographer:
         if t.pr_number:
             already_merged = await self.git.is_pr_merged_for_task(task_id)
             if not already_merged:
+                ceo_env = await self._maybe_route_head_branch_to_ceo(
+                    pm_agent_id, task_id, t, target
+                )
+                if ceo_env is not None:
+                    return ceo_env
                 try:
                     merge_result = await self.git.pr_merge(
                         t.pr_number,

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -7398,12 +7398,20 @@ class TaskService(BaseService):
     # =========================================================================
 
     def _escalate_to_ceo_refusal(
-        self, task: TaskTable
+        self, task: TaskTable, *, allow_subtask_ceo_merge: bool = False
     ) -> tuple[str, dict[str, Any]] | None:
         """Eligibility checks for ``escalate_to_ceo``, extracted to keep that
         method's own cyclomatic complexity within the xenon gate. Returns
         ``(log_message, log_kwargs)`` when escalation must be refused, or
-        ``None`` when `task` is eligible."""
+        ``None`` when `task` is eligible.
+
+        ``allow_subtask_ceo_merge`` bypasses the parent/root guard for a leaf
+        whose PR targets the CEO-only head env branch (a branchless
+        coordination-root parent makes ``resolve_parent_branch`` fall back to
+        the project head branch, so ``pr_merge`` would CEO_ONLY-fail and the
+        cell PM would bounce escalate_up -> main-pm forever). Set only by
+        ``cell_pm_complete``'s head-branch routing; the ``escalate_to_ceo``
+        verb never passes it."""
         if task.status != TaskStatus.AWAITING_PM_REVIEW:
             return (
                 "Cannot escalate to CEO - task not in PM review",
@@ -7413,9 +7421,14 @@ class TaskService(BaseService):
         # EXCEPT a MegaTask root-subtask, which IS parented (the umbrella) yet
         # carries its own project/branch/PR and behaves as a root for
         # git/CEO purposes (is_batch_root_subtask). A plain subtask (no
-        # batch_id) is still refused.
-        if task.parent_task_id and not is_batch_root_subtask(
-            batch_id=task.batch_id, parent_task_id=task.parent_task_id
+        # batch_id) is still refused - UNLESS allow_subtask_ceo_merge routes a
+        # leaf whose PR targets the CEO-only head branch (see the param doc).
+        if (
+            task.parent_task_id
+            and not is_batch_root_subtask(
+                batch_id=task.batch_id, parent_task_id=task.parent_task_id
+            )
+            and not allow_subtask_ceo_merge
         ):
             return (
                 "Cannot escalate subtask to CEO - only parent tasks allowed",
@@ -7447,6 +7460,7 @@ class TaskService(BaseService):
         agent_role: str = "cell_pm",
         notes: str | None = None,
         actor_agent_id: UUID | None = None,
+        allow_subtask_ceo_merge: bool = False,
     ) -> TaskTable | None:
         """
         Escalate a task to CEO for final approval (PM only).
@@ -7465,6 +7479,13 @@ class TaskService(BaseService):
                 to the specific PM/Board agent (every sibling transition
                 forwards the actor; without it the record is role-only and
                 ambiguous across same-role PMs).
+            allow_subtask_ceo_merge: Bypass the parent/root guard for a leaf
+                whose PR targets the CEO-only head env branch (a branchless
+                coordination-root parent makes ``resolve_parent_branch`` fall
+                back to the project head branch, so ``pr_merge`` would
+                CEO_ONLY-fail and the cell PM would bounce escalate_up ->
+                main-pm forever). Set only by ``cell_pm_complete``'s head-branch
+                routing; the ``escalate_to_ceo`` verb never passes it.
 
         Returns:
             The escalated task or None if escalation not allowed
@@ -7473,7 +7494,9 @@ class TaskService(BaseService):
         if not task:
             return None
 
-        refusal = self._escalate_to_ceo_refusal(task)
+        refusal = self._escalate_to_ceo_refusal(
+            task, allow_subtask_ceo_merge=allow_subtask_ceo_merge
+        )
         if refusal:
             message, kwargs = refusal
             self.log.warning(message, task_id=str(task_id), **kwargs)

--- a/tests/unit/gateway/test_choreographer_completion_guards.py
+++ b/tests/unit/gateway/test_choreographer_completion_guards.py
@@ -183,6 +183,108 @@ async def test_cell_pm_complete_allows_decision_without_separate_reflect() -> No
     task_svc.cell_pm_complete.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_cell_pm_complete_routes_head_branch_leaf_to_ceo_approval() -> None:
+    """A leaf whose parent is a branchless coordination root resolves its
+    merge target to the project head env branch (slave/master), and pr_merge
+    is CEO-only for the head branch. cell_pm_complete must route such a leaf
+    to awaiting_ceo_approval (the CEO merge turn) instead of calling pr_merge
+    (which would CEO_ONLY-fail and bounce the cell PM escalate_up -> main-pm).
+    Live: 5612b225/PR 856 (blocked 3x), 5b780794/PR 840.
+    """
+    pm_id = uuid4()
+    leaf_id = uuid4()
+    parent_id = uuid4()
+    proj_id = uuid4()
+    t = MagicMock(
+        id=leaf_id,
+        status="awaiting_pm_review",
+        assigned_to=pm_id,
+        pr_number=840,
+        team="backend",
+        branch_name="feature/backend/5b780794",
+        parent_task_id=parent_id,
+        project_id=proj_id,
+    )
+    parent = MagicMock(id=parent_id, branch_name=None)  # branchless coord root
+    after = MagicMock(**{**t.__dict__, "status": "awaiting_ceo_approval"})
+    task_svc = AsyncMock()
+    task_svc.get.side_effect = lambda tid, _t=t, _p=parent, _pid=parent_id: (
+        _p if tid == _pid else _t
+    )
+    task_svc.all_subtasks_terminal.return_value = True
+    task_svc.get_subtasks.return_value = []
+    task_svc.project_default_branch_for_task.return_value = "slave"
+    task_svc.escalate_to_ceo.return_value = after
+    journal_svc = AsyncMock()
+    journal_svc.has_decision_for_task.return_value = True
+    journal_svc.latest_decision_at.return_value = datetime.now(UTC)
+    journal_svc.has_reflect_for_task.return_value = True
+    git_svc = AsyncMock()
+    git_svc.is_pr_merged_for_task.return_value = False
+    deps = _make_deps(task=task_svc, journal=journal_svc, git=git_svc)
+    c = Choreographer(deps)
+
+    env = await c.cell_pm_complete(pm_id, leaf_id, "cell scope reviewed and approved")
+
+    body = env.as_dict()
+    assert body["error"] is None
+    assert body["status"] == "awaiting_ceo_approval"
+    task_svc.escalate_to_ceo.assert_awaited_once()
+    # The subtask guard bypass is the whole fix.
+    kwargs = task_svc.escalate_to_ceo.call_args.kwargs
+    assert kwargs.get("allow_subtask_ceo_merge") is True
+    git_svc.pr_merge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cell_pm_complete_merges_when_parent_has_branch() -> None:
+    """Negative: a leaf whose parent HAS a branch resolves target to that
+    branch (not the head branch), so the CEO routing does NOT fire and the
+    normal pr_merge path runs. Guards against the fix over-routing every
+    leaf merge.
+    """
+    pm_id = uuid4()
+    leaf_id = uuid4()
+    parent_id = uuid4()
+    proj_id = uuid4()
+    t = MagicMock(
+        id=leaf_id,
+        status="awaiting_pm_review",
+        assigned_to=pm_id,
+        pr_number=841,
+        team="backend",
+        branch_name="feature/backend/leaf",
+        parent_task_id=parent_id,
+        project_id=proj_id,
+    )
+    parent = MagicMock(id=parent_id, branch_name="feature/main_pm/cellroot")
+    after = MagicMock(**{**t.__dict__, "status": "completed"})
+    task_svc = AsyncMock()
+    task_svc.get.side_effect = lambda tid, _t=t, _p=parent, _pid=parent_id: (
+        _p if tid == _pid else _t
+    )
+    task_svc.all_subtasks_terminal.return_value = True
+    task_svc.get_subtasks.return_value = []
+    task_svc.project_default_branch_for_task.return_value = "slave"
+    task_svc.cell_pm_complete.return_value = after
+    journal_svc = AsyncMock()
+    journal_svc.has_decision_for_task.return_value = True
+    journal_svc.latest_decision_at.return_value = datetime.now(UTC)
+    journal_svc.has_reflect_for_task.return_value = True
+    git_svc = AsyncMock()
+    git_svc.is_pr_merged_for_task.return_value = False
+    git_svc.pr_merge.return_value = {"merge_commit_sha": "abc"}
+    deps = _make_deps(task=task_svc, journal=journal_svc, git=git_svc)
+    c = Choreographer(deps)
+
+    env = await c.cell_pm_complete(pm_id, leaf_id, "cell scope reviewed and approved")
+
+    assert env.error is None
+    task_svc.escalate_to_ceo.assert_not_awaited()
+    git_svc.pr_merge.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # main_pm_complete subtask gate (root-task case)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
A leaf dev task whose PR targets the project head env branch (e.g. `slave`) because its parent is a branchless coordination root hit a dead end at `awaiting_pm_review`. The cell PM `pr_merge` raises `CEO_ONLY` (no agent merges the head branch), `cell_pm_complete` only catches `MergeConflictError` (not `UnauthorizedError`), so the PM bounce-escalates to main-pm (same wall) and loops `BLOCKED` until manual CEO intervention. Live incident: task 5612b225 / PR 856 blocked 3x on 2026-08-10; task 5b780794 / PR 840 needed a manual CEO override to escape.

## Fix
`cell_pm_complete` now detects `resolve_parent_branch == project head branch` BEFORE attempting `pr_merge` and routes the task straight to `awaiting_ceo_approval` via `escalate_to_ceo(allow_subtask_ceo_merge=True)`, mirroring the manual CEO merge path. The parent/subtask refusal guard in `_escalate_to_ceo_refusal` gains an `allow_subtask_ceo_merge` opt-out (status guard and PR guard intact, `is_pr_waived` exemption unchanged) so a genuine leaf can escalate to the CEO without the umbrella/root-only restriction blocking it.

## Tests
Two new cases in `test_choreographer_completion_guards.py`: a head-branch leaf (branchless parent, head == `slave`) routes to `awaiting_ceo_approval` with `pr_merge` NOT called; a normal branched parent still merges via `pr_merge`. 12 tests pass, ruff + format clean.