### PR TITLE
fix(task): guard root_owned AC coverage to actual roots

### DIFF
--- a/roboco/services/gateway/choreographer/_impl.py
+++ b/roboco/services/gateway/choreographer/_impl.py
@@ -4544,6 +4544,38 @@ class Choreographer:
             context_briefing=briefing,
         ).with_introspection(task=after, role=role_str)
 
+    @staticmethod
+    def _self_declare_result(
+        child: Any, briefing: dict[str, Any]
+    ) -> tuple[Envelope | None, Any]:
+        """Resolve a root-owned self-declare (caller is ``child``'s assignee).
+
+        Returns ``(None, child)`` when ``child`` is a true root (no parent) so
+        its own ``parent_ac_refs`` count as self-coverage at the read-side
+        gate. A coordination task that HAS a parent is rejected: the
+        ``_parent_ac_ref_sets`` guard only treats own refs as self-coverage
+        when ``parent_task_id`` is None, so self-declaring here would stamp
+        refs that silently do nothing. Reject up front rather than return a
+        silent no-op that looks like success.
+        """
+        if child.parent_task_id is None:
+            return None, child
+        return (
+            Envelope.invalid_state(
+                message=(
+                    "root-owned self-declare is reserved for a true"
+                    " coordination root (a task with no parent)"
+                ),
+                remediate=(
+                    "this task has a parent, so self-declared refs would"
+                    " be inert; declare coverage on the parent's criteria"
+                    " via the child-declare flow instead"
+                ),
+                context_briefing=briefing,
+            ),
+            None,
+        )
+
     async def _declare_coverage_guard(
         self, pm_agent_id: UUID, child: Any, agent: Any, briefing: dict[str, Any]
     ) -> tuple[Envelope | None, Any]:
@@ -4573,7 +4605,7 @@ class Choreographer:
                 None,
             )
         if child.assigned_to == pm_agent_id:
-            return None, child
+            return self._self_declare_result(child, briefing)
         if not child.parent_task_id:
             return (
                 Envelope.invalid_state(

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -10730,10 +10730,12 @@ class TaskService(BaseService):
         ``root_owned`` is the parent's OWN ``parent_ac_refs`` (declared on
         itself via ``declare_coverage(task_id=<own root>, ...)``) — criteria
         only the root's own machinery satisfies (e.g. PR-supersede, closing a
-        contributor PR), never a cell. Root-owned refs are unconditionally
-        folded into both ``claimed`` and ``verified``: there is no child
-        status to gate on, the work happens at/after the root's own
-        submit/supersede by construction.
+        contributor PR), never a cell. Only applies when the loaded task IS a
+        root (``parent_task_id is None``); a non-root task's ``parent_ac_refs``
+        are upward refs towards its own parent, not self-coverage, and stay
+        inert. Root-owned refs are unconditionally folded into both ``claimed``
+        and ``verified``: there is no child status to gate on, the work happens
+        at/after the root's own submit/supersede by construction.
 
         A parent whose ``acceptance_criteria_ids`` is empty or out of length
         with ``acceptance_criteria`` (a legacy row from before every AC
@@ -10759,7 +10761,11 @@ class TaskService(BaseService):
                 claimed |= refset
             if status == TaskStatus.COMPLETED:
                 verified |= refset
-        root_owned = self._normalize_ac_refs(parent, parent.parent_ac_refs)
+        root_owned = (
+            self._normalize_ac_refs(parent, parent.parent_ac_refs)
+            if parent.parent_task_id is None
+            else set()
+        )
         if root_owned:
             any_declared = True
             claimed |= root_owned

--- a/tests/integration/test_lifecycle_real_db.py
+++ b/tests/integration/test_lifecycle_real_db.py
@@ -954,13 +954,13 @@ async def test_cell_pm_complete_routes_ceo_only_head_branch_to_ceo(
 
     env = await c.cell_pm_complete(
         cell_pm_agent.id,
-        leaf.id,
+        UUID(str(leaf.id)),
         notes="LGTM - routing to CEO for the head-branch merge.",
     )
     assert env.error is None, f"complete failed: {env.message}"
     assert env.status == Status.AWAITING_CEO_APPROVAL.value
 
-    final = await task_service.get(leaf.id)
+    final = await task_service.get(UUID(str(leaf.id)))
     assert final is not None
     assert str(final.status) == Status.AWAITING_CEO_APPROVAL.value
 

--- a/tests/unit/gateway/test_choreographer_pm.py
+++ b/tests/unit/gateway/test_choreographer_pm.py
@@ -1501,3 +1501,31 @@ async def test_declare_coverage_self_declare_rejected_for_non_owner() -> None:
     env = await c.declare_coverage(pm_id, root_id, ["id-a"])
     assert env.error == "invalid_state"
     task_svc.add_parent_ac_refs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_declare_coverage_self_declare_rejected_for_non_root() -> None:
+    """Root-owned self-declare on a coordination task that HAS a parent (e.g.
+    a cell coordination root parented to a Main PM root) is rejected. The
+    read-side guard in _parent_ac_ref_sets only treats a task's own
+    parent_ac_refs as self-coverage when parent_task_id is None, so
+    self-declaring here would stamp refs that silently do nothing at the
+    gate. Reject up front rather than return a silent no-op."""
+    pm_id = uuid4()
+    cell_root_id = uuid4()
+    cell_root = MagicMock(
+        id=cell_root_id,
+        assigned_to=pm_id,
+        parent_task_id=uuid4(),
+        acceptance_criteria=["cell a", "cell b"],
+        acceptance_criteria_ids=["id-a", "id-b"],
+    )
+    task_svc = AsyncMock()
+    task_svc.get.return_value = cell_root
+    task_svc.agent_for.return_value = MagicMock(role="cell_pm", team="backend")
+    deps = _make_deps(task=task_svc)
+    c = Choreographer(deps)
+
+    env = await c.declare_coverage(pm_id, cell_root_id, ["id-a"])
+    assert env.error == "invalid_state"
+    task_svc.add_parent_ac_refs.assert_not_awaited()

--- a/tests/unit/services/test_task.py
+++ b/tests/unit/services/test_task.py
@@ -1698,6 +1698,7 @@ async def test_parent_ac_coverage_marks_root_owned_claimed_by() -> None:
         acceptance_criteria=["crit a", "crit b", "crit c"],
         acceptance_criteria_ids=["id-a", "id-b", "id-c"],
         parent_ac_refs=["id-a"],
+        parent_task_id=None,
     )
     svc = _svc_with_children(parent, [(TaskStatus.COMPLETED, ["id-b"])])
     assert await svc.parent_ac_coverage(parent.id) == [
@@ -1734,6 +1735,7 @@ async def test_uncovered_parent_acs_root_owned_satisfied_without_child() -> None
         acceptance_criteria=["crit a", "crit b"],
         acceptance_criteria_ids=["id-a", "id-b"],
         parent_ac_refs=["id-a"],
+        parent_task_id=None,
     )
     svc = _svc_with_children(parent, [])
     assert await svc.uncovered_parent_acceptance_criteria(parent.id) == ["crit b"]
@@ -1745,6 +1747,7 @@ async def test_unclaimed_parent_acs_root_owned_counts_as_claimed() -> None:
         acceptance_criteria=["crit a", "crit b"],
         acceptance_criteria_ids=["id-a", "id-b"],
         parent_ac_refs=["id-a"],
+        parent_task_id=None,
     )
     svc = _svc_with_children(parent, [])
     assert await svc.unclaimed_parent_acceptance_criteria(parent.id) == ["crit b"]
@@ -1762,10 +1765,88 @@ async def test_production_replay_mixed_child_and_root_owned_coverage() -> None:
         acceptance_criteria=[f"crit {i}" for i in range(5)],
         acceptance_criteria_ids=ids,
         parent_ac_refs=["id-3", "id-4"],
+        parent_task_id=None,
     )
     svc = _svc_with_children(parent, [(TaskStatus.COMPLETED, ["id-0", "id-1", "id-2"])])
     assert await svc.unclaimed_parent_acceptance_criteria(parent.id) == []
     assert await svc.uncovered_parent_acceptance_criteria(parent.id) == []
+
+
+@pytest.mark.asyncio
+async def test_leaf_parent_ac_refs_not_root_owned_on_self() -> None:
+    # Regression: a leaf child (has parent_task_id, non-empty parent_ac_refs
+    # declared UPWARDS towards its parent, no children of its own) must NOT
+    # treat those refs as root-owned self-coverage. The live incident leaf
+    # 9bd12bd5 carried 11 parent_ac_refs that were its PARENT's criterion
+    # ids (upward refs), not its own. Under the old code those armed the AC
+    # gate and false-positive rejected cell_pm_complete with "N parent
+    # acceptance criteria not covered." The refs here deliberately do NOT
+    # match the leaf's own acceptance_criteria_ids (they reference the
+    # parent's criteria) so this test FAILS if the root_owned guard is
+    # reverted: old code returns all 3 leaf ACs as uncovered, new code
+    # returns [] (any_declared stays False, the gate is inert).
+    leaf = _build_task(
+        acceptance_criteria=["leaf a", "leaf b", "leaf c"],
+        acceptance_criteria_ids=["id-a", "id-b", "id-c"],
+        parent_ac_refs=["parent-1", "parent-2", "parent-3"],
+        parent_task_id=uuid4(),
+    )
+    svc = _svc_with_children(leaf, [])
+    assert await svc.uncovered_parent_acceptance_criteria(leaf.id) == []
+    assert await svc.unclaimed_parent_acceptance_criteria(leaf.id) == []
+
+
+@pytest.mark.asyncio
+async def test_root_owned_still_fires_for_true_root_with_uncovered_acs() -> None:
+    # A real root (parent_task_id is None) with root_owned refs AND children
+    # that do NOT cover all criteria -- the gate still fires for the
+    # uncovered ones. root_owned folds into claimed+verified, but criteria
+    # not in root_owned and not covered by a completed child still block.
+    root = _build_task(
+        acceptance_criteria=["crit a", "crit b", "crit c"],
+        acceptance_criteria_ids=["id-a", "id-b", "id-c"],
+        parent_ac_refs=["id-a"],
+        parent_task_id=None,
+    )
+    svc = _svc_with_children(root, [(TaskStatus.IN_PROGRESS, ["id-b"])])
+    assert await svc.uncovered_parent_acceptance_criteria(root.id) == [
+        "crit b",
+        "crit c",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_intermediate_task_parent_ac_refs_not_root_owned() -> None:
+    # A cell-root-level task that has a parent_task_id (it is itself a child
+    # of the Main PM root) and carries parent_ac_refs -- those refs are
+    # upward refs towards its parent, NOT root-owned coverage on itself.
+    # Same guard as the leaf case, different position in the tree.
+    cell_root = _build_task(
+        acceptance_criteria=["cell a", "cell b"],
+        acceptance_criteria_ids=["id-a", "id-b"],
+        parent_ac_refs=["id-a", "id-b"],
+        parent_task_id=uuid4(),
+    )
+    svc = _svc_with_children(cell_root, [(TaskStatus.COMPLETED, ["id-a"])])
+    # Only "cell b" is uncovered (no root_owned shortcut for the cell root).
+    assert await svc.uncovered_parent_acceptance_criteria(cell_root.id) == [
+        "cell b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_root_owned_refs_fold_into_verified_for_true_root() -> None:
+    # A root with parent_ac_refs covering some of its own criteria -- those
+    # criteria count as covered (claimed+verified) even with no children.
+    root = _build_task(
+        acceptance_criteria=["crit a", "crit b"],
+        acceptance_criteria_ids=["id-a", "id-b"],
+        parent_ac_refs=["id-a"],
+        parent_task_id=None,
+    )
+    svc = _svc_with_children(root, [])
+    assert await svc.uncovered_parent_acceptance_criteria(root.id) == ["crit b"]
+    assert await svc.unclaimed_parent_acceptance_criteria(root.id) == ["crit b"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Leaf task 9bd12bd5 got stuck at awaiting_pm_review: the cell PM resumed its PARENT (paused to in_progress) instead of completing the child, because _parent_ac_ref_sets applied a task own parent_ac_refs as root-owned self-coverage unconditionally. A leaf child upward refs (declared towards its parent) armed the AC gate and false-positive rejected cell_pm_complete with "N parent acceptance criteria not covered."

Fix: guard root_owned on parent_task_id is None, so only a real root own parent_ac_refs are self-coverage; a non-root upward refs stay inert. Single chokepoint fixes all four callers (submit_up, cell_pm_complete, submit_root, escalate_to_ceo). Plus write-side alignment: _declare_coverage_guard rejects a PM self-declaring root-owned on a task that has a parent (those refs would be inert).

Regression test uses UPWARD refs (the parent criterion ids, not the leaf own) so it actually fails under the old guard and passes under the new. Verified by reverting the guard.
Gate: ruff/mypy clean, 188 tests.