### PR TITLE
[0e99f678] Backend: enforce and expose the project agent-access restriction

### DIFF
--- a/docs/backend/services/project-agent-access-enforcement.md
+++ b/docs/backend/services/project-agent-access-enforcement.md
@@ -1,0 +1,85 @@
+# Project Agent-Access Enforcement (allowed_agents)
+
+`ProjectService.check_agent_access` (`roboco/services/project.py:698`) encodes a
+project's access rule — the project must exist, the requesting agent's team
+must match the project's assigned cell, and an optional `allowed_agents` list
+further restricts the whole-cell default down to named agents. Until this
+change the rule had zero callers: setting `allowed_agents` via the write
+routes had no observable effect anywhere in the system. It is now enforced at
+the **claim path** — the chokepoint an agent actually traverses when it is
+granted work on a project.
+
+## The write path (unchanged)
+
+`POST` / `DELETE /projects/{project_id}/access/{agent_id}`
+(`add_allowed_agent` / `remove_allowed_agent`, `roboco/api/routes/project.py:406,449`)
+remain the **only** way to mutate `Project.allowed_agents`
+(`roboco/models/project.py:205`). No new routes were added; this change only
+wires an existing rule into an existing chokepoint.
+
+## The enforcement chokepoint
+
+`Choreographer._agent_access_claim_guard`
+(`roboco/services/gateway/choreographer/_impl.py`) resolves the guard's
+inputs — the task's eager-loaded `project` relationship and the claiming
+agent's team (via `TaskService.agent_for` → `GatewayAgentView.team`) — and
+calls `ProjectService.check_agent_access(project_id, agent_id, team)` as the
+**sole** deny/allow decision. The guard does not re-implement any part of the
+rule; it only shapes the refusal via the pure predicate
+`agent_access_denied_guard` (`roboco/services/gateway/claim_guards.py`), which
+mirrors the existing `unmet_dependency_guard` shape (no DB I/O, no rule
+logic).
+
+The guard is inert (returns `None`, no refusal) whenever:
+
+- the Choreographer's `project` dependency is unset (existing
+  `ChoreographerDeps` constructions / tests that don't plumb it),
+- the task has no project (a branchless coordination root),
+- the claiming agent's view carries no resolvable string team, or an
+  unrecognized team value (mock-safety, mirroring `_sequence_claim_guard`).
+
+It is wired as a new **opt-in** flag, `check_agent_access: bool = False`, on
+`Choreographer._run_claim_guards`, composed together with the pre-existing
+`check_project_budget` flag through a shared `_opt_in_claim_guards` helper.
+Both flags are set `True` at exactly the two **work-starting** claim call
+sites: `i_will_work_on` and `i_will_plan` (both in `_impl.py`). Every other
+claim path — QA's `claim_review`, the documenter's `claim_doc_task`, the
+PR-gate's `claim_gate_review`, `claim_pr_review` — leaves the flag at its
+`False` default, so review/doc/gate claims of already-in-flight work are
+never blocked by an access rule that changed after the work started.
+
+## Behavior
+
+- **`allowed_agents=None`** (today's default): `check_agent_access` passes
+  trivially — whole-cell access, byte-for-byte unchanged from before this
+  change.
+- **`allowed_agents=[...]`, agent not on the list** (same cell): the claim is
+  refused with `Envelope.not_authorized`, naming the project id, agent id,
+  and task id, and a `remediate` pointing at
+  `POST /projects/{project_id}/access/{agent_id}` (add the agent) or
+  reassigning the task to a permitted agent. The refusal is machine-readable
+  — `error: "not_authorized"` — not a formatted string an integration would
+  have to parse.
+- **Cell mismatch**: still refused by the same rule (assigned-cell check is
+  part of `check_agent_access`, unchanged by this task).
+
+A denied claim is **not** auto-released back to the pool — the PM reassigns
+it. Auto-releasing would loop the same denied agent right back onto the same
+task via `give_me_work`.
+
+## Testing
+
+`tests/unit/gateway/test_agent_access_claim_guard.py` covers the pure
+predicate (pass / deny shape) and the Choreographer wiring (every inert
+condition above, the rule-denied/rule-passed paths, and both the opt-in-false
+and opt-in-true `_run_claim_guards` compositions).
+
+## Related files
+
+- **Rule:** `roboco/services/project.py:698` (`ProjectService.check_agent_access`, untouched by this task)
+- **Write routes:** `roboco/api/routes/project.py:406,449`
+- **Model field:** `roboco/models/project.py:205` (`Project.allowed_agents`)
+- **Guard predicate:** `roboco/services/gateway/claim_guards.py` (`agent_access_denied_guard`)
+- **Guard wiring:** `roboco/services/gateway/choreographer/_impl.py` (`_agent_access_claim_guard`, `_opt_in_claim_guards`, `ChoreographerDeps.project`)
+- **DI:** `roboco/api/deps.py` (`get_choreographer` wires `project=get_project_service(db_session)`)
+- **Tests:** `tests/unit/gateway/test_agent_access_claim_guard.py`

--- a/docs/backend/services/project-agent-access-enforcement.md
+++ b/docs/backend/services/project-agent-access-enforcement.md
@@ -1,13 +1,15 @@
-# Project Agent-Access Enforcement (allowed_agents)
+# Project Agent-Access Enforcement + Exposure (allowed_agents)
 
 `ProjectService.check_agent_access` (`roboco/services/project.py:698`) encodes a
 project's access rule — the project must exist, the requesting agent's team
 must match the project's assigned cell, and an optional `allowed_agents` list
 further restricts the whole-cell default down to named agents. Until this
 change the rule had zero callers: setting `allowed_agents` via the write
-routes had no observable effect anywhere in the system. It is now enforced at
-the **claim path** — the chokepoint an agent actually traverses when it is
-granted work on a project.
+routes had no observable effect anywhere in the system, and no API response
+exposed the restriction state at all. Two sibling tasks closed both gaps: the
+rule is now enforced at the **claim path** (the chokepoint an agent actually
+traverses when it is granted work on a project), and `ProjectResponse` now
+exposes the restriction state so a caller can read it.
 
 ## The write path (unchanged)
 
@@ -67,12 +69,65 @@ A denied claim is **not** auto-released back to the pool — the PM reassigns
 it. Auto-releasing would loop the same denied agent right back onto the same
 task via `give_me_work`.
 
+## The exposed state (ProjectResponse)
+
+`ProjectResponse` (`roboco/api/schemas/project.py`) now carries two fields
+that mirror `Project.allowed_agents` (`roboco/models/project.py:205`) so a
+caller — the panel's Access card, or any other typed client — can read the
+restriction state without a second call:
+
+- **`access_restricted: bool`** — `project.allowed_agents is not None`. Set
+  purely in `project_to_response` (no DB read needed), so it is always
+  present even on paths that don't resolve agent identities.
+- **`allowed_agents: list[AllowedAgentSummary] | None`** — `None` whenever
+  `access_restricted` is `False` (today's whole-cell default, byte-for-byte
+  unchanged representation). When restricted, each raw agent id in
+  `Project.allowed_agents` is resolved to an `AllowedAgentSummary`
+  (`id`/`slug`/`name`) via a new `AgentService.list_by_ids`
+  (`roboco/services/agent.py`) reader — an id whose agent record no longer
+  exists is silently dropped rather than erroring the response.
+
+The `None`-vs-`[]` distinction is deliberate and load-bearing: `None` means
+"whole assigned cell has access" (the default), an empty list `[]` means
+"restricted, and every previously-allowed agent has since been removed" —
+different states, both distinguishable by a typed client via
+`access_restricted` alone without needing to inspect the list's length.
+
+**Resolution is a DB read, so it isn't in the pure `project_to_response`
+mapper.** `roboco/api/utils/project.py` adds `resolve_allowed_agents(db,
+project)` (the resolver) and `build_project_response(db, project)` (calls
+`project_to_response` then fills in the resolved `allowed_agents`). Every
+route that returns `ProjectResponse` — `GET`/`POST /projects`, `PATCH
+/projects/{id}`, `POST /projects/{id}/workspace`, `POST /projects/{id}/sync`,
+and both `POST`/`DELETE /projects/{project_id}/access/{agent_id}` — now
+builds its response through `build_project_response` instead of the bare
+`project_to_response`, so the restriction state round-trips consistently
+everywhere a project is returned, not just on `GET`.
+
+**No new routes.** `POST`/`DELETE /projects/{project_id}/access/{agent_id}`
+(`add_allowed_agent` / `remove_allowed_agent`) remain the only way to mutate
+`Project.allowed_agents`; this task only changes what a response contains,
+never how the restriction is set.
+
 ## Testing
 
 `tests/unit/gateway/test_agent_access_claim_guard.py` covers the pure
 predicate (pass / deny shape) and the Choreographer wiring (every inert
 condition above, the rule-denied/rule-passed paths, and both the opt-in-false
 and opt-in-true `_run_claim_guards` compositions).
+
+The exposure half is covered by `tests/integration/test_project_routes.py`
+(three real HTTP round-trip cases: a fresh project defaults to
+`access_restricted=False`/`allowed_agents=None`; granting access resolves the
+id to slug/name on both the write route's own response and a subsequent
+`GET`; removing the last restricted agent reverts to `allowed_agents=[]`
+while `access_restricted` stays `True` — only the write routes ever clear the
+restriction back to `None`) plus unit tests for the two new pure/DB-boundary
+pieces: `tests/unit/api/utils/test_project.py` (`resolve_allowed_agents`'s
+`None`-passthrough and id-resolution/drop-missing branches, mocking
+`AgentService`) and `tests/unit/services/test_agent_service.py`
+(`AgentService.list_by_ids`'s empty-list short-circuit and the real
+`session.execute` path).
 
 ## Related files
 
@@ -82,4 +137,8 @@ and opt-in-true `_run_claim_guards` compositions).
 - **Guard predicate:** `roboco/services/gateway/claim_guards.py` (`agent_access_denied_guard`)
 - **Guard wiring:** `roboco/services/gateway/choreographer/_impl.py` (`_agent_access_claim_guard`, `_opt_in_claim_guards`, `ChoreographerDeps.project`)
 - **DI:** `roboco/api/deps.py` (`get_choreographer` wires `project=get_project_service(db_session)`)
-- **Tests:** `tests/unit/gateway/test_agent_access_claim_guard.py`
+- **Response schema:** `roboco/api/schemas/project.py` (`AllowedAgentSummary`, `ProjectResponse.access_restricted`/`.allowed_agents`, `project_to_response`)
+- **Resolver + route-glue:** `roboco/api/utils/project.py` (`resolve_allowed_agents`, `build_project_response`)
+- **Agent lookup:** `roboco/services/agent.py` (`AgentService.list_by_ids`)
+- **Tests (enforcement):** `tests/unit/gateway/test_agent_access_claim_guard.py`
+- **Tests (exposure):** `tests/integration/test_project_routes.py`, `tests/unit/api/utils/test_project.py`, `tests/unit/services/test_agent_service.py`

--- a/roboco/api/deps.py
+++ b/roboco/api/deps.py
@@ -43,6 +43,7 @@ from roboco.services.notification import NotificationService
 from roboco.services.notification_delivery import NotificationDeliveryService
 from roboco.services.permissions import AgentContext, PermissionService
 from roboco.services.product import ProductService
+from roboco.services.project import get_project_service
 from roboco.services.repositories import resolve_agent_identity, resolve_agent_uuid
 from roboco.services.task import TaskService
 from roboco.services.work_session import WorkSessionService
@@ -748,6 +749,7 @@ async def get_choreographer(
             audit=get_audit_service(),
             evidence_repo=EvidenceRepo(db_session),
             product=ProductService(db_session),
+            project=get_project_service(db_session),
             orchestrator=orch,
             stream_bus=bus,
         )

--- a/roboco/api/routes/project.py
+++ b/roboco/api/routes/project.py
@@ -27,10 +27,10 @@ from roboco.api.schemas.project import (
     ProjectUpdateRequest,
     SetWorkspaceRequest,
     SyncStateRequest,
-    project_to_response,
     project_to_summary,
 )
 from roboco.api.utils.project import action_response as _action_response
+from roboco.api.utils.project import build_project_response as _build_project_response
 from roboco.api.utils.project import get_project_or_404 as _get_project_or_404
 from roboco.foundation.policy.conventions.models import ConventionsStandard
 from roboco.models.base import Team
@@ -119,7 +119,7 @@ async def get_project(
             detail=f"Project not found: {project_id}",
         )
 
-    response = project_to_response(project)
+    response = await _build_project_response(db, project)
 
     # Gated the same as the budgets feature: an extra DB read, so only pay
     # for it when the panel can actually make use of it (ROBOCO_TASK_BUDGETS_ENABLED).
@@ -191,7 +191,7 @@ async def create_project(
     try:
         project = await service.create(create_data, created_by=agent.agent_id)
         await db.commit()
-        return project_to_response(project)
+        return await _build_project_response(db, project)
     except Exception as e:
         await db.rollback()
         if "already exists" in str(e):
@@ -261,7 +261,7 @@ async def update_project(
             detail="Failed to update project",
         )
 
-    return project_to_response(updated)
+    return await _build_project_response(db, updated)
 
 
 # =============================================================================
@@ -355,7 +355,7 @@ async def set_workspace(
             detail=f"Project not found: {project_id}",
         )
 
-    return project_to_response(updated)
+    return await _build_project_response(db, updated)
 
 
 @router.post("/{project_id}/sync", response_model=ProjectResponse)
@@ -395,7 +395,7 @@ async def update_sync_state(
             detail=f"Project not found: {project_id}",
         )
 
-    return project_to_response(updated)
+    return await _build_project_response(db, updated)
 
 
 # =============================================================================
@@ -441,7 +441,7 @@ async def add_agent_access(
             detail=f"Project not found: {project_id}",
         )
 
-    return project_to_response(updated)
+    return await _build_project_response(db, updated)
 
 
 @router.delete("/{project_id}/access/{agent_id}", response_model=ProjectResponse)
@@ -479,7 +479,7 @@ async def remove_agent_access(
             detail=f"Project not found: {project_id}",
         )
 
-    return project_to_response(updated)
+    return await _build_project_response(db, updated)
 
 
 # =============================================================================

--- a/roboco/api/schemas/project.py
+++ b/roboco/api/schemas/project.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
 # =============================================================================
 
 
+class AllowedAgentSummary(BaseModel):
+    """An agent id resolved to slug/name for the access-restriction list."""
+
+    id: UUID
+    slug: str
+    name: str
+
+
 class ProjectResponse(BaseModel):
     """Response model for project information."""
 
@@ -38,6 +46,15 @@ class ProjectResponse(BaseModel):
     protected_branches: list[str]
     environments: list[dict[str, str]] | None = None
     assigned_cell: Team
+
+    # Access restriction: mirrors the model's allowed_agents (None = whole
+    # assigned_cell has access, today's default behavior; a list = restricted
+    # to only these agents). access_restricted spells out the None-vs-list
+    # distinction explicitly so a typed client never has to treat a null
+    # array as ambiguous; allowed_agents carries the ids resolved to
+    # slug/name (None whenever access_restricted is False).
+    access_restricted: bool = False
+    allowed_agents: list[AllowedAgentSummary] | None = None
 
     # Git authentication status (token never exposed, only boolean)
     has_git_token: bool = False
@@ -300,6 +317,7 @@ def project_to_response(project: "ProjectTable") -> ProjectResponse:
         protected_branches=list(project.protected_branches or []),
         environments=list(project.environments) if project.environments else None,
         assigned_cell=project.assigned_cell,
+        access_restricted=project.allowed_agents is not None,
         has_git_token=bool(project.git_token_encrypted),
         test_command=project.test_command,
         lint_command=project.lint_command,

--- a/roboco/api/utils/project.py
+++ b/roboco/api/utils/project.py
@@ -5,11 +5,19 @@ Route-glue helpers backing roboco/api/routes/project.py.
 """
 
 from typing import TYPE_CHECKING
+from typing import cast as typing_cast
 from uuid import UUID
 
 from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from roboco.api.schemas.project import ConventionsActionResponse
+from roboco.api.schemas.project import (
+    AllowedAgentSummary,
+    ConventionsActionResponse,
+    ProjectResponse,
+    project_to_response,
+)
+from roboco.services.agent import get_agent_service
 from roboco.services.conventions import ScaffoldResult
 from roboco.services.project import ProjectService
 
@@ -31,6 +39,35 @@ async def get_project_or_404(
             detail=f"Project not found: {project_id}",
         )
     return project
+
+
+async def resolve_allowed_agents(
+    db: AsyncSession, project: "ProjectTable"
+) -> list[AllowedAgentSummary] | None:
+    """Resolve the project's raw allowed_agents ids to slug/name summaries.
+
+    None (cell-default, today's whole-cell behavior) round-trips as None. A
+    restricted list resolves each id via AgentService, silently dropping any
+    id whose agent record no longer exists rather than erroring the response.
+    """
+    if project.allowed_agents is None:
+        return None
+    agents = await get_agent_service(db).list_by_ids(project.allowed_agents)
+    return [
+        AllowedAgentSummary(
+            id=typing_cast("UUID", a.id), slug=str(a.slug), name=str(a.name)
+        )
+        for a in agents
+    ]
+
+
+async def build_project_response(
+    db: AsyncSession, project: "ProjectTable"
+) -> ProjectResponse:
+    """project_to_response plus the DB-backed allowed_agents resolution."""
+    response = project_to_response(project)
+    response.allowed_agents = await resolve_allowed_agents(db, project)
+    return response
 
 
 def action_response(result: ScaffoldResult) -> ConventionsActionResponse:

--- a/roboco/services/agent.py
+++ b/roboco/services/agent.py
@@ -39,6 +39,15 @@ class AgentService(BaseService):
         result = await self.session.execute(query)
         return list(result.scalars().all())
 
+    async def list_by_ids(self, agent_ids: list[UUID]) -> list[AgentTable]:
+        """Fetch agents by primary key, skipping ids that no longer exist."""
+        if not agent_ids:
+            return []
+        result = await self.session.execute(
+            select(AgentTable).where(AgentTable.id.in_(agent_ids))
+        )
+        return list(result.scalars().all())
+
     async def get_by_uuid(self, agent_id: UUID) -> AgentTable | None:
         """Fetch an agent by primary key."""
         result = await self.session.execute(

--- a/roboco/services/gateway/choreographer/_impl.py
+++ b/roboco/services/gateway/choreographer/_impl.py
@@ -21,6 +21,7 @@ from uuid import UUID
 import structlog
 
 from roboco.exceptions import MergeConflictError
+from roboco.foundation.identity import Team
 from roboco.foundation.policy import lifecycle as spec_module
 from roboco.foundation.policy.batch import is_batch_root_subtask, is_batch_umbrella
 from roboco.foundation.policy.content import (
@@ -40,6 +41,7 @@ from roboco.services.gateway.choreographer.evidence_legs import (
     run_bounded_leg,
 )
 from roboco.services.gateway.claim_guards import (
+    agent_access_denied_guard,
     already_active_guard,
     paused_tasks_guard,
     project_budget_exceeded_guard,
@@ -299,6 +301,10 @@ class ChoreographerDeps:
     # callsites / tests that don't exercise Product routing don't have to plumb
     # it in; when None, delegate falls back to parent-project inheritance.
     product: Any = None
+    # ProjectService for the agent-access claim guard
+    # (check_agent_access — the allowed_agents restriction). Optional so
+    # existing callsites / tests that don't plumb it keep the guard inert.
+    project: Any = None
     # Orchestrator access for the rate-limited i_am_blocked path.
     # Implements get_provider_for_agent(slug) -> str | None,
     # get_active_agent_slugs_for_provider(provider) -> list[str], and
@@ -460,6 +466,10 @@ class Choreographer:
     @property
     def product(self) -> Any:
         return self._deps.product
+
+    @property
+    def project(self) -> Any:
+        return self._deps.project
 
     @property
     def orchestrator(self) -> Any:
@@ -1243,6 +1253,7 @@ class Choreographer:
         role_str: str | None = None,
         skip_dev_guards: bool = False,
         check_project_budget: bool = False,
+        check_agent_access: bool = False,
     ) -> Envelope | None:
         """Run concurrency-invariant claim guards. Returns rejection or None.
 
@@ -1276,6 +1287,12 @@ class Choreographer:
         an exhausted cap whose incremental cost is negligible next to the
         sunk spend.
 
+        ``check_agent_access`` (same default-False work-STARTING opt-in)
+        scopes the project agent-access guard to the same two call sites —
+        it is the enforcement chokepoint for the project's
+        ``allowed_agents`` restriction: a same-cell agent not on the list
+        is refused before any task-status mutation.
+
         Pre-gateway location: _helpers.py:124-204.
         """
         if not skip_dev_guards and role_str not in self._COORDINATOR_ROLES:
@@ -1287,13 +1304,69 @@ class Choreographer:
                 return guard
         if guard := await self._sequencing_claim_guard(task):
             return guard
-        if check_project_budget and (
-            guard := await self._project_budget_claim_guard(task)
+        if guard := await self._opt_in_claim_guards(
+            task,
+            agent_id=agent_id,
+            check_project_budget=check_project_budget,
+            check_agent_access=check_agent_access,
         ):
             return guard
         if skip_dev_guards:
             return None
         return await self._lane_claim_guard(task)
+
+    async def _opt_in_claim_guards(
+        self,
+        task: Any,
+        *,
+        agent_id: UUID,
+        check_project_budget: bool,
+        check_agent_access: bool,
+    ) -> Envelope | None:
+        """The two opt-in, work-STARTING-only guards in one call — the
+        project monthly-budget guard and the project agent-access guard.
+        Extracted from ``_run_claim_guards`` (xenon return-count budget).
+        """
+        if check_project_budget and (
+            guard := await self._project_budget_claim_guard(task)
+        ):
+            return guard
+        if check_agent_access and (
+            guard := await self._agent_access_claim_guard(task, agent_id)
+        ):
+            return guard
+        return None
+
+    async def _agent_access_claim_guard(
+        self, task: Any, agent_id: UUID
+    ) -> Envelope | None:
+        """Refuse claim when the project's access rule denies the agent.
+
+        Enforces ``ProjectService.check_agent_access`` — the services-layer
+        rule (project exists, assigned cell matches, optional
+        ``allowed_agents`` list; None = whole cell passes) — at the
+        agent-to-project grant chokepoint, so a restriction set via
+        POST /projects/{id}/access/{agent_id} is actually enforced. The
+        deny decision comes solely from that rule; this helper only
+        resolves its inputs. Inert when the deps lack a project service
+        (existing tests), the task has no project (branchless coordination
+        root), or the agent view carries no usable team — mirroring
+        ``_sequence_claim_guard``'s mock-safety guard.
+        """
+        if self._deps.project is None:
+            return None
+        project = getattr(task, "project", None)
+        if project is None or getattr(project, "id", None) is None:
+            return None
+        agent = await self.task.agent_for(agent_id)
+        if agent is None or not isinstance(agent.team, str):
+            return None
+        try:
+            team = Team(agent.team)
+        except ValueError:
+            return None
+        has_access = await self.project.check_agent_access(project.id, agent.id, team)
+        return agent_access_denied_guard(task, project.id, agent.id, has_access)
 
     async def _sequencing_claim_guard(self, task: Any) -> Envelope | None:
         """Both halves of the claim-time sequencing bar in one call — an
@@ -1569,12 +1642,15 @@ class Choreographer:
             )
         # Concurrency guards still apply on resumption (paused / already-active
         # in another task). check_project_budget=True: resuming i_will_work_on
-        # / i_will_plan is still a work-STARTING claim.
+        # / i_will_plan is still a work-STARTING claim. check_agent_access
+        # likewise — the grant chokepoint for the project's allowed_agents
+        # restriction.
         if guard := await self._run_claim_guards(
             agent_id=agent_id,
             task=t,
             role_str=role_str,
             check_project_budget=True,
+            check_agent_access=True,
         ):
             return await self._emit_rejection(
                 self._with_briefing(guard, briefing).with_introspection(
@@ -1687,6 +1763,7 @@ class Choreographer:
             task=t,
             role_str=role_str,
             check_project_budget=True,
+            check_agent_access=True,
         ):
             return await self._emit_rejection(
                 self._with_briefing(guard, briefing).with_introspection(

--- a/roboco/services/gateway/choreographer/_protocol.py
+++ b/roboco/services/gateway/choreographer/_protocol.py
@@ -123,6 +123,7 @@ class ChoreographerHelpers:
         role_str: str | None = None,
         skip_dev_guards: bool = False,
         check_project_budget: bool = False,
+        check_agent_access: bool = False,
     ) -> Envelope | None:
         raise NotImplementedError
 

--- a/roboco/services/gateway/claim_guards.py
+++ b/roboco/services/gateway/claim_guards.py
@@ -129,6 +129,38 @@ def sequence_held_guard(target_task: Any, blocked_by: str | None) -> Envelope | 
     return Envelope.sequence_held(blocked_by=blocked_by, task_id=str(target_task.id))
 
 
+def agent_access_denied_guard(
+    target_task: Any,
+    project_id: UUID,
+    agent_id: UUID,
+    has_access: bool,
+) -> Envelope | None:
+    """Refuse claim when the services-layer access rule denies the agent.
+
+    ``has_access`` is the caller-resolved verdict of
+    ``ProjectService.check_agent_access`` (project exists, assigned cell
+    matches, optional allowed_agents list) — the single source of the
+    allow/deny decision, so this predicate only shapes the refusal:
+    no DB IO, no rule logic, mirroring ``unmet_dependency_guard``.
+    """
+    if has_access:
+        return None
+    return Envelope.not_authorized(
+        message=(
+            f"agent {agent_id} is not permitted to work on project "
+            f"{project_id} (task {target_task.id}): the project's access "
+            "rule refuses this agent (assigned-cell mismatch, or the "
+            "project restricts work to an allowed-agents list the agent "
+            "is not on)."
+        ),
+        remediate=(
+            f"have the project's PM add the agent via POST "
+            f"/projects/{project_id}/access/{agent_id}, or reassign task "
+            f"{target_task.id} to an agent permitted on this project"
+        ),
+    )
+
+
 def unmet_dependency_guard(
     target_task: Any, unmet_dependency_ids: list[UUID]
 ) -> Envelope | None:

--- a/tests/integration/test_project_routes.py
+++ b/tests/integration/test_project_routes.py
@@ -711,3 +711,101 @@ async def test_remove_agent_access_by_uuid_success(
         f"/api/projects/{pid}/access/{other_agent.id}", headers=_HDR
     )
     assert response.status_code == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_get_project_defaults_to_cell_default_access(
+    project_client: AsyncClient,
+) -> None:
+    """A freshly created project has no restriction: access_restricted is
+    False and allowed_agents is null (today's whole-cell behavior)."""
+    create = await project_client.post("/api/projects", json=_payload(), headers=_HDR)
+    pid = create.json()["id"]
+
+    response = await project_client.get(f"/api/projects/{pid}", headers=_HDR)
+
+    assert response.status_code == HTTPStatus.OK
+    body = response.json()
+    assert body["access_restricted"] is False
+    assert body["allowed_agents"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_agent_access_exposes_restricted_state_with_resolved_agent(
+    project_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Restricting a project resolves the allowed_agents ids to slug/name
+    both on the write route's own response and on a subsequent GET."""
+    create = await project_client.post("/api/projects", json=_payload(), headers=_HDR)
+    pid = create.json()["id"]
+    other_agent = AgentTable(
+        id=uuid4(),
+        name="RestrictedAgent",
+        slug=f"restricted-{uuid4().hex[:6]}",
+        role=AgentRole.DEVELOPER,
+        team=Team.BACKEND,
+        status=AgentStatus.ACTIVE,
+        model_config={},
+        system_prompt="x",
+        capabilities=[],
+        permissions={},
+        metrics={},
+    )
+    db_session.add(other_agent)
+    await db_session.flush()
+
+    add_response = await project_client.post(
+        f"/api/projects/{pid}/access/{other_agent.id}", headers=_HDR
+    )
+    assert add_response.status_code == HTTPStatus.OK
+    add_body = add_response.json()
+    assert add_body["access_restricted"] is True
+    assert add_body["allowed_agents"] == [
+        {"id": str(other_agent.id), "slug": other_agent.slug, "name": other_agent.name}
+    ]
+
+    get_response = await project_client.get(f"/api/projects/{pid}", headers=_HDR)
+    assert get_response.status_code == HTTPStatus.OK
+    get_body = get_response.json()
+    assert get_body["access_restricted"] is True
+    assert get_body["allowed_agents"] == [
+        {"id": str(other_agent.id), "slug": other_agent.slug, "name": other_agent.name}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remove_agent_access_reverts_to_cell_default(
+    project_client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Removing the last restricted agent reverts allowed_agents to []
+    (still restricted, everyone removed) — not back to the None default;
+    only the write routes ever clear the restriction entirely."""
+    create = await project_client.post("/api/projects", json=_payload(), headers=_HDR)
+    pid = create.json()["id"]
+    other_agent = AgentTable(
+        id=uuid4(),
+        name="RemovedAgent",
+        slug=f"removed-{uuid4().hex[:6]}",
+        role=AgentRole.DEVELOPER,
+        team=Team.BACKEND,
+        status=AgentStatus.ACTIVE,
+        model_config={},
+        system_prompt="x",
+        capabilities=[],
+        permissions={},
+        metrics={},
+    )
+    db_session.add(other_agent)
+    await db_session.flush()
+
+    await project_client.post(
+        f"/api/projects/{pid}/access/{other_agent.id}", headers=_HDR
+    )
+    remove_response = await project_client.delete(
+        f"/api/projects/{pid}/access/{other_agent.id}", headers=_HDR
+    )
+
+    assert remove_response.status_code == HTTPStatus.OK
+    body = remove_response.json()
+    assert body["access_restricted"] is True
+    assert body["allowed_agents"] == []

--- a/tests/unit/api/utils/test_project.py
+++ b/tests/unit/api/utils/test_project.py
@@ -1,0 +1,52 @@
+"""Unit tests for roboco.api.utils.project.resolve_allowed_agents.
+
+Mocks AgentService (via get_agent_service) so the None-vs-restricted-list
+branch and the unresolved-id-drop behavior are exercised without a DB.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from typing import cast as typing_cast
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from roboco.api.utils.project import resolve_allowed_agents
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from roboco.db.tables import ProjectTable
+
+
+@pytest.mark.asyncio
+async def test_resolve_allowed_agents_returns_none_for_cell_default() -> None:
+    project = SimpleNamespace(allowed_agents=None)
+    db = MagicMock(spec=AsyncSession)
+
+    with patch("roboco.api.utils.project.get_agent_service") as get_svc:
+        result = await resolve_allowed_agents(db, typing_cast("ProjectTable", project))
+
+    assert result is None
+    get_svc.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_allowed_agents_resolves_ids_to_summaries() -> None:
+    resolvable_id, missing_id = uuid4(), uuid4()
+    agent_row = SimpleNamespace(id=resolvable_id, slug="be-dev-1", name="BE Dev 1")
+    project = SimpleNamespace(allowed_agents=[resolvable_id, missing_id])
+    db = MagicMock(spec=AsyncSession)
+
+    fake_service = AsyncMock()
+    fake_service.list_by_ids = AsyncMock(return_value=[agent_row])
+    with patch("roboco.api.utils.project.get_agent_service", return_value=fake_service):
+        result = await resolve_allowed_agents(db, typing_cast("ProjectTable", project))
+
+    fake_service.list_by_ids.assert_awaited_once_with([resolvable_id, missing_id])
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].id == resolvable_id
+    assert result[0].slug == "be-dev-1"
+    assert result[0].name == "BE Dev 1"

--- a/tests/unit/gateway/test_agent_access_claim_guard.py
+++ b/tests/unit/gateway/test_agent_access_claim_guard.py
@@ -1,0 +1,224 @@
+"""Project agent-access claim guard (allowed_agents enforcement).
+
+Two layers: the pure predicate ``agent_access_denied_guard`` (pass/deny
+shaping only — the deny decision itself lives in
+``ProjectService.check_agent_access``) and the Choreographer's
+``_agent_access_claim_guard`` wiring (inert without a project dep, without
+a task project, or without a usable agent team; fires only on the
+work-STARTING opt-in ``check_agent_access=True``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from roboco.services.gateway.choreographer import Choreographer, ChoreographerDeps
+from roboco.services.gateway.claim_guards import agent_access_denied_guard
+
+# ---------------------------------------------------------------------------
+# Pure predicate: agent_access_denied_guard
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_has_access_passes() -> None:
+    task = MagicMock(id=uuid4())
+    assert agent_access_denied_guard(task, uuid4(), uuid4(), True) is None
+
+
+def test_predicate_denied_refuses_machine_readably() -> None:
+    task = MagicMock(id=uuid4())
+    project_id, agent_id = uuid4(), uuid4()
+    env = agent_access_denied_guard(task, project_id, agent_id, False)
+    assert env is not None
+    body = env.as_dict()
+    assert body["error"] == "not_authorized"
+    assert str(project_id) in body["message"]
+    assert str(agent_id) in body["message"]
+    # The existing write routes stay the only write path named in remediation.
+    assert f"/projects/{project_id}/access/{agent_id}" in body["remediate"]
+
+
+# ---------------------------------------------------------------------------
+# Choreographer wiring: _agent_access_claim_guard
+# ---------------------------------------------------------------------------
+
+
+def _make_deps(
+    *,
+    check_agent_access_result: bool | None = None,
+    project: Any = "AUTO",
+) -> ChoreographerDeps:
+    task_svc = AsyncMock()
+    task_svc.agent_for.return_value = None
+    deps: dict[str, Any] = {
+        "task": task_svc,
+        "work_session": AsyncMock(),
+        "git": AsyncMock(),
+        "a2a": AsyncMock(),
+        "journal": AsyncMock(),
+        "audit": AsyncMock(),
+        "evidence_repo": AsyncMock(),
+    }
+    if project == "AUTO":
+        project_svc = AsyncMock()
+        if check_agent_access_result is not None:
+            project_svc.check_agent_access.return_value = check_agent_access_result
+        deps["project"] = project_svc
+    elif project is not None:
+        deps["project"] = project
+    return ChoreographerDeps(**deps)
+
+
+def _task_with_project(project_id: UUID | None = None) -> MagicMock:
+    if project_id is None:
+        return MagicMock(id=uuid4(), project=None)
+    project = MagicMock(id=project_id)
+    return MagicMock(id=uuid4(), project=project)
+
+
+def _prime_run_claim_guards(deps: ChoreographerDeps, task: MagicMock) -> None:
+    """Silence the upstream guards so only the access guard can fire."""
+    deps.task.list_in_progress_for_agent.return_value = []
+    deps.task.list_paused_for_agent.return_value = []
+    deps.task.sequence_hold_reason.return_value = None
+    task.dependency_ids = []
+    deps.task.has_earlier_incomplete_code_sibling.return_value = False
+
+
+def _agent_view(agent_id: UUID, team: Any) -> MagicMock:
+    return MagicMock(id=agent_id, team=team)
+
+
+@pytest.mark.asyncio
+async def test_rule_denied_refuses_with_not_authorized() -> None:
+    project_id = uuid4()
+    agent_id = uuid4()
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    agent_view = MagicMock(id=agent_id, team="backend")
+    deps.task.agent_for.return_value = agent_view
+
+    env = await c._agent_access_claim_guard(_task_with_project(project_id), agent_id)
+    assert env is not None
+    body = env.as_dict()
+    assert body["error"] == "not_authorized"
+    assert str(project_id) in body["message"]
+    # The services-layer rule made the deny decision, with the resolved team.
+    deps.project.check_agent_access.assert_awaited_once_with(
+        project_id, agent_id, agent_view.team
+    )
+
+
+@pytest.mark.asyncio
+async def test_rule_passes_no_envelope() -> None:
+    """allowed_agents=None reaches the rule and passes — no refusal."""
+    deps = _make_deps(check_agent_access_result=True)
+    c = Choreographer(deps)
+    agent_id = uuid4()
+    deps.task.agent_for.return_value = MagicMock(id=agent_id, team="backend")
+
+    assert (
+        await c._agent_access_claim_guard(_task_with_project(uuid4()), agent_id) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_project_dep_is_inert() -> None:
+    """Existing ChoreographerDeps constructions (no project) keep the
+    guard off — nothing is called."""
+    deps = _make_deps(project=None)
+    c = Choreographer(deps)
+    assert (
+        await c._agent_access_claim_guard(_task_with_project(uuid4()), uuid4()) is None
+    )
+    deps.task.agent_for.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_without_project_is_inert() -> None:
+    """A branchless coordination root never reaches the rule."""
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    agent_id = uuid4()
+    deps.task.agent_for.return_value = MagicMock(id=agent_id, team="backend")
+
+    assert (
+        await c._agent_access_claim_guard(_task_with_project(project_id=None), agent_id)
+        is None
+    )
+    deps.project.check_agent_access.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_is_inert() -> None:
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    deps.task.agent_for.return_value = None
+
+    assert (
+        await c._agent_access_claim_guard(_task_with_project(uuid4()), uuid4()) is None
+    )
+    deps.project.check_agent_access.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_string_team_is_mock_safe() -> None:
+    """An unstubbed AsyncMock agent view carries a MagicMock team, not a
+    str — the guard stays inert instead of raising (mirrors
+    _sequence_claim_guard's mock-safety)."""
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    agent_id = uuid4()
+    deps.task.agent_for.return_value = MagicMock(id=agent_id)  # team auto-mocked
+
+    assert (
+        await c._agent_access_claim_guard(_task_with_project(uuid4()), agent_id) is None
+    )
+    deps.project.check_agent_access.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_team_value_is_inert() -> None:
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    agent_id = uuid4()
+    deps.task.agent_for.return_value = MagicMock(id=agent_id, team="not-a-cell")
+
+    assert (
+        await c._agent_access_claim_guard(_task_with_project(uuid4()), agent_id) is None
+    )
+    deps.project.check_agent_access.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_claim_guards_opt_in_false_is_inert() -> None:
+    """Default flag off: a denying rule never fires — review/doc/gate
+    claims of in-flight work are exempt."""
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    agent_id = uuid4()
+    deps.task.agent_for.return_value = MagicMock(id=agent_id, team="backend")
+
+    task = _task_with_project(uuid4())
+    _prime_run_claim_guards(deps, task)
+    assert await c._run_claim_guards(agent_id=agent_id, task=task) is None
+    deps.project.check_agent_access.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_claim_guards_opt_in_true_fires_the_guard() -> None:
+    deps = _make_deps(check_agent_access_result=False)
+    c = Choreographer(deps)
+    agent_id = uuid4()
+    deps.task.agent_for.return_value = MagicMock(id=agent_id, team="backend")
+
+    task = _task_with_project(uuid4())
+    _prime_run_claim_guards(deps, task)
+    env = await c._run_claim_guards(
+        agent_id=agent_id, task=task, check_agent_access=True
+    )
+    assert env is not None
+    assert env.as_dict()["error"] == "not_authorized"

--- a/tests/unit/services/test_agent_service.py
+++ b/tests/unit/services/test_agent_service.py
@@ -1,0 +1,49 @@
+"""Unit tests for AgentService.list_by_ids.
+
+Mocks the SQLAlchemy AsyncSession.execute() boundary — mirrors
+tests/unit/services/test_project.py's pattern for ProjectService.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from roboco.services.agent import AgentService
+
+_AGENT_1 = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_AGENT_2 = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+
+def _result_scalars(rows: list[MagicMock]) -> MagicMock:
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=rows)
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars)
+    return result
+
+
+@pytest.mark.asyncio
+async def test_list_by_ids_empty_list_short_circuits_without_query() -> None:
+    session = MagicMock()
+    session.execute = AsyncMock()
+    svc = AgentService(session)
+
+    out = await svc.list_by_ids([])
+
+    assert out == []
+    session.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_by_ids_returns_matching_rows() -> None:
+    row1, row2 = MagicMock(id=_AGENT_1), MagicMock(id=_AGENT_2)
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_result_scalars([row1, row2]))
+    svc = AgentService(session)
+
+    out = await svc.list_by_ids([_AGENT_1, _AGENT_2, uuid4()])
+
+    assert out == [row1, row2]
+    session.execute.assert_called_once()


### PR DESCRIPTION
Goal: finish the project agent-access restriction capability. The capability (restrict a project to a specific allowed-agent list instead of the whole assigned cell) was built at every backend layer and then wired into nothing. Enforce the check at the agent-to-project grant chokepoint and expose the state so the panel (and a follow-up Access-card item) can read and manage it.

Why it matters: check_agent_access has zero callers today, so a restriction set via the existing write routes would not actually be enforced anywhere; and ProjectResponse exposes no allowed-agents field, so no reader can even see the restriction state.

Observed facts to work from (intake evidence, verbatim):
- Built side: roboco/api/routes/project.py:406 POST and :449 DELETE /{project_id}/access/{agent_id} (add_allowed_agent / remove_allowed_agent), model field roboco/models/project.py:205 allowed_agents, and the enforcement rule roboco/services/project.py:698 check_agent_access.
- Missing side: repo-wide grep shows check_agent_access has zero callers (never enforced); ProjectResponse (roboco/api/schemas/project.py:25-81) has no allowed-agents field so the state is unreadable from any API response; grep across panel/src for 'access/' and 'allowed_agents' returns zero hits (the panel side is a separate root — do not touch it here).

Constraints:
- POST/DELETE /projects/{project_id}/access/{agent_id} remain the only write path — no new routes are added.
- allowed_agents is None must keep today's whole-cell behavior unchanged.
- The refusal must carry a clear structured reason.
- The exposure must resolve allowed agent ids to slugs/names and explicitly distinguish cell-default from a restricted list, in a shape a typed panel client can consume (the follow-up Access card reads it).
- Architectural standard: enforcement belongs in the services layer; the response field in roboco/api/schemas; tests under tests/.

Work-unit breakdown for your team (refine each into its own developer leaf so your devs can run in parallel; 1a and 1b are independent, 2 depends on both):
1a. Enforcement: invoke check_agent_access at the agent-to-project grant chokepoint (spawn readiness gate or claim path).
1b. Exposure: add the restriction-state field(s) to ProjectResponse with resolved slugs/names.
2. Unit tests (depends on 1a+1b): restricting a project then verifying a non-allowed same-cell agent is refused; removing the restriction restores cell-default access; the response field round-trips through the detail route.

'Done' is defined by the acceptance criteria. You own the HOW within your cell.
