### PR TITLE
fix(a2a): tolerate NULL content so admin/participant views stop 500ing

### DIFF
--- a/roboco/services/a2a.py
+++ b/roboco/services/a2a.py
@@ -1035,6 +1035,7 @@ class A2AService:
             unread = (
                 conv.unread_by_a if agent_slug == conv.agent_a else conv.unread_by_b
             )
+            preview = last_msg.content[:100] if last_msg and last_msg.content else None
 
             summaries.append(
                 A2AConversationSummary(
@@ -1046,7 +1047,7 @@ class A2AService:
                     message_count=conv.message_count,
                     unread_count=unread,
                     last_message_at=conv.last_message_at,
-                    last_message_preview=(last_msg.content[:100] if last_msg else None),
+                    last_message_preview=preview,
                 )
             )
 
@@ -1082,6 +1083,7 @@ class A2AService:
         summaries = []
         for conv in conversations:
             last_msg = await self._last_message(cast("UUID", conv.id))
+            preview = last_msg.content[:100] if last_msg and last_msg.content else None
             summaries.append(
                 A2AConversationAdminSummary(
                     id=str(conv.id),
@@ -1092,7 +1094,7 @@ class A2AService:
                     status=conv.status,
                     message_count=conv.message_count,
                     last_message_at=conv.last_message_at,
-                    last_message_preview=(last_msg.content[:100] if last_msg else None),
+                    last_message_preview=preview,
                     created_at=conv.created_at,
                     updated_at=conv.updated_at,
                 )
@@ -1626,7 +1628,7 @@ class A2AService:
             {
                 "conversation_id": str(m.conversation_id),
                 "from_agent": m.from_agent,
-                "content": m.content,
+                "content": m.content or "(message content unavailable)",
                 "created_at": m.created_at.isoformat() if m.created_at else None,
             }
             for m in msgs
@@ -1767,7 +1769,12 @@ class A2AService:
             id=str(msg.id),
             conversation_id=str(msg.conversation_id),
             from_agent=msg.from_agent,
-            content=msg.content,
+            # ponytail: a2a_messages.content is nullable in the DB; 1815 pre-gap
+            # rows recovered from the Aug 2026 NAS outage carry NULL content (the
+            # heap extractor could not parse the varlena). The model requires a
+            # non-empty str, so coerce NULL to an honest placeholder instead of
+            # 500ing the whole conversation view.
+            content=msg.content or "(message content unavailable)",
             message_kind=msg.message_kind,
             skill=msg.skill,
             response_to_id=str(msg.response_to_id) if msg.response_to_id else None,

--- a/tests/integration/test_lifecycle_real_db.py
+++ b/tests/integration/test_lifecycle_real_db.py
@@ -954,13 +954,13 @@ async def test_cell_pm_complete_routes_ceo_only_head_branch_to_ceo(
 
     env = await c.cell_pm_complete(
         cell_pm_agent.id,
-        leaf.id,
+        UUID(str(leaf.id)),
         notes="LGTM - routing to CEO for the head-branch merge.",
     )
     assert env.error is None, f"complete failed: {env.message}"
     assert env.status == Status.AWAITING_CEO_APPROVAL.value
 
-    final = await task_service.get(leaf.id)
+    final = await task_service.get(UUID(str(leaf.id)))
     assert final is not None
     assert str(final.status) == Status.AWAITING_CEO_APPROVAL.value
 


### PR DESCRIPTION
A2A admin/participant endpoints 500 when a conversation row has NULL content. This tolerates the NULL so the views render instead of crashing.

Root cause: content column was nullable but the read paths dereferenced it without a guard. Guard added at the read layer; no schema change.

Gate: ruff/mypy clean, tests pass.