### PR TITLE
fix(supersede): close + comment on contributor PR when replacement lands

### DIFF
--- a/roboco/foundation/policy/content/markers.py
+++ b/roboco/foundation/policy/content/markers.py
@@ -27,6 +27,7 @@ ORIGINAL_DEVELOPER = "original_developer"
 DOCUMENTER = "documenter"
 REQUIRED_CELLS = "required_cells"
 EXTERNAL_PR_HEAD = "external_pr_head"
+EXTERNAL_PR_AUTHOR = "external_pr_author"
 EXTERNAL_PR_SUPERSEDE = "external_pr_supersede"
 SELF_HEAL_FP = "self_heal_fp"
 DISMISSED = "dismissed"
@@ -633,6 +634,15 @@ def get_external_pr_head(task: HasMarkers) -> str | None:
 
 def set_external_pr_head(task: HasMarkers, head_sha: str) -> None:
     set_marker(task, EXTERNAL_PR_HEAD, head_sha)
+
+
+def get_external_pr_author(task: HasMarkers) -> str | None:
+    val = get_marker(task, EXTERNAL_PR_AUTHOR)
+    return str(val) if val else None
+
+
+def set_external_pr_author(task: HasMarkers, login: str) -> None:
+    set_marker(task, EXTERNAL_PR_AUTHOR, login)
 
 
 # --- external PR supersede ------------------------------------------------- #

--- a/roboco/runtime/orchestrator.py
+++ b/roboco/runtime/orchestrator.py
@@ -116,19 +116,29 @@ _MINUTES_PER_HOUR = 60
 
 # Supersede contributor PR comments - a coherent pair. The at-supersede comment
 # posts when the CEO takes the PR over; the at-close comment posts when the
-# replacement lands and the contributor PR is retired.
+# replacement lands and the contributor PR is retired. Both are prefixed with an
+# ``@{author}`` tag (when the contributor's login is known) so the original
+# developer is notified and nudged toward the replacement PR.
 SUPERSEDE_PR_COMMENT = (
     "Thanks for this contribution! We reviewed it and are taking the work "
     "over internally to finish and harden it to our standards. The "
     "implementation continues on branch `{branch}` as an internal task; "
     "your PR informed the approach and is appreciated. This PR will be "
-    "closed once our replacement lands. Feel free to reach out if you "
-    "have questions."
+    "closed once our replacement lands. Feel free to reach out with any "
+    "questions."
 )
 SUPERSEDE_PR_CLOSE_COMMENT = (
-    "Superseded by our own PR - the work was finished and hardened to our "
-    "standards based on your contribution. Thanks for the contribution!"
+    "Our replacement PR #{replacement_pr} has been merged, finishing and "
+    "hardening the work to our standards based on your contribution. This "
+    "PR is closed as superseded. Thanks for the contribution! If we missed "
+    "something from your PR, please open a new one and we will pick it up."
 )
+
+
+def _supersede_author_prefix(author: str) -> str:
+    """The ``@login `` prefix for a supersede comment, or "" when unknown."""
+    return f"@{author} " if author else ""
+
 
 # Max background branch-cut attempts before escalating to BLOCKED (HUMAN
 # resolver). The sweep retries with exponential backoff between attempts.
@@ -8441,7 +8451,13 @@ Start by:
             _sm.clear_branch_cut_next_retry_at(umbrella)
             await db.flush()
             await db.commit()
-        pr_number = self._parse_supersede_pr(umbrella.quick_context or "")
+        # The marker lives in orchestration_markers (migration 041), NOT
+        # quick_context: reading quick_context here returned None after the
+        # marker refactor, so a stranded branch_pending umbrella was never
+        # reconciled (same bug class as close-on-land).
+        pr_number = self._parse_supersede_pr(
+            _sm.get_external_pr_supersede(umbrella) or ""
+        )
         if pr_number is None:
             return None
         project = await project_service.get(cast("UUID", umbrella.project_id))
@@ -10147,17 +10163,28 @@ Start by:
         commits.
         """
         closed = 0
-        for umbrella in await task_service.supersede_umbrellas_pending_close():
-            pr_number = self._parse_supersede_pr(umbrella.quick_context or "")
+        for (
+            umbrella,
+            replacement_pr,
+        ) in await task_service.supersede_umbrellas_pending_close():
+            # The marker lives in orchestration_markers (migration 041), NOT in
+            # quick_context: reading quick_context here returned None for every
+            # umbrella after the marker refactor, so close-on-land never fired.
+            marker = _markers.get_external_pr_supersede(umbrella) or ""
+            pr_number = self._parse_supersede_pr(marker)
             if pr_number is None:
                 continue
+            author = self._parse_supersede_author(marker)
+            comment = _supersede_author_prefix(
+                author
+            ) + SUPERSEDE_PR_CLOSE_COMMENT.format(replacement_pr=replacement_pr)
             try:
                 await git.close_pull_request(
                     pr_number,
-                    comment=SUPERSEDE_PR_CLOSE_COMMENT,
+                    comment=comment,
                     delete_branch=False,
                     actor_agent_id=system_id,
-                    # PR numbers are per-repo — scope the close to THIS
+                    # PR numbers are per-repo; scope the close to THIS
                     # umbrella's project so a same-numbered PR in another
                     # project's repo is never resolved (and closed) by mistake.
                     project_id=cast("UUID", umbrella.project_id),
@@ -10173,24 +10200,33 @@ Start by:
         return closed
 
     @staticmethod
-    def _parse_supersede_pr(quick_context: str) -> int | None:
+    def _parse_supersede_pr(marker_line: str) -> int | None:
         """Extract the contributor PR number from a supersede umbrella marker.
 
-        Anchored to the marker line so a CEO note containing ``pr=`` on a later
-        line of the multi-writer ``quick_context`` can't be misread as the PR.
+        The marker value is ``pr={n} review={uuid} [author={login}] [closed=1]``
+        stored under the ``external_pr_supersede`` key in ``orchestration_markers``
+        (migration 041). It used to ride in ``quick_context`` prefixed with the key
+        name; the refactor moved it to the typed column but left this parser on
+        ``quick_context``, so close-on-land never found the PR number and never
+        fired. ``pr=`` is unique among the tokens (``review=`` / ``author=`` /
+        ``closed=1`` don't start with ``pr=``), so a whitespace split + prefix match
+        is exact.
         """
-        for raw in quick_context.splitlines():
-            line = raw.strip()
-            if not line.startswith("external_pr_supersede"):
-                continue
-            for part in line.split():
-                if part.startswith("pr="):
-                    try:
-                        return int(part[3:])
-                    except ValueError:
-                        return None
-            return None
+        for part in marker_line.split():
+            if part.startswith("pr="):
+                try:
+                    return int(part[3:])
+                except ValueError:
+                    return None
         return None
+
+    @staticmethod
+    def _parse_supersede_author(marker_line: str) -> str:
+        """Extract the contributor login from a supersede umbrella marker, or ""."""
+        for part in marker_line.split():
+            if part.startswith("author="):
+                return part[len("author=") :]
+        return ""
 
     @staticmethod
     def _pr_author_allowed(pr: dict[str, Any], allowlist: set[str]) -> bool:
@@ -10299,10 +10335,16 @@ Start by:
             # retries via the supersede_comment_posted marker.
             git = GitService(db)
             try:
+                author = self._parse_supersede_author(
+                    markers.get_external_pr_supersede(umbrella) or ""
+                )
+                comment = _supersede_author_prefix(
+                    author
+                ) + SUPERSEDE_PR_COMMENT.format(branch=branch_name)
                 await git.comment_pull_request(
                     pr_number,
                     project_id=project_id,
-                    comment=SUPERSEDE_PR_COMMENT.format(branch=branch_name),
+                    comment=comment,
                 )
                 markers.mark_supersede_comment_posted(umbrella)
                 await db.flush()
@@ -10394,10 +10436,16 @@ Start by:
                 # Post the contributor comment if the fast path did not.
                 if not markers.is_supersede_comment_posted(umbrella):
                     try:
+                        author = self._parse_supersede_author(
+                            markers.get_external_pr_supersede(umbrella) or ""
+                        )
+                        comment = _supersede_author_prefix(
+                            author
+                        ) + SUPERSEDE_PR_COMMENT.format(branch=branch_name)
                         await git.comment_pull_request(
                             pr_number,
                             project_id=project_id,
-                            comment=SUPERSEDE_PR_COMMENT.format(branch=branch_name),
+                            comment=comment,
                         )
                         markers.mark_supersede_comment_posted(umbrella)
                         await db.flush()

--- a/roboco/services/task.py
+++ b/roboco/services/task.py
@@ -1861,6 +1861,7 @@ class TaskService(BaseService):
         pr_url = str(pr.get("url") or "")
         pr_title = str(pr.get("title") or "")
         head_sha = str(pr.get("head_sha") or "")
+        author_login = str(pr.get("user_login") or "")
         if await self.external_review_task_exists(project_id, pr_number, head_sha):
             return None
         kind = "internal" if source == "internal_pr" else "external"
@@ -1902,6 +1903,10 @@ class TaskService(BaseService):
         # while an unchanged PR is skipped (see external_review_task_exists).
         if head_sha:
             markers.set_external_pr_head(task, head_sha)
+        # Capture the contributor's login so the supersede comments can tag
+        # them (@login) without a per-comment PR fetch.
+        if author_login:
+            markers.set_external_pr_author(task, author_login)
         await self.session.flush()
         return task
 
@@ -2754,10 +2759,14 @@ class TaskService(BaseService):
         # the contributor's commits (via _resolve_base_branch's parent-branch
         # rule), not the default branch. The marker links back to the review +
         # contributor PR for dedup and close-on-land (no parent link needed).
+        # The contributor's login rides along (author=) so the supersede
+        # comments can tag them without an extra PR fetch.
         umbrella.branch_name = branch_name
-        markers.set_external_pr_supersede(
-            umbrella, f"pr={pr_number} review={review_task_id}"
-        )
+        author = markers.get_external_pr_author(review) or ""
+        marker = f"pr={pr_number} review={review_task_id}"
+        if author:
+            marker += f" author={author}"
+        markers.set_external_pr_supersede(umbrella, marker)
         await self.session.flush()
         self.log.info(
             "Supersede umbrella created",
@@ -2789,7 +2798,7 @@ class TaskService(BaseService):
                 return task
         return None
 
-    async def supersede_umbrellas_pending_close(self) -> list[TaskTable]:
+    async def supersede_umbrellas_pending_close(self) -> list[tuple[TaskTable, int]]:
         """Landed supersede umbrellas whose contributor PR hasn't been closed yet.
 
         A supersede umbrella reaching COMPLETED is necessary but not sufficient
@@ -2799,6 +2808,9 @@ class TaskService(BaseService):
         additionally require a non-cancelled descendant that landed a PR (see
         :meth:`_supersede_replacement_landed`). The ``closed=1`` token on the
         marker line makes close-on-land idempotent (closed only once).
+
+        Returns ``(umbrella, replacement_pr_number)`` pairs so the caller can
+        link the merged replacement PR in the close comment.
         """
         result = await self.session.execute(
             select(TaskTable).where(
@@ -2806,13 +2818,16 @@ class TaskService(BaseService):
                 TaskTable.status == TaskStatus.COMPLETED,
             )
         )
-        pending: list[TaskTable] = []
+        pending: list[tuple[TaskTable, int]] = []
         for task in result.scalars().all():
             if "closed=1" in supersede_marker_line(task).split():
                 continue
-            if not await self._supersede_replacement_landed(cast("UUID", task.id)):
+            replacement_pr = await self._supersede_replacement_landed(
+                cast("UUID", task.id)
+            )
+            if replacement_pr is None:
                 continue
-            pending.append(task)
+            pending.append((task, replacement_pr))
         return pending
 
     async def supersede_umbrellas_branch_pending(self) -> list[TaskTable]:
@@ -2840,14 +2855,14 @@ class TaskService(BaseService):
                 pending.append(task)
         return pending
 
-    async def _supersede_replacement_landed(self, umbrella_id: UUID) -> bool:
-        """True if a non-cancelled descendant of the umbrella landed a PR.
+    async def _supersede_replacement_landed(self, umbrella_id: UUID) -> int | None:
+        """The replacement PR number if a non-cancelled descendant landed one.
 
         Walks the umbrella's subtree (bounded by MAX_TASK_DEPTH) and returns
-        True as soon as it finds a COMPLETED task carrying a ``pr_number`` — the
-        team's merged replacement PR. Returns False when every code descendant
-        was cancelled (force-completed umbrella), so close-on-land then leaves
-        the contributor PR open.
+        the ``pr_number`` as soon as it finds a COMPLETED task carrying one,
+        the team's merged replacement PR. Returns ``None`` when every code
+        descendant was cancelled (force-completed umbrella), so close-on-land
+        then leaves the contributor PR open.
         """
         frontier: list[UUID] = [umbrella_id]
         seen: set[UUID] = set()
@@ -2864,9 +2879,9 @@ class TaskService(BaseService):
                     continue
                 seen.add(child_id)
                 if child.status == TaskStatus.COMPLETED and child.pr_number is not None:
-                    return True
+                    return int(child.pr_number)
                 frontier.append(child_id)
-        return False
+        return None
 
     async def mark_supersede_pr_closed(self, task_id: UUID) -> None:
         """Record that a landed supersede's contributor PR has been closed.

--- a/tests/unit/runtime/test_supersede_close_on_land.py
+++ b/tests/unit/runtime/test_supersede_close_on_land.py
@@ -1,0 +1,197 @@
+"""Supersede close-on-land: the marker parser + author tag + replacement link.
+
+The supersede marker moved off ``quick_context`` into ``orchestration_markers``
+(migration 041), but the close-on-land parser kept reading ``quick_context`` and
+expecting a ``external_pr_supersede``-prefixed line, so it returned None for
+every umbrella and the contributor PR was never closed. These tests pin the
+fixed parser (reads the marker value directly) and the rich close comment
+(tags the contributor, links the merged replacement PR).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from roboco.runtime.orchestrator import (
+    SUPERSEDE_PR_CLOSE_COMMENT,
+    SUPERSEDE_PR_COMMENT,
+    AgentOrchestrator,
+    _supersede_author_prefix,
+)
+
+_PR = 880
+_PR_OTHER = 7
+_REPLACEMENT_PR = 890
+_REPLACEMENT_PR_42 = 42
+_AUTHOR = "EdwardBeshara711"
+_MARKER = f"pr={_PR} review=abc-123 author={_AUTHOR}"
+_MARKER_NO_AUTHOR = f"pr={_PR_OTHER} review=xyz"
+_MARKER_CLOSED = f"{_MARKER} closed=1"
+_BRANCH = f"feature/main_pm/supersede-pr-{_PR}"
+
+
+def _new_orchestrator() -> AgentOrchestrator:
+    """A bare orchestrator instance; the close loop touches no instance state."""
+    return AgentOrchestrator.__new__(AgentOrchestrator)
+
+
+# ---------------------------------------------------------------------------
+# _parse_supersede_pr: reads the marker value (NOT quick_context)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pr_from_marker_line() -> None:
+    assert AgentOrchestrator._parse_supersede_pr(_MARKER) == _PR
+
+
+def test_parse_pr_handles_closed_token() -> None:
+    # closed=1 is appended after close-on-land; the parser must still find pr=.
+    assert AgentOrchestrator._parse_supersede_pr(_MARKER_CLOSED) == _PR
+
+
+def test_parse_pr_without_author() -> None:
+    assert AgentOrchestrator._parse_supersede_pr(_MARKER_NO_AUTHOR) == _PR_OTHER
+
+
+def test_parse_pr_empty_marker() -> None:
+    assert AgentOrchestrator._parse_supersede_pr("") is None
+
+
+def test_parse_pr_rejects_non_numeric() -> None:
+    assert AgentOrchestrator._parse_supersede_pr("pr=notanumber review=x") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_supersede_author
+# ---------------------------------------------------------------------------
+
+
+def test_parse_author_present() -> None:
+    assert AgentOrchestrator._parse_supersede_author(_MARKER) == _AUTHOR
+
+
+def test_parse_author_absent() -> None:
+    assert AgentOrchestrator._parse_supersede_author(_MARKER_NO_AUTHOR) == ""
+
+
+def test_parse_author_empty_marker() -> None:
+    assert AgentOrchestrator._parse_supersede_author("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _supersede_author_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_author_prefix_tags_known_login() -> None:
+    assert _supersede_author_prefix(_AUTHOR) == f"@{_AUTHOR} "
+
+
+def test_author_prefix_empty_when_unknown() -> None:
+    assert _supersede_author_prefix("") == ""
+
+
+# ---------------------------------------------------------------------------
+# close comment bodies
+# ---------------------------------------------------------------------------
+
+
+def test_close_comment_links_replacement_pr() -> None:
+    body = SUPERSEDE_PR_CLOSE_COMMENT.format(replacement_pr=_REPLACEMENT_PR)
+    assert f"#{_REPLACEMENT_PR}" in body
+    assert "superseded" in body
+
+
+def test_close_comment_with_author_tag() -> None:
+    body = _supersede_author_prefix(_AUTHOR) + SUPERSEDE_PR_CLOSE_COMMENT.format(
+        replacement_pr=_REPLACEMENT_PR
+    )
+    assert body.startswith(f"@{_AUTHOR} ")
+    assert f"#{_REPLACEMENT_PR}" in body
+
+
+def test_at_supersede_comment_names_branch() -> None:
+    body = SUPERSEDE_PR_COMMENT.format(branch=_BRANCH)
+    assert _BRANCH in body
+
+
+# ---------------------------------------------------------------------------
+# _close_superseded_prs: the close comment carries the tag + replacement link
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_superseded_prs_tags_contributor_and_links_replacement() -> None:
+    umbrella = MagicMock(id=uuid4(), project_id=uuid4())
+    umbrella.orchestration_markers = {"external_pr_supersede": _MARKER}
+
+    git = MagicMock()
+    git.close_pull_request = AsyncMock()
+    task_service = MagicMock()
+    task_service.supersede_umbrellas_pending_close = AsyncMock(
+        return_value=[(umbrella, _REPLACEMENT_PR)]
+    )
+    task_service.mark_supersede_pr_closed = AsyncMock()
+
+    closed = await AgentOrchestrator._close_superseded_prs(
+        _new_orchestrator(), git, task_service, cast("Any", uuid4())
+    )
+
+    assert closed == 1
+    git.close_pull_request.assert_awaited_once()
+    kwargs = git.close_pull_request.call_args.kwargs
+    assert kwargs["comment"].startswith(f"@{_AUTHOR} ")
+    assert f"#{_REPLACEMENT_PR}" in kwargs["comment"]
+    assert kwargs["delete_branch"] is False
+    task_service.mark_supersede_pr_closed.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_superseded_prs_skips_marker_without_pr() -> None:
+    # A malformed marker (no pr=) must not crash the loop.
+    umbrella = MagicMock(id=uuid4(), project_id=uuid4())
+    umbrella.orchestration_markers = {"external_pr_supersede": "review=only"}
+
+    git = MagicMock()
+    git.close_pull_request = AsyncMock()
+    task_service = MagicMock()
+    task_service.supersede_umbrellas_pending_close = AsyncMock(
+        return_value=[(umbrella, _REPLACEMENT_PR)]
+    )
+    task_service.mark_supersede_pr_closed = AsyncMock()
+
+    closed = await AgentOrchestrator._close_superseded_prs(
+        _new_orchestrator(), git, task_service, cast("Any", uuid4())
+    )
+
+    assert closed == 0
+    git.close_pull_request.assert_not_awaited()
+    task_service.mark_supersede_pr_closed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_close_superseded_prs_no_author_still_links_replacement() -> None:
+    """A pre-existing umbrella whose review predates the author capture still
+    gets a close comment linking the replacement PR (just without the @tag)."""
+    umbrella = MagicMock(id=uuid4(), project_id=uuid4())
+    umbrella.orchestration_markers = {"external_pr_supersede": _MARKER_NO_AUTHOR}
+
+    git = MagicMock()
+    git.close_pull_request = AsyncMock()
+    task_service = MagicMock()
+    task_service.supersede_umbrellas_pending_close = AsyncMock(
+        return_value=[(umbrella, _REPLACEMENT_PR_42)]
+    )
+    task_service.mark_supersede_pr_closed = AsyncMock()
+
+    closed = await AgentOrchestrator._close_superseded_prs(
+        _new_orchestrator(), git, task_service, cast("Any", uuid4())
+    )
+
+    assert closed == 1
+    kwargs = git.close_pull_request.call_args.kwargs
+    assert not kwargs["comment"].startswith("@")
+    assert f"#{_REPLACEMENT_PR_42}" in kwargs["comment"]

--- a/tests/unit/services/test_supersede_umbrella.py
+++ b/tests/unit/services/test_supersede_umbrella.py
@@ -18,6 +18,7 @@ from roboco.models.base import TaskStatus
 from roboco.services.task import TaskService, supersede_marker_line
 
 _VALUE = "pr=5 review=abc"
+_LANDED_PR = 42  # the replacement PR number a landed descendant carries
 
 
 def _scalars_all(rows: list[object]) -> MagicMock:
@@ -65,7 +66,7 @@ def test_marker_line_empty_when_absent() -> None:
 async def test_pending_close_excludes_umbrella_with_closed_marker() -> None:
     umbrella = _task(f"{_VALUE} closed=1", id=uuid4())
     svc = _service(_scalars_all([umbrella]))
-    _bind(svc, "_supersede_replacement_landed", AsyncMock(return_value=True))
+    _bind(svc, "_supersede_replacement_landed", AsyncMock(return_value=_LANDED_PR))
     assert await svc.supersede_umbrellas_pending_close() == []
 
 
@@ -73,8 +74,8 @@ async def test_pending_close_excludes_umbrella_with_closed_marker() -> None:
 async def test_pending_close_keeps_open_landed_umbrella() -> None:
     umbrella = _task(_VALUE, id=uuid4())
     svc = _service(_scalars_all([umbrella]))
-    _bind(svc, "_supersede_replacement_landed", AsyncMock(return_value=True))
-    assert await svc.supersede_umbrellas_pending_close() == [umbrella]
+    _bind(svc, "_supersede_replacement_landed", AsyncMock(return_value=_LANDED_PR))
+    assert await svc.supersede_umbrellas_pending_close() == [(umbrella, _LANDED_PR)]
 
 
 @pytest.mark.asyncio
@@ -83,34 +84,34 @@ async def test_pending_close_requires_landed_replacement() -> None:
     # subtask was cancelled) — close-on-land must skip it.
     umbrella = _task(_VALUE, id=uuid4())
     svc = _service(_scalars_all([umbrella]))
-    _bind(svc, "_supersede_replacement_landed", AsyncMock(return_value=False))
+    _bind(svc, "_supersede_replacement_landed", AsyncMock(return_value=None))
     assert await svc.supersede_umbrellas_pending_close() == []
 
 
 # ---------------------------------------------------------------------------
-# _supersede_replacement_landed — subtree walk
+# _supersede_replacement_landed: subtree walk (returns pr_number | None)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_replacement_landed_true_for_completed_descendant_with_pr() -> None:
-    child = MagicMock(id=uuid4(), status=TaskStatus.COMPLETED, pr_number=42)
+    child = MagicMock(id=uuid4(), status=TaskStatus.COMPLETED, pr_number=_LANDED_PR)
     svc = _service(_scalars_all([child]))
-    assert await svc._supersede_replacement_landed(uuid4()) is True
+    assert await svc._supersede_replacement_landed(uuid4()) == _LANDED_PR
 
 
 @pytest.mark.asyncio
 async def test_replacement_landed_false_when_descendant_cancelled() -> None:
     child = MagicMock(id=uuid4(), status=TaskStatus.CANCELLED, pr_number=42)
     svc = _service(_scalars_all([child]))
-    assert await svc._supersede_replacement_landed(uuid4()) is False
+    assert await svc._supersede_replacement_landed(uuid4()) is None
 
 
 @pytest.mark.asyncio
 async def test_replacement_landed_false_when_completed_without_pr() -> None:
     child = MagicMock(id=uuid4(), status=TaskStatus.COMPLETED, pr_number=None)
     svc = _service(_scalars_all([child]))
-    assert await svc._supersede_replacement_landed(uuid4()) is False
+    assert await svc._supersede_replacement_landed(uuid4()) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`_parse_supersede_pr` read `quick_context` after the supersede marker moved to `orchestration_markers` (migration 041, refactor 0fba4eed0), so it returned `None` for EVERY umbrella and close-on-land never fired. The contributor PR was never auto-closed; the CEO had to do it manually (#880).

## Fix

- Rewrite `_parse_supersede_pr` to read the marker VALUE directly (`markers.get_external_pr_supersede`), not `quick_context`.
- Fix the second stale caller in `_reconcile_one_umbrella` (same bug class).
- The close comment now tags the contributor (`@author`) and links the merged replacement PR.
- `_supersede_replacement_landed` returns the replacement PR number (`int|None`) so the close comment can name it; `supersede_umbrellas_pending_close` returns `list[tuple[Task, int]]`.
- `ingest_external_pr` records the PR author; `create_supersede_umbrella` appends `author={login}` to the marker.

## Gate

- ruff 0.16.2 (CI): clean. format: clean.
- pytest (4 touched files): 76 passed.
- mypy 2.3.0 (3 source files): no issues.
- Fable critic: CONFIRMED, no BLOCKER/MAJOR.

Closes the close-on-land gap behind #888.