### PR TITLE
fix(supersede): background the branch cut, post contributor comment, add restart-safe reconciliation

### DIFF
--- a/panel/src/components/dashboard/pr-review-queue.tsx
+++ b/panel/src/components/dashboard/pr-review-queue.tsx
@@ -67,11 +67,21 @@ export function PrReviewQueue({ className }: PrReviewQueueProps) {
     mutationFn: (taskId: string) => tasksApi.supersedeExternalPr(taskId),
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: ["tasks"] });
-      toast.success(
-        res.ok
-          ? "Superseding — the org is taking the PR over"
-          : "Supersede did not start",
-      );
+      if (res.already_superseded) {
+        toast.success(
+          "Already superseded - the task was created by a prior call",
+        );
+      } else if (res.status === "cutting_branch") {
+        toast.success(
+          "Superseding - cutting the branch now, the org is taking the PR over",
+        );
+      } else {
+        toast.success(
+          res.ok
+            ? "Superseding - the org is taking the PR over"
+            : "Supersede did not start",
+        );
+      }
       close();
     },
     onError: (e) =>

--- a/panel/src/lib/api/tasks.ts
+++ b/panel/src/lib/api/tasks.ts
@@ -1041,11 +1041,19 @@ export const tasksApi = {
   // CEO authorizes the org to take over a reviewed external PR.
   supersedeExternalPr: async (
     taskId: string,
-  ): Promise<{ ok: boolean; supersede_task_id?: string; branch?: string }> => {
+  ): Promise<{
+    ok: boolean;
+    supersede_task_id?: string;
+    branch?: string;
+    status?: string;
+    already_superseded?: boolean;
+  }> => {
     const { data } = await api.post<{
       ok: boolean;
       supersede_task_id?: string;
       branch?: string;
+      status?: string;
+      already_superseded?: boolean;
     }>("/tasks/" + taskId + "/supersede-external-pr");
     return data;
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,11 @@ select = [
 # every kwarg is independently override-able by callers/tests, same
 # bundling-adds-no-clarity rationale as prompter.py above.
 "roboco/services/github_provisioning.py" = ["PLR0913"]
+# ensure_workspace carries the workspace-resolution contract (project_slug,
+# agent_id, git_url, default_branch, force, skip_refresh) - skip_refresh is
+# the supersede branch-cut path's skip of the 60s origin refresh-fetch;
+# bundling would just relocate the same named fields behind one hop.
+"roboco/services/workspace.py" = ["PLR0913"]
 # Gateway methods are typed verb surfaces — agent-facing kwargs reflect the
 # verb contract (task title, description, acceptance criteria, assignee, etc.). Bundling
 # into a dataclass hides the field-by-field schema the LLM needs at the

--- a/roboco/foundation/policy/content/markers.py
+++ b/roboco/foundation/policy/content/markers.py
@@ -68,6 +68,10 @@ WAR_ROOM_BRIEF = "war_room_brief"
 BARFLY_CANDIDATES = "barfly_candidates"
 BARFLY_REPLY_REF = "barfly_reply_ref"
 PR_WAIVED = "pr_waived"
+BRANCH_PENDING = "branch_pending"
+SUPERSEDE_COMMENT_POSTED = "supersede_comment_posted"
+BRANCH_CUT_FAILED = "branch_cut_failed"
+BRANCH_CUT_NEXT_RETRY_AT = "branch_cut_next_retry_at"
 
 
 def get_marker(task: HasMarkers, key: str, default: Any = None) -> Any:
@@ -843,6 +847,69 @@ def clear_pr_waived(task: HasMarkers) -> None:
     round is NOT itself waiving PR creation.
     """
     clear_marker(task, PR_WAIVED)
+
+
+# --- supersede branch-pending (async branch cut) --------------------------- #
+# The CEO's supersede-external-PR action commits the umbrella first, stamps
+# branch_pending, and returns within the 60s client window. The branch cut
+# (workspace resolve + fetch refs/pull/{n}/head + push) runs in a background
+# task; the dispatcher skips a branch_pending umbrella so Main PM is not
+# routed until the branch is ready. SUPERSEDE_COMMENT_POSTED tracks whether
+# the contributor-facing PR comment was delivered (fast-path or background).
+# BRANCH_CUT_FAILED stores the failure attempt count (int) so the sweep can
+# apply a backoff; after MAX_BRANCH_CUT_ATTEMPTS it escalates to BLOCKED.
+# BRANCH_CUT_NEXT_RETRY_AT is the epoch timestamp the sweep waits for before
+# retrying a failed cut.
+
+
+def is_branch_pending(task: HasMarkers) -> bool:
+    return bool(get_marker(task, BRANCH_PENDING, False))
+
+
+def mark_branch_pending(task: HasMarkers) -> None:
+    set_marker(task, BRANCH_PENDING, True)
+
+
+def clear_branch_pending(task: HasMarkers) -> None:
+    clear_marker(task, BRANCH_PENDING)
+
+
+def is_supersede_comment_posted(task: HasMarkers) -> bool:
+    return bool(get_marker(task, SUPERSEDE_COMMENT_POSTED, False))
+
+
+def mark_supersede_comment_posted(task: HasMarkers) -> None:
+    set_marker(task, SUPERSEDE_COMMENT_POSTED, True)
+
+
+def is_branch_cut_failed(task: HasMarkers) -> bool:
+    return bool(get_marker(task, BRANCH_CUT_FAILED, False))
+
+
+def get_branch_cut_attempts(task: HasMarkers) -> int:
+    val = get_marker(task, BRANCH_CUT_FAILED, 0)
+    return int(val) if isinstance(val, (int, float)) else 1
+
+
+def mark_branch_cut_failed(task: HasMarkers, attempts: int = 1) -> None:
+    set_marker(task, BRANCH_CUT_FAILED, attempts)
+
+
+def clear_branch_cut_failed(task: HasMarkers) -> None:
+    clear_marker(task, BRANCH_CUT_FAILED)
+
+
+def get_branch_cut_next_retry_at(task: HasMarkers) -> float | None:
+    val = get_marker(task, BRANCH_CUT_NEXT_RETRY_AT, None)
+    return float(val) if isinstance(val, (int, float)) else None
+
+
+def set_branch_cut_next_retry_at(task: HasMarkers, ts: float) -> None:
+    set_marker(task, BRANCH_CUT_NEXT_RETRY_AT, ts)
+
+
+def clear_branch_cut_next_retry_at(task: HasMarkers) -> None:
+    clear_marker(task, BRANCH_CUT_NEXT_RETRY_AT)
 
 
 # --- escalate_up/unblock oscillation breaker -------------------------------

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -114,6 +114,27 @@ AGENT_BASE_IMAGE = "roboco-agent-base"
 # Minutes in an hour, for formatting an elapsed duration as "Xh Ym".
 _MINUTES_PER_HOUR = 60
 
+# Supersede contributor PR comments - a coherent pair. The at-supersede comment
+# posts when the CEO takes the PR over; the at-close comment posts when the
+# replacement lands and the contributor PR is retired.
+SUPERSEDE_PR_COMMENT = (
+    "Thanks for this contribution! We reviewed it and are taking the work "
+    "over internally to finish and harden it to our standards. The "
+    "implementation continues on branch `{branch}` as an internal task; "
+    "your PR informed the approach and is appreciated. This PR will be "
+    "closed once our replacement lands. Feel free to reach out if you "
+    "have questions."
+)
+SUPERSEDE_PR_CLOSE_COMMENT = (
+    "Superseded by our own PR - the work was finished and hardened to our "
+    "standards based on your contribution. Thanks for the contribution!"
+)
+
+# Max background branch-cut attempts before escalating to BLOCKED (HUMAN
+# resolver). The sweep retries with exponential backoff between attempts.
+_MAX_BRANCH_CUT_ATTEMPTS = 3
+_BRANCH_CUT_BACKOFF_BASE_SECONDS = 60.0
+
 # Port on which each agent's Claude Code SDK server listens inside its container.
 # Referenced by write-hooks (_finalize_spawn_session, _sweep_token_snapshots,
 # _sweep_budget_exceeded) to build the SDK health/usage URL.
@@ -949,6 +970,22 @@ def _is_held_ceo_source(task: dict[str, Any]) -> bool:
     return source == SELF_HEAL_SOURCE and not task.get("confirmed_by_human")
 
 
+def _is_branch_pending(task: dict[str, Any]) -> bool:
+    """A supersede umbrella whose branch cut is still in progress or failed.
+
+    The dispatcher must NOT route it to Main PM until the background branch
+    cut completes and clears the marker. ``branch_cut_failed`` (set after a
+    failed cut, kept through the retry backoff or after a CEO unblock of a
+    BLOCKED umbrella) is treated the same way: the sweep re-runs the cut and
+    clears the marker on success. ``orchestration_markers`` is carried on the
+    task dict from ``task_to_response`` so the dispatcher sees it.
+    """
+    om = task.get("orchestration_markers")
+    if not isinstance(om, dict):
+        return False
+    return bool(om.get("branch_pending")) or bool(om.get("branch_cut_failed"))
+
+
 def _is_non_dev_dispatch_source(task: dict[str, Any]) -> bool:
     """Sources ``_dispatch_dev_work`` must skip: every CEO-held source plus the
     Board exploration cycles (``board_roadmap`` / feature-spotlight exploration
@@ -1221,6 +1258,11 @@ class AgentOrchestrator:
         # spawn two umbrellas for the same PR (the check is read-then-write
         # with no DB-level uniqueness).
         self._supersede_lock = asyncio.Lock()
+        # In-flight branch cuts (umbrella id strings) so the reconciliation
+        # sweep does not double-spawn a second _cut_supersede_branch for an
+        # umbrella whose first cut is still running (~90-390s). Cleared in
+        # _cut_supersede_branch's finally block.
+        self._supersede_cuts_in_flight: set[str] = set()
         # Serialize concurrent live-chat starts for the single-id interactive
         # agents (intake / secretary). Each has a fixed agent id, so two
         # concurrent starts race on the container name (``docker run --name
@@ -8298,7 +8340,9 @@ Start by:
         await self._sweep_superseded_prs()
 
     async def _sweep_superseded_prs(self) -> None:
-        """Retire the contributor PR for any supersede umbrella that landed.
+        """Retire the contributor PR for any supersede umbrella that landed,
+        and reconcile branch_pending umbrellas stranded by an orchestrator
+        restart.
 
         Dormant in a standard deployment: when no ``external_pr_supersede``
         umbrellas exist the lookup returns nothing and no GitHub call is made,
@@ -8320,6 +8364,96 @@ Start by:
             except Exception as e:
                 await db.rollback()
                 logger.warning("Supersede close-on-land sweep failed", error=str(e))
+
+        # Reconcile branch_pending / branch_cut_failed umbrellas (restart-safe).
+        to_reconcile = await self._collect_supersede_reconciliations(session_factory)
+        for uid, slug, pr_num, pid, branch in to_reconcile:
+            # F2: claim the in-flight slot before spawning.
+            if uid in self._supersede_cuts_in_flight:
+                continue
+            self._supersede_cuts_in_flight.add(uid)
+            logger.info(
+                "supersede: reconciling branch_pending umbrella",
+                umbrella_id=uid,
+                pr_number=pr_num,
+            )
+            bg = asyncio.create_task(
+                self._cut_supersede_branch(
+                    umbrella_id=uid,
+                    project_slug=slug,
+                    pr_number=pr_num,
+                    project_id=pid,
+                    branch_name=branch,
+                )
+            )
+            self._bg_tasks.add(bg)
+            bg.add_done_callback(self._bg_tasks.discard)
+
+    async def _collect_supersede_reconciliations(
+        self, session_factory: Any
+    ) -> list[tuple[str, str, int, Any, str]]:
+        """Build the (uid, slug, pr, pid, branch) list for the sweep to spawn.
+
+        Handles in-flight dedup (F2), backoff (F3), and re-arm after CEO
+        unblock of a branch_cut_failed umbrella (F4). Returns [] on any
+        lookup error so the sweep tick is best-effort.
+        """
+        import time
+
+        from roboco.foundation.policy.content import markers as _sm
+        from roboco.services.project import get_project_service
+        from roboco.services.task import get_task_service
+
+        now = time.time()
+        try:
+            async with session_factory() as db:
+                task_service = get_task_service(db)
+                project_service = get_project_service(db)
+                pending = await task_service.supersede_umbrellas_branch_pending()
+                to_reconcile: list[tuple[str, str, int, Any, str]] = []
+                for umbrella in pending:
+                    entry = await self._reconcile_one_umbrella(
+                        umbrella, now, project_service, db, _sm
+                    )
+                    if entry is not None:
+                        to_reconcile.append(entry)
+        except Exception as e:
+            logger.warning("Supersede branch-pending sweep lookup failed", error=str(e))
+            return []
+        return to_reconcile
+
+    async def _reconcile_one_umbrella(
+        self, umbrella: Any, now: float, project_service: Any, db: Any, _sm: Any
+    ) -> tuple[str, str, int, Any, str] | None:
+        """Check one umbrella for sweep reconciliation. Returns the tuple to
+        spawn, or None if it should be skipped (in-flight, backoff, no PR)."""
+        uid = str(umbrella.id)
+        if uid in self._supersede_cuts_in_flight:
+            return None
+        retry_at = _sm.get_branch_cut_next_retry_at(umbrella)
+        if retry_at is not None and now < retry_at:
+            return None
+        # branch_cut_failed but NOT branch_pending: CEO unblocked after
+        # exhaustion. Re-arm for a fresh cut.
+        if _sm.is_branch_cut_failed(umbrella) and not _sm.is_branch_pending(umbrella):
+            _sm.mark_branch_pending(umbrella)
+            _sm.clear_branch_cut_failed(umbrella)
+            _sm.clear_branch_cut_next_retry_at(umbrella)
+            await db.flush()
+            await db.commit()
+        pr_number = self._parse_supersede_pr(umbrella.quick_context or "")
+        if pr_number is None:
+            return None
+        project = await project_service.get(cast("UUID", umbrella.project_id))
+        if project is None:
+            return None
+        return (
+            uid,
+            project.slug,
+            pr_number,
+            cast("UUID", umbrella.project_id),
+            umbrella.branch_name or "",
+        )
 
     async def _sweep_dangling_images(self) -> None:
         """Prune dangling (<none>) Docker images left by agent-image rebuilds.
@@ -10020,11 +10154,7 @@ Start by:
             try:
                 await git.close_pull_request(
                     pr_number,
-                    comment=(
-                        "Superseded by the roboco team's own PR — the work was "
-                        "finished and hardened to our standards. Thanks for the "
-                        "contribution!"
-                    ),
+                    comment=SUPERSEDE_PR_CLOSE_COMMENT,
                     delete_branch=False,
                     actor_agent_id=system_id,
                     # PR numbers are per-repo — scope the close to THIS
@@ -10087,18 +10217,28 @@ Start by:
         """CEO-authorized takeover of a reviewed external PR.
 
         Confirms the review task (this CEO action is the human confirmation that
-        authorizes running the contributor's code), cuts a roboco-owned branch
-        off the contributor's fork head (refs/pull/{n}/head — the only point
-        untrusted code enters a roboco branch), and creates the supersede
-        umbrella for Main PM to delegate to a cell. Returns a status dict.
+        authorizes running the contributor's code), creates the supersede
+        umbrella (committed with a ``branch_pending`` marker), and returns
+        immediately. The branch cut (workspace resolve + fetch
+        ``refs/pull/{n}/head`` + push) runs in a background task so the CEO
+        does not hit the 60s client timeout. The dispatcher skips a
+        ``branch_pending`` umbrella so Main PM is not routed until the branch
+        is ready. On success the marker is cleared and the dispatcher is
+        woken; on failure the sweep retries with exponential backoff up to
+        ``_MAX_BRANCH_CUT_ATTEMPTS`` times, after which the umbrella is
+        BLOCKED (HUMAN resolver) and the CEO is notified with the recovery
+        action (unblock to re-run the cut, or cancel). A reconciliation sweep
+        on the sweep tick recovers umbrellas stranded by an orchestrator
+        restart and retries failed cuts after the backoff window.
         """
         from roboco.db import get_db_context
+        from roboco.foundation.policy.content import markers
         from roboco.models.base import TaskStatus
         from roboco.services.git import GitService
         from roboco.services.project import get_project_service
         from roboco.services.task import get_task_service
 
-        # Serialize concurrent CEO calls (double-click) — the dedup check and
+        # Serialize concurrent CEO calls (double-click) - the dedup check and
         # the umbrella/branch creation are not atomic across DB sessions.
         async with self._supersede_lock, get_db_context() as db:
             task_service = get_task_service(db)
@@ -10114,15 +10254,16 @@ Start by:
             if review.status != TaskStatus.COMPLETED:
                 return {
                     "ok": False,
-                    "error": "review not complete — review the PR first",
+                    "error": "review not complete - review the PR first",
                 }
             project = await get_project_service(db).get(cast("UUID", review.project_id))
             if project is None:
                 return {"ok": False, "error": "project not found"}
             pr_number = int(review.pr_number)
             project_id = cast("UUID", review.project_id)
-            # Idempotent: a repeat call returns the existing umbrella — no second
-            # branch cut, no duplicate cell takeover.
+            # Idempotent: a repeat call returns the existing umbrella - no second
+            # branch cut, no duplicate cell takeover. Covers branch_pending
+            # umbrellas too (a retry during the cut short-circuits here).
             existing = await task_service.find_supersede_umbrella(project_id, pr_number)
             if existing is not None:
                 return {
@@ -10135,29 +10276,263 @@ Start by:
             branch_name = f"feature/main_pm/supersede-pr-{pr_number}"
             # The CEO authorized fetching + finishing the contributor's code.
             review.confirmed_by_human = True
-            # Create the umbrella BEFORE the push: a create failure then can't
-            # orphan a pushed branch. Only a commit failure after the push could
-            # (rare) — the branch is logged so an orphan stays discoverable.
+            # Create the umbrella with branch_pending marker BEFORE any git op.
+            # The commit here is the point of no return - the umbrella exists
+            # and the dispatcher gate (branch_pending) holds it until the
+            # background branch cut clears the marker.
             umbrella = await task_service.create_supersede_umbrella(
                 review_task_id=review_task_id,
                 branch_name=branch_name,
                 created_by=system_id,
             )
-            umbrella_id = str(umbrella.id) if umbrella is not None else None
+            # create_supersede_umbrella returns None only if the review task
+            # is missing or not a PR-review source - both already validated
+            # above. If a race deletes the review between the check and the
+            # create, the .id access raises (500, acceptable for that race).
+            umbrella = cast("Any", umbrella)
+            umbrella_id = str(umbrella.id)
+            markers.mark_branch_pending(umbrella)
+            await db.flush()
+            # Try the contributor comment in the fast path (skip_refresh: the
+            # comment only needs the remote URL, not fresh refs). If it fails
+            # (workspace not cloned yet, forge error), the background task
+            # retries via the supersede_comment_posted marker.
             git = GitService(db)
-            workspace = await git.get_workspace(project.slug, agent_id=system_id)
-            logger.warning(
-                "supersede: cutting roboco branch off untrusted fork PR head",
+            try:
+                await git.comment_pull_request(
+                    pr_number,
+                    project_id=project_id,
+                    comment=SUPERSEDE_PR_COMMENT.format(branch=branch_name),
+                )
+                markers.mark_supersede_comment_posted(umbrella)
+                await db.flush()
+            except Exception as exc:
+                logger.warning(
+                    "supersede: fast-path contributor comment failed, "
+                    "deferring to background task",
+                    pr_number=pr_number,
+                    error=str(exc),
+                )
+            await db.commit()
+            # Claim the in-flight slot BEFORE releasing the supersede lock so a
+            # reconciliation sweep tick landing between the commit and the
+            # spawn cannot double-spawn a concurrent branch cut.
+            self._supersede_cuts_in_flight.add(umbrella_id)
+        # Background the slow git ops (workspace clone up to 300s, fetch +
+        # checkout + push, each 30s). Fire-and-forget; the reconciliation
+        # sweep recovers on restart.
+        bg = asyncio.create_task(
+            self._cut_supersede_branch(
+                umbrella_id=umbrella_id,
+                project_slug=project.slug,
+                pr_number=pr_number,
+                project_id=project_id,
+                branch_name=branch_name,
+            )
+        )
+        self._bg_tasks.add(bg)
+        bg.add_done_callback(self._bg_tasks.discard)
+        return {
+            "ok": True,
+            "supersede_task_id": umbrella_id,
+            "branch": branch_name,
+            "status": "cutting_branch",
+        }
+
+    async def _cut_supersede_branch(
+        self,
+        *,
+        umbrella_id: str,
+        project_slug: str,
+        pr_number: int,
+        project_id: "UUID",
+        branch_name: str,
+    ) -> None:
+        """Background branch cut for a supersede umbrella.
+
+        Resolves the workspace (skip_refresh: the branch is cut from
+        ``refs/pull/{n}/head``, not an existing local branch), posts the
+        contributor PR comment if it was not posted in the fast path, fetches
+        the PR head ref, and pushes the roboco-owned branch. On success
+        clears ``branch_pending`` and wakes the dispatcher. On failure
+        increments the ``branch_cut_failed`` attempt count and applies a
+        backoff so the reconciliation sweep retries; after
+        ``_MAX_BRANCH_CUT_ATTEMPTS`` failures the umbrella is BLOCKED (HUMAN
+        resolver) and the CEO is notified. Called from
+        ``supersede_external_pr`` (asyncio task) and from the reconciliation
+        sweep (restart-safe).
+        """
+        from roboco.db import get_db_context
+        from roboco.foundation.policy.content import markers
+        from roboco.models.base import TaskStatus
+        from roboco.services.git import GitService
+        from roboco.services.task import get_task_service
+        from roboco.utils.converters import require_uuid
+
+        try:
+            async with get_db_context() as db:
+                task_service = get_task_service(db)
+                umbrella = await task_service.get(require_uuid(umbrella_id))
+                if umbrella is None or umbrella.status == TaskStatus.CANCELLED:
+                    return
+                # If branch_cut_failed but NOT branch_pending, this was
+                # unblocked by the CEO after exhaustion — reset for a fresh
+                # cut. (The sweep also does this, but guard here too in case
+                # the spawn came from supersede_external_pr's retry path.)
+                if markers.is_branch_cut_failed(
+                    umbrella
+                ) and not markers.is_branch_pending(umbrella):
+                    markers.mark_branch_pending(umbrella)
+                    markers.clear_branch_cut_failed(umbrella)
+                    markers.clear_branch_cut_next_retry_at(umbrella)
+                    await db.flush()
+                # Already completed by a prior run (race with sweep).
+                if not markers.is_branch_pending(umbrella):
+                    return
+                git = GitService(db)
+                system_id = _foundation.AGENTS["system"].uuid
+                # Post the contributor comment if the fast path did not.
+                if not markers.is_supersede_comment_posted(umbrella):
+                    try:
+                        await git.comment_pull_request(
+                            pr_number,
+                            project_id=project_id,
+                            comment=SUPERSEDE_PR_COMMENT.format(branch=branch_name),
+                        )
+                        markers.mark_supersede_comment_posted(umbrella)
+                        await db.flush()
+                    except Exception as exc:
+                        logger.warning(
+                            "supersede: background contributor comment failed",
+                            pr_number=pr_number,
+                            error=str(exc),
+                        )
+                logger.warning(
+                    "supersede: cutting roboco branch off untrusted fork PR head",
+                    branch=branch_name,
+                    pr_number=pr_number,
+                    project=project_slug,
+                )
+                workspace = await git.get_workspace(
+                    project_slug, agent_id=system_id, skip_refresh=True
+                )
+                await git.create_branch_from_pr_head(
+                    workspace, project_slug, pr_number, branch_name
+                )
+                # Success: clear the gate, clear any prior failure markers,
+                # and wake the dispatcher.
+                markers.clear_branch_pending(umbrella)
+                markers.clear_branch_cut_failed(umbrella)
+                markers.clear_branch_cut_next_retry_at(umbrella)
+                await db.commit()
+            self._dispatch_wake.set()
+        except Exception as exc:
+            logger.error(
+                "supersede: background branch cut failed",
+                umbrella_id=umbrella_id,
                 branch=branch_name,
                 pr_number=pr_number,
-                project=project.slug,
+                error=str(exc),
             )
-            await git.create_branch_from_pr_head(
-                workspace, project.slug, pr_number, branch_name
+            await self._fail_supersede_branch_cut(umbrella_id, branch_name, exc)
+        finally:
+            # F2: release the in-flight slot so the sweep can retry.
+            self._supersede_cuts_in_flight.discard(umbrella_id)
+
+    async def _fail_supersede_branch_cut(
+        self, umbrella_id: str, branch_name: str, exc: Exception
+    ) -> None:
+        """Handle a supersede branch-cut failure with retry + backoff.
+
+        On failures below ``_MAX_BRANCH_CUT_ATTEMPTS``: keep
+        ``branch_pending``, increment ``branch_cut_failed`` attempt count,
+        and set a ``branch_cut_next_retry_at`` backoff so the sweep retries
+        without hammering every 60s. On the final failure: clear
+        ``branch_pending``, set BLOCKED (HUMAN resolver), and notify the CEO.
+        The commit happens BEFORE the notification (F7) so a notify failure
+        can't roll back the status transition.
+        """
+        import time
+
+        from roboco.db import get_db_context
+        from roboco.foundation.policy.content import markers
+        from roboco.models.base import BlockerResolverType, TaskStatus
+        from roboco.services.task import get_task_service
+        from roboco.utils.converters import require_uuid
+
+        try:
+            async with get_db_context() as db:
+                task_service = get_task_service(db)
+                umbrella = await task_service.get(require_uuid(umbrella_id))
+                if umbrella is None:
+                    return
+                # If the marker was already cleared (a concurrent sweep
+                # succeeded), do not block a finished umbrella.
+                if not markers.is_branch_pending(umbrella):
+                    return
+                attempts = markers.get_branch_cut_attempts(umbrella) + 1
+                if attempts < _MAX_BRANCH_CUT_ATTEMPTS:
+                    # Retry with backoff: keep branch_pending so the sweep
+                    # re-runs the cut after the backoff window expires.
+                    backoff = _BRANCH_CUT_BACKOFF_BASE_SECONDS * (2 ** (attempts - 1))
+                    markers.mark_branch_cut_failed(umbrella, attempts)
+                    markers.set_branch_cut_next_retry_at(
+                        umbrella, time.time() + backoff
+                    )
+                    await db.commit()
+                    logger.warning(
+                        "supersede: branch cut failed, will retry",
+                        umbrella_id=umbrella_id,
+                        attempts=attempts,
+                        backoff_seconds=backoff,
+                        error=str(exc),
+                    )
+                    return
+                # Exhausted retries: escalate to BLOCKED.
+                umbrella.blocker_resolver_type = BlockerResolverType.HUMAN
+                markers.mark_branch_cut_failed(umbrella, attempts)
+                markers.clear_branch_pending(umbrella)
+                markers.clear_branch_cut_next_retry_at(umbrella)
+                await task_service.admin_set_status(
+                    require_uuid(umbrella_id),
+                    TaskStatus.BLOCKED,
+                    actor_role="system",
+                )
+                await db.commit()
+            # F7: notify CEO AFTER the commit so a notify failure can't
+            # roll back the BLOCKED transition. Best-effort in its own
+            # session.
+            try:
+                async with get_db_context() as notify_db:
+                    from roboco.services.notification_delivery import (
+                        get_notification_delivery_service,
+                    )
+
+                    notify_task_service = get_task_service(notify_db)
+                    umbrella_fresh = await notify_task_service.get(
+                        require_uuid(umbrella_id)
+                    )
+                    if umbrella_fresh is not None:
+                        delivery = get_notification_delivery_service(notify_db)
+                        await delivery.notify_ceo_of_supersede_branch_cut_failure(
+                            task=umbrella_fresh,
+                            task_id=require_uuid(umbrella_id),
+                            branch=branch_name,
+                            error=str(exc),
+                        )
+                        await notify_db.commit()
+            except Exception as notify_exc:
+                logger.warning(
+                    "supersede: CEO notify failed after branch cut failure",
+                    umbrella_id=umbrella_id,
+                    error=str(notify_exc),
+                )
+        except Exception as inner:
+            logger.warning(
+                "supersede: failed to handle branch cut failure",
+                umbrella_id=umbrella_id,
+                error=str(inner),
             )
-            await db.commit()
-        self._dispatch_wake.set()
-        return {"ok": True, "supersede_task_id": umbrella_id, "branch": branch_name}
 
     async def _rate_limit_probe_loop(self) -> None:
         """Background loop: probe rate-limited providers every ~30 seconds.
@@ -14434,6 +14809,11 @@ Start now: evidence(task_id="{task_id}")
             # (external-PR review, release proposals, X posts/replies, and a
             # not-yet-confirmed self-heal fix task) — see _is_held_ceo_source.
             if _is_held_ceo_source(task):
+                continue
+            # A supersede umbrella whose branch cut is still in progress
+            # (background task or pending reconciliation). Main PM must not
+            # be routed until the branch is ready.
+            if _is_branch_pending(task):
                 continue
             assigned_to = task.get("assigned_to")
             if assigned_to:

--- a/roboco/services/git.py
+++ b/roboco/services/git.py
@@ -587,7 +587,11 @@ class GitService(BaseService):
         return await self._token_for_project(parts[0])
 
     async def get_workspace(
-        self, project_slug: str, agent_id: UUID | None = None
+        self,
+        project_slug: str,
+        agent_id: UUID | None = None,
+        *,
+        skip_refresh: bool = False,
     ) -> Path:
         """Get the workspace path for an agent on a project."""
         project_service = get_project_service(self.session)
@@ -615,6 +619,7 @@ class GitService(BaseService):
                     agent_id=agent_id,
                     git_url=project.git_url,
                     default_branch=head_branch(project),
+                    skip_refresh=skip_refresh,
                 )
             else:
                 workspace = await workspace_service.resolve_workspace(
@@ -5686,6 +5691,41 @@ class GitService(BaseService):
         behind = int(parts[0]) if valid and parts[0].isdigit() else 0
         ahead = int(parts[1]) if valid and parts[1].isdigit() else 0
         return behind, ahead
+
+    async def comment_pull_request(
+        self,
+        pr_number: int,
+        *,
+        project_id: UUID,
+        comment: str,
+    ) -> None:
+        """Post a comment on PR ``pr_number`` without closing it.
+
+        Resolves the repo ref and git token directly from the project record
+        (NOT from a workspace clone) so the comment never triggers a 300s
+        clone. Used by the supersede flow to notify the contributor at
+        supersede time and at close-on-land.
+        """
+        from sqlalchemy import select
+
+        from roboco.db.tables import TaskTable as _TaskTable
+
+        result = await self.session.execute(
+            select(_TaskTable)
+            .where(_TaskTable.pr_number == pr_number)
+            .where(_TaskTable.project_id == project_id)
+            .limit(1)
+        )
+        task = result.scalar_one_or_none()
+        if task is None:
+            raise NotFoundError("PR", str(pr_number))
+        project = await self._project_for_task(task)
+        if project is None:
+            raise NotFoundError("Project for task", str(task.id))
+
+        git_token = await self._get_project_token_or_raise(project.slug)
+        repo_ref = self._parse_git_url(project.git_url)
+        await self._forge.create_issue_comment(repo_ref, git_token, pr_number, comment)
 
     async def close_pull_request(
         self,

--- a/roboco/services/notification_delivery.py
+++ b/roboco/services/notification_delivery.py
@@ -1478,6 +1478,46 @@ class NotificationDeliveryService(BaseService):
             task_id=task_id, subject=notification.subject, actionable=True
         )
 
+    async def notify_ceo_of_supersede_branch_cut_failure(
+        self,
+        *,
+        task: TaskTable,
+        task_id: UUID,
+        branch: str,
+        error: str,
+    ) -> None:
+        """CEO notification: the background branch cut exhausted retries.
+
+        The umbrella is BLOCKED with HUMAN resolver after
+        ``_MAX_BRANCH_CUT_ATTEMPTS`` failures. The CEO can unblock the task
+        (the reconciliation sweep re-runs the cut) or cancel the umbrella.
+        """
+        ceo = await self._get_ceo_agent()
+        if not ceo:
+            return
+        from_agent = cast("UUID", task.assigned_to) if task.assigned_to else ceo.id
+        notification = NotificationTable(
+            type=NotificationType.APPROVAL,
+            priority=NotificationPriority.HIGH,
+            from_agent=from_agent,
+            to_agents=[ceo.id],
+            subject=f"Supersede branch cut failed: {(task.title or 'Unknown')[:60]}",
+            body=(
+                f"Task {task_display(task, task_id)} was blocked: the background "
+                f"branch cut for '{branch}' failed after multiple retries - "
+                f"{error[:300]}.\n\n"
+                "Unblock the task to re-run the branch cut (the reconciliation "
+                "sweep picks it up automatically), or cancel the task if the "
+                "git/forge credentials or repo are the problem."
+            ),
+            related_task_id=task_id,
+            requires_ack=ACK_REQUIRED_BY_TYPE[NotificationType.APPROVAL],
+        )
+        await self._persist_and_deliver(notification)
+        await self._notify_telegram(
+            task_id=task_id, subject=notification.subject, actionable=True
+        )
+
     async def notify_ceo_of_completion(self, *, task: TaskTable, task_id: UUID) -> None:
         """CEO-facing completion notification with the granular effort breakdown.
 

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -2815,6 +2815,31 @@ class TaskService(BaseService):
             pending.append(task)
         return pending
 
+    async def supersede_umbrellas_branch_pending(self) -> list[TaskTable]:
+        """Supersede umbrellas whose branch cut is still in progress or needs retry.
+
+        A ``branch_pending`` marker means the CEO's supersede action committed
+        the umbrella but the background branch cut (fetch
+        ``refs/pull/{n}/head`` + push) has not completed yet. A
+        ``branch_cut_failed`` marker on a non-BLOCKED, non-CANCELLED umbrella
+        means the CEO unblocked it after exhaustion and the sweep should
+        re-run the cut. The reconciliation sweep re-runs the cut for both so
+        an orchestrator restart does not strand the umbrella.
+        """
+        result = await self.session.execute(
+            select(TaskTable).where(
+                TaskTable.source == "external_pr_supersede",
+                TaskTable.status != TaskStatus.CANCELLED,
+            )
+        )
+        pending: list[TaskTable] = []
+        for task in result.scalars().all():
+            if markers.is_branch_pending(task) or (
+                markers.is_branch_cut_failed(task) and task.status != TaskStatus.BLOCKED
+            ):
+                pending.append(task)
+        return pending
+
     async def _supersede_replacement_landed(self, umbrella_id: UUID) -> bool:
         """True if a non-cancelled descendant of the umbrella landed a PR.
 

--- a/roboco/services/workspace.py
+++ b/roboco/services/workspace.py
@@ -1377,6 +1377,8 @@ class WorkspaceService:
         git_url: str | None = None,
         default_branch: str = "main",
         force: bool = False,
+        *,
+        skip_refresh: bool = False,
     ) -> Path:
         """
         Ensure workspace exists, cloning if necessary.
@@ -1396,6 +1398,11 @@ class WorkspaceService:
             force: When True, bypass the 30s refresh-fetch TTL cache and
                 always run ``git fetch origin`` on a healthy workspace.
                 Defaults to False so existing callers are unaffected.
+            skip_refresh: When True, skip the refresh-fetch entirely on a
+                healthy workspace. Used by the supersede branch-cut path,
+                which fetches ``refs/pull/{n}/head`` (not an existing local
+                branch), so the 60s origin refresh is wasted I/O. The clone
+                path (workspace does not exist) still runs.
 
         Returns:
             Path to the workspace directory
@@ -1440,7 +1447,9 @@ class WorkspaceService:
                 # -math.inf as default means "never fetched" — guarantees
                 # the first call always runs the fetch regardless of clock value.
                 last_fetch = self._fetch_cache.get(str(workspace), -math.inf)
-                if force or (now - last_fetch) >= _FETCH_CACHE_TTL_SECONDS:
+                if not skip_refresh and (
+                    force or (now - last_fetch) >= _FETCH_CACHE_TTL_SECONDS
+                ):
                     # Repair broken-ref debris first so the fetch (and the
                     # agent's later `git diff/log origin/...`) doesn't trip on a
                     # ref left corrupt by an interrupted recovery.

--- a/tests/integration/test_lifecycle_real_db.py
+++ b/tests/integration/test_lifecycle_real_db.py
@@ -954,13 +954,13 @@ async def test_cell_pm_complete_routes_ceo_only_head_branch_to_ceo(
 
     env = await c.cell_pm_complete(
         cell_pm_agent.id,
-        leaf.id,
+        UUID(str(leaf.id)),
         notes="LGTM - routing to CEO for the head-branch merge.",
     )
     assert env.error is None, f"complete failed: {env.message}"
     assert env.status == Status.AWAITING_CEO_APPROVAL.value
 
-    final = await task_service.get(leaf.id)
+    final = await task_service.get(UUID(str(leaf.id)))
     assert final is not None
     assert str(final.status) == Status.AWAITING_CEO_APPROVAL.value
 

--- a/tests/unit/runtime/test_supersede_branch_cut.py
+++ b/tests/unit/runtime/test_supersede_branch_cut.py
@@ -1,0 +1,448 @@
+"""Supersede branch-cut async path: dispatcher gate, in-flight dedup, retry
+backoff, and the workspace-decoupled contributor comment.
+
+Covers the findings from the adversarial review of the supersede timeout fix:
+F2 (double-spawn), F3 (retry/backoff model), F4 (dispatcher gate checks
+branch_cut_failed), F5 (comment_pull_request never clones), F6 (tests).
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from roboco.foundation.policy.content import markers
+from roboco.models.base import TaskStatus
+from roboco.runtime.orchestrator import (
+    AgentOrchestrator,
+    _is_branch_pending,
+)
+from roboco.services.git import GitService
+
+_PR_NUM = 99
+_PR_42 = 42
+_ATTEMPTS = 3
+_PRIOR_FAILURES = 2
+_RETRY_TS = 12345.6
+
+# ---------------------------------------------------------------------------
+# F4 / F6(a): dispatcher gate skips branch_pending AND branch_cut_failed
+# ---------------------------------------------------------------------------
+
+
+def test_is_branch_pending_true_for_branch_pending() -> None:
+    task: dict[str, Any] = {"orchestration_markers": {"branch_pending": True}}
+    assert _is_branch_pending(task) is True
+
+
+def test_is_branch_pending_true_for_branch_cut_failed() -> None:
+    """F4: branch_cut_failed must also gate the dispatcher (a CEO-unblocked
+    umbrella whose cut hasn't re-run yet must not be routed to Main PM)."""
+    task: dict[str, Any] = {
+        "orchestration_markers": {"branch_cut_failed": 3},
+    }
+    assert _is_branch_pending(task) is True
+
+
+def test_is_branch_pending_false_when_clean() -> None:
+    task: dict[str, Any] = {"orchestration_markers": {"other": 1}}
+    assert _is_branch_pending(task) is False
+
+
+def test_is_branch_pending_false_when_no_markers() -> None:
+    task: dict[str, Any] = {"orchestration_markers": None}
+    assert _is_branch_pending(task) is False
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_skips_branch_pending_umbrella() -> None:
+    """A branch_pending supersede umbrella must NOT be routed to Main PM."""
+    tasks = [
+        {
+            "id": "A",
+            "source": "external_pr_supersede",
+            "assigned_to": None,
+            "orchestration_markers": {"branch_pending": True},
+        },
+        {
+            "id": "B",
+            "source": "manual",
+            "assigned_to": None,
+            "orchestration_markers": None,
+        },
+    ]
+    stub = MagicMock()
+    stub._fetch_tasks = AsyncMock(return_value=tasks)
+    stub._is_task_handled_this_tick = MagicMock(return_value=False)
+    stub._resolve_agent_slug = MagicMock(return_value="main-pm-1")
+    stub._BOARD_AGENTS = frozenset()
+    stub._route_unassigned_pm_task = AsyncMock()
+    stub._handle_pm_assigned_task = AsyncMock()
+    stub._handle_board_assigned_task = AsyncMock()
+    stub._dispatch_board_program_exploration = AsyncMock(return_value=False)
+
+    client: Any = MagicMock()
+    await AgentOrchestrator._dispatch_pm_work(cast("AgentOrchestrator", stub), client)
+
+    routed = [c.args[1]["id"] for c in stub._route_unassigned_pm_task.await_args_list]
+    assert routed == ["B"]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_skips_branch_cut_failed_umbrella() -> None:
+    """F4: a branch_cut_failed umbrella (e.g. CEO unblocked after exhaustion)
+    must NOT be routed to Main PM until the sweep re-runs the cut."""
+    tasks = [
+        {
+            "id": "A",
+            "source": "external_pr_supersede",
+            "assigned_to": None,
+            "orchestration_markers": {"branch_cut_failed": 3},
+        },
+    ]
+    stub = MagicMock()
+    stub._fetch_tasks = AsyncMock(return_value=tasks)
+    stub._is_task_handled_this_tick = MagicMock(return_value=False)
+    stub._resolve_agent_slug = MagicMock(return_value="main-pm-1")
+    stub._BOARD_AGENTS = frozenset()
+    stub._route_unassigned_pm_task = AsyncMock()
+    stub._handle_pm_assigned_task = AsyncMock()
+    stub._handle_board_assigned_task = AsyncMock()
+    stub._dispatch_board_program_exploration = AsyncMock(return_value=False)
+
+    client: Any = MagicMock()
+    await AgentOrchestrator._dispatch_pm_work(cast("AgentOrchestrator", stub), client)
+
+    stub._route_unassigned_pm_task.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# F2 / F6(b): sweep does not double-spawn for an in-flight umbrella
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_in_flight_umbrella() -> None:
+    """The sweep must not spawn a second _cut_supersede_branch for an
+    umbrella whose cut is already running."""
+    umbrella_id = uuid4()
+    orch = MagicMock()
+    orch._supersede_cuts_in_flight = {str(umbrella_id)}
+    orch._bg_tasks = set()
+    orch._cut_supersede_branch = AsyncMock()
+
+    umbrella = SimpleNamespace(
+        id=umbrella_id,
+        quick_context="external_pr_supersede pr=42 review=abc",
+        project_id=uuid4(),
+        branch_name="feature/main_pm/supersede-pr-42",
+        status=TaskStatus.PENDING,
+        orchestration_markers={"branch_pending": True},
+    )
+
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    session_factory = MagicMock(return_value=mock_session)
+
+    mock_task_service = MagicMock()
+    mock_task_service.supersede_umbrellas_branch_pending = AsyncMock(
+        return_value=[umbrella]
+    )
+    mock_project_service = MagicMock()
+    mock_project_service.get = AsyncMock(
+        return_value=SimpleNamespace(slug="test-project")
+    )
+
+    with (
+        patch("roboco.services.task.get_task_service", return_value=mock_task_service),
+        patch(
+            "roboco.services.project.get_project_service",
+            return_value=mock_project_service,
+        ),
+    ):
+        to_reconcile = await AgentOrchestrator._collect_supersede_reconciliations(
+            cast("AgentOrchestrator", orch), session_factory
+        )
+
+    # The in-flight umbrella is filtered out.
+    assert to_reconcile == []
+    orch._cut_supersede_branch.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# F3 / F6(c): failure path retries with backoff, then escalates to BLOCKED
+# ---------------------------------------------------------------------------
+
+
+def _marker_task(**kw: Any) -> SimpleNamespace:
+    om = kw.pop("orchestration_markers", None) or {}
+    return SimpleNamespace(orchestration_markers=om, **kw)
+
+
+@pytest.mark.asyncio
+async def test_fail_keeps_branch_pending_and_sets_backoff_below_max() -> None:
+    """F3(a): below MAX_ATTEMPTS, failure keeps branch_pending so the sweep
+    retries, and stamps a backoff so it doesn't hammer every 60s."""
+    orch = MagicMock()
+    orch._supersede_cuts_in_flight = set()
+
+    umbrella = _marker_task(
+        id=uuid4(),
+        branch_name="feature/main_pm/supersede-pr-42",
+        orchestration_markers={"branch_pending": True},
+    )
+
+    mock_task_service = MagicMock()
+    mock_task_service.get = AsyncMock(return_value=umbrella)
+    mock_task_service.admin_set_status = AsyncMock()
+
+    db_mock = AsyncMock()
+    db_mock.commit = AsyncMock()
+    db_mock.flush = AsyncMock()
+
+    with (
+        patch("roboco.db.get_db_context") as ctx_mock,
+        patch("roboco.services.task.get_task_service", return_value=mock_task_service),
+    ):
+        ctx_mock.return_value.__aenter__ = AsyncMock(return_value=db_mock)
+        ctx_mock.return_value.__aexit__ = AsyncMock(return_value=None)
+        await AgentOrchestrator._fail_supersede_branch_cut(
+            cast("AgentOrchestrator", orch),
+            str(umbrella.id),
+            "feature/main_pm/supersede-pr-42",
+            RuntimeError("clone failed"),
+        )
+
+    # branch_pending is kept; branch_cut_failed stores attempt count.
+    assert markers.is_branch_pending(umbrella) is True
+    assert markers.get_branch_cut_attempts(umbrella) == 1
+    assert markers.get_branch_cut_next_retry_at(umbrella) is not None
+    # admin_set_status (BLOCKED) is NOT called below MAX_ATTEMPTS.
+    mock_task_service.admin_set_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fail_escalates_to_blocked_at_max_attempts() -> None:
+    """F3(a): at MAX_ATTEMPTS, failure clears branch_pending, sets BLOCKED,
+    and notifies the CEO (after the commit, per F7)."""
+    orch = MagicMock()
+    orch._supersede_cuts_in_flight = set()
+
+    # Pre-stamp 2 prior failures so this call hits the MAX.
+    umbrella = _marker_task(
+        id=uuid4(),
+        branch_name="feature/main_pm/supersede-pr-42",
+        orchestration_markers={
+            "branch_pending": True,
+            "branch_cut_failed": 2,
+            "branch_cut_next_retry_at": time.time() - 1,
+        },
+    )
+
+    mock_task_service = MagicMock()
+    mock_task_service.get = AsyncMock(return_value=umbrella)
+    mock_task_service.admin_set_status = AsyncMock()
+
+    mock_notify_service = MagicMock()
+    mock_notify_service.notify_ceo_of_supersede_branch_cut_failure = AsyncMock()
+
+    db_mock = AsyncMock()
+    db_mock.commit = AsyncMock()
+    db_mock.flush = AsyncMock()
+
+    sessions = [db_mock, db_mock]  # main session, then notify session
+
+    class _Ctx:
+        async def __aenter__(self) -> Any:
+            return sessions.pop(0)
+
+        async def __aexit__(self, *a: object) -> None:
+            pass
+
+    with (
+        patch("roboco.db.get_db_context", return_value=_Ctx()),
+        patch("roboco.services.task.get_task_service", return_value=mock_task_service),
+        patch(
+            "roboco.services.notification_delivery.get_notification_delivery_service",
+            return_value=mock_notify_service,
+        ),
+    ):
+        await AgentOrchestrator._fail_supersede_branch_cut(
+            cast("AgentOrchestrator", orch),
+            str(umbrella.id),
+            "feature/main_pm/supersede-pr-42",
+            RuntimeError("clone failed 3rd time"),
+        )
+
+    # branch_pending is cleared; BLOCKED was set.
+    assert markers.is_branch_pending(umbrella) is False
+    assert markers.get_branch_cut_attempts(umbrella) == _ATTEMPTS
+    mock_task_service.admin_set_status.assert_awaited_once()
+    # CEO was notified.
+    mock_notify_service.notify_ceo_of_supersede_branch_cut_failure.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# F5 / F6(e): comment_pull_request resolves token + remote from the project,
+# never calling get_workspace / ensure_workspace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_comment_pull_request_does_not_clone() -> None:
+    """F5: comment_pull_request must resolve the repo ref from the project's
+    git_url, NOT from a workspace clone. get_workspace / ensure_workspace
+    must never be called."""
+    session = MagicMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(
+            scalar_one_or_none=MagicMock(
+                return_value=MagicMock(
+                    id=uuid4(),
+                    pr_number=42,
+                    project_id=uuid4(),
+                )
+            )
+        )
+    )
+
+    git = GitService(session)
+    project = SimpleNamespace(
+        slug="test-project",
+        git_url="https://github.com/owner/repo.git",
+    )
+    git._project_for_task = AsyncMock(return_value=project)  # type: ignore[method-assign]
+    git._get_project_token_or_raise = AsyncMock(return_value="fake-token")  # type: ignore[method-assign]
+
+    mock_forge = MagicMock()
+    mock_forge.create_issue_comment = AsyncMock()
+
+    # Spy: if get_workspace is called, the test fails.
+    workspace_spy = AsyncMock(
+        side_effect=AssertionError(
+            "comment_pull_request must not call get_workspace (F5: no clone)"
+        )
+    )
+
+    with (
+        patch.object(GitService, "_forge", new=mock_forge),
+        patch.object(GitService, "get_workspace", new=workspace_spy),
+    ):
+        await git.comment_pull_request(
+            _PR_42,
+            project_id=uuid4(),
+            comment="test comment",
+        )
+
+    mock_forge.create_issue_comment.assert_awaited_once()
+    # Verify the repo_ref came from the project git_url, not a workspace.
+    call_args = mock_forge.create_issue_comment.call_args
+    repo_ref = call_args.args[0]
+    assert repo_ref.owner == "owner"
+    assert repo_ref.repo == "repo"
+
+
+@pytest.mark.asyncio
+async def test_comment_pull_request_posts_on_correct_pr() -> None:
+    """F6(d): the comment is posted on the PR number passed to the call."""
+    session = MagicMock()
+    session.execute = AsyncMock(
+        return_value=MagicMock(
+            scalar_one_or_none=MagicMock(
+                return_value=MagicMock(
+                    id=uuid4(),
+                    pr_number=_PR_NUM,
+                    project_id=uuid4(),
+                )
+            )
+        )
+    )
+
+    git = GitService(session)
+    project = SimpleNamespace(
+        slug="test-project",
+        git_url="https://github.com/owner/repo.git",
+    )
+    git._project_for_task = AsyncMock(return_value=project)  # type: ignore[method-assign]
+    git._get_project_token_or_raise = AsyncMock(return_value="fake-token")  # type: ignore[method-assign]
+
+    mock_forge = MagicMock()
+    mock_forge.create_issue_comment = AsyncMock()
+
+    with patch.object(GitService, "_forge", new=mock_forge):
+        await git.comment_pull_request(
+            _PR_NUM,
+            project_id=uuid4(),
+            comment="supersede comment",
+        )
+
+    call_args = mock_forge.create_issue_comment.call_args
+    # (repo_ref, token, pr_number, comment)
+    assert call_args.args[2] == _PR_NUM
+    assert call_args.args[3] == "supersede comment"
+
+
+# ---------------------------------------------------------------------------
+# F6(d): supersede_comment_posted marker prevents double-posting
+# ---------------------------------------------------------------------------
+
+
+def test_comment_posted_marker_prevents_double_post() -> None:
+    """The background cut checks is_supersede_comment_posted before posting;
+    if the fast path already posted, the marker is set and the background
+    path skips."""
+    task = _marker_task()
+    assert markers.is_supersede_comment_posted(task) is False
+    markers.mark_supersede_comment_posted(task)
+    assert markers.is_supersede_comment_posted(task) is True
+
+
+# ---------------------------------------------------------------------------
+# Marker helpers: branch_cut_failed stores attempt count
+# ---------------------------------------------------------------------------
+
+
+def test_branch_cut_failed_stores_attempts() -> None:
+    task = _marker_task()
+    assert markers.get_branch_cut_attempts(task) == 0
+    markers.mark_branch_cut_failed(task, _PRIOR_FAILURES)
+    assert markers.get_branch_cut_attempts(task) == _PRIOR_FAILURES
+    assert markers.is_branch_cut_failed(task) is True
+    markers.clear_branch_cut_failed(task)
+    assert markers.is_branch_cut_failed(task) is False
+
+
+def test_branch_cut_next_retry_at_round_trip() -> None:
+    task = _marker_task()
+    assert markers.get_branch_cut_next_retry_at(task) is None
+    markers.set_branch_cut_next_retry_at(task, _RETRY_TS)
+    assert markers.get_branch_cut_next_retry_at(task) == _RETRY_TS
+    markers.clear_branch_cut_next_retry_at(task)
+    assert markers.get_branch_cut_next_retry_at(task) is None
+
+
+def test_cut_success_clears_all_failure_markers() -> None:
+    """On a successful cut, _cut_supersede_branch clears branch_pending,
+    branch_cut_failed, and branch_cut_next_retry_at so the dispatcher gates
+    release the umbrella."""
+    task = _marker_task()
+    markers.mark_branch_pending(task)
+    markers.mark_branch_cut_failed(task, 2)
+    markers.set_branch_cut_next_retry_at(task, time.time() + 60)
+    # Simulate the success path's marker clears.
+    markers.clear_branch_pending(task)
+    markers.clear_branch_cut_failed(task)
+    markers.clear_branch_cut_next_retry_at(task)
+    assert markers.is_branch_pending(task) is False
+    assert markers.is_branch_cut_failed(task) is False
+    assert markers.get_branch_cut_next_retry_at(task) is None
+    # The dispatcher gate must now release the umbrella.
+    assert (
+        _is_branch_pending({"orchestration_markers": task.orchestration_markers})
+        is False
+    )


### PR DESCRIPTION
Superseding an inbound external PR timed out at the 60s client limit while the umbrella task still got created, because the branch cut (clone + fetch + checkout + push from refs/pull/{n}/head) ran synchronously inside the HTTP request and uvicorn does not cancel the endpoint on client disconnect.

Fix: commit the umbrella first with a branch_pending marker and return status=cutting_branch immediately, so the CEO never sees a timeout. The branch cut runs in a background task; a restart-safe ~60s sweep reconciles if it died or the orchestrator restarted. Retry with 60s/120s backoff, 3rd failure escalates to BLOCKED with a truthful CEO notification. A contributor PR comment is posted at supersede time (resolves repo+token from the project record, no clone) so the contributor knows the org took the PR over. In-flight tracking prevents double-spawn (slot claimed under the lock before release).

Markers: branch_pending, branch_cut_failed, branch_cut_next_retry_at, supersede_comment_posted.
Gate: ruff/mypy clean, 15 tests.